### PR TITLE
Apply typo fix for apphost

### DIFF
--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -1200,7 +1200,7 @@ var AppInfo = {};
         console.log("Begin onAppReady");
 
         // ensure that appHost is loaded in this point
-        require(['appHost'], function (appHost) {
+        require(['apphost'], function (appHost) {
             var isInBackground = -1 !== self.location.href.toString().toLowerCase().indexOf("start=backgroundsync");
 
             window.Emby = {};


### PR DESCRIPTION
This PR only fixes a typo for apphost in site.js that makes #162 into a blackscreen when loaded in android client (at least).