### PR TITLE
Add sorting for music albums in an artist's details page

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -25,6 +25,7 @@
  - [DrPandemic](https://github.com/drpandemic)
  - [Oddstr13](https://github.com/oddstr13)
  - [petermcneil](https://github.com/petermcneil)
+ - [lewazo](https://github.com/lewazo)
 
 # Emby Contributors
 

--- a/src/scripts/itembynamedetailpage.js
+++ b/src/scripts/itembynamedetailpage.js
@@ -132,7 +132,9 @@ define(["connectionManager", "listView", "cardBuilder", "imageLoader", "libraryB
                     IncludeItemTypes: "MusicAlbum",
                     PersonTypes: "",
                     ArtistIds: "",
-                    AlbumArtistIds: ""
+                    AlbumArtistIds: "",
+                    SortOrder: "Descending",
+                    SortBy: "ProductionYear,Sortname"
                 }, {
                     shape: "square",
                     playFromHere: !0,


### PR DESCRIPTION
Fixes https://github.com/jellyfin/jellyfin-web/issues/344

This is a pretty simple fix to make sure that the music albums are sorted by ProductionYear and SortName in descending order, so it acts the same way as the "More from «ArtistName»" section.