### PR TITLE
Fix preload background color

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -78,7 +78,7 @@
         }
 
         .preload {
-            background-color: #000;
+            background-color: #101010;
         }
 
         .hide, .mouseIdle .hide-mouse-idle, .mouseIdle-tv .hide-mouse-idle-tv {


### PR DESCRIPTION
**Changes**
Changes the background color used when Jellyfin initially loads to use the default background color `#101010` instead of pure black.

**Issues**
N/A
