### PR TITLE
Resolve some android seeking issues

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -2536,7 +2536,6 @@ define(['events', 'datetime', 'appSettings', 'itemHelper', 'pluginManager', 'pla
 
                     } else {
 
-                        playerStartPositionTicks = null;
                         contentType = getMimeType(type.toLowerCase(), mediaSource.TranscodingContainer);
 
                         if (mediaUrl.toLowerCase().indexOf('copytimestamps=true') === -1) {


### PR DESCRIPTION
I believe this allows android to seek, but I think there's more to it than this quick fix - the cordova app seems to be getting transcodes / remuxes when it is not fully necessary which makes this bug worse.

**Changes**
Prevents a removal of the startPositionTicks variable so that the progress bar is not reset to 0:00 when seeking

**Issues**
#263
possibly https://github.com/jellyfin/jellyfin-android/issues/133 