### PR TITLE
Change channel mapper to sort list

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,6 +22,7 @@
  - [LogicalPhallacy](https://github.com/LogicalPhallacy)
  - [thornbill](https://github.com/thornbill)
  - [Oddstr13](https://github.com/oddstr13)
+ - [petermcneil](https://github.com/petermcneil)
 
 # Emby Contributors
 

--- a/src/components/channelmapper/channelmapper.js
+++ b/src/components/channelmapper/channelmapper.js
@@ -26,17 +26,20 @@ define(["dialogHelper", "loading", "connectionManager", "globalize", "actionshee
         }
 
         function onChannelsElementClick(e) {
-            var btnMap = parentWithClass(e.target, "btnMap");
+            const btnMap = parentWithClass(e.target, "btnMap");
             if (btnMap) {
-                var channelId = btnMap.getAttribute("data-id"),
-                    providerChannelId = btnMap.getAttribute("data-providerid"),
-                    menuItems = currentMappingOptions.ProviderChannels.map(function(m) {
-                        return {
-                            name: m.Name,
-                            id: m.Id,
-                            selected: m.Id.toLowerCase() === providerChannelId.toLowerCase()
-                        }
-                    });
+                const channelId = btnMap.getAttribute("data-id");
+                const providerChannelId = btnMap.getAttribute("data-providerid");
+                const menuItems = currentMappingOptions.ProviderChannels.map(function(m) {
+                    return {
+                        name: m.Name,
+                        id: m.Id,
+                        selected: m.Id.toLowerCase() === providerChannelId.toLowerCase()
+                    }
+                }).sort(function (a, b) {
+                    return a.name.localeCompare(b.name);
+                });
+
                 actionsheet.show({
                     positionTo: btnMap,
                     items: menuItems

--- a/src/components/channelmapper/channelmapper.js
+++ b/src/components/channelmapper/channelmapper.js
@@ -26,11 +26,11 @@ define(["dialogHelper", "loading", "connectionManager", "globalize", "actionshee
         }
 
         function onChannelsElementClick(e) {
-            const btnMap = parentWithClass(e.target, "btnMap");
+            var btnMap = parentWithClass(e.target, "btnMap");
             if (btnMap) {
-                const channelId = btnMap.getAttribute("data-id");
-                const providerChannelId = btnMap.getAttribute("data-providerid");
-                const menuItems = currentMappingOptions.ProviderChannels.map(function(m) {
+                var channelId = btnMap.getAttribute("data-id");
+                var providerChannelId = btnMap.getAttribute("data-providerid");
+                var menuItems = currentMappingOptions.ProviderChannels.map(function(m) {
                     return {
                         name: m.Name,
                         id: m.Id,


### PR DESCRIPTION
**Changes**
Channel mapper used to have a randomly sorted list making it difficult to find channels, as XMLTV returns 200+ channels to sort through.

**Issues**
Fixes https://github.com/jellyfin/jellyfin/issues/1429
