### PR TITLE
Initial support for keyboard navigation (for webOS remote etc.)

### DIFF
--- a/src/components/keyboardnavigation.js
+++ b/src/components/keyboardnavigation.js
@@ -1,0 +1,36 @@
+define(['inputmanager', 'focusManager'], function(inputmanager, focusManager) {
+    'use strict';
+
+    console.log("keyboardnavigation");
+
+    function enable() {
+        document.addEventListener('keydown', function(e) {
+            var capture = true;
+
+            switch (e.keyCode) {
+            case 37: // ArrowLeft
+                inputmanager.handle('left');
+                break;
+            case 38: // ArrowUp
+                inputmanager.handle('up');
+                break;
+            case 39: // ArrowRight
+                inputmanager.handle('right');
+                break;
+            case 40: // ArrowDown
+                inputmanager.handle('down');
+                break;
+            default:
+                capture = false;
+            }
+            if (capture) {
+                console.log("Disabling default event handling");
+                e.preventDefault();
+            }
+        });
+
+    }
+    return {
+        enable: enable,
+    };
+});

--- a/src/controllers/itemdetailpage.js
+++ b/src/controllers/itemdetailpage.js
@@ -322,6 +322,25 @@ define(["loading", "appRouter", "layoutManager", "connectionManager", "cardBuild
             itemBirthLocation.classList.remove("hide"), itemBirthLocation.innerHTML = globalize.translate("BirthPlaceValue").replace("{0}", gmap)
         } else itemBirthLocation.classList.add("hide");
         setPeopleHeader(page, item), loading.hide()
+
+        try {
+            require(["focusManager"], function(focusManager) {
+                [".btnResume", ".btnPlay"].every(function (cls) {
+                    
+                    var elems = page.querySelectorAll(cls);
+                    
+                    for (var i = 0; i < elems.length; i++) {
+                        if (focusManager.isCurrentlyFocusable(elems[i])) {
+                            focusManager.focus(elems[i]);
+                            return false;
+                        }
+                    }
+                    return true;
+                });
+            });
+        } catch (e) {
+            console.log(e);
+        }
     }
 
     function logoImageUrl(item, apiClient, options) {

--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -484,6 +484,9 @@ var AppInfo = {};
                         onGlobalizeInit(browser);
                     });
                 });
+                require(["keyboardnavigation"], function(keyboardnavigation) {
+                    keyboardnavigation.enable();
+                });
             });
         });
     }
@@ -880,6 +883,7 @@ var AppInfo = {};
         define("serverNotifications", [componentsPath + "/serverNotifications/serverNotifications"], returnFirstDependency);
         define("appFooter-shared", ["appFooter"], createSharedAppFooter);
         define("skinManager", [componentsPath + "/skinManager"], returnFirstDependency);
+        define("keyboardnavigation", [componentsPath + "/keyboardnavigation"], returnFirstDependency);
         define("connectionManager", [], function () {
             return ConnectionManager;
         });


### PR DESCRIPTION
Adds handling of keyboard events in order to support TV remotes such as in webOS.
Currently only handles arrow keys (up, down, left, right) and this is enough for basic navigation and watching movies.
It currently *partially* implements #303.

### There are still a few issues that should probably be fixed before merging: ###
- [ ] Users on login screen do not highlight when selected
- [ ] Radio buttons do not highlight when they are not checked
- [ ] Item listings need focus move on load, similar to what I've done for the `Resume` and `Play` buttons on item details.
- [ ] Navigating (focusing) over tabs load their content, potentially making it awkward to navigate to the user menu in the upper right corner.
- [ ] Moving focus to items (partially) off screen does not scroll/change the view in webOS 3
 *Potentially related to the fact that scrolling on any page moves only the top bar - but selecting items off the screen does not move the bar.*
  Seems to be working in webOS 4

Some of those issues are less severe, and might not belong in this PR rather than a general UI cleanup?
#### Scrolling not working in webOS 3 ####
![Scrolling moves only the top bar](https://user-images.githubusercontent.com/638706/57352526-e8a0d200-7165-11e9-920f-d2d32ed1225c.png)



PS: This pr also includes the commits from #309, as they are a requirement for even loading the web app to test this - I'm assuming the related diffs will disappear from this view once that one is merged)