### PR TITLE
Make types more consistent

### DIFF
--- a/src/bower_components/emby-webcomponents/browserdeviceprofile.js
+++ b/src/bower_components/emby-webcomponents/browserdeviceprofile.js
@@ -751,7 +751,7 @@ define(['browser'], function (browser) {
                 Condition: 'Equals',
                 Property: 'IsSecondaryAudio',
                 Value: 'false',
-                IsRequired: 'false'
+                IsRequired: false
             });
         }
 
@@ -780,7 +780,7 @@ define(['browser'], function (browser) {
                         Condition: 'Equals',
                         Property: 'IsSecondaryAudio',
                         Value: 'false',
-                        IsRequired: 'false'
+                        IsRequired: false
                     }
                 ]
             });


### PR DESCRIPTION
There is no instance I can find where these values are ever *actually* strings. Changing them to boolean improves consistency.

If you look, other instances of `IsRequired` were already boolean. No idea why only these 2 were strings.