### PR TITLE
Correct 404 on autoPlayDetect.js

### DIFF
--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -703,7 +703,7 @@ var AppInfo = {};
             itemHelper: componentsPath + "/itemhelper",
             itemShortcuts: componentsPath + "/shortcuts",
             playQueueManager: componentsPath + "/playback/playqueuemanager",
-            autoPlayDetect: componentsPath + "/playback/autoPlayDetect",
+            autoPlayDetect: componentsPath + "/playback/autoplaydetect",
             nowPlayingHelper: componentsPath + "/playback/nowplayinghelper",
             pluginManager: componentsPath + "/pluginmanager",
             packageManager: componentsPath + "/packagemanager"


### PR DESCRIPTION
**Changes**
This modifies a hardcoded reference to autoPlayDetect.js which has been renamed to autoplaydetect.js - because this is case sensitive it results in a 404.

**Issues**
Fixes #267