### PR TITLE
Correct the naming of iPad and iPhone

### DIFF
--- a/src/components/apphost.js
+++ b/src/components/apphost.js
@@ -107,10 +107,10 @@ define(["appSettings", "browser", "events", "htmlMediaHelper"], function (appSet
         deviceName = browser.tizen ? "Samsung Smart TV" : browser.web0s ? "LG Smart TV" : browser.operaTv ? "Opera TV" : browser.xboxOne ? "Xbox One" : browser.ps4 ? "Sony PS4" : browser.chrome ? "Chrome" : browser.edge ? "Edge" : browser.firefox ? "Firefox" : browser.msie ? "Internet Explorer" : browser.opera ? "Opera" : "Web Browser";
 
         if (browser.ipad) {
-            deviceName += " Ipad";
+            deviceName += " iPad";
         } else {
             if (browser.iphone) {
-                deviceName += " Iphone";
+                deviceName += " iPhone";
             } else {
                 if (browser.android) {
                     deviceName += " Android";


### PR DESCRIPTION
**Changes**
Puts the correct capitalization of iPad and iPhone in appHost.js.

**Issues**
Fixes #310.

**Notes**
No other impact is expected - all checks I've found will either force the text to all lowercase, or do a comparison while ignoring case. This will simply display the names properly in the clients view of the Dashboard.