### PR TITLE
Fixed Home Backdrop Not Loading

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,6 +16,7 @@
  - [grafixeyehero](https://github.com/grafixeyehero)
  - [Drago96](https://github.com/drago-96)
  - [ViXXoR](https://github.com/ViXXoR)
+ - [nkmerrill] (https://github.com/nkmerrill)
 
 # Emby Contributors
 

--- a/src/scripts/autobackdrops.js
+++ b/src/scripts/autobackdrops.js
@@ -39,7 +39,7 @@ define(["backdrop", "userSettings", "libraryMenu"], function(backdrop, userSetti
         })
     }
     var cache = {};
-    pageClassOn("pagebeforeshow", "page", function() {
+    pageClassOn("pageshow", "page", function() {
         var page = this;
         if (!page.classList.contains("selfBackdropPage"))
             if (page.classList.contains("backdropPage"))


### PR DESCRIPTION
Changed backdrop initialization module to load on page show instead of
before page show so that home page continues to load backdrop image
even after changing page.

Also added my name to contributors.