### PR TITLE
 Better progressive playback controls of bottom pages

### DIFF
--- a/src/bower_components/emby-webcomponents/nowplayingbar/nowplayingbar.css
+++ b/src/bower_components/emby-webcomponents/nowplayingbar/nowplayingbar.css
@@ -119,40 +119,47 @@
     height: 1.2em !important;
 }
 
+@media all and (max-width: 73em) {
+
+    .nowPlayingBarRight .nowPlayingBarUserDataButtons {
+        display: none;
+    }
+}
 
 @media all and (max-width: 70em) {
 
-    .nowPlayingBarUserDataButtons {
+    .nowPlayingBarRight .toggleRepeatButton {
         display: none;
     }
 }
 
 @media all and (max-width: 67em) {
 
-    .nowPlayingBar .muteButton, .nowPlayingBar .unmuteButton, .toggleRepeatButton {
+    .nowPlayingBarCenter .nowPlayingBarCurrentTime {
         display: none !important;
     }
-}
 
-
-@media all and (max-width: 64em) {
-
-    .nowPlayingBarCurrentTime {
-        display: none !important;
-    }
-    
 }
 
 @media all and (max-width: 61em) {
 
-    .nowPlayingBarCenter {
+    .nowPlayingBarCenter .stopButton {
         display: none !important;
     }
 
 }
 
 
-@media all and (min-width: 61em) {
+@media all and (max-width: 55em) {
+
+    .nowPlayingBarCenter .nextTrackButton, .nowPlayingBarCenter .previousTrackButton, .nowPlayingBarCenter .playPauseButton {
+        display: none !important;
+    }
+
+}
+
+
+@media all and (min-width: 55em) {
 
     .nowPlayingBarRight .playPauseButton {
         display: none;
@@ -161,7 +168,7 @@
 }
 
 @media all and (max-width: 41em) {
-    
+
     .nowPlayingImage {
         display: none;
     }
@@ -174,5 +181,13 @@
     .nowPlayingBarVolumeSliderContainer {
         display: none !important;
     }
-   
+
+}
+
+@media all and (max-width: 27em) {
+
+    .nowPlayingBar .muteButton, .nowPlayingBar .unmuteButton {
+        display: none !important;
+    }
+
 }

--- a/src/bower_components/emby-webcomponents/nowplayingbar/nowplayingbar.css
+++ b/src/bower_components/emby-webcomponents/nowplayingbar/nowplayingbar.css
@@ -142,7 +142,7 @@
 
 }
 
-@media all and (max-width: 58em) {
+@media all and (max-width: 56em) {
 
     .nowPlayingBarCenter {
         display: none !important;
@@ -151,7 +151,7 @@
 }
 
 
-@media all and (min-width: 58em) {
+@media all and (min-width: 56em) {
 
     .nowPlayingBarRight .playPauseButton {
         display: none;

--- a/src/bower_components/emby-webcomponents/nowplayingbar/nowplayingbar.css
+++ b/src/bower_components/emby-webcomponents/nowplayingbar/nowplayingbar.css
@@ -119,14 +119,15 @@
     height: 1.2em !important;
 }
 
-@media all and (max-width: 68em) {
+
+@media all and (max-width: 70em) {
 
     .nowPlayingBarUserDataButtons {
         display: none;
     }
 }
 
-@media all and (max-width: 63em) {
+@media all and (max-width: 67em) {
 
     .nowPlayingBar .muteButton, .nowPlayingBar .unmuteButton, .toggleRepeatButton {
         display: none !important;
@@ -134,7 +135,7 @@
 }
 
 
-@media all and (max-width: 58em) {
+@media all and (max-width: 64em) {
 
     .nowPlayingImage {
         display: none;
@@ -142,17 +143,24 @@
     
 }
 
-@media all and (max-width: 53em) {
+@media all and (max-width: 61em) {
+
+    .nowPlayingBarCurrentTime {
+        display: none !important;
+    }
+
+}
+
+@media all and (max-width: 50em) {
 
     .nowPlayingBarCenter {
         display: none !important;
     }
-    .nowPlayingBarInfoContainer {
-        max-width: 12em;
-    }    
+
 }
 
-@media all and (min-width: 53em) {
+
+@media all and (min-width: 50em) {
 
     .nowPlayingBarRight .playPauseButton {
         display: none;
@@ -161,10 +169,10 @@
 
 }
 
-@media all and (max-width: 33em) {
+@media all and (max-width: 40em) {
 
     .nowPlayingBarVolumeSliderContainer {
         display: none !important;
     }
-    
+   
 }

--- a/src/bower_components/emby-webcomponents/nowplayingbar/nowplayingbar.css
+++ b/src/bower_components/emby-webcomponents/nowplayingbar/nowplayingbar.css
@@ -119,38 +119,52 @@
     height: 1.2em !important;
 }
 
-@media all and (max-width: 87.5em) {
+@media all and (max-width: 68em) {
 
     .nowPlayingBarUserDataButtons {
         display: none;
     }
 }
 
-@media all and (max-width: 55em) {
+@media all and (max-width: 63em) {
 
-    .nowPlayingBarVolumeSliderContainer, .nowPlayingBar .muteButton, .nowPlayingBar .unmuteButton {
+    .nowPlayingBar .muteButton, .nowPlayingBar .unmuteButton, .toggleRepeatButton {
         display: none !important;
     }
 }
 
-@media all and (max-width: 45em) {
+
+@media all and (max-width: 58em) {
+
+    .nowPlayingImage {
+        display: none;
+    }
+    
+}
+
+@media all and (max-width: 53em) {
 
     .nowPlayingBarCenter {
         display: none !important;
     }
-
-    .toggleRepeatButton {
-        display: none;
-    }
+    .nowPlayingBarInfoContainer {
+        max-width: 12em;
+    }    
 }
 
-@media all and (min-width: 45em) {
+@media all and (min-width: 53em) {
 
     .nowPlayingBarRight .playPauseButton {
         display: none;
     }
 
-    .nowPlayingBarInfoContainer {
-        max-width: 40%;
+
+}
+
+@media all and (max-width: 33em) {
+
+    .nowPlayingBarVolumeSliderContainer {
+        display: none !important;
     }
+    
 }

--- a/src/bower_components/emby-webcomponents/nowplayingbar/nowplayingbar.css
+++ b/src/bower_components/emby-webcomponents/nowplayingbar/nowplayingbar.css
@@ -119,21 +119,22 @@
     height: 1.2em !important;
 }
 
-@media all and (max-width: 73em) {
+
+@media all and (max-width: 70em) {
 
     .nowPlayingBarRight .nowPlayingBarUserDataButtons {
         display: none;
     }
 }
 
-@media all and (max-width: 70em) {
-
-    .nowPlayingBarRight .toggleRepeatButton {
-        display: none;
+@media all and (max-width: 66em) {
+    .toggleRepeatButton {
+        display: none !important;
     }
 }
 
-@media all and (max-width: 67em) {
+
+@media all and (max-width: 62em) {
 
     .nowPlayingBarCenter .nowPlayingBarCurrentTime {
         display: none !important;
@@ -141,25 +142,16 @@
 
 }
 
-@media all and (max-width: 61em) {
+@media all and (max-width: 58em) {
 
-    .nowPlayingBarCenter .stopButton {
+    .nowPlayingBarCenter {
         display: none !important;
     }
 
 }
 
 
-@media all and (max-width: 55em) {
-
-    .nowPlayingBarCenter .nextTrackButton, .nowPlayingBarCenter .previousTrackButton, .nowPlayingBarCenter .playPauseButton {
-        display: none !important;
-    }
-
-}
-
-
-@media all and (min-width: 55em) {
+@media all and (min-width: 58em) {
 
     .nowPlayingBarRight .playPauseButton {
         display: none;
@@ -167,27 +159,26 @@
 
 }
 
-@media all and (max-width: 41em) {
+@media all and (max-width: 40em) {
 
-    .nowPlayingImage {
+    .nowPlayingBarInfoContainer .nowPlayingImage {
         display: none;
     }
 
 }
 
-
 @media all and (max-width: 36em) {
 
-    .nowPlayingBarVolumeSliderContainer {
+    .nowPlayingBarRight .nowPlayingBarVolumeSliderContainer {
         display: none !important;
     }
 
 }
 
-@media all and (max-width: 27em) {
+@media all and (max-width: 24em) {
 
-    .nowPlayingBar .muteButton, .nowPlayingBar .unmuteButton {
-        display: none !important;
-    }
+  .nowPlayingBar .muteButton, .nowPlayingBar .unmuteButton {
+    display: none;
+  }
 
 }

--- a/src/bower_components/emby-webcomponents/nowplayingbar/nowplayingbar.css
+++ b/src/bower_components/emby-webcomponents/nowplayingbar/nowplayingbar.css
@@ -126,7 +126,7 @@
     }
 }
 
-@media all and (max-width: 68.75em) {
+@media all and (max-width: 55em) {
 
     .nowPlayingBarVolumeSliderContainer, .nowPlayingBar .muteButton, .nowPlayingBar .unmuteButton {
         display: none !important;

--- a/src/bower_components/emby-webcomponents/nowplayingbar/nowplayingbar.css
+++ b/src/bower_components/emby-webcomponents/nowplayingbar/nowplayingbar.css
@@ -137,21 +137,13 @@
 
 @media all and (max-width: 64em) {
 
-    .nowPlayingImage {
-        display: none;
+    .nowPlayingBarCurrentTime {
+        display: none !important;
     }
     
 }
 
 @media all and (max-width: 61em) {
-
-    .nowPlayingBarCurrentTime {
-        display: none !important;
-    }
-
-}
-
-@media all and (max-width: 50em) {
 
     .nowPlayingBarCenter {
         display: none !important;
@@ -160,16 +152,24 @@
 }
 
 
-@media all and (min-width: 50em) {
+@media all and (min-width: 61em) {
 
     .nowPlayingBarRight .playPauseButton {
         display: none;
     }
 
+}
+
+@media all and (max-width: 41em) {
+    
+    .nowPlayingImage {
+        display: none;
+    }
 
 }
 
-@media all and (max-width: 40em) {
+
+@media all and (max-width: 36em) {
 
     .nowPlayingBarVolumeSliderContainer {
         display: none !important;

--- a/src/bower_components/emby-webcomponents/nowplayingbar/nowplayingbar.css
+++ b/src/bower_components/emby-webcomponents/nowplayingbar/nowplayingbar.css
@@ -133,7 +133,7 @@
     }
 }
 
-@media all and (max-width: 50em) {
+@media all and (max-width: 45em) {
 
     .nowPlayingBarCenter {
         display: none !important;
@@ -144,7 +144,7 @@
     }
 }
 
-@media all and (min-width: 50em) {
+@media all and (min-width: 45em) {
 
     .nowPlayingBarRight .playPauseButton {
         display: none;

--- a/src/bower_components/emby-webcomponents/nowplayingbar/nowplayingbar.js
+++ b/src/bower_components/emby-webcomponents/nowplayingbar/nowplayingbar.js
@@ -56,7 +56,7 @@ define(['require', 'datetime', 'itemHelper', 'events', 'browser', 'imageLoader',
 
         html += '<button is="paper-icon-button-light" class="muteButton mediaButton"><i class="md-icon">&#xE050;</i></button>';
 
-        html += '<div class="sliderContainer nowPlayingBarVolumeSliderContainer hide" style="width:150px;vertical-align:middle;display:inline-flex;">';
+        html += '<div class="sliderContainer nowPlayingBarVolumeSliderContainer hide" style="width:9em;vertical-align:middle;display:inline-flex;">';
         html += '<input type="range" is="emby-slider" pin step="1" min="0" max="100" value="0" class="slider-medium-thumb nowPlayingBarVolumeSlider"/>';
         html += '</div>';
 

--- a/src/bower_components/emby-webcomponents/nowplayingbar/nowplayingbar.js
+++ b/src/bower_components/emby-webcomponents/nowplayingbar/nowplayingbar.js
@@ -56,7 +56,7 @@ define(['require', 'datetime', 'itemHelper', 'events', 'browser', 'imageLoader',
 
         html += '<button is="paper-icon-button-light" class="muteButton mediaButton"><i class="md-icon">&#xE050;</i></button>';
 
-        html += '<div class="sliderContainer nowPlayingBarVolumeSliderContainer hide" style="width:100px;vertical-align:middle;display:inline-flex;">';
+        html += '<div class="sliderContainer nowPlayingBarVolumeSliderContainer hide" style="width:150px;vertical-align:middle;display:inline-flex;">';
         html += '<input type="range" is="emby-slider" pin step="1" min="0" max="100" value="0" class="slider-medium-thumb nowPlayingBarVolumeSlider"/>';
         html += '</div>';
 

--- a/src/css/nowplaying.css
+++ b/src/css/nowplaying.css
@@ -189,11 +189,23 @@
     width: 9em
 }
 
+@media all and (max-width:50em) {
+    .nowPlayingInfoButtons .nowPlayingPageUserDataButtons {
+        display: none !important
+    }
+}
+
+@media all and (max-width:47em) {
+    .nowPlayingInfoButtons .repeatToggleButton {
+        display: none !important
+    }
+}
+
 @media all and (max-width:34em) {
 
-    .btnNowPlayingFastForward,
-    .btnNowPlayingRewind,
-    .playlist .listItemMediaInfo {
+    .nowPlayingInfoButtons .btnNowPlayingFastForward,
+    .nowPlayingInfoButtons .btnNowPlayingRewind,
+    .nowPlayingInfoButtons .playlist .listItemMediaInfo {
         display: none !important
     }
 }

--- a/src/css/nowplaying.css
+++ b/src/css/nowplaying.css
@@ -186,7 +186,7 @@
 }
 
 .nowPlayingVolumeSliderContainer {
-    width: 6em
+    width: 9em
 }
 
 @media all and (max-width:34em) {

--- a/src/css/videoosd.css
+++ b/src/css/videoosd.css
@@ -138,7 +138,7 @@
 }
 
 .osdVolumeSliderContainer {
-    width: 6.5em;
+    width: 9em;
     -webkit-box-flex: 1;
     -webkit-flex-grow: 1;
     flex-grow: 1
@@ -244,8 +244,13 @@
     }
 }
 
-@media all and (max-width:37.5em) {
+@media all and (max-width:43em) {
     .videoOsdBottom .volumeButtons {
+        display: none !important
+    }
+}
+@media all and (max-width:50em) {
+    .videoOsdBottom .btnFastForward, .videoOsdBottom .btnRewind {
         display: none !important
     }
 }


### PR DESCRIPTION
The volume slider is important to conserve at most width for audio playing.
The new value of hiding seems best balanced.

Only tested on last Firefox on Linux. Other tests for a better compromise are welcome.