### PR TITLE
Remember device volume/mute on Chromecast playback stop

### DIFF
--- a/src/components/chromecast/chromecastplayer.js
+++ b/src/components/chromecast/chromecastplayer.js
@@ -574,8 +574,15 @@ define(['appSettings', 'userSettings', 'playbackManager', 'connectionManager', '
 
             events.trigger(instance, "playbackstop", [state]);
 
+            var state = instance.lastPlayerData.PlayState || {};
+            var volume = state.VolumeLevel;
+            var mute = state.IsMuted;
+
             // Reset this so the next query doesn't make it appear like content is playing.
             instance.lastPlayerData = {};
+            instance.lastPlayerData.PlayState = {};
+            instance.lastPlayerData.PlayState.VolumeLevel = volume;
+            instance.lastPlayerData.PlayState.IsMuted = mute;
         });
 
         events.on(instance._castPlayer, "playbackprogress", function (e, data) {

--- a/src/components/chromecast/chromecastplayer.js
+++ b/src/components/chromecast/chromecastplayer.js
@@ -575,8 +575,8 @@ define(['appSettings', 'userSettings', 'playbackManager', 'connectionManager', '
             events.trigger(instance, "playbackstop", [state]);
 
             var state = instance.lastPlayerData.PlayState || {};
-            var volume = state.VolumeLevel;
-            var mute = state.IsMuted;
+            var volume = state.VolumeLevel || 0.5;
+            var mute = state.IsMuted || false;
 
             // Reset this so the next query doesn't make it appear like content is playing.
             instance.lastPlayerData = {};


### PR DESCRIPTION
when playback stops while connected to a chromecast device the playstate was completely reset, including volume/mute. Those should not be reset since the volume of the device does not change on playback stop and i.e. the remote control panel should still show the correct (device) volume.