### PR TITLE
Remove filter from library collection type options

### DIFF
--- a/src/components/medialibrarycreator/medialibrarycreator.js
+++ b/src/components/medialibrarycreator/medialibrarycreator.js
@@ -42,11 +42,9 @@ define(["loading", "dialogHelper", "dom", "jQuery", "components/libraryoptionsed
     }
 
     function getCollectionTypeOptionsHtml(collectionTypeOptions) {
-        return collectionTypeOptions.filter(function(i) {
-            return i.isSelectable
-        }).map(function(i) {
-            return '<option value="' + i.value + '">' + i.name + "</option>"
-        }).join("")
+        return collectionTypeOptions.map(function(i) {
+            return '<option value="' + i.value + '">' + i.name + "</option>";
+        }).join("");
     }
 
     function initEditor(page, collectionTypeOptions) {


### PR DESCRIPTION
It's never set apparently. And it broke in #27 because it was assumed it would be set. The old implementation only checked specifically for `false`.