### PR TITLE
Enable and fix PiP for Safari

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,9 +16,10 @@
  - [grafixeyehero](https://github.com/grafixeyehero)
  - [Drago96](https://github.com/drago-96)
  - [ViXXoR](https://github.com/ViXXoR)
- - [nkmerrill] (https://github.com/nkmerrill)
- - [TtheCreator] (https://github.com/Tthecreator)
+ - [nkmerrill](https://github.com/nkmerrill)
+ - [TtheCreator](https://github.com/Tthecreator)
  - [RazeLighter777](https://github.com/RazeLighter777)
+ - [anthonylavado](https://github.com/anthonylavado)
 
 # Emby Contributors
 

--- a/src/bower_components/emby-webcomponents/htmlvideoplayer/plugin.js
+++ b/src/bower_components/emby-webcomponents/htmlvideoplayer/plugin.js
@@ -1443,7 +1443,7 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
         var list = [];
 
         var video = document.createElement('video');
-        if ((video.webkitSupportsPresentationMode && typeof video.webkitSetPresentationMode === "function") || (document.pictureInPictureEnabled)) {
+        if (video.webkitSupportsPresentationMode && typeof video.webkitSetPresentationMode === "function" || document.pictureInPictureEnabled) {
             list.push('PictureInPicture');
         }
 

--- a/src/bower_components/emby-webcomponents/htmlvideoplayer/plugin.js
+++ b/src/bower_components/emby-webcomponents/htmlvideoplayer/plugin.js
@@ -1446,7 +1446,6 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
         if (video.webkitSupportsPresentationMode && typeof video.webkitSetPresentationMode === "function" || document.pictureInPictureEnabled) {
             list.push('PictureInPicture');
         }
-
         else if (browser.ipad) {
 
             // Unfortunately this creates a false positive on devices where its' not actually supported

--- a/src/bower_components/emby-webcomponents/htmlvideoplayer/plugin.js
+++ b/src/bower_components/emby-webcomponents/htmlvideoplayer/plugin.js
@@ -1443,12 +1443,10 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
         var list = [];
 
         var video = document.createElement('video');
-        if (video.webkitSupportsPresentationMode && typeof video.webkitSetPresentationMode === "function") {
+        if ((video.webkitSupportsPresentationMode && typeof video.webkitSetPresentationMode === "function") || (document.pictureInPictureEnabled)) {
             list.push('PictureInPicture');
         }
-        if (document.pictureInPictureEnabled) {
-            list.push('PictureInPicture');
-        }
+
         else if (browser.ipad) {
 
             // Unfortunately this creates a false positive on devices where its' not actually supported

--- a/src/bower_components/emby-webcomponents/htmlvideoplayer/plugin.js
+++ b/src/bower_components/emby-webcomponents/htmlvideoplayer/plugin.js
@@ -1443,9 +1443,9 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
         var list = [];
 
         var video = document.createElement('video');
-        //if (video.webkitSupportsPresentationMode && video.webkitSupportsPresentationMode('picture-in-picture') && typeof video.webkitSetPresentationMode === "function") {
-        //    list.push('PictureInPicture');
-        //}
+        if (video.webkitSupportsPresentationMode && typeof video.webkitSetPresentationMode === "function") {
+            list.push('PictureInPicture');
+        }
         if (document.pictureInPictureEnabled) {
             list.push('PictureInPicture');
         }


### PR DESCRIPTION
This enables the previously commented out lines that would enable Picture in Picture support for Safari.
Also fixed IF condition to match the Apple developer reccomendation: https://developer.apple.com/documentation/webkitjs/adding_picture_in_picture_to_your_safari_media_controls

Fixes #101.