### PR TITLE
Fix inconsistent UI coloring around settings drawer

### DIFF
--- a/src/bower_components/emby-webcomponents/themes/dark/theme.css
+++ b/src/bower_components/emby-webcomponents/themes/dark/theme.css
@@ -287,7 +287,7 @@ html {
 }
 
 .mainDrawer {
-    background-color: #1c1c1c
+    background-color: #101010
 }
 
 .navMenuOption:hover {


### PR DESCRIPTION
Before, It matched the header bars coloration. With the header matching the larger background, I have corrected drawer coloration.

For reference, before:

![screenshot_20190116_070655](https://user-images.githubusercontent.com/1992688/51250614-ec190f00-1964-11e9-9641-a264a9029302.png)

![screenshot_20190116_075523](https://user-images.githubusercontent.com/1992688/51250622-f20ef000-1964-11e9-89ee-4075477e1c04.png)
After: 