### PR TITLE
Fix menu jumping up and down

### DIFF
--- a/src/css/librarybrowser.css
+++ b/src/css/librarybrowser.css
@@ -247,23 +247,17 @@
         width: 20.205em !important;
         font-size: 94%
     }
+    
+    .headerTabs {
+    	margin-top: -2em;
+    }
 
     .dashboardDocument .mainDrawer-scrollContainer {
         margin-top: 5em !important
     }
 
-    .dashboardDocument withSectionTabs .mainDrawer-scrollContainer {
-        margin-top: 8.7em !important
-    }
-
     .dashboardDocument .skinBody {
         left: 20em
-    }
-}
-
-@media all and (min-width:40em) and (max-width:84em) {
-    .dashboardDocument.withSectionTabs .mainDrawer-scrollContainer {
-        margin-top: 8.4em !important
     }
 }
 
@@ -315,12 +309,8 @@
         top: 5.7em !important
     }
 
-    .dashboardDocument.withSectionTabs .mainDrawer-scrollContainer {
-        margin-top: 6.1em !important
-    }
-
     .dashboardDocument .mainDrawer-scrollContainer {
-        margin-top: 6.3em !important
+        margin-top: 6.1em !important
     }
 }
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
This is an attempt to fix #158 without changing header tabs behavior.

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Just move up headerTabs and remove 'withSectionTabs' specific margin-tops in css.

## Before: 
![before-without-tabs](https://user-images.githubusercontent.com/15638041/61222624-58f64180-a71b-11e9-8ae0-a856fc016a9e.png)
![before-with-tabs](https://user-images.githubusercontent.com/15638041/61222626-5b589b80-a71b-11e9-8e3a-584f127c2bc3.png)

## After:
![after-without-tabs](https://user-images.githubusercontent.com/15638041/61222643-63184000-a71b-11e9-87a8-66bc7a74cbe0.png)
![after-with-tabs](https://user-images.githubusercontent.com/15638041/61222648-64e20380-a71b-11e9-8af9-98be0334492e.png)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

#158 
