### PR TITLE
Fix logout session storage

### DIFF
--- a/src/bower_components/apiclient/apiclientcore.js
+++ b/src/bower_components/apiclient/apiclientcore.js
@@ -303,6 +303,7 @@ define(["events", "appStorage"], function(events, appStorage) {
     }, ApiClient.prototype.logout = function() {
         stopBitrateDetection(this), this.closeWebSocket();
         var done = function() {
+            appStorage.removeItem("user-" + this._currentUser.Id + "-" + this._currentUser.ServerId)
             this.setAuthenticationInfo(null, null)
         }.bind(this);
         if (this.accessToken()) {


### PR DESCRIPTION
When logging out, the user session wouldn't be destroyed on the client. This PR cleans the user session from local storage when logging out.

Fixes https://github.com/jellyfin/jellyfin-web/issues/233
