### PR TITLE
Fix certain elements getting incorrectly centered on firefox

### DIFF
--- a/src/components/emby-button/emby-button.css
+++ b/src/components/emby-button/emby-button.css
@@ -50,9 +50,9 @@
     vertical-align: initial;
 }
 
-.button-link-inline {
+/*.button-link-inline {
     display: inline;
-}
+}*/
 
 .button-link:hover {
     text-decoration: underline;

--- a/src/components/emby-button/emby-button.css
+++ b/src/components/emby-button/emby-button.css
@@ -50,10 +50,6 @@
     vertical-align: initial;
 }
 
-/*.button-link-inline {
-    display: inline;
-}*/
-
 .button-link:hover {
     text-decoration: underline;
 }

--- a/src/components/emby-button/emby-button.js
+++ b/src/components/emby-button/emby-button.js
@@ -28,10 +28,7 @@ define(['browser', 'dom', 'layoutManager', 'shell', 'appRouter', 'apphost', 'css
 
         this.classList.add('emby-button');
 
-        if (browser.firefox) {
-            // a ff hack is needed for vertical alignment
-            this.classList.add('button-link-inline');
-        }
+        this.classList.add('button-link-inline');
 
         if (layoutManager.tv) {
             if (this.getAttribute('data-focusscale') !== 'false') {

--- a/src/components/emby-button/emby-button.js
+++ b/src/components/emby-button/emby-button.js
@@ -28,8 +28,6 @@ define(['browser', 'dom', 'layoutManager', 'shell', 'appRouter', 'apphost', 'css
 
         this.classList.add('emby-button');
 
-        this.classList.add('button-link-inline');
-
         if (layoutManager.tv) {
             if (this.getAttribute('data-focusscale') !== 'false') {
                 this.classList.add('emby-button-focusscale');


### PR DESCRIPTION
note it's better to remove the class button-link-inline. For know i just disabled form css 

before 
Firefox
![58764365-1514f780-8534-11e9-8962-2ce7ebe96016](https://user-images.githubusercontent.com/32230989/58988277-fe97c600-87e9-11e9-9f30-2cd8bf84da9f.png)
![Screenshot_2019-06-05 Jellyfin](https://user-images.githubusercontent.com/32230989/58989492-b201ba00-87ec-11e9-98b1-8adba8cc9748.png)
![Screenshot_2019-06-05 Jellyfin(1)](https://user-images.githubusercontent.com/32230989/58989547-ce055b80-87ec-11e9-82dd-de015bda9f40.png)


chrome
![58764371-2e1da880-8534-11e9-9d55-eecd4151dfe6](https://user-images.githubusercontent.com/32230989/58988291-08212e00-87ea-11e9-892b-f72760a0a80d.png)
![Screenshot (4)](https://user-images.githubusercontent.com/32230989/58989523-c0e86c80-87ec-11e9-8372-ebad2ca9bb78.png)
![Screenshot (5)](https://user-images.githubusercontent.com/32230989/58989579-db224a80-87ec-11e9-8a37-cf6b4b3374b6.png)


