### PR TITLE
When playing on Chromecast make volume buttons change chromecast volume

### DIFF
--- a/src/components/chromecast/chromecastplayer.js
+++ b/src/components/chromecast/chromecastplayer.js
@@ -220,7 +220,9 @@ define(['appSettings', 'userSettings', 'playbackManager', 'connectionManager', '
             this.session = null;
             this.deviceState = DEVICE_STATE.IDLE;
             this.castPlayerState = PLAYER_STATE.IDLE;
-
+            document.removeEventListener("volumeupbutton", onVolumeUpKeyDown, false);
+            document.removeEventListener("volumedownbutton", onVolumeDownKeyDown, false);
+    
             //console.log('sessionUpdateListener: setting currentMediaSession to null');
             this.currentMediaSession = null;
 
@@ -258,6 +260,9 @@ define(['appSettings', 'userSettings', 'playbackManager', 'connectionManager', '
         this.session.addMediaListener(this.sessionMediaListener.bind(this));
         this.session.addUpdateListener(this.sessionUpdateListener.bind(this));
 
+        document.addEventListener("volumeupbutton", onVolumeUpKeyDown, false);
+        document.addEventListener("volumedownbutton", onVolumeDownKeyDown, false);
+
         events.trigger(this, 'connect');
 
         this.sendMessage({
@@ -265,6 +270,14 @@ define(['appSettings', 'userSettings', 'playbackManager', 'connectionManager', '
             command: 'Identify'
         });
     };
+
+    function onVolumeUpKeyDown() {
+        playbackManager.volumeUp();
+    }
+    
+    function onVolumeDownKeyDown() {
+        playbackManager.volumeDown();
+    }
 
     /**
      * session update listener
@@ -305,6 +318,8 @@ define(['appSettings', 'userSettings', 'playbackManager', 'connectionManager', '
         //console.log(message);
         this.deviceState = DEVICE_STATE.IDLE;
         this.castPlayerState = PLAYER_STATE.IDLE;
+        document.removeEventListener("volumeupbutton", onVolumeUpKeyDown, false);
+        document.removeEventListener("volumedownbutton", onVolumeDownKeyDown, false);
 
         //console.log('onStopAppSuccess: setting currentMediaSession to null');
         this.currentMediaSession = null;
@@ -786,13 +801,13 @@ define(['appSettings', 'userSettings', 'playbackManager', 'connectionManager', '
         });
     };
 
-     ChromecastPlayer.prototype.volumeDown = function () {
-        vol = this._castPlayer.session.receiver.volume.level;
+    ChromecastPlayer.prototype.volumeDown = function () {
+        var vol = this._castPlayer.session.receiver.volume.level;
         if (vol == null)
         {
             vol = 0.5;
         }
-        vol -= 0.02;
+        vol -= 0.05;
         vol = Math.max(vol, 0);
 
         this._castPlayer.session.setReceiverVolumeLevel(vol);
@@ -811,12 +826,12 @@ define(['appSettings', 'userSettings', 'playbackManager', 'connectionManager', '
     };
 
     ChromecastPlayer.prototype.volumeUp = function () {
-        vol = this._castPlayer.session.receiver.volume.level;
+        var vol = this._castPlayer.session.receiver.volume.level;
         if (vol == null)
         {
             vol = 0.5;
         }
-        vol += 0.02;
+        vol += 0.05;
         vol = Math.min(vol, 1);
 
         this._castPlayer.session.setReceiverVolumeLevel(vol);


### PR DESCRIPTION
The ideal solution would be to update the cordova chromecast plugin to the new CAF version, that would handle this automatically.
Until then this workaround will intercept the volume keys and change the chromecast device volume instead of the mobile phone's. I also changed the volume steps from 2% to 5% per press - otherwise changing volume would feel like it's taking forever.