### PR TITLE
Fix local chromecast play behind reverse proxy

### DIFF
--- a/src/components/chromecast/chromecasthelpers.js
+++ b/src/components/chromecast/chromecasthelpers.js
@@ -187,8 +187,13 @@ define(['events'], function (events) {
         return apiClient.getEndpointInfo().then(function (endpoint) {
             if (endpoint.IsInNetwork) {
                 return apiClient.getPublicSystemInfo().then(function (info) {
-                    addToCache(serverAddress, info.LocalAddress);
-                    return info.LocalAddress;
+                    var localAddress = info.LocalAddress
+                    if (!localAddress) {
+                        console.log("No valid local address returned, defaulting to external one")
+                        localAddress = serverAddress;
+                    }
+                    addToCache(serverAddress, localAddress);
+                    return localAddress;
                 });
             } else {
                 addToCache(serverAddress, serverAddress);


### PR DESCRIPTION
**Changes**
When using a HTTPS reverse proxy (for eg. traefik in fron of docker
jellyfin), there's no valid advertised local address.
Let's default to external one in such case, relying on the home router
to properly route it internally.

**Issues**
Fixes https://github.com/jellyfin/jellyfin/issues/791 for me.
