### PR TITLE
Show album thumbnail and artist image in page itemdetail

### DIFF
--- a/src/scripts/itemdetailpage.js
+++ b/src/scripts/itemdetailpage.js
@@ -252,7 +252,7 @@ define(["loading", "appRouter", "layoutManager", "connectionManager", "cardBuild
         var imgUrl, screenWidth = screen.availWidth,
             hasbackdrop = !1,
             itemBackdropElement = page.querySelector("#itemBackdrop"),
-            usePrimaryImage = "Video" === item.MediaType && "Movie" !== item.Type && "Trailer" !== item.Type || item.MediaType && "Video" !== item.MediaType;
+            usePrimaryImage = ("Video" === item.MediaType && "Movie" !== item.Type && "Trailer" !== item.Type) || (item.MediaType && "Video" !== item.MediaType) || ("MusicAlbum" === item.Type) || ("MusicArtist" === item.Type);
         return "Program" === item.Type && item.ImageTags && item.ImageTags.Thumb ? (imgUrl = apiClient.getScaledImageUrl(item.Id, {
             type: "Thumb",
             index: 0,


### PR DESCRIPTION
Fixes #15.
Now the detail pages of albums and artists on mobile have the correct images.