### PR TITLE
Remove extraneous padding from sliders

### DIFF
--- a/src/components/emby-slider/emby-slider.css
+++ b/src/components/emby-slider/emby-slider.css
@@ -17,7 +17,6 @@ _:-ms-input-placeholder {
     -ms-user-select: none;
     user-select: none;
     outline: 0;
-    padding: 1em 0;
     color: #00a4dc;
     -webkit-align-self: center;
     -ms-flex-item-align: center;


### PR DESCRIPTION
**Changes**
Removes the extra 1em of padding from sliders to prevent overflowing on top of ui buttons. In testing on chrome, firefox, and edge on windows, this doesn't appear to make any appearance changes.

**Issues**
Fixes #282 