### PR TITLE
Fix to enable tuner edit again

### DIFF
--- a/src/controllers/livetvtuner.js
+++ b/src/controllers/livetvtuner.js
@@ -6,7 +6,7 @@ define(["globalize", "loading", "libraryMenu", "dom", "emby-input", "emby-button
     }
 
     function fillTypes(view, currentId) {
-        ApiClient.getJSON(ApiClient.getUrl("LiveTv/TunerHosts/Types")).then(function(types) {
+        return ApiClient.getJSON(ApiClient.getUrl("LiveTv/TunerHosts/Types")).then(function(types) {
             var selectType = view.querySelector(".selectType");
             var html = "";
             html += types.map(function(tuner) {


### PR DESCRIPTION
When going to Dashboard->Live TV->Tuner Devices->[Any Tuner]-> ... ->Edit the user was brought to a page that did not allow for editing of the tuner properties.  The console shows this error:

![Capture](https://user-images.githubusercontent.com/2521542/60534817-46feb280-9cc8-11e9-826a-002471c9ea8e.JPG)

This PR fixes this problem.