### PR TITLE
Fix server name input type

### DIFF
--- a/src/addserver.html
+++ b/src/addserver.html
@@ -3,7 +3,7 @@
         <form class="manualServerForm" style="margin: 0 auto;">
             <h1 style="text-align: left;">${HeaderConnectToServer}</h1>
             <div class="inputContainer">
-                <input is="emby-input" type="url" id="txtServerHost" required="required" label="${LabelServerHost}" />
+                <input is="emby-input" type="text" id="txtServerHost" required="required" label="${LabelServerHost}" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off" />
                 <div class="fieldDescription" style="text-align: left;">${LabelServerHostHelp}</div>
             </div>
             <br />


### PR DESCRIPTION
**Changes**
url type is too strict for what should be a host name/address

**Issues**
I don't see any issues logged for this yet, but it has been mentioned on Riot.
