### PR TITLE
Improvements to the quality of artworks and user images

### DIFF
--- a/src/components/activitylog.js
+++ b/src/components/activitylog.js
@@ -13,8 +13,7 @@ define(["events", "globalize", "dom", "datetime", "userSettings", "serverNotific
         if (entry.UserId && entry.UserPrimaryImageTag) {
             html += '<i class="listItemIcon md-icon" style="width:2em!important;height:2em!important;padding:0;color:transparent;background-color:' + color + ";background-image:url('" + apiClient.getUserImageUrl(entry.UserId, {
                 type: "Primary",
-                tag: entry.UserPrimaryImageTag,
-                height: 40
+                tag: entry.UserPrimaryImageTag
             }) + "');background-repeat:no-repeat;background-position:center center;background-size: cover;\">dvr</i>"
         } else {
             html += '<i class="listItemIcon md-icon" style="background-color:' + color + '">' + icon + '</i>';

--- a/src/components/backdrop/backdrop.js
+++ b/src/components/backdrop/backdrop.js
@@ -181,21 +181,6 @@ define(['browser', 'connectionManager', 'playbackManager', 'dom', 'css!./style']
         currentLoadingBackdrop = instance;
     }
 
-    var standardWidths = [480, 720, 1280, 1440, 1920];
-    function getBackdropMaxWidth() {
-
-        var width = dom.getWindowSize().innerWidth;
-
-        if (standardWidths.indexOf(width) !== -1) {
-            return width;
-        }
-
-        var roundScreenTo = 100;
-        width = Math.floor(width / roundScreenTo) * roundScreenTo;
-
-        return Math.min(width, 1920);
-    }
-
     function getItemImageUrls(item, imageOptions) {
 
         imageOptions = imageOptions || {};
@@ -209,7 +194,6 @@ define(['browser', 'connectionManager', 'playbackManager', 'dom', 'css!./style']
                 return apiClient.getScaledImageUrl(item.BackdropItemId || item.Id, Object.assign(imageOptions, {
                     type: "Backdrop",
                     tag: imgTag,
-                    maxWidth: getBackdropMaxWidth(),
                     index: index
                 }));
             });
@@ -222,7 +206,6 @@ define(['browser', 'connectionManager', 'playbackManager', 'dom', 'css!./style']
                 return apiClient.getScaledImageUrl(item.ParentBackdropItemId, Object.assign(imageOptions, {
                     type: "Backdrop",
                     tag: imgTag,
-                    maxWidth: getBackdropMaxWidth(),
                     index: index
                 }));
             });

--- a/src/components/cardbuilder/card.css
+++ b/src/components/cardbuilder/card.css
@@ -232,9 +232,10 @@ button {
     left: 0;
     right: 0;
     bottom: 0;
-    background-size: contain;
+    background-size: cover;
     background-repeat: no-repeat;
-    background-position: center bottom;
+    background-position: center;
+    border: none;
 }
 
 .cardImage-img {
@@ -259,6 +260,10 @@ button {
 .coveredImage {
     background-size: 100% 100%;
     background-position: center center;
+}
+
+.cardProfilePhoto {
+    border-radius: 100%;
 }
 
 .coveredImage-noScale {

--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -471,7 +471,6 @@ define(['datetime', 'imageLoader', 'connectionManager', 'itemHelper', 'focusMana
 
                 imgUrl = apiClient.getScaledImageUrl(item.Id, {
                     type: "Thumb",
-                    maxWidth: width,
                     tag: item.ImageTags.Thumb
                 });
 
@@ -479,7 +478,6 @@ define(['datetime', 'imageLoader', 'connectionManager', 'itemHelper', 'focusMana
 
                 imgUrl = apiClient.getScaledImageUrl(item.Id, {
                     type: "Banner",
-                    maxWidth: width,
                     tag: item.ImageTags.Banner
                 });
 
@@ -487,7 +485,6 @@ define(['datetime', 'imageLoader', 'connectionManager', 'itemHelper', 'focusMana
 
                 imgUrl = apiClient.getScaledImageUrl(item.Id, {
                     type: "Disc",
-                    maxWidth: width,
                     tag: item.ImageTags.Disc
                 });
 
@@ -495,7 +492,6 @@ define(['datetime', 'imageLoader', 'connectionManager', 'itemHelper', 'focusMana
 
                 imgUrl = apiClient.getScaledImageUrl(item.Id, {
                     type: "Logo",
-                    maxWidth: width,
                     tag: item.ImageTags.Logo
                 });
 
@@ -503,7 +499,6 @@ define(['datetime', 'imageLoader', 'connectionManager', 'itemHelper', 'focusMana
 
                 imgUrl = apiClient.getScaledImageUrl(item.ParentLogoItemId, {
                     type: "Logo",
-                    maxWidth: width,
                     tag: item.ParentLogoImageTag
                 });
 
@@ -511,7 +506,6 @@ define(['datetime', 'imageLoader', 'connectionManager', 'itemHelper', 'focusMana
 
                 imgUrl = apiClient.getScaledImageUrl(item.SeriesId, {
                     type: "Thumb",
-                    maxWidth: width,
                     tag: item.SeriesThumbImageTag
                 });
 
@@ -519,7 +513,6 @@ define(['datetime', 'imageLoader', 'connectionManager', 'itemHelper', 'focusMana
 
                 imgUrl = apiClient.getScaledImageUrl(item.ParentThumbItemId, {
                     type: "Thumb",
-                    maxWidth: width,
                     tag: item.ParentThumbImageTag
                 });
 
@@ -527,7 +520,6 @@ define(['datetime', 'imageLoader', 'connectionManager', 'itemHelper', 'focusMana
 
                 imgUrl = apiClient.getScaledImageUrl(item.Id, {
                     type: "Backdrop",
-                    maxWidth: width,
                     tag: item.BackdropImageTags[0]
                 });
 
@@ -537,7 +529,6 @@ define(['datetime', 'imageLoader', 'connectionManager', 'itemHelper', 'focusMana
 
                 imgUrl = apiClient.getScaledImageUrl(item.ParentBackdropItemId, {
                     type: "Backdrop",
-                    maxWidth: width,
                     tag: item.ParentBackdropImageTags[0]
                 });
 
@@ -547,8 +538,6 @@ define(['datetime', 'imageLoader', 'connectionManager', 'itemHelper', 'focusMana
 
                 imgUrl = apiClient.getScaledImageUrl(item.Id, {
                     type: "Primary",
-                    maxHeight: height,
-                    maxWidth: width,
                     tag: item.ImageTags.Primary
                 });
 
@@ -569,8 +558,6 @@ define(['datetime', 'imageLoader', 'connectionManager', 'itemHelper', 'focusMana
 
                 imgUrl = apiClient.getScaledImageUrl(item.PrimaryImageItemId || item.Id || item.ItemId, {
                     type: "Primary",
-                    maxHeight: height,
-                    maxWidth: width,
                     tag: item.PrimaryImageTag
                 });
 
@@ -589,7 +576,6 @@ define(['datetime', 'imageLoader', 'connectionManager', 'itemHelper', 'focusMana
 
                 imgUrl = apiClient.getScaledImageUrl(item.ParentPrimaryImageItemId, {
                     type: "Primary",
-                    maxWidth: width,
                     tag: item.ParentPrimaryImageTag
                 });
             }
@@ -597,7 +583,6 @@ define(['datetime', 'imageLoader', 'connectionManager', 'itemHelper', 'focusMana
 
                 imgUrl = apiClient.getScaledImageUrl(item.SeriesId, {
                     type: "Primary",
-                    maxWidth: width,
                     tag: item.SeriesPrimaryImageTag
                 });
             }
@@ -607,8 +592,6 @@ define(['datetime', 'imageLoader', 'connectionManager', 'itemHelper', 'focusMana
 
                 imgUrl = apiClient.getScaledImageUrl(item.AlbumId, {
                     type: "Primary",
-                    maxHeight: height,
-                    maxWidth: width,
                     tag: item.AlbumPrimaryImageTag
                 });
 
@@ -623,7 +606,6 @@ define(['datetime', 'imageLoader', 'connectionManager', 'itemHelper', 'focusMana
 
                 imgUrl = apiClient.getScaledImageUrl(item.Id, {
                     type: "Thumb",
-                    maxWidth: width,
                     tag: item.ImageTags.Thumb
                 });
 
@@ -632,7 +614,6 @@ define(['datetime', 'imageLoader', 'connectionManager', 'itemHelper', 'focusMana
 
                 imgUrl = apiClient.getScaledImageUrl(item.Id, {
                     type: "Backdrop",
-                    maxWidth: width,
                     tag: item.BackdropImageTags[0]
                 });
 
@@ -640,7 +621,6 @@ define(['datetime', 'imageLoader', 'connectionManager', 'itemHelper', 'focusMana
 
                 imgUrl = apiClient.getScaledImageUrl(item.Id, {
                     type: "Thumb",
-                    maxWidth: width,
                     tag: item.ImageTags.Thumb
                 });
 
@@ -648,7 +628,6 @@ define(['datetime', 'imageLoader', 'connectionManager', 'itemHelper', 'focusMana
 
                 imgUrl = apiClient.getScaledImageUrl(item.SeriesId, {
                     type: "Thumb",
-                    maxWidth: width,
                     tag: item.SeriesThumbImageTag
                 });
 
@@ -656,7 +635,6 @@ define(['datetime', 'imageLoader', 'connectionManager', 'itemHelper', 'focusMana
 
                 imgUrl = apiClient.getScaledImageUrl(item.ParentThumbItemId, {
                     type: "Thumb",
-                    maxWidth: width,
                     tag: item.ParentThumbImageTag
                 });
 
@@ -664,7 +642,6 @@ define(['datetime', 'imageLoader', 'connectionManager', 'itemHelper', 'focusMana
 
                 imgUrl = apiClient.getScaledImageUrl(item.ParentBackdropItemId, {
                     type: "Backdrop",
-                    maxWidth: width,
                     tag: item.ParentBackdropImageTags[0]
                 });
 

--- a/src/components/emby-button/emby-button.css
+++ b/src/components/emby-button/emby-button.css
@@ -147,15 +147,15 @@
         vertical-align: middle;
     }
 
-    .paper-icon-button-light > img {
-        width: 1.72em;
-        /* Can't use 100% height or it will stretch past the boundaries in safari */
-        /*height: 100%;*/
+    .paper-icon-button-light > div {
         max-height: 100%;
+        transform: scale(2);
         /* Make sure its on top of the ripple */
         position: relative;
         z-index: 1;
         vertical-align: middle;
+        display: inline;
+        margin: 0 auto;
     }
 
 .emby-button-foreground {

--- a/src/controllers/dashboardpage.js
+++ b/src/controllers/dashboardpage.js
@@ -304,7 +304,7 @@ define(["datetime", "events", "itemHelper", "serverNotifications", "dom", "globa
                 html += "</div>";
                 html += '<div class="flex align-items-center justify-content-center">';
                 var userImage = DashboardPage.getUserImage(session);
-                html += userImage ? '<img style="height:1.71em;border-radius:50px;margin-right:.5em;" src="' + userImage + '" />' : '<div style="height:1.71em;"></div>';
+                html += userImage ? '<div class="activitylogUserPhoto" style="background-image:url(\'' + userImage + "');\"></div>" : '<div style="height:1.71em;"></div>';
                 html += '<div class="sessionUserName">';
                 html += DashboardPage.getUsersHtml(session);
                 html += "</div>";
@@ -507,7 +507,6 @@ define(["datetime", "events", "itemHelper", "serverNotifications", "dom", "globa
             if (session.UserId && session.UserPrimaryImageTag) {
                 return ApiClient.getUserImageUrl(session.UserId, {
                     tag: session.UserPrimaryImageTag,
-                    height: 24,
                     type: "Primary"
                 });
             }

--- a/src/controllers/itemdetailpage.js
+++ b/src/controllers/itemdetailpage.js
@@ -343,9 +343,9 @@ define(["loading", "appRouter", "layoutManager", "connectionManager", "cardBuild
         try {
             require(["focusManager"], function(focusManager) {
                 [".btnResume", ".btnPlay"].every(function (cls) {
-                    
+
                     var elems = page.querySelectorAll(cls);
-                    
+
                     for (var i = 0; i < elems.length; i++) {
                         if (focusManager.isCurrentlyFocusable(elems[i])) {
                             focusManager.focus(elems[i]);
@@ -429,31 +429,24 @@ define(["loading", "appRouter", "layoutManager", "connectionManager", "cardBuild
             detectRatio = !1;
         imageTags.Primary ? (url = apiClient.getScaledImageUrl(item.Id, {
             type: "Primary",
-            maxHeight: 460,
             tag: item.ImageTags.Primary
         }), detectRatio = !0) : item.BackdropImageTags && item.BackdropImageTags.length ? (url = apiClient.getScaledImageUrl(item.Id, {
             type: "Backdrop",
-            maxHeight: 360,
             tag: item.BackdropImageTags[0]
         }), shape = "thumb") : imageTags.Thumb ? (url = apiClient.getScaledImageUrl(item.Id, {
             type: "Thumb",
-            maxHeight: 360,
             tag: item.ImageTags.Thumb
         }), shape = "thumb") : imageTags.Disc ? (url = apiClient.getScaledImageUrl(item.Id, {
             type: "Disc",
-            maxHeight: 360,
             tag: item.ImageTags.Disc
         }), shape = "square") : item.AlbumId && item.AlbumPrimaryImageTag ? (url = apiClient.getScaledImageUrl(item.AlbumId, {
             type: "Primary",
-            maxHeight: 360,
             tag: item.AlbumPrimaryImageTag
         }), shape = "square") : item.SeriesId && item.SeriesPrimaryImageTag ? url = apiClient.getScaledImageUrl(item.SeriesId, {
             type: "Primary",
-            maxHeight: 360,
             tag: item.SeriesPrimaryImageTag
         }) : item.ParentPrimaryImageItemId && item.ParentPrimaryImageTag && (url = apiClient.getScaledImageUrl(item.ParentPrimaryImageItemId, {
             type: "Primary",
-            maxHeight: 360,
             tag: item.ParentPrimaryImageTag
         })), html += '<div style="position:relative;">', editable && (html += "<a class='itemDetailGalleryLink' is='emby-linkbutton' style='display:block;padding:2px;margin:0;' href='#'>"), detectRatio && item.PrimaryImageAspectRatio && (item.PrimaryImageAspectRatio >= 1.48 ? shape = "thumb" : item.PrimaryImageAspectRatio >= .85 && item.PrimaryImageAspectRatio <= 1.34 && (shape = "square")), html += "<img class='itemDetailImage lazy' src='data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=' />", editable && (html += "</a>");
         var progressHtml = item.IsFolder || !item.UserData ? "" : indicators.getProgressBarHtml(item);
@@ -608,7 +601,7 @@ define(["loading", "appRouter", "layoutManager", "connectionManager", "cardBuild
                 itemMiscInfo[i].classList.add("hide");
             }
         }
-        
+
         reloadUserDataButtons(page, item);
         renderLinks(externalLinksElem, item);
         renderUserInfo(page, item);
@@ -986,7 +979,7 @@ define(["loading", "appRouter", "layoutManager", "connectionManager", "cardBuild
         if (!canPlaySomeItemInCollection(items)) {
             hideAll(page, "btnPlay", false);
             hideAll(page, "btnShuffle", false);
-        }   
+        }
     }
 
     function renderCollectionItemType(page, parentItem, type, items) {

--- a/src/controllers/loginpage.js
+++ b/src/controllers/loginpage.js
@@ -71,11 +71,11 @@ define(["apphost", "appSettings", "dom", "connectionManager", "loading", "cardSt
                     tag: user.PrimaryImageTag,
                     type: "Primary"
                 });
-                html += '<div class="cardImageContainer coveredImage coveredImage-noScale cardProfilePhoto" style="background-image:url(\'' + imgUrl + "');\"></div>";
+                html += '<div class="cardImageContainer coveredImage coveredImage-noScale" style="background-image:url(\'' + imgUrl + "');\"></div>";
             } else {
                 var background = getMetroColor(user.Id);
                 imgUrl = "img/logindefault.png";
-                html += '<div class="cardImageContainer coveredImage coveredImage-noScale cardProfilePhoto" style="background-image:url(\'' + imgUrl + "');background-color:" + background + ';"></div>';
+                html += '<div class="cardImageContainer coveredImage coveredImage-noScale" style="background-image:url(\'' + imgUrl + "');background-color:" + background + ';"></div>';
             }
             html += "</div>";
             html += "</div>";

--- a/src/controllers/loginpage.js
+++ b/src/controllers/loginpage.js
@@ -71,11 +71,11 @@ define(["apphost", "appSettings", "dom", "connectionManager", "loading", "cardSt
                     tag: user.PrimaryImageTag,
                     type: "Primary"
                 });
-                html += '<div class="cardImageContainer coveredImage coveredImage-noScale" style="background-image:url(\'' + imgUrl + "');\"></div>";
+                html += '<div class="cardImageContainer coveredImage coveredImage-noScale cardProfilePhoto" style="background-image:url(\'' + imgUrl + "');\"></div>";
             } else {
                 var background = getMetroColor(user.Id);
                 imgUrl = "img/logindefault.png";
-                html += '<div class="cardImageContainer coveredImage coveredImage-noScale" style="background-image:url(\'' + imgUrl + "');background-color:" + background + ';"></div>';
+                html += '<div class="cardImageContainer coveredImage coveredImage-noScale cardProfilePhoto" style="background-image:url(\'' + imgUrl + "');background-color:" + background + ';"></div>';
             }
             html += "</div>";
             html += "</div>";

--- a/src/controllers/myprofile.js
+++ b/src/controllers/myprofile.js
@@ -11,7 +11,6 @@ define(["controllers/userpasswordpage", "loading", "libraryMenu", "apphost", "em
             var imageUrl = "img/logindefault.png";
             if (user.PrimaryImageTag) {
                 imageUrl = ApiClient.getUserImageUrl(user.Id, {
-                    height: 200,
                     tag: user.PrimaryImageTag,
                     type: "Primary"
                 });

--- a/src/css/dashboard.css
+++ b/src/css/dashboard.css
@@ -252,6 +252,16 @@ div[data-role=controlgroup] a.ui-btn-active {
     width: 100% !important
 }
 
+.activitylogUserPhoto {
+    height:1.71em;
+    width:1.71em;
+    border-radius:100%;
+    margin-right:.5em;
+    background-size:cover;
+    background-repeat:no-repeat;
+    background-position:center;
+}
+
 @media all and (min-width:40em) {
     .activeSession {
         width: 100% !important

--- a/src/css/librarybrowser.css
+++ b/src/css/librarybrowser.css
@@ -67,9 +67,12 @@
     display: inline-block
 }
 
-.headerUserButtonRound img {
+.headerUserButtonRound div {
     -webkit-border-radius: 100em;
-    border-radius: 100em
+    border-radius: 100em;
+    background-size: cover;
+    background-repeat: no-repeat;
+    background-position: center center;
 }
 
 .headerButton {

--- a/src/myprofile.html
+++ b/src/myprofile.html
@@ -2,7 +2,7 @@
     <div class="padded-left padded-right padded-bottom-page">
         <div class="readOnlyContent" style="margin: 0 auto; padding: 0 1em;">
             <div style="position:relative;display:inline-block;max-width:200px;">
-                <img id="image" width="200px" />
+                <img id="image" width="200px" style="background-repeat:no-repeat;background-position:center;border-radius:100%;background-size:cover;" />
                 <input id="uploadImage" type="file" accept="image/*" style="position:absolute;right:0;width:100%;height:100%;opacity:0;" />
             </div>
             <div style="vertical-align:top;margin:1em 2em;display:inline-block;">

--- a/src/scripts/librarymenu.js
+++ b/src/scripts/librarymenu.js
@@ -25,11 +25,6 @@ define(["dom", "layoutManager", "inputManager", "connectionManager", "events", "
         if (user && user.name) {
             if (user.imageUrl) {
                 var url = user.imageUrl;
-
-                if (user.supportsImageParams) {
-                    url += "&height=" + Math.round(26 * Math.max(window.devicePixelRatio || 1, 2));
-                }
-
                 updateHeaderUserButton(url);
                 hasImage = true;
             }
@@ -80,7 +75,7 @@ define(["dom", "layoutManager", "inputManager", "connectionManager", "events", "
     function updateHeaderUserButton(src) {
         if (src) {
             headerUserButton.classList.add("headerUserButtonRound");
-            headerUserButton.innerHTML = '<img src="' + src + '" />';
+            headerUserButton.innerHTML = '<div class="headerButton headerButtonRight paper-icon-button-light headerUserButtonRound" style="background-image:url(\'' + src + "');\"></div>";
         } else {
             headerUserButton.classList.remove("headerUserButtonRound");
             headerUserButton.innerHTML = '<i class="md-icon">&#xE7FD;</i>';


### PR DESCRIPTION
This Pull Request attempts to improve some quirks of how profile photos were displayed in Jellyfin Web in User's dashboard page (activity log and user panel) and login page (when users aren't hidden from login screens), as well as how artwork and photos from actors and movies are displayed.

**Before (Profile Photos):**

![58699115-0a742a00-839d-11e9-837c-d90af9aa4347](https://user-images.githubusercontent.com/10274099/59025445-77cc0300-8854-11e9-83bf-c61972c47589.png)
![58699119-0b0cc080-839d-11e9-8d97-2331cda29882](https://user-images.githubusercontent.com/10274099/59025461-82869800-8854-11e9-80dc-2d6118af755a.png)
![Captura1-3](https://user-images.githubusercontent.com/10274099/59027302-f2971d00-8858-11e9-94d5-ba0e1903fbea.PNG)
![Captura1-1](https://user-images.githubusercontent.com/10274099/59027867-6dad0300-885a-11e9-925c-3e64b7160344.PNG)


**After (Profile Photos):**

![58699117-0b0cc080-839d-11e9-8294-7b9f3277a3fc](https://user-images.githubusercontent.com/10274099/59027354-0d699180-8859-11e9-85ad-b4a9945f9f08.png)
![58699118-0b0cc080-839d-11e9-9e55-5217f2542110](https://user-images.githubusercontent.com/10274099/59027363-13f80900-8859-11e9-93e0-6ae17d7f628b.png)
![58752554-19e49780-84b1-11e9-96b0-6980c53c08ac](https://user-images.githubusercontent.com/10274099/59027424-4275e400-8859-11e9-91ba-5236bdf2625b.png)
![Captura2-1](https://user-images.githubusercontent.com/10274099/59027882-77366b00-885a-11e9-8f9a-159150baf26a.PNG)


All the profile photo scaling performed by the server is now removed. Now images are scaled by the browser using CSS. Although using the full resolution image might be seen as an overkill for data usage (specially in mobile devices), modern browsers use the cache for that matter in an intelligent way, so, in my opinion, we have two benefits here: 

1. Images always have great quality, no matter the resolution of the device
2. The user image is only downloaded one time at full resolution, instead of downloading it in smaller sizes multiple times in different places of the web app.

(The mobile version is one place where you can see the benefit of having the high resolution photo. As you can see, there are no seams, no matter how you scale the page):

![58752578-7fd11f00-84b1-11e9-93dc-52f58ddfe0c3](https://user-images.githubusercontent.com/10274099/59027825-4d7d4400-885a-11e9-84b9-e8aa17dc5245.png)


The same has been applied to the artwork, backgrounds and actor's portrait's of the media: Now the images are always downloaded at full resolution and are scaled by the browser itself. The gain in quality is really noticeable:

**Before:**

![Captura1-2](https://user-images.githubusercontent.com/10274099/59027957-a4831900-885a-11e9-920a-d560b82672a4.PNG)
![Captura1](https://user-images.githubusercontent.com/10274099/59027959-a51baf80-885a-11e9-8cb0-8f56d3642ea2.PNG)

**After:**

![Captura2](https://user-images.githubusercontent.com/10274099/59027976-b1a00800-885a-11e9-9dc7-5d36d736464b.PNG)
![Captura2-2](https://user-images.githubusercontent.com/10274099/59027977-b1a00800-885a-11e9-89d7-e223c1e17710.PNG)
