### PR TITLE
Fix text overflow not displaying ellipsis in cards

### DIFF
--- a/src/components/cardbuilder/card.css
+++ b/src/components/cardbuilder/card.css
@@ -315,6 +315,12 @@ button {
     padding-top: .24em;
 }
 
+.cardText > .textActionButton {
+    width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 .innerCardFooter > .cardText {
     padding: .3em .5em;
 }


### PR DESCRIPTION
**Changes**
This corrects an issue with text buttons inside cards not handling overflowing text correctly.

***Before***
![Screenshot_2019-04-25 Jellyfin](https://user-images.githubusercontent.com/3450688/56751861-037e4a00-6755-11e9-931f-ae0878f8227e.png)

***After***
![Screenshot_2019-04-25 Jellyfin(1)](https://user-images.githubusercontent.com/3450688/56751936-290b5380-6755-11e9-8377-3973e215fbd9.png)

**Issues**
None
