### PR TITLE
Add 'Series' button to Live TV menu off homesection

### DIFF
--- a/src/components/homesections/homesections.js
+++ b/src/components/homesections/homesections.js
@@ -703,7 +703,7 @@ define(['connectionManager', 'cardBuilder', 'appSettings', 'dom', 'apphost', 'la
 
                 html += '<a style="margin-left:.5em;margin-right:0;" is="emby-linkbutton" href="' + appRouter.getRouteUrl('livetv', {
                     serverId: apiClient.serverId(),
-                    section: 'seriesrecording' 
+                    section: 'seriesrecording'
                 }) + '" class="raised"><span>' + globalize.translate('Series') + '</span></a>';
 
                 html += '</div>';

--- a/src/components/homesections/homesections.js
+++ b/src/components/homesections/homesections.js
@@ -701,6 +701,11 @@ define(['connectionManager', 'cardBuilder', 'appSettings', 'dom', 'apphost', 'la
                     section: 'dvrschedule'
                 }) + '" class="raised"><span>' + globalize.translate('Schedule') + '</span></a>';
 
+                html += '<a style="margin-left:.5em;margin-right:0;" is="emby-linkbutton" href="' + appRouter.getRouteUrl('livetv', {
+                    serverId: apiClient.serverId(),
+                    section: 'seriesrecording' 
+                }) + '" class="raised"><span>' + globalize.translate('Series') + '</span></a>';
+
                 html += '</div>';
                 if (enableScrollX()) {
                     html += '</div>';

--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -1044,6 +1044,11 @@ var AppInfo = {};
                         return "livetv.html?tab=4&serverId=" + options.serverId;
                     }
 
+                    if ("seriesrecording" === options.section) {
+                        return "livetv.html?tab=5&serverId=" + options.serverId;
+                    }
+
+		if ("seriesrecording" === options.section) { return "livetv.html?tab=5&serverId=" + options.serverId; }
                     return "livetv.html?serverId=" + options.serverId;
                 }
 

--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -1048,10 +1048,6 @@ var AppInfo = {};
                         return "livetv.html?tab=5&serverId=" + options.serverId;
                     }
 
-		if ("seriesrecording" === options.section) { return "livetv.html?tab=5&serverId=" + options.serverId; }
-                    return "livetv.html?serverId=" + options.serverId;
-                }
-
                 if ("SeriesTimer" == itemType) {
                     return "itemdetails.html?seriesTimerId=" + id + "&serverId=" + serverId;
                 }

--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -1048,6 +1048,9 @@ var AppInfo = {};
                         return "livetv.html?tab=5&serverId=" + options.serverId;
                     }
 
+                    return "livetv.html?serverId=" + options.serverId;
+                }
+
                 if ("SeriesTimer" == itemType) {
                     return "itemdetails.html?seriesTimerId=" + id + "&serverId=" + serverId;
                 }


### PR DESCRIPTION
The Live TV section was missing the 'Series' button off of the home page.  This PR adds this missing button.

![image](https://user-images.githubusercontent.com/2521542/60279960-a83d1500-98c7-11e9-8493-df6529a495fe.png)


**Changes**
Added 'seriesrecording' options section which returns the value linked to the Series Recording page

**Issues**
Fixes https://github.com/jellyfin/jellyfin-web/issues/371