### PR TITLE
Correct syntax error in networkPath

### DIFF
--- a/src/dashboard/dashboardgeneral.js
+++ b/src/dashboard/dashboardgeneral.js
@@ -97,7 +97,7 @@ define(["jQuery", "loading", "fnchecked", "emby-checkbox", "emby-textarea", "emb
                             $("#txtMetadataPath", view).val(path);
                         }
                         if (networkPath) {
-                            $("#txtMetadataNetworkPath", view).val(networkPath));
+                            $("#txtMetadataNetworkPath", view).val(networkPath);
                         }
                         picker.close();
                     },


### PR DESCRIPTION
**Changes**
Why are there so many brackets in Javascript... why...

Triggered a syntax error during the jellyfin/jellyfin-android bulid process:

```
[01:30:24] 'scripts:dashboard' errored after 1.29 s
[01:30:24] GulpUglifyError: unable to minify JavaScript
Caused by: SyntaxError: Unexpected token: punc ())
File: /repo/src/jellyfin-web/src/dashboard/dashboardgeneral.js
Line: 100
Col: 79
[01:30:24] 'default' errored after 1.32 s
```

**Issues**
N/A
