### PR TITLE
Enable blurred footer in chrome

### DIFF
--- a/src/components/appfooter/appfooter.js
+++ b/src/components/appfooter/appfooter.js
@@ -7,10 +7,7 @@ define(['browser', 'css!./appfooter'], function (browser) {
 
         elem.classList.add('appfooter');
 
-        if (!browser.chrome) {
-            // chrome does not display this properly
-            elem.classList.add('appfooter-blurred');
-        }
+        elem.classList.add('appfooter-blurred');
 
         document.body.appendChild(elem);
 

--- a/src/scripts/librarymenu.js
+++ b/src/scripts/librarymenu.js
@@ -894,11 +894,7 @@ define(["dom", "layoutManager", "inputManager", "connectionManager", "events", "
         headerSettingsButton = skinHeader.querySelector(".headerSettingsButton");
         headerCastButton = skinHeader.querySelector(".headerCastButton");
         headerSearchButton = skinHeader.querySelector(".headerSearchButton");
-
-        if (!browser.chrome) {
-            skinHeader.classList.add("skinHeader-blurred");
-        }
-
+        skinHeader.classList.add("skinHeader-blurred");
         lazyLoadViewMenuBarImages();
         bindMenuEvents();
     })();


### PR DESCRIPTION
Enables blurred footer also in chrome

**Changes**
Displays the now playing bar blurred in chrome as in other browsers

Before
![image](https://user-images.githubusercontent.com/14938497/62621609-99ad3900-b91c-11e9-88ff-b3ef8b99d91f.png)

After
![image](https://user-images.githubusercontent.com/14938497/62621625-9ca82980-b91c-11e9-8c16-4bd16b9b728f.png)
