### PR TITLE
Add Rescan Button to headerRight section

### DIFF
--- a/src/components/refreshdialog/refreshdialog.js
+++ b/src/components/refreshdialog/refreshdialog.js
@@ -21,6 +21,7 @@ define(['shell', 'dialogHelper', 'loading', 'layoutManager', 'connectionManager'
             hider: ''
         }
 
+        
         if (show.simple) {
 
             simpleDialog.hider = 'hide';
@@ -55,57 +56,18 @@ define(['shell', 'dialogHelper', 'loading', 'layoutManager', 'connectionManager'
         html += '<div class="fldSelectPlaylist selectContainer ' + simpleDialog.hider + '">';
         html += '<select is="emby-select" id="selectMetadataRefreshMode" label="' + globalize.translate('LabelRefreshMode') + '">';
 
-        if (show.scanNewAndUpdated){
+        if (show.scanNewAndUpdated || !show.simple){
             html += '<option value="scan">' + globalize.translate('ScanForNewAndUpdatedFiles') + '</option>';
         }
 
-        if (show.updateMissing){
+        if (show.updateMissing || !show.simple){
             html += '<option value="missing">' + globalize.translate('SearchForMissingMetadata') + '</option>';
         }
 
-        if (show.replaceAll){
+        if (show.replaceAll || !show.simple){
             html += '<option value="all" selected>' + globalize.translate('ReplaceAllMetadata') + '</option>';
         }
         
-        html += '</select>';
-        html += '</div>';
-
-        html += '<label class="checkboxContainer hide fldReplaceExistingImages">';
-        html += '<input type="checkbox" is="emby-checkbox" class="chkReplaceImages" />';
-        html += '<span>' + globalize.translate('ReplaceExistingImages') + '</span>';
-        html += '</label>';
-
-        html += '<div class="fieldDescription">';
-        html += globalize.translate('RefreshDialogHelp');
-        html += '</div>';
-
-        html += '<input type="hidden" class="fldSelectedItemIds" />';
-
-        html += '<br />';
-        html += '<div class="formDialogFooter">';
-        html += '<button is="emby-button" type="submit" class="raised btnSubmit block formDialogFooterItem button-submit">' + globalize.translate('Refresh') + '</button>';
-        html += '</div>';
-
-        html += '</form>';
-        html += '</div>';
-        html += '</div>';
-
-        return html;
-    }
-
-    function getEditorHtml() {
-
-        var html = '';
-
-        html += '<div class="formDialogContent smoothScrollY" style="padding-top:2em;">';
-        html += '<div class="dialogContentInner dialog-content-centered">';
-        html += '<form style="margin:auto;">';
-
-        html += '<div class="fldSelectPlaylist selectContainer">';
-        html += '<select is="emby-select" id="selectMetadataRefreshMode" label="' + globalize.translate('LabelRefreshMode') + '">';
-        html += '<option value="scan">' + globalize.translate('ScanForNewAndUpdatedFiles') + '</option>';
-        html += '<option value="missing">' + globalize.translate('SearchForMissingMetadata') + '</option>';
-        html += '<option value="all" selected>' + globalize.translate('ReplaceAllMetadata') + '</option>';
         html += '</select>';
         html += '</div>';
 
@@ -188,6 +150,11 @@ define(['shell', 'dialogHelper', 'loading', 'layoutManager', 'connectionManager'
             this.options.show.updateMissing = options.show.updateMissing || false;
             this.options.show.replaceAll = options.show.replaceAll || false;
         }
+        else {
+            this.options.show = { 
+                simple: false
+            }
+        }
     }
 
     RefreshDialog.prototype.show = function () {
@@ -218,12 +185,7 @@ define(['shell', 'dialogHelper', 'loading', 'layoutManager', 'connectionManager'
 
         html += '</div>';
 
-        if ( this.options.show !== null ){
-            html += getDialogHtml(this.options.show);
-        }
-        else{
-            html += getEditorHtml();
-        }
+        html += getDialogHtml(this.options.show);
         
         dlg.innerHTML = html;
 

--- a/src/components/refreshdialog/refreshdialog.js
+++ b/src/components/refreshdialog/refreshdialog.js
@@ -14,6 +14,85 @@ define(['shell', 'dialogHelper', 'loading', 'layoutManager', 'connectionManager'
         return elem;
     }
 
+    function getDialogHtml(show) {
+
+        // If there is only one options passed, show a simpler dialog
+        var simpleDialog = {
+            hider: ''
+        }
+
+        if (show.simple) {
+
+            simpleDialog.hider = 'hide';
+
+            if (show.scanNewAndUpdated){
+                simpleDialog.text = globalize.translate('ScanForNewAndUpdatedFiles');
+            }
+            else if (show.updateMissing){
+                simpleDialog.text = globalize.translate('SearchForMissingMetadata');
+            }
+            else if (show.replaceAll){
+                simpleDialog.text = globalize.translate('ReplaceAllMetadata');
+            }
+            else {
+                show.simple = false;
+                simpleDialog.hider = '';
+            }
+        }
+
+
+        var html = '';
+
+        html += '<div class="formDialogContent smoothScrollY" style="padding-top:2em;">';
+        html += '<div class="dialogContentInner dialog-content-centered">';
+
+        if (show.simple) {
+            html += '<p>' + globalize.translate('LabelRefreshMode') + ': ' + simpleDialog.text + '</p>'
+        }
+
+
+        html += '<form style="margin:auto;">';
+        html += '<div class="fldSelectPlaylist selectContainer' + simpleDialog.hider + '">';
+        html += '<select is="emby-select" id="selectMetadataRefreshMode" label="' + globalize.translate('LabelRefreshMode') + '">';
+
+        if (show.scanNewAndUpdated){
+            html += '<option value="scan">' + globalize.translate('ScanForNewAndUpdatedFiles') + '</option>';
+        }
+
+        if (show.updateMissing){
+            html += '<option value="missing">' + globalize.translate('SearchForMissingMetadata') + '</option>';
+        }
+
+        if (show.replaceAll){
+            html += '<option value="all" selected>' + globalize.translate('ReplaceAllMetadata') + '</option>';
+        }
+        
+        html += '</select>';
+        html += '</div>';
+
+        html += '<label class="checkboxContainer hide fldReplaceExistingImages">';
+        html += '<input type="checkbox" is="emby-checkbox" class="chkReplaceImages" />';
+        html += '<span>' + globalize.translate('ReplaceExistingImages') + '</span>';
+        html += '</label>';
+
+        html += '<div class="fieldDescription">';
+        html += globalize.translate('RefreshDialogHelp');
+        html += '</div>';
+
+        html += '<input type="hidden" class="fldSelectedItemIds" />';
+
+        html += '<br />';
+        html += '<div class="formDialogFooter">';
+        html += '<button is="emby-button" type="submit" class="raised btnSubmit block formDialogFooterItem button-submit">' + globalize.translate('Refresh') + '</button>';
+        html += '</div>';
+
+        html += '</form>';
+        html += '</div>';
+        html += '</div>';
+
+        return html;
+    }
+
     function getEditorHtml() {
 
         var html = '';
@@ -100,6 +179,15 @@ define(['shell', 'dialogHelper', 'loading', 'layoutManager', 'connectionManager'
 
     function RefreshDialog(options) {
         this.options = options;
+
+        // Make sure show options are set if options.show exists
+        this.options.show = options.show || null;
+        if (this.options.show !== null) {
+            this.options.show.simple = options.show.simple || false;
+            this.options.show.scanNewAndUpdated = options.show.scanNewAndUpdated || false;
+            this.options.show.updateMissing = options.show.updateMissing || false;
+            this.options.show.replaceAll = options.show.replaceAll || false;
+        }
     }
 
     RefreshDialog.prototype.show = function () {
@@ -130,8 +218,13 @@ define(['shell', 'dialogHelper', 'loading', 'layoutManager', 'connectionManager'
 
         html += '</div>';
 
-        html += getEditorHtml();
-
+        if ( this.options.show !== null ){
+            html += getDialogHtml(this.options.show);
+        }
+        else{
+            html += getEditorHtml();
+        }
+        
         dlg.innerHTML = html;
 
         dlg.querySelector('form').addEventListener('submit', onSubmit.bind(this));

--- a/src/components/refreshdialog/refreshdialog.js
+++ b/src/components/refreshdialog/refreshdialog.js
@@ -47,12 +47,12 @@ define(['shell', 'dialogHelper', 'loading', 'layoutManager', 'connectionManager'
         html += '<div class="dialogContentInner dialog-content-centered">';
 
         if (show.simple) {
-            html += '<p>' + globalize.translate('LabelRefreshMode') + ': ' + simpleDialog.text + '</p>'
+            html += '<h3>' + globalize.translate('LabelRefreshMode') + ' ' + simpleDialog.text + '</h3>'
         }
 
 
         html += '<form style="margin:auto;">';
-        html += '<div class="fldSelectPlaylist selectContainer' + simpleDialog.hider + '">';
+        html += '<div class="fldSelectPlaylist selectContainer ' + simpleDialog.hider + '">';
         html += '<select is="emby-select" id="selectMetadataRefreshMode" label="' + globalize.translate('LabelRefreshMode') + '">';
 
         if (show.scanNewAndUpdated){

--- a/src/scripts/librarymenu.js
+++ b/src/scripts/librarymenu.js
@@ -118,6 +118,9 @@ define(["dom", "layoutManager", "inputManager", "connectionManager", "events", "
         if (headerSearchButton) {
             headerSearchButton.addEventListener("click", showSearch);
         }
+        if (headerRefreshButton) {
+            headerRefreshButton.addEventListener("click", refreshCurrentLibrary);
+        }
 
         headerUserButton.addEventListener("click", onHeaderUserButtonClick);
         headerHomeButton.addEventListener("click", onHeaderHomeButtonClick);
@@ -126,6 +129,19 @@ define(["dom", "layoutManager", "inputManager", "connectionManager", "events", "
 
         if (headerSettingsButton) {
             headerSettingsButton.addEventListener("click", onSettingsClick);
+        }
+    }
+
+    function refreshCurrentLibrary(){
+        var currentLibraryId = getTopParentId() || getParentId();
+        if (currentLibraryId !== null) {
+            require(["refreshDialog"], function(refreshDialog) {
+                new refreshDialog({
+                    itemIds: [currentLibraryId],
+                    serverId: getCurrentApiClient().serverId(),
+                    mode: "scan"
+                }).show()
+            })
         }
     }
 
@@ -582,6 +598,9 @@ define(["dom", "layoutManager", "inputManager", "connectionManager", "events", "
         }
     }
 
+    function getParentId() {
+        return getParameterByName("parentId") || null;
+    }
     function getTopParentId() {
         return getParameterByName("topParentId") || null;
     }
@@ -723,6 +742,21 @@ define(["dom", "layoutManager", "inputManager", "connectionManager", "events", "
         }
     }
 
+    function updateRefreshButton(){
+        if (!headerRefreshButton) {
+            headerRefreshButton = document.querySelector(".headerRefreshButton");
+        }
+
+        var refreshId = getTopParentId() || getParentId();
+        
+        if ( refreshId !== null){
+            headerRefreshButton.classList.remove("hide");
+        }
+        else {
+            headerRefreshButton.classList.add("hide");
+        }
+    }
+
     function initHeadRoom(elem) {
         require(["headroom-window"], function (headroom) {
             headroom.add(elem);
@@ -780,6 +814,7 @@ define(["dom", "layoutManager", "inputManager", "connectionManager", "events", "
     var headerBackButton;
     var headerUserButton;
     var currentUser;
+    var headerRefreshButton;
     var headerSettingsButton;
     var headerCastButton;
     var headerSearchButton;
@@ -886,7 +921,8 @@ define(["dom", "layoutManager", "inputManager", "connectionManager", "events", "
         if (!e.detail.isRestored) {
             window.scrollTo(0, 0);
         }
-
+        
+        updateRefreshButton();
         updateTitle(page);
         updateBackButton(page);
         updateLibraryNavLinks(page);
@@ -906,6 +942,7 @@ define(["dom", "layoutManager", "inputManager", "connectionManager", "events", "
         html += '<button is="paper-icon-button-light" class="headerCastButton castButton headerButton headerButtonRight hide"><i class="md-icon">&#xE307;</i></button>';
         html += '<button type="button" is="paper-icon-button-light" class="headerButton headerButtonRight headerSearchButton hide"><i class="md-icon">&#xE8B6;</i></button>';
         html += '<button is="paper-icon-button-light" class="headerButton headerButtonRight headerUserButton hide"><i class="md-icon">&#xE7FD;</i></button>';
+        html += '<button is="paper-icon-button-light" class="headerButton headerButtonRight headerRefreshButton hide"><i class="md-icon">refresh</i></button>';
 
         if (!layoutManager.mobile) {
             html += '<button is="paper-icon-button-light" class="headerButton headerButtonRight headerSettingsButton hide"><i class="md-icon">dashboard</i></button>';
@@ -920,6 +957,7 @@ define(["dom", "layoutManager", "inputManager", "connectionManager", "events", "
         headerHomeButton = skinHeader.querySelector(".headerHomeButton");
         headerUserButton = skinHeader.querySelector(".headerUserButton");
         headerSettingsButton = skinHeader.querySelector(".headerSettingsButton");
+        headerRefreshButton = skinHeader.querySelector(".headerRefreshButton");
         headerCastButton = skinHeader.querySelector(".headerCastButton");
         headerSearchButton = skinHeader.querySelector(".headerSearchButton");
 

--- a/src/scripts/librarymenu.js
+++ b/src/scripts/librarymenu.js
@@ -754,7 +754,7 @@ define(["dom", "layoutManager", "inputManager", "connectionManager", "events", "
 
         var refreshId = getTopParentId() || getParentId();
         
-        if ( refreshId !== null){
+        if (refreshId !== null) {
             headerRefreshButton.classList.remove("hide");
         }
         else {

--- a/src/scripts/librarymenu.js
+++ b/src/scripts/librarymenu.js
@@ -139,7 +139,12 @@ define(["dom", "layoutManager", "inputManager", "connectionManager", "events", "
                 new refreshDialog({
                     itemIds: [currentLibraryId],
                     serverId: getCurrentApiClient().serverId(),
-                    mode: "scan"
+                    show: {
+                        simple: true,
+                        scanNewAndUpdated: true,
+                        updateMissing: false,
+                        replaceAll: false
+                    }
                 }).show()
             })
         }


### PR DESCRIPTION
This adds a rescan button to all libraries/collections and allows every user to rescan/update a library.

**My use case**
I have a few different users who can upload their photos to my NAS (mounted via nfs) into their library. This allows them to trigger a scan for new photos immediately without cron jobs (or me) getting involved.
(Or Script-Fu to work with the API from the NAS.)

**Changes**
1. Add a Rescan button to the headerRight Section of the home
2. Add getParentId function for libraries not identified by 'topParentId'
3. Add Function to perform rescan

**Issues**
Outstanding: Currently refreshDialog does not provide an option to limit the rescan types, meaning a user can have the full power of an admin rescan (refresh all metadata + replace images).
Outstanding: Would be good to implement a permission/policy item to only allow select users to use this.