### PR TITLE
Fix syntax error in site.js

### DIFF
--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -67,7 +67,7 @@ var Dashboard = {
                     loginPage = "login.html";
                 }
                 Dashboard.navigate(loginPage);
-            }
+            })
         },
         getConfigurationPageUrl: function(name) {
             return "configurationpage?name=" + encodeURIComponent(name)


### PR DESCRIPTION
Fixes a syntax error from #96 - damn you JS and C# and your endless braces and brackets...

```
[00:26:46] GulpUglifyError: unable to minify JavaScript
Caused by: SyntaxError: Unexpected token punc «}», expected punc «,»
File: /repo/src/jellyfin-web/src/scripts/site.js
Line: 71
Col: 8
[00:26:46] 'default' errored after 4.69 s
```