### PR TITLE
Solve random dark pane over video playing in fullscreen mode

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -1731,7 +1731,7 @@ define(['events', 'datetime', 'appSettings', 'itemHelper', 'pluginManager', 'pla
 
                 var maxBitrate = params.MaxStreamingBitrate || self.getMaxStreamingBitrate(player);
 
-                var currentPlayOptions = currentItem.playOptions || {};
+                var currentPlayOptions = currentItem.playOptions || getDefaultPlayOptions();
 
                 getPlaybackInfo(player, apiClient, currentItem, deviceProfile, maxBitrate, ticks, true, currentMediaSource.Id, audioStreamIndex, subtitleStreamIndex, liveStreamId, params.EnableDirectPlay, params.EnableDirectStream, params.AllowVideoStreamCopy, params.AllowAudioStreamCopy).then(function (result) {
 
@@ -2698,7 +2698,7 @@ define(['events', 'datetime', 'appSettings', 'itemHelper', 'pluginManager', 'pla
 
             if (newItem) {
 
-                var newItemPlayOptions = newItem.playOptions || {};
+                var newItemPlayOptions = newItem.playOptions || getDefaultPlayOptions();
 
                 playInternal(newItem, newItemPlayOptions, function () {
                     setPlaylistState(newItem.PlaylistItemId, newItemIndex);
@@ -2803,7 +2803,7 @@ define(['events', 'datetime', 'appSettings', 'itemHelper', 'pluginManager', 'pla
 
                 console.log('playing next track');
 
-                var newItemPlayOptions = newItemInfo.item.playOptions || {};
+                var newItemPlayOptions = newItemInfo.item.playOptions || getDefaultPlayOptions();
 
                 playInternal(newItemInfo.item, newItemPlayOptions, function () {
                     setPlaylistState(newItemInfo.item.PlaylistItemId, newItemInfo.index);
@@ -2826,7 +2826,7 @@ define(['events', 'datetime', 'appSettings', 'itemHelper', 'pluginManager', 'pla
 
                 if (newItem) {
 
-                    var newItemPlayOptions = newItem.playOptions || {};
+                    var newItemPlayOptions = newItem.playOptions || getDefaultPlayOptions();
                     newItemPlayOptions.startPositionTicks = 0;
 
                     playInternal(newItem, newItemPlayOptions, function () {
@@ -2997,7 +2997,7 @@ define(['events', 'datetime', 'appSettings', 'itemHelper', 'pluginManager', 'pla
             var player = this;
             setCurrentPlayerInternal(player);
 
-            var playOptions = item.playOptions || {};
+            var playOptions = item.playOptions || getDefaultPlayOptions();
             var isFirstItem = playOptions.isFirstItem;
             var fullscreen = playOptions.fullscreen;
 


### PR DESCRIPTION
This PR addresses a bug that supposedly renders a dark pane over the video when playing.

I managed to replicate this problem when one file ends and the next one starts playing by itselt, for a specific file. This issue is caused because the property `playOptions` of the item being playing is missing sometimes. The dark pane shows when the property fullscreen represents a false result to a condition. This condition represents when a video is playing but not in the full viewport space available. To mitigate this problem, fallback points has been added when getting playOptions with an existing function for the effect.

I already tested these changes with jf-android.
