### PR TITLE
Revert "Add Master codeowners"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,0 @@
-# Jellyfin CODEOWNERS file (`master` branch)
-
-# Require org owner approvals for all files, when merging to master
-*   @joshuaboniface @nvllsvm


### PR DESCRIPTION
Reverts jellyfin/jellyfin-web#24

We reverted this in the main repo as unnecessary. Revert it here too.