### PR TITLE
Fix 522

### DIFF
--- a/src/scripts/userpasswordpage.js
+++ b/src/scripts/userpasswordpage.js
@@ -37,6 +37,11 @@ define(["loading", "libraryMenu", "emby-linkbutton"], function(loading, libraryM
             var userId = params.userId,
                 currentPassword = view.querySelector("#txtCurrentPassword").value,
                 newPassword = view.querySelector("#txtNewPassword").value;
+            if(view.querySelector("#fldCurrentPassword").classList.contains("hide")) {
+                // Firefox does not respect autocomplete=off, so clear it if the field is supposed to be hidden (and blank)
+                // This should only happen when user.HasConfiguredPassword is false, but this information is not passed on
+                currentPassword = "";
+            }
             ApiClient.updateUserPassword(userId, currentPassword, newPassword).then(function() {
                 loading.hide(), require(["toast"], function(toast) {
                     toast(Globalize.translate("PasswordSaved"))


### PR DESCRIPTION
Fixes https://github.com/jellyfin/jellyfin/issues/522

userpasswordpage.html has autocomplete=off on these fields, but firefox promptly ignores that.

This fix checks if the field is hidden and if so, then it doesn't submit it. The reason for it being so indirect is that I'm a noob and didn't know where a global variable for user.HasConfiguredPassword would be put..
I have hadded a descriptive comment to help anyone looking at this fix in the future.