### PR TITLE
Remove outdated Firefox check for slider bubble

### DIFF
--- a/src/components/emby-slider/emby-slider.js
+++ b/src/components/emby-slider/emby-slider.js
@@ -141,34 +141,31 @@ define(['browser', 'dom', 'layoutManager', 'css!./emby-slider', 'registerElement
             passive: true
         });
 
-        // In firefox this feature disrupts the ability to move the slider
-        if (!browser.firefox) {
-            dom.addEventListener(this, (window.PointerEvent ? 'pointermove' : 'mousemove'), function (e) {
+        dom.addEventListener(this, (window.PointerEvent ? 'pointermove' : 'mousemove'), function (e) {
 
-                if (!this.dragging) {
-                    var rect = this.getBoundingClientRect();
-                    var clientX = e.clientX;
-                    var bubbleValue = (clientX - rect.left) / rect.width;
-                    bubbleValue *= 100;
-                    updateBubble(this, bubbleValue, sliderBubble);
+            if (!this.dragging) {
+                var rect = this.getBoundingClientRect();
+                var clientX = e.clientX;
+                var bubbleValue = (clientX - rect.left) / rect.width;
+                bubbleValue *= 100;
+                updateBubble(this, bubbleValue, sliderBubble);
 
-                    if (hasHideClass) {
-                        sliderBubble.classList.remove('hide');
-                        hasHideClass = false;
-                    }
+                if (hasHideClass) {
+                    sliderBubble.classList.remove('hide');
+                    hasHideClass = false;
                 }
+            }
 
-            }, {
-                passive: true
-            });
+        }, {
+            passive: true
+        });
 
-            dom.addEventListener(this, (window.PointerEvent ? 'pointerleave' : 'mouseleave'), function () {
-                sliderBubble.classList.add('hide');
-                hasHideClass = true;
-            }, {
-                passive: true
-            });
-        }
+        dom.addEventListener(this, (window.PointerEvent ? 'pointerleave' : 'mouseleave'), function () {
+            sliderBubble.classList.add('hide');
+            hasHideClass = true;
+        }, {
+            passive: true
+        });
 
         if (!supportsNativeProgressStyle) {
 


### PR DESCRIPTION
**Changes**
The seekbar "bubble" (tooltip with timestamp of hovered point) was disabled in firefox, evidently because of some previous incompatibility. In my testing this is no longer necessary.

**Issues**
Fixes #288
