### PR TITLE
Exit fullscreen automatically after video playback ends

### DIFF
--- a/src/bower_components/emby-webcomponents/fullscreen/fullscreenmanager.js
+++ b/src/bower_components/emby-webcomponents/fullscreen/fullscreenmanager.js
@@ -29,11 +29,14 @@ define(['events', 'dom'], function (events, dom) {
         }
         if (element.webkitEnterFullscreen) {
             element.webkitEnterFullscreen();
-        } 
+        }
     };
 
     fullscreenManager.prototype.exitFullscreen = function () {
 
+        if (!this.isFullScreen()) {
+            return;
+        }
         if (document.exitFullscreen) {
             document.exitFullscreen();
         } else if (document.mozCancelFullScreen) {
@@ -47,9 +50,15 @@ define(['events', 'dom'], function (events, dom) {
         }
     };
 
+    // TODO: use screenfull.js
     fullscreenManager.prototype.isFullScreen = function () {
-
-        return document.fullscreen || document.mozFullScreen || document.webkitIsFullScreen || document.msFullscreenElement ? true : false;
+        return document.fullscreen ||
+            document.mozFullScreen ||
+            document.webkitIsFullScreen ||
+            document.msFullscreenElement ||  /* IE/Edge syntax */
+            document.fullscreenElement || /* Standard syntax */
+            document.webkitFullscreenElement || /* Chrome, Safari and Opera syntax */
+            document.mozFullScreenElement; /* Firefox syntax */
     };
 
     var manager = new fullscreenManager();

--- a/src/bower_components/emby-webcomponents/htmlvideoplayer/plugin.js
+++ b/src/bower_components/emby-webcomponents/htmlvideoplayer/plugin.js
@@ -692,6 +692,7 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
 
                 dlg.parentNode.removeChild(dlg);
             }
+
             fullscreenManager.exitFullscreen();
         };
 

--- a/src/bower_components/emby-webcomponents/htmlvideoplayer/plugin.js
+++ b/src/bower_components/emby-webcomponents/htmlvideoplayer/plugin.js
@@ -1,4 +1,4 @@
-define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackManager', 'appRouter', 'appSettings', 'connectionManager', 'htmlMediaHelper', 'itemHelper'], function (browser, require, events, appHost, loading, dom, playbackManager, appRouter, appSettings, connectionManager, htmlMediaHelper, itemHelper) {
+define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackManager', 'appRouter', 'appSettings', 'connectionManager', 'htmlMediaHelper', 'itemHelper', 'fullscreenManager'], function (browser, require, events, appHost, loading, dom, playbackManager, appRouter, appSettings, connectionManager, htmlMediaHelper, itemHelper, fullscreenManager) {
     "use strict";
 
     var mediaManager;
@@ -692,6 +692,7 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
 
                 dlg.parentNode.removeChild(dlg);
             }
+            fullscreenManager.exitFullscreen();
         };
 
         function onEnded() {


### PR DESCRIPTION
Ideally, the video element or its parent container should be fullscreened and none of this would be necessary, _BUT_ video osd is in a separate container, so video element cannot be fullscreened without the osd disappearing...

So this change is the next best solution I could think of. Maybe I'll look into refactoring videoosd to wrap the video element. 

Thoughts?

Fixes https://github.com/jellyfin/jellyfin/issues/923