### PR TITLE
Fix Issue #213 - Direct Playback broken in Chrome 73

### DIFF
--- a/src/components/filesystem.js
+++ b/src/components/filesystem.js
@@ -6,11 +6,13 @@ define([], function () {
             if (window.NativeShell && window.NativeShell.FileSystem) {
                 return window.NativeShell.FileSystem.fileExists(path);
             }
+            return Promise.reject();
         },
         directoryExists: function (path) {
             if (window.NativeShell && window.NativeShell.FileSystem) {
                 return window.NativeShell.FileSystem.directoryExists(path);
             }
+            return Promise.reject();
         }
     };
 });


### PR DESCRIPTION
**Changes**
Adding a `return Promise.reject()` fallback to `filesystem.js` when window.NativeShell is not available
Thanks to @thornbill for the quick fix provided in the issue.

**Issues**
Fixes #213 

**Testing done**
Implemented change locally.
Played back file causing issue before.
Playback working fine