### PR TITLE
Add top offset and bottom offset margins in emby-scrollbuttons

### DIFF
--- a/src/bower_components/emby-webcomponents/emby-scrollbuttons/emby-scrollbuttons.css
+++ b/src/bower_components/emby-webcomponents/emby-scrollbuttons/emby-scrollbuttons.css
@@ -4,8 +4,8 @@
 
 .scrollbuttoncontainer {
     position: absolute;
-    top: 0;
-    bottom: 0;
+    top: 10%;
+    bottom: 35%;
     align-items: center;
     justify-content: center;
     z-index: 1;


### PR DESCRIPTION
**Issues**
Arrow buttons cover the options menu in the dash #142

**Before**

![before](https://user-images.githubusercontent.com/32230989/53026778-a45e3980-3474-11e9-9f44-4728754bf8ac.jpg)

**After**

![after](https://user-images.githubusercontent.com/32230989/53026824-c061db00-3474-11e9-8292-1118b2c8731e.jpg)

**optional**  **removing gradient**

![optional](https://user-images.githubusercontent.com/32230989/53026942-0159ef80-3475-11e9-8888-313b05ec0e37.jpg)

