### PR TITLE
Add multiserver support for web client

### DIFF
--- a/src/components/apphost.js
+++ b/src/components/apphost.js
@@ -144,6 +144,7 @@ define(["appSettings", "browser", "events", "htmlMediaHelper"], function(appSett
         features.push("displaylanguage");
         features.push("otherapppromotions");
         features.push("targetblank");
+        features.push("multiserver");
         browser.orsay || browser.tizen || browser.msie || !(browser.firefox || browser.ps4 || browser.edge || cueSupported()) || features.push("subtitleappearancesettings");
         browser.orsay || browser.tizen || features.push("subtitleburnsettings");
         browser.tv || browser.ps4 || browser.xboxOne || features.push("fileinput");

--- a/src/components/apphost.js
+++ b/src/components/apphost.js
@@ -140,7 +140,6 @@ define(["appSettings", "browser", "events", "htmlMediaHelper"], function(appSett
         (browser.tv || browser.xboxOne || browser.ps4 || browser.mobile) && features.push("physicalvolumecontrol");
         browser.tv || browser.xboxOne || browser.ps4 || features.push("remotecontrol");
         browser.operaTv || browser.tizen || browser.orsay || browser.web0s || browser.edgeUwp || features.push("remotevideo");
-        // might require isNativeApp check if any other issues surface
         features.push("displaylanguage");
         features.push("otherapppromotions");
         features.push("targetblank");

--- a/src/login.html
+++ b/src/login.html
@@ -36,24 +36,20 @@
         <div class="visualLoginForm" style="text-align: center;">
             <h1 style="margin-top:1em;">${HeaderPleaseSignIn}</h1>
             <div id="divUsers" class="itemsContainer vertical-wrap centered"></div>
-
-            <div class="readOnlyContent" style="margin: 2em auto 0;">
-                <button is="emby-button" type="button" class="raised cancel block btnManual">
-                    <span>${ButtonManualLogin}</span>
-                </button>
-            </div>
         </div>
 
         <div class="readOnlyContent" style="margin: .5em auto 1em;">
+            <button is="emby-button" type="button" class="raised cancel block btnManual">
+                <span>${ButtonManualLogin}</span>
+            </button>
+
             <button is="emby-button" type="button" class="raised cancel block btnForgotPassword">
                 <span>${ButtonForgotPassword}</span>
             </button>
 
-            <div class="connectButtons hide">
-                <a is="emby-linkbutton" href="selectserver.html" class="raised block">
-                    <span>${ButtonChangeServer}</span>
-                </a>
-            </div>
+            <a is="emby-linkbutton" href="selectserver.html" class="raised block">
+                <span>${ButtonChangeServer}</span>
+            </a>
 
             <p class="disclaimer" style="text-align: center; margin-top: 2em;"></p>
         </div>

--- a/src/scripts/addpluginpage.js
+++ b/src/scripts/addpluginpage.js
@@ -28,28 +28,27 @@ define(["jQuery", "loading", "libraryMenu", "globalize", "connectionManager", "e
     }
 
     function renderPluginInfo(page, pkg, pluginSecurityInfo) {
-        if (!AppInfo.isNativeApp)
-            if (pkg.isPremium) {
-                $(".premiumPackage", page).show();
-                var regStatus = "";
-                if (pkg.isRegistered) regStatus += "<p style='color:green;'>", regStatus += globalize.translate("MessageFeatureIncludedWithSupporter");
-                else {
-                    var expDateTime = new Date(pkg.expDate).getTime(),
-                        nowTime = (new Date).getTime();
-                    expDateTime <= nowTime ? (regStatus += "<p style='color:red;'>", regStatus += globalize.translate("MessageTrialExpired")) : expDateTime > new Date(1970, 1, 1).getTime() && (regStatus += "<p style='color:blue;'>", regStatus += globalize.translate("MessageTrialWillExpireIn").replace("{0}", Math.round(expDateTime - nowTime) / 864e5))
-                }
-                if (regStatus += "</p>", $("#regStatus", page).html(regStatus), pluginSecurityInfo.IsMBSupporter)
-                    if ($(".premiumDescription", page).hide(), $(".supporterDescription", page).hide(), pkg.price > 0) {
-                        $(".premiumHasPrice", page).show(), $("#featureId", page).val(pkg.featureId), $("#featureName", page).val(pkg.name), $("#amount", page).val(pkg.price), $("#regPrice", page).html("<h3>" + globalize.translate("ValuePriceUSD").replace("{0}", "$" + pkg.price.toFixed(2)) + "</h3>"), $("#ppButton", page).hide();
-                        var url = "https://mb3admin.local/admin/service/user/getPayPalEmail?id=" + pkg.owner;
-                        fetch(url).then(function(response) {
-                            return response.json()
-                        }).then(function(dev) {
-                            dev.payPalEmail && ($("#payPalEmail", page).val(dev.payPalEmail), $("#ppButton", page).show())
-                        })
-                    } else $(".premiumHasPrice", page).hide();
-                else pkg.price ? ($(".premiumDescription", page).show(), $(".supporterDescription", page).hide()) : ($(".premiumDescription", page).hide(), $(".supporterDescription", page).show()), $("#ppButton", page).hide()
-            } else $(".premiumPackage", page).hide()
+        if (pkg.isPremium) {
+            $(".premiumPackage", page).show();
+            var regStatus = "";
+            if (pkg.isRegistered) regStatus += "<p style='color:green;'>", regStatus += globalize.translate("MessageFeatureIncludedWithSupporter");
+            else {
+                var expDateTime = new Date(pkg.expDate).getTime(),
+                    nowTime = (new Date).getTime();
+                expDateTime <= nowTime ? (regStatus += "<p style='color:red;'>", regStatus += globalize.translate("MessageTrialExpired")) : expDateTime > new Date(1970, 1, 1).getTime() && (regStatus += "<p style='color:blue;'>", regStatus += globalize.translate("MessageTrialWillExpireIn").replace("{0}", Math.round(expDateTime - nowTime) / 864e5))
+            }
+            if (regStatus += "</p>", $("#regStatus", page).html(regStatus), pluginSecurityInfo.IsMBSupporter)
+                if ($(".premiumDescription", page).hide(), $(".supporterDescription", page).hide(), pkg.price > 0) {
+                    $(".premiumHasPrice", page).show(), $("#featureId", page).val(pkg.featureId), $("#featureName", page).val(pkg.name), $("#amount", page).val(pkg.price), $("#regPrice", page).html("<h3>" + globalize.translate("ValuePriceUSD").replace("{0}", "$" + pkg.price.toFixed(2)) + "</h3>"), $("#ppButton", page).hide();
+                    var url = "https://mb3admin.local/admin/service/user/getPayPalEmail?id=" + pkg.owner;
+                    fetch(url).then(function(response) {
+                        return response.json()
+                    }).then(function(dev) {
+                        dev.payPalEmail && ($("#payPalEmail", page).val(dev.payPalEmail), $("#ppButton", page).show())
+                    })
+                } else $(".premiumHasPrice", page).hide();
+            else pkg.price ? ($(".premiumDescription", page).show(), $(".supporterDescription", page).hide()) : ($(".premiumDescription", page).hide(), $(".supporterDescription", page).show()), $("#ppButton", page).hide()
+        } else $(".premiumPackage", page).hide()
     }
 
     function renderPackage(pkg, installedPlugins, pluginSecurityInfo, page) {

--- a/src/scripts/addpluginpage.js
+++ b/src/scripts/addpluginpage.js
@@ -44,10 +44,19 @@ define(["jQuery", "loading", "libraryMenu", "globalize", "connectionManager", "e
             var msg = globalize.translate("MessageInstallPluginFromApp");
             $("#nonServerMsg", page).html(msg).show();
         }
-        pkg.shortDescription ? $("#tagline", page).show().html(pkg.shortDescription) : $("#tagline", page).hide();
+        if (pkg.shortDescription) {
+            $("#tagline", page).show().html(pkg.shortDescription);
+        } else {
+            $("#tagline", page).hide();
+        }
         $("#overview", page).html(pkg.overview || "");
         $("#developer", page).html(pkg.owner);
-        pkg.richDescUrl ? ($("#pViewWebsite", page).show(), $("#pViewWebsite a", page).attr("href", pkg.richDescUrl)) : $("#pViewWebsite", page).hide();
+        if (pkg.richDescUrl) {
+            $("#pViewWebsite", page).show();
+            $("#pViewWebsite a", page).attr("href", pkg.richDescUrl);
+        } else {
+            $("#pViewWebsite", page).hide();
+        }
         if (pkg.previewImage || pkg.thumbImage) {
             var img = pkg.previewImage ? pkg.previewImage : pkg.thumbImage;
             $("#pPreviewImage", page).show().html("<img class='pluginPreviewImg' src='" + img + "' style='max-width: 100%;' />");

--- a/src/scripts/addpluginpage.js
+++ b/src/scripts/addpluginpage.js
@@ -55,21 +55,37 @@ define(["jQuery", "loading", "libraryMenu", "globalize", "connectionManager", "e
         var installedPlugin = installedPlugins.filter(function(ip) {
             return ip.Name == pkg.name
         })[0];
-        if (populateVersions(pkg, page, installedPlugin), populateHistory(pkg, page), $(".pluginName", page).html(pkg.name), "Server" == pkg.targetSystem) $("#btnInstallDiv", page).removeClass("hide"), $("#nonServerMsg", page).hide(), $("#pSelectVersion", page).removeClass("hide");
-        else {
-            $("#btnInstallDiv", page).addClass("hide"), $("#pSelectVersion", page).addClass("hide");
+        populateVersions(pkg, page, installedPlugin);
+        populateHistory(pkg, page);
+        $(".pluginName", page).html(pkg.name);
+        if ("Server" == pkg.targetSystem) {
+            $("#btnInstallDiv", page).removeClass("hide");
+            $("#nonServerMsg", page).hide();
+            $("#pSelectVersion", page).removeClass("hide");
+        } else {
+            $("#btnInstallDiv", page).addClass("hide");
+            $("#pSelectVersion", page).addClass("hide");
             var msg = globalize.translate("MessageInstallPluginFromApp");
-            $("#nonServerMsg", page).html(msg).show()
+            $("#nonServerMsg", page).html(msg).show();
         }
-        if (pkg.shortDescription ? $("#tagline", page).show().html(pkg.shortDescription) : $("#tagline", page).hide(), $("#overview", page).html(pkg.overview || ""), $("#developer", page).html(pkg.owner), renderPluginInfo(page, pkg, pluginSecurityInfo), pkg.richDescUrl ? ($("#pViewWebsite", page).show(), $("#pViewWebsite a", page).attr("href", pkg.richDescUrl)) : $("#pViewWebsite", page).hide(), pkg.previewImage || pkg.thumbImage) {
+        pkg.shortDescription ? $("#tagline", page).show().html(pkg.shortDescription) : $("#tagline", page).hide();
+        $("#overview", page).html(pkg.overview || "");
+        $("#developer", page).html(pkg.owner);
+        renderPluginInfo(page, pkg, pluginSecurityInfo);
+        pkg.richDescUrl ? ($("#pViewWebsite", page).show(), $("#pViewWebsite a", page).attr("href", pkg.richDescUrl)) : $("#pViewWebsite", page).hide();
+        if (pkg.previewImage || pkg.thumbImage) {
             var img = pkg.previewImage ? pkg.previewImage : pkg.thumbImage;
-            $("#pPreviewImage", page).show().html("<img class='pluginPreviewImg' src='" + img + "' style='max-width: 100%;' />")
-        } else $("#pPreviewImage", page).hide().html("");
+            $("#pPreviewImage", page).show().html("<img class='pluginPreviewImg' src='" + img + "' style='max-width: 100%;' />");
+        } else {
+            $("#pPreviewImage", page).hide().html("");
+        }
         if (installedPlugin) {
             var currentVersionText = globalize.translate("MessageYouHaveVersionInstalled").replace("{0}", "<strong>" + installedPlugin.Version + "</strong>");
-            $("#pCurrentVersion", page).show().html(currentVersionText)
-        } else $("#pCurrentVersion", page).hide().html("");
-        loading.hide()
+            $("#pCurrentVersion", page).show().html(currentVersionText);
+        } else {
+            $("#pCurrentVersion", page).hide().html("");
+        }
+        loading.hide();
     }
 
     function alertText(options) {

--- a/src/scripts/addpluginpage.js
+++ b/src/scripts/addpluginpage.js
@@ -27,30 +27,6 @@ define(["jQuery", "loading", "libraryMenu", "globalize", "connectionManager", "e
         }
     }
 
-    function renderPluginInfo(page, pkg, pluginSecurityInfo) {
-        if (pkg.isPremium) {
-            $(".premiumPackage", page).show();
-            var regStatus = "";
-            if (pkg.isRegistered) regStatus += "<p style='color:green;'>", regStatus += globalize.translate("MessageFeatureIncludedWithSupporter");
-            else {
-                var expDateTime = new Date(pkg.expDate).getTime(),
-                    nowTime = (new Date).getTime();
-                expDateTime <= nowTime ? (regStatus += "<p style='color:red;'>", regStatus += globalize.translate("MessageTrialExpired")) : expDateTime > new Date(1970, 1, 1).getTime() && (regStatus += "<p style='color:blue;'>", regStatus += globalize.translate("MessageTrialWillExpireIn").replace("{0}", Math.round(expDateTime - nowTime) / 864e5))
-            }
-            if (regStatus += "</p>", $("#regStatus", page).html(regStatus), pluginSecurityInfo.IsMBSupporter)
-                if ($(".premiumDescription", page).hide(), $(".supporterDescription", page).hide(), pkg.price > 0) {
-                    $(".premiumHasPrice", page).show(), $("#featureId", page).val(pkg.featureId), $("#featureName", page).val(pkg.name), $("#amount", page).val(pkg.price), $("#regPrice", page).html("<h3>" + globalize.translate("ValuePriceUSD").replace("{0}", "$" + pkg.price.toFixed(2)) + "</h3>"), $("#ppButton", page).hide();
-                    var url = "https://mb3admin.local/admin/service/user/getPayPalEmail?id=" + pkg.owner;
-                    fetch(url).then(function(response) {
-                        return response.json()
-                    }).then(function(dev) {
-                        dev.payPalEmail && ($("#payPalEmail", page).val(dev.payPalEmail), $("#ppButton", page).show())
-                    })
-                } else $(".premiumHasPrice", page).hide();
-            else pkg.price ? ($(".premiumDescription", page).show(), $(".supporterDescription", page).hide()) : ($(".premiumDescription", page).hide(), $(".supporterDescription", page).show()), $("#ppButton", page).hide()
-        } else $(".premiumPackage", page).hide()
-    }
-
     function renderPackage(pkg, installedPlugins, pluginSecurityInfo, page) {
         var installedPlugin = installedPlugins.filter(function(ip) {
             return ip.Name == pkg.name
@@ -71,7 +47,6 @@ define(["jQuery", "loading", "libraryMenu", "globalize", "connectionManager", "e
         pkg.shortDescription ? $("#tagline", page).show().html(pkg.shortDescription) : $("#tagline", page).hide();
         $("#overview", page).html(pkg.overview || "");
         $("#developer", page).html(pkg.owner);
-        renderPluginInfo(page, pkg, pluginSecurityInfo);
         pkg.richDescUrl ? ($("#pViewWebsite", page).show(), $("#pViewWebsite a", page).attr("href", pkg.richDescUrl)) : $("#pViewWebsite", page).hide();
         if (pkg.previewImage || pkg.thumbImage) {
             var img = pkg.previewImage ? pkg.previewImage : pkg.thumbImage;

--- a/src/scripts/librarymenu.js
+++ b/src/scripts/librarymenu.js
@@ -198,12 +198,10 @@ define(["dom", "layoutManager", "inputManager", "connectionManager", "events", "
         html += "</h3>";
         if (user.localUser) {
             html += '<a is="emby-linkbutton" class="navMenuOption lnkMediaFolder lnkMySettings" href="mypreferencesmenu.html"><i class="md-icon navMenuOptionIcon">settings</i><span class="navMenuOptionText">' + globalize.translate("ButtonSettings") + "</span></a>";
-        }
-        if (AppInfo.isNativeApp) {
             html += '<a is="emby-linkbutton" class="navMenuOption lnkMediaFolder" data-itemid="selectserver" href="selectserver.html?showuser=1"><i class="md-icon navMenuOptionIcon">wifi</i><span class="navMenuOptionText">' + globalize.translate("ButtonSelectServer") + "</span></a>";
-        }
-        if (user.localUser && !user.localUser.EnableAutoLogin) {
-            html += '<a is="emby-linkbutton" class="navMenuOption lnkMediaFolder btnLogout" data-itemid="logout" href="#"><i class="md-icon navMenuOptionIcon">exit_to_app</i><span class="navMenuOptionText">' + globalize.translate("ButtonSignOut") + "</span></a>";
+            if (!localUser.EnableAutoLogin) {
+                html += '<a is="emby-linkbutton" class="navMenuOption lnkMediaFolder btnLogout" data-itemid="logout" href="#"><i class="md-icon navMenuOptionIcon">exit_to_app</i><span class="navMenuOptionText">' + globalize.translate("ButtonSignOut") + "</span></a>";
+            }
         }
         html += "</div>";
 

--- a/src/scripts/librarymenu.js
+++ b/src/scripts/librarymenu.js
@@ -199,7 +199,7 @@ define(["dom", "layoutManager", "inputManager", "connectionManager", "events", "
         if (user.localUser) {
             html += '<a is="emby-linkbutton" class="navMenuOption lnkMediaFolder lnkMySettings" href="mypreferencesmenu.html"><i class="md-icon navMenuOptionIcon">settings</i><span class="navMenuOptionText">' + globalize.translate("ButtonSettings") + "</span></a>";
             html += '<a is="emby-linkbutton" class="navMenuOption lnkMediaFolder" data-itemid="selectserver" href="selectserver.html?showuser=1"><i class="md-icon navMenuOptionIcon">wifi</i><span class="navMenuOptionText">' + globalize.translate("ButtonSelectServer") + "</span></a>";
-            if (!localUser.EnableAutoLogin) {
+            if (!user.localUser.EnableAutoLogin) {
                 html += '<a is="emby-linkbutton" class="navMenuOption lnkMediaFolder btnLogout" data-itemid="logout" href="#"><i class="md-icon navMenuOptionIcon">exit_to_app</i><span class="navMenuOptionText">' + globalize.translate("ButtonSignOut") + "</span></a>";
             }
         }

--- a/src/scripts/loginpage.js
+++ b/src/scripts/loginpage.js
@@ -89,9 +89,10 @@ define(["appSettings", "dom", "connectionManager", "loading", "cardStyle", "emby
             var apiClient = getApiClient();
             apiClient.getPublicUsers().then(function(users) {
                 users.length ? users.length && users[0].EnableAutoLogin ? authenticateUserByName(view, apiClient, users[0].Name, "") : (showVisualForm(), loadUserList(view, apiClient, users)) : (view.querySelector("#txtManualName").value = "", showManualForm(view, !1, !1)), loading.hide()
-            }), apiClient.getJSON(apiClient.getUrl("Branding/Configuration")).then(function(options) {
+            });
+            apiClient.getJSON(apiClient.getUrl("Branding/Configuration")).then(function(options) {
                 view.querySelector(".disclaimer").textContent = options.LoginDisclaimer || ""
-            }), AppInfo.isNativeApp ? view.querySelector(".connectButtons").classList.remove("hide") : view.querySelector(".connectButtons").classList.add("hide")
-        })
+            });
+        });
     }
 });

--- a/src/scripts/mypreferencescommon.js
+++ b/src/scripts/mypreferencescommon.js
@@ -21,6 +21,7 @@ define(["apphost", "connectionManager", "listViewStyle", "emby-linkbutton"], fun
             } else {
                 page.querySelector(".selectServer").classList.add("hide");
             }
+
             connectionManager.user(ApiClient).then(function(user) {
                 if (user.localUser && !user.localUser.EnableAutoLogin) {
                     view.querySelector(".btnLogout").classList.remove("hide");

--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -33,10 +33,7 @@ function pageIdOn(eventName, id, fn) {
 }
 var Dashboard = {
         allowPluginPages: function(pluginId) {
-            var allowedPluginConfigs = ["b0daa30f-2e09-4083-a6ce-459d9fecdd80", "de228f12-e43e-4bd9-9fc0-2830819c3b92", "899c12c7-5b40-4c4e-9afd-afd74a685eb1", "14f5f69e-4c8d-491b-8917-8e90e8317530", "02528C96-F727-44D7-BE87-9EEF040758C3", "dc372f99-4e0e-4c6b-8c18-2b887ca4530c", "830fc68f-b964-4d2f-b139-48e22cd143c", "b9f0c474-e9a8-4292-ae41-eb3c1542f4cd", "7cfbb821-e8fd-40ab-b64e-a7749386a6b2", "4C2FDA1C-FD5E-433A-AD2B-718E0B73E9A9", "cd5a19be-7676-48ef-b64f-a17c98f2b889", "b2ff6a63-303a-4a84-b937-6e12f87e3eb9", "0277E613-3EC0-4360-A3DE-F8AF0AABB5E9", "9464BD84-D30D-4404-B2AD-DFF4E12D5FC5", "9574ac10-bf23-49bc-949f-924f23cfa48f", "66fd72a4-7e8e-4f22-8d1c-022ce4b9b0d5", "4DCB591C-0FA2-4C5D-A7E5-DABE37164C8B", "8e791e2a-058a-4b12-8493-8bf69d92d685", "577f89eb-58a7-4013-be06-9a970ddb1377", "6153FDF0-40CC-4457-8730-3B4A19512BAE", "de228f12-e43e-4bd9-9fc0-2830819c3b92", "6C3B6965-C257-47C2-AA02-64457AE21D91", "2FE79C34-C9DC-4D94-9DF2-2F3F36764414", "0417264b-5a93-4ad0-a1f0-b87569b7cf80", "e711475e-efad-431b-8527-033ba9873a34", "AB95885A-1D0E-445E-BDBF-80C1912C98C5", "F015EA06-B413-47F1-BF15-F049A799658B", "986a7283-205a-4436-862d-23135c067f8a", "8abc6789-fde2-4705-8592-4028806fa343", "2850d40d-9c66-4525-aa46-968e8ef04e97"].map(function(i) {
-                return i.toLowerCase()
-            });
-            return !(AppInfo.isNativeApp && -1 === allowedPluginConfigs.indexOf((pluginId || "").toLowerCase()))
+            return true;
         },
         getCurrentUser: function() {
             return window.ApiClient.getCurrentUser(!1)

--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -57,8 +57,8 @@ var Dashboard = {
         onServerChanged: function(userId, accessToken, apiClient) {
             apiClient = apiClient || window.ApiClient, window.ApiClient = apiClient
         },
-        logout: function(logoutWithServer) {
-            function onLogoutDone() {
+        logout: function() {
+            ConnectionManager.logout().then(function() {
                 var loginPage;
                 if (AppInfo.isNativeApp) {
                     loginPage = "selectserver.html";
@@ -67,7 +67,7 @@ var Dashboard = {
                     loginPage = "login.html";
                 }
                 Dashboard.navigate(loginPage);
-            }!1 === logoutWithServer ? onLogoutDone() : ConnectionManager.logout().then(onLogoutDone)
+            }
         },
         getConfigurationPageUrl: function(name) {
             return "configurationpage?name=" + encodeURIComponent(name)
@@ -959,10 +959,18 @@ var Dashboard = {
 
     function onWebComponentsReady(browser) {
         var initialDependencies = [];
-        window.Promise && !browser.web0s || initialDependencies.push("bower_components/emby-webcomponents/native-promise-only/lib/npo.src"), initRequireWithBrowser(browser), "cordova" !== self.appMode && "android" !== self.appMode || (AppInfo.isNativeApp = !0), require(initialDependencies, init)
+        if (!window.Promise || browser.web0s) {
+            initialDependencies.push("bower_components/emby-webcomponents/native-promise-only/lib/npo.src");
+        }
+        initRequireWithBrowser(browser);
+        if (self.appMode === 'cordova' || self.appMode === 'android' || self.appMode === 'standalone') {
+            AppInfo.isNativeApp = true;
+        }
+        require(initialDependencies, init);
     }
+
     var localApiClient;
-    ! function() {
+    return function() {
         var urlArgs = "v=" + (window.dashboardVersion || (new Date).getDate());
         var bowerPath = getBowerPath();
         var apiClientBowerPath = bowerPath + "/emby-apiclient";
@@ -1252,7 +1260,7 @@ var Dashboard = {
             }, appRouter.showVideoOsd = function() {
                 return Dashboard.navigate("videoosd.html")
             }, appRouter.showSelectServer = function() {
-                AppInfo.isNativeApp ? Dashboard.navigate("selectserver.html") : Dashboard.navigate("login.html")
+                Dashboard.navigate(AppInfo.isNativeApp ? "selectserver.html" : "login.html")
             }, appRouter.showWelcome = function() {
                 Dashboard.navigate(AppInfo.isNativeApp ? "selectserver.html" : "login.html")
             }, appRouter.showSettings = function() {


### PR DESCRIPTION
This enables multiserver support for the bundled web client for two reasons.

1. Why hide an option for no reason?
2. Some users may want this enabled.

This is exactly the same in Plex where you can select another server without leaving the current web frontend. I personally think this is useful, and it also works really well from the bundled frontend from my testing. I was able to switch between my dev and prod servers and the API calls were routed to the active server while the frontend calls were left on the current connection. I tested media playback, modifying user settings, and using the dashboard and everything worked fine for me.