### PR TITLE
Add string for LabelFolder

### DIFF
--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -639,6 +639,7 @@
     "LabelFailed": "Failed",
     "LabelFileOrUrl": "File or url:",
     "LabelFinish": "Finish",
+    "LabelFolder": "Folder:",
     "LabelFont": "Font:",
     "LabelForgotPasswordUsernameHelp": "Enter your username, if you remember it.",
     "LabelFormat": "Format:",


### PR DESCRIPTION
**Issues**
Localization of LabelFolder is missing during setup wizard #421
