### PR TITLE
Use same css rules for section tabs

### DIFF
--- a/src/css/librarybrowser.css
+++ b/src/css/librarybrowser.css
@@ -230,7 +230,6 @@
 }
 
 @media all and (min-width:40em) {
-
     .dashboardDocument .adminDrawerLogo,
     .dashboardDocument .mainDrawerButton {
         display: none !important
@@ -252,18 +251,8 @@
         margin-top: 5em !important
     }
 
-    .dashboardDocument withSectionTabs .mainDrawer-scrollContainer {
-        margin-top: 8.7em !important
-    }
-
     .dashboardDocument .skinBody {
         left: 20em
-    }
-}
-
-@media all and (min-width:40em) and (max-width:84em) {
-    .dashboardDocument.withSectionTabs .mainDrawer-scrollContainer {
-        margin-top: 8.4em !important
     }
 }
 
@@ -275,11 +264,11 @@
 
 @media all and (max-width:84em) {
     .withSectionTabs .headerTop {
-        padding-bottom: .2em
+        padding-bottom: 0.2em;
     }
 
     .sectionTabs {
-        font-size: 83.5%
+        font-size: 83.5%;
     }
 }
 
@@ -315,12 +304,8 @@
         top: 5.7em !important
     }
 
-    .dashboardDocument.withSectionTabs .mainDrawer-scrollContainer {
-        margin-top: 6.1em !important
-    }
-
     .dashboardDocument .mainDrawer-scrollContainer {
-        margin-top: 6.3em !important
+        margin-top: 6em !important;
     }
 }
 

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1347,7 +1347,7 @@
     "TabMyPlugins": "My Plugins",
     "TabNetworks": "Networks",
     "TabNetworking": "Networking",
-    "TabNfoSettings": "NFO settings",
+    "TabNfoSettings": "NFO Settings",
     "TabNotifications": "Notifications",
     "TabOther": "Other",
     "TabParentalControl": "Parental Control",


### PR DESCRIPTION
I made some minor changes to #389 so those improvements don't get lost. The different styles for each screen size are kept but the special case for section tabs is gone to prevent the issue.