### PR TITLE
Fix restart button API call

### DIFF
--- a/src/controllers/dashboardpage.js
+++ b/src/controllers/dashboardpage.js
@@ -750,7 +750,7 @@ define(["datetime", "events", "itemHelper", "serverNotifications", "dom", "globa
                     var page = dom.parentWithClass(btn, "page");
                     buttonEnabled(page.querySelector("#btnRestartServer"), false);
                     buttonEnabled(page.querySelector("#btnShutdown"), false);
-                    Dashboard.restartServer();
+                    ApiClient.restartServer();
                 });
             });
         },


### PR DESCRIPTION
**Changes**
The API call for the Restart button was being done as `Dashboard.restart`, not `ApiClient.restart` like it should have been. The Shutdown button did work and also used `ApiClient` instead.

**Issues**
N/A
