### PR TITLE
Redirect when loading video player fails

### DIFF
--- a/src/controllers/videoosd.js
+++ b/src/controllers/videoosd.js
@@ -1227,16 +1227,22 @@ define(["playbackManager", "dom", "inputmanager", "datetime", "itemHelper", "med
             Emby.Page.setTransparency("full");
         });
         view.addEventListener("viewshow", function (e) {
-            events.on(playbackManager, "playerchange", onPlayerChange);
-            bindToPlayer(playbackManager.getCurrentPlayer());
-            dom.addEventListener(document, window.PointerEvent ? "pointermove" : "mousemove", onPointerMove, {
-                passive: true
-            });
-            showOsd();
-            inputManager.on(window, onInputCommand);
-            dom.addEventListener(window, "keydown", onWindowKeyDown, {
-                passive: true
-            });
+            try {
+                events.on(playbackManager, "playerchange", onPlayerChange);
+                bindToPlayer(playbackManager.getCurrentPlayer());
+                dom.addEventListener(document, window.PointerEvent ? "pointermove" : "mousemove", onPointerMove, {
+                    passive: true
+                });
+                showOsd();
+                inputManager.on(window, onInputCommand);
+                dom.addEventListener(window, "keydown", onWindowKeyDown, {
+                    passive: true
+                });
+            } catch(e) {
+                require(['appRouter'], function(appRouter) {
+                    appRouter.showDirect('/');
+                });
+            }
         });
         view.addEventListener("viewbeforehide", function () {
             if (statsOverlay) {


### PR DESCRIPTION
**Changes**
When reloading the video player, it gets stuck in a weird broken state.
![image](https://user-images.githubusercontent.com/3250155/57197056-91fe8280-6f30-11e9-9cd6-0ca23c5b0d70.png)

I'm not 100% sure it's the right solution to the problem, but this PR force a redirect to the home page when loading the player fails. We can't really rescue by trying to reload the right video, because AFAIK we don't know what's the video after a page reload.

I personally prefer to go back to a good state (home page) than staying on a broken page.