### PR TITLE
Fix secondery title position and show year on tv show ui

### DIFF
--- a/src/scripts/movies.js
+++ b/src/scripts/movies.js
@@ -77,7 +77,8 @@ define(["loading", "layoutManager", "userSettings", "events", "libraryBrowser", 
                 lazy: !0,
                 cardLayout: !0,
                 showTitle: !0,
-                showYear: !0
+                showYear: !0,
+                centerText: !0
             }) : "Banner" == viewStyle ? cardBuilder.getCardsHtml({
                 items: items,
                 shape: "banner",
@@ -94,6 +95,7 @@ define(["loading", "layoutManager", "userSettings", "events", "libraryBrowser", 
                 context: "movies",
                 showTitle: !0,
                 showYear: !0,
+                centerText: !0,
                 lazy: !0,
                 cardLayout: !0
             }) : cardBuilder.getCardsHtml({

--- a/src/scripts/movietrailers.js
+++ b/src/scripts/movietrailers.js
@@ -67,7 +67,8 @@ define(["layoutManager", "loading", "events", "libraryBrowser", "imageLoader", "
                     context: "movies",
                     cardLayout: !0,
                     showTitle: !0,
-                    showYear: !0
+                    showYear: !0,
+                    centerText: !0
                 }) : "Banner" == viewStyle ? cardBuilder.getCardsHtml({
                     items: result.Items,
                     shape: "banner",
@@ -83,6 +84,7 @@ define(["layoutManager", "loading", "events", "libraryBrowser", "imageLoader", "
                     context: "movies",
                     showTitle: !0,
                     showYear: !0,
+                    centerText: !0,
                     cardLayout: !0
                 }) : cardBuilder.getCardsHtml({
                     items: result.Items,

--- a/src/scripts/tvshows.js
+++ b/src/scripts/tvshows.js
@@ -77,7 +77,8 @@ define(["layoutManager", "loading", "events", "libraryBrowser", "imageLoader", "
                     context: "tvshows",
                     cardLayout: !0,
                     showTitle: !0,
-                    showYear: !0
+                    showYear: !0,
+                    centerText: !0
                 }) : "Banner" == viewStyle ? cardBuilder.getCardsHtml({
                     items: result.Items,
                     shape: "banner",
@@ -93,6 +94,7 @@ define(["layoutManager", "loading", "events", "libraryBrowser", "imageLoader", "
                     context: "tvshows",
                     showTitle: !0,
                     showYear: !0,
+                    centerText: !0,
                     cardLayout: !0
                 }) : cardBuilder.getCardsHtml({
                     items: result.Items,
@@ -101,7 +103,8 @@ define(["layoutManager", "loading", "events", "libraryBrowser", "imageLoader", "
                     centerText: !0,
                     lazy: !0,
                     overlayMoreButton: !0,
-                    showTitle: !0
+                    showTitle: !0,
+                    showYear: !0
                 });
                 var i, length, elems = tabContent.querySelectorAll(".paging");
                 for (i = 0, length = elems.length; i < length; i++) elems[i].innerHTML = pagingHtml;


### PR DESCRIPTION
Fix Secondery title to be center for movie, tvshow and movietriller show year for tvshow

Minor UI Issues https://github.com/jellyfin/jellyfin-web/issues/302

Before
![Screenshot_2019-05-15 Jellyfin(3)](https://user-images.githubusercontent.com/32230989/57806235-6157ed80-7767-11e9-8492-e0456d7cb67c.png)
![Screenshot_2019-05-15 Jellyfin(2)](https://user-images.githubusercontent.com/32230989/57806244-67e66500-7767-11e9-908a-bbd0f6b6948c.png)

After
![Screenshot_2019-05-15 Jellyfin(1)](https://user-images.githubusercontent.com/32230989/57806267-70d73680-7767-11e9-8084-7488aeee713c.png)
![Screenshot_2019-05-15 Jellyfin](https://user-images.githubusercontent.com/32230989/57806272-72a0fa00-7767-11e9-854a-c4f08d0ae51d.png)
