### PR TITLE
Move download action to major button for books (itemdetailspage)

### DIFF
--- a/src/components/itemcontextmenu.js
+++ b/src/components/itemcontextmenu.js
@@ -133,7 +133,8 @@ define(['apphost', 'globalize', 'connectionManager', 'itemHelper', 'appRouter', 
             }
         }
 
-        if (item.CanDownload && appHost.supports('filedownload')) {
+        // Books are promoted to major download Button and therefor excluded in the context menu
+        if ((item.CanDownload && appHost.supports('filedownload')) && item.Type !== "Book") {
             commands.push({
                 name: globalize.translate('Download'),
                 id: 'download'

--- a/src/controllers/itemdetailpage.js
+++ b/src/controllers/itemdetailpage.js
@@ -323,6 +323,10 @@ define(["loading", "appRouter", "layoutManager", "connectionManager", "cardBuild
         } else itemBirthLocation.classList.add("hide");
         setPeopleHeader(page, item), loading.hide()
 
+        if (item.Type === "Book") {
+            hideAll(page, "btnDownload", true);
+        }
+
         try {
             require(["focusManager"], function(focusManager) {
                 [".btnResume", ".btnPlay"].every(function (cls) {
@@ -1174,6 +1178,17 @@ define(["loading", "appRouter", "layoutManager", "connectionManager", "cardBuild
                 reload(self, view, params)
             }
 
+            function onDownloadClick() {
+                require(['fileDownloader'], function (fileDownloader) {
+                    var downloadHref = apiClient.getItemDownloadUrl(currentItem.Id);
+                    fileDownloader.download([{
+                        url: downloadHref,
+                        itemId: currentItem.Id,
+                        serverId: currentItem.serverId
+                    }]);
+                });
+            }
+
             function onMoreCommandsClick() {
                 var button = this;
                 apiClient.getCurrentUser().then(function(user) {
@@ -1223,6 +1238,7 @@ define(["loading", "appRouter", "layoutManager", "connectionManager", "cardBuild
             bindAll(view, ".btnCancelSeriesTimer", "click", onCancelSeriesTimerClick);
             bindAll(view, ".btnCancelTimer", "click", onCancelTimerClick);
             bindAll(view, ".btnDeleteItem", "click", onDeleteClick);
+            bindAll(view, ".btnDownload", "click", onDownloadClick);
             view.querySelector(".btnMoreCommands i").innerHTML = "&#xE5D3;";
             view.querySelector(".trackSelections").addEventListener("submit", onTrackSelectionsSubmit);
             view.querySelector(".btnSplitVersions").addEventListener("click", function() {

--- a/src/itemdetails.html
+++ b/src/itemdetails.html
@@ -74,12 +74,12 @@
                         <button is="emby-button" type="button" class="button-flat btnDownload hide detailButton-mobile">
                             <div class="detailButton-mobile-content">
                                 <i class="md-icon detailButton-mobile-icon">&#xe884;</i>
-                                <div class="detailButton-mobile-text">Download</div>
+                                <div class="detailButton-mobile-text">${ButtonDownload}</div>
                             </div>
                         </button>
 
                         <button is="emby-button" type="button" class="raised btnDownload hide detailButton">
-                            <span>Download</span>
+                            <span>${ButtonDownload}</span>
                         </button>
 
                         <button is="emby-button" type="button" class="button-flat btnPlayTrailer hide detailButton-mobile">

--- a/src/itemdetails.html
+++ b/src/itemdetails.html
@@ -71,6 +71,17 @@
                             <span>${ButtonPlay}</span>
                         </button>
 
+                        <button is="emby-button" type="button" class="button-flat btnDownload hide detailButton-mobile">
+                            <div class="detailButton-mobile-content">
+                                <i class="md-icon detailButton-mobile-icon">&#xe884;</i>
+                                <div class="detailButton-mobile-text">Download</div>
+                            </div>
+                        </button>
+
+                        <button is="emby-button" type="button" class="raised btnDownload hide detailButton">
+                            <span>Download</span>
+                        </button>
+
                         <button is="emby-button" type="button" class="button-flat btnPlayTrailer hide detailButton-mobile">
                             <div class="detailButton-mobile-content">
                                 <i class="md-icon detailButton-mobile-icon">&#xE8DA;</i>


### PR DESCRIPTION
**Changes**
Because EBooks can't be viewed within jellyfin-web this change promotes the download action from the context menu to a always visible button. 
