### PR TITLE
send android clients to select server before login

### DIFF
--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -62,7 +62,8 @@ var Dashboard = {
         },
         logout: function(logoutWithServer) {
             function onLogoutDone() {
-                Dashboard.navigate("login.html")
+                var loginPage;
+                AppInfo.isNativeApp ? (loginPage = "selectserver.html", window.ApiClient = null) : loginPage = "login.html", Dashboard.navigate(loginPage)
             }!1 === logoutWithServer ? onLogoutDone() : ConnectionManager.logout().then(onLogoutDone)
         },
         getConfigurationPageUrl: function(name) {
@@ -1033,7 +1034,7 @@ var Dashboard = {
             }, appRouter.showSelectServer = function() {
                 AppInfo.isNativeApp ? Dashboard.navigate("selectserver.html") : Dashboard.navigate("login.html")
             }, appRouter.showWelcome = function() {
-                Dashboard.navigate("login.html")
+                AppInfo.isNativeApp ? Dashboard.navigate("selectserver.html") : Dashboard.navigate("login.html")
             }, appRouter.showSettings = function() {
                 Dashboard.navigate("mypreferencesmenu.html")
             }, appRouter.showGuide = function() {


### PR DESCRIPTION
This will also need to be implemented for the standalone web client, since `login` assumes an ApiClient has been initialized but that isn't the case until `selectserver` has been called. The behavior is probably different when a user is logged in, but this would solve the inital login issue. We should use a new variable like `isBundledWithServer` to determine if a server must be selected first, and if `isNativeApp` is only used for this purpose we can replace it in favor of a unified variable.