### PR TITLE
Add prepare script for git installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "dev": "webpack --mode development",
     "build": "webpack --mode production",
-    "lint": "eslint src"
+    "lint": "eslint src",
+    "prepare": "webpack --mode production"
   }
 }


### PR DESCRIPTION
**Changes**
This adds a `prepare` script to allow projects to use npm to install the git repository as a dependency. Otherwise the `dist` directory does not get generated.

**Issues**
N/A
