### PR TITLE
Make the toggle track visible on all themes

### DIFF
--- a/src/bower_components/emby-webcomponents/emby-toggle/emby-toggle.css
+++ b/src/bower_components/emby-webcomponents/emby-toggle/emby-toggle.css
@@ -41,7 +41,7 @@
 }
 
 .mdl-switch__track {
-    background: rgba(0,0,0, 0.2);
+    background: rgba(255,255,255, 0.2);
     height: 1em;
     border-radius: 1em;
     cursor: pointer;

--- a/src/bower_components/emby-webcomponents/emby-toggle/emby-toggle.css
+++ b/src/bower_components/emby-webcomponents/emby-toggle/emby-toggle.css
@@ -41,7 +41,7 @@
 }
 
 .mdl-switch__track {
-    background: rgba(255,255,255, 0.2);
+    background: rgba(128,128,128, 0.5);
     height: 1em;
     border-radius: 1em;
     cursor: pointer;


### PR DESCRIPTION
The default toggle track colour was essentially a transparent black. While this works on brighter themes, it didn't work on the now default dark theme. It is now set to a "middle grey" that is visible on all themes (light or dark).

Fixes #67.