### PR TITLE
Return inner promise in createConnectionManager

### DIFF
--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -275,7 +275,7 @@ var AppInfo = {};
             var credentialProviderInstance = new credentialProvider();
             var promises = [apphost.getSyncProfile(), apphost.init()];
 
-            Promise.all(promises).then(function (responses) {
+            return Promise.all(promises).then(function (responses) {
                 var deviceProfile = responses[0];
                 var capabilities = Dashboard.capabilities(apphost);
 
@@ -293,7 +293,7 @@ var AppInfo = {};
                         console.log("creating ApiClient singleton");
 
                         var apiClient = new apiClientFactory(Dashboard.serverAddress(), apphost.appName(), apphost.appVersion(), apphost.deviceName(), apphost.deviceId(), window.devicePixelRatio);
-                        
+
                         apiClient.enableAutomaticNetworking = false;
                         apiClient.manualAddressOnly = true;
 


### PR DESCRIPTION
**Changes**
The require didn't return anything which caused a race condition wherein the connection manager wouldn't always be loaded before execution continued after calling `createConnectionManager`. I've added a return to fix it.
**Issues**
Fixes this:

```
site.js?v=10.2.2:1587 Uncaught (in promise) ReferenceError: ConnectionManager is not defined
    at site.js?v=10.2.2:1587
    at Object.execCb (alameda.js?v=10.2.2:391)
    at defineModule (alameda.js?v=10.2.2:145)
    at main (alameda.js?v=10.2.2:346)
    at callDep (alameda.js?v=10.2.2:291)
    at waitForDep (alameda.js?v=10.2.2:177)
    at alameda.js?v=10.2.2:345
    at Array.forEach (<anonymous>)
    at main (alameda.js?v=10.2.2:343)
    at takeQueue (alameda.js?v=10.2.2:84)
```