### PR TITLE
Allow Jellyfin and Emby to coexist on the same domain

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -21,6 +21,7 @@
  - [RazeLighter777](https://github.com/RazeLighter777)
  - [LogicalPhallacy](https://github.com/LogicalPhallacy)
  - [thornbill](https://github.com/thornbill)
+ - [Oddstr13](https://github.com/oddstr13)
 
 # Emby Contributors
 

--- a/src/bower_components/apiclient/credentials.js
+++ b/src/bower_components/apiclient/credentials.js
@@ -13,7 +13,7 @@ define(["events", "appStorage"], function(events, appStorage) {
     }
 
     function Credentials(key) {
-        this.key = key || "servercredentials3"
+        this.key = key || "jellyfin_credentials"
     }
     return Credentials.prototype.clear = function() {
         this._credentials = null, appStorage.removeItem(this.key)


### PR DESCRIPTION
Jellyfin and Emby both overwrite the `servercredentials3` local storage object when saved auth doesn't match. Renaming this key allows both to stay logged in on the same domain.

See jellyfin/jellyfin-apiclient-javascript#14 for corresponding apiclient pr
