### PR TITLE
Fix Thumb rendering without thumbnails

### DIFF
--- a/src/components/cardbuilder/cardbuilder.js
+++ b/src/components/cardbuilder/cardbuilder.js
@@ -1267,13 +1267,6 @@ define(['datetime', 'imageLoader', 'connectionManager', 'itemHelper', 'focusMana
             var showTitle = options.showTitle === 'auto' ? true : (options.showTitle || item.Type === 'PhotoAlbum' || item.Type === 'Folder');
             var overlayText = options.overlayText;
 
-            if (forceName && !options.cardLayout) {
-
-                if (overlayText == null) {
-                    overlayText = true;
-                }
-            }
-
             var cardImageContainerClass = 'cardImageContainer';
             var coveredImage = options.coverImage || imgInfo.coverImage;
 


### PR DESCRIPTION
**Changes**
The initial problem was occurring when rendering a page in `Thumb` (`options.cardLayout = false`) mode and the media didn't have a thumbnail (`forceName = true`). In this specific situation, it would try to render the title in the `innerCardFooter` rather than in the `outerCardFooter`. Those footers would render the title in a `<button>`, but the `innerCardFooter` was already rendered in a `<button>`. This double `<button>` was breaking the browser's HTML renderers. 

This fix prevents the usage of `innerCardFooter` and fallbacks to `outerCardFooter`.

Before:
![image](https://user-images.githubusercontent.com/3250155/56483998-4c0ade80-649b-11e9-896d-d4724964cc30.png)

After (you can see it also fixed the title positioning):
![image](https://user-images.githubusercontent.com/3250155/56483949-0a7a3380-649b-11e9-8314-05f00f1593ff.png)


**Issues**
Closes https://github.com/jellyfin/jellyfin-web/issues/228