### PR TITLE
Change Chromecast volume instead while casting

### DIFF
--- a/src/components/chromecast/chromecastplayer.js
+++ b/src/components/chromecast/chromecastplayer.js
@@ -779,12 +779,15 @@ define(['appSettings', 'userSettings', 'playbackManager', 'connectionManager', '
         });
     };
 
-    ChromecastPlayer.prototype.volumeDown = function () {
+     ChromecastPlayer.prototype.volumeDown = function () {
+        vol = this._castPlayer.session.receiver.volume.level;
+        if (vol == null)
+            vol = 0.5;
+        vol -= 0.02;
+        vol = Math.max(vol, 0);
 
-        this._castPlayer.sendMessage({
-            options: {},
-            command: 'VolumeDown'
-        });
+        this._castPlayer.session.setReceiverVolumeLevel(vol);
+
     };
 
     ChromecastPlayer.prototype.endSession = function () {
@@ -799,24 +802,22 @@ define(['appSettings', 'userSettings', 'playbackManager', 'connectionManager', '
     };
 
     ChromecastPlayer.prototype.volumeUp = function () {
+        vol = this._castPlayer.session.receiver.volume.level;
+        if (vol == null)
+            vol = 0.5;
+        vol += 0.02;
+        vol = Math.min(vol, 1);
 
-        this._castPlayer.sendMessage({
-            options: {},
-            command: 'VolumeUp'
-        });
+        this._castPlayer.session.setReceiverVolumeLevel(vol);
     };
 
     ChromecastPlayer.prototype.setVolume = function (vol) {
 
         vol = Math.min(vol, 100);
         vol = Math.max(vol, 0);
-
-        this._castPlayer.sendMessage({
-            options: {
-                volume: vol
-            },
-            command: 'SetVolume'
-        });
+        vol = vol / 100;
+        
+        this._castPlayer.session.setReceiverVolumeLevel(vol);
     };
 
     ChromecastPlayer.prototype.unpause = function () {

--- a/src/components/chromecast/chromecastplayer.js
+++ b/src/components/chromecast/chromecastplayer.js
@@ -782,7 +782,9 @@ define(['appSettings', 'userSettings', 'playbackManager', 'connectionManager', '
      ChromecastPlayer.prototype.volumeDown = function () {
         vol = this._castPlayer.session.receiver.volume.level;
         if (vol == null)
+        {
             vol = 0.5;
+        }
         vol -= 0.02;
         vol = Math.max(vol, 0);
 
@@ -804,7 +806,9 @@ define(['appSettings', 'userSettings', 'playbackManager', 'connectionManager', '
     ChromecastPlayer.prototype.volumeUp = function () {
         vol = this._castPlayer.session.receiver.volume.level;
         if (vol == null)
+        {
             vol = 0.5;
+        }
         vol += 0.02;
         vol = Math.min(vol, 1);
 


### PR DESCRIPTION
When changing volume connected to chromecast change the device volume instead of the jellyfin-player volume. This is more in line with other cast enabled apps.
