### PR TITLE
Fix some issues with the user preference page

### DIFF
--- a/src/controllers/loginpage.js
+++ b/src/controllers/loginpage.js
@@ -146,12 +146,8 @@ define(["apphost", "appSettings", "dom", "connectionManager", "loading", "cardSt
             var apiClient = getApiClient();
             apiClient.getPublicUsers().then(function(users) {
                 if (users.length) {
-                    if (users[0].EnableAutoLogin) {
-                        authenticateUserByName(view, apiClient, users[0].Name, "");
-                    } else {
-                        showVisualForm();
-                        loadUserList(view, apiClient, users);
-                    }
+                    showVisualForm();
+                    loadUserList(view, apiClient, users);
                 } else {
                     view.querySelector("#txtManualName").value = "";
                     showManualForm(view, false, false);

--- a/src/controllers/mypreferencescommon.js
+++ b/src/controllers/mypreferencescommon.js
@@ -7,14 +7,15 @@ define(["apphost", "connectionManager", "listViewStyle", "emby-button"], functio
         });
 
         view.addEventListener("viewshow", function() {
-            var page = this;
+            // this page can also be used by admins to change user preferences from the user edit page
             var userId = params.userId || Dashboard.getCurrentUserId();
+            var page = this;
 
-            page.querySelector(".lnkDisplayPreferences").setAttribute("href", "mypreferencesdisplay.html?userId=" + userId);
-            page.querySelector(".lnkLanguagePreferences").setAttribute("href", "mypreferenceslanguages.html?userId=" + userId);
-            page.querySelector(".lnkSubtitleSettings").setAttribute("href", "mypreferencessubtitles.html?userId=" + userId);
-            page.querySelector(".lnkHomeScreenPreferences").setAttribute("href", "mypreferenceshome.html?userId=" + userId);
             page.querySelector(".lnkMyProfile").setAttribute("href", "myprofile.html?userId=" + userId);
+            page.querySelector(".lnkDisplayPreferences").setAttribute("href", "mypreferencesdisplay.html?userId=" + userId);
+            page.querySelector(".lnkHomePreferences").setAttribute("href", "mypreferenceshome.html?userId=" + userId);
+            page.querySelector(".lnkLanguagePreferences").setAttribute("href", "mypreferenceslanguages.html?userId=" + userId);
+            page.querySelector(".lnkSubtitlePreferences").setAttribute("href", "mypreferencessubtitles.html?userId=" + userId);
 
             if (appHost.supports("multiserver")) {
                 page.querySelector(".selectServer").classList.remove("hide")
@@ -22,19 +23,15 @@ define(["apphost", "connectionManager", "listViewStyle", "emby-button"], functio
                 page.querySelector(".selectServer").classList.add("hide");
             }
 
-            connectionManager.user(ApiClient).then(function(user) {
-                if (user.localUser && !user.localUser.EnableAutoLogin) {
-                    view.querySelector(".btnLogout").classList.remove("hide");
-                } else {
-                    view.querySelector(".btnLogout").classList.add("hide");
-                }
-            });
+            // hide the actions if user preferences are being edited for a different user
+            if (params.userId && params.userId !== Dashboard.getCurrentUserId) {
+                page.querySelector(".userSection").classList.add("hide");
+                page.querySelector(".adminSection").classList.add("hide");
+            }
 
-            Dashboard.getCurrentUser().then(function(user) {
+            ApiClient.getUser(userId).then(function(user) {
                 page.querySelector(".headerUsername").innerHTML = user.Name;
-                if (user.Policy.IsAdministrator) {
-                    page.querySelector(".adminSection").classList.remove("hide");
-                } else {
+                if (!user.Policy.IsAdministrator) {
                     page.querySelector(".adminSection").classList.add("hide");
                 }
             });

--- a/src/mypreferencesmenu.html
+++ b/src/mypreferencesmenu.html
@@ -22,7 +22,7 @@
                     </div>
                 </a>
 
-                <a is="emby-linkbutton" style="display:block; padding: 0; margin:0;" data-ripple="false" href="#" class="lnkHomeScreenPreferences listItem-border">
+                <a is="emby-linkbutton" style="display:block; padding: 0; margin:0;" data-ripple="false" href="#" class="lnkHomePreferences listItem-border">
                     <div class="listItem">
                         <i class="md-icon listItemIcon listItemIcon-transparent">home</i>
                         <div class="listItemBody">
@@ -40,7 +40,7 @@
                     </div>
                 </a>
 
-                <a is="emby-linkbutton" style="display:block; padding: 0; margin:0;" data-ripple="false" href="#" class="lnkSubtitleSettings listItem-border">
+                <a is="emby-linkbutton" style="display:block; padding: 0; margin:0;" data-ripple="false" href="#" class="lnkSubtitlePreferences listItem-border">
                     <div class="listItem">
                         <i class="md-icon listItemIcon listItemIcon-transparent">closed_caption</i>
                         <div class="listItemBody">
@@ -49,52 +49,43 @@
                     </div>
                 </a>
             </div>
-            <div class="verticalSection verticalSection-extrabottompadding">
+            <div class="adminSection verticalSection verticalSection-extrabottompadding">
                 <h2 class="sectionTitle" style="padding-left:.25em;">${HeaderAdmin}</h2>
-                <div>
-                    <a is="emby-linkbutton" href="dashboard.html" style="display: block; padding: 0; margin:0;" class="listItem-border">
-                        <div class="listItem">
-                            <i class="md-icon listItemIcon listItemIcon-transparent">dashboard</i>
-                            <div class="listItemBody">
-                                <div class="listItemBodyText">${TabDashboard}</div>
-                            </div>
+                <a is="emby-linkbutton" href="dashboard.html" style="display: block; padding: 0; margin:0;" class="listItem-border">
+                    <div class="listItem">
+                        <i class="md-icon listItemIcon listItemIcon-transparent">dashboard</i>
+                        <div class="listItemBody">
+                            <div class="listItemBodyText">${TabDashboard}</div>
                         </div>
-                    </a>
-                </div>
-                <div>
-                    <a is="emby-linkbutton" href="edititemmetadata.html" style="display: block; padding: 0; margin:0;" class="listItem-border">
-                        <div class="listItem">
-                            <i class="md-icon listItemIcon listItemIcon-transparent">mode_edit</i>
-                            <div class="listItemBody">
-                                <div class="listItemBodyText">${Metadata}</div>
-                            </div>
+                    </div>
+                </a>
+                <a is="emby-linkbutton" href="edititemmetadata.html" style="display: block; padding: 0; margin:0;" class="listItem-border">
+                    <div class="listItem">
+                        <i class="md-icon listItemIcon listItemIcon-transparent">mode_edit</i>
+                        <div class="listItemBody">
+                            <div class="listItemBodyText">${Metadata}</div>
                         </div>
-                    </a>
-                </div>
+                    </div>
+                </a>
             </div>
-
-            <div class="adminSection hide verticalSection verticalSection-extrabottompadding">
+            <div class="userSection verticalSection verticalSection-extrabottompadding">
                 <h2 class="sectionTitle" style="padding-left:.25em;">${HeaderUser}</h2>
-                <div>
-                    <a is="emby-linkbutton" style="display:block; padding: 0; margin:0;" data-ripple="false" href="selectserver.html" class="selectServer hide listItem-border">
-                        <div class="listItem">
-                            <i class="md-icon listItemIcon listItemIcon-transparent">wifi</i>
-                            <div class="listItemBody">
-                                <div class="listItemBodyText">${HeaderSelectServer}</div>
-                            </div>
+                <a is="emby-linkbutton" style="display:block; padding: 0; margin:0;" data-ripple="false" href="selectserver.html" class="selectServer hide listItem-border">
+                    <div class="listItem">
+                        <i class="md-icon listItemIcon listItemIcon-transparent">wifi</i>
+                        <div class="listItemBody">
+                            <div class="listItemBodyText">${HeaderSelectServer}</div>
                         </div>
-                    </a>
-                </div>
-                <div>
-                    <a is="emby-linkbutton" style="display:block; padding: 0; margin:0;" data-ripple="false" href="#" class="btnLogout hide listItem-border">
-                        <div class="listItem">
-                            <i class="md-icon listItemIcon listItemIcon-transparent">exit_to_app</i>
-                            <div class="listItemBody">
-                                <div class="listItemBodyText">${ButtonSignOut}</div>
-                            </div>
+                    </div>
+                </a>
+                <a is="emby-linkbutton" style="display:block; padding: 0; margin:0;" data-ripple="false" href="#" class="btnLogout listItem-border">
+                    <div class="listItem">
+                        <i class="md-icon listItemIcon listItemIcon-transparent">exit_to_app</i>
+                        <div class="listItemBody">
+                            <div class="listItemBodyText">${ButtonSignOut}</div>
                         </div>
-                    </a>
-                </div>
+                    </div>
+                </a>
             </div>
         </div>
     </div>

--- a/src/scripts/librarymenu.js
+++ b/src/scripts/librarymenu.js
@@ -201,11 +201,9 @@ define(["dom", "layoutManager", "inputManager", "connectionManager", "events", "
             if (appHost.supports("multiserver")) {
                 html += '<a is="emby-linkbutton" class="navMenuOption lnkMediaFolder" data-itemid="selectserver" href="selectserver.html?showuser=1"><i class="md-icon navMenuOptionIcon">wifi</i><span class="navMenuOptionText">' + globalize.translate("ButtonSelectServer") + "</span></a>";
             }
-            if (!user.localUser.EnableAutoLogin) {
-                html += '<a is="emby-linkbutton" class="navMenuOption lnkMediaFolder btnLogout" data-itemid="logout" href="#"><i class="md-icon navMenuOptionIcon">exit_to_app</i><span class="navMenuOptionText">' + globalize.translate("ButtonSignOut") + "</span></a>";
-            }
+            html += '<a is="emby-linkbutton" class="navMenuOption lnkMediaFolder btnLogout" data-itemid="logout" href="#"><i class="md-icon navMenuOptionIcon">exit_to_app</i><span class="navMenuOptionText">' + globalize.translate("ButtonSignOut") + "</span></a>";
+            html += "</div>";
         }
-        html += "</div>";
 
         // add buttons to navigation drawer
         navDrawerScrollContainer.innerHTML = html;


### PR DESCRIPTION
The EnableAutoLogin field is only used when there is one user on the server and they have a blank password, but I don't think this should be a feature. This does not break the client auto login, so after logging in once they will stay logged in just like any other service. It only removes the weird functionality that didn't even require clicking a user profile once.

There were also some issues with editing another user's preferences from the dashboard from this page, which I also resolved here. The `user` and `admin` sections should be hidden since those aren't related, and the username should get updated to the user currently getting edited.