### PR TITLE
Don't hide play all and shuffle buttons on mobile

### DIFF
--- a/src/music.html
+++ b/src/music.html
@@ -3,8 +3,8 @@
     <style>
         @media all and (max-width: 32em) {
 
-            .musicglobalButton {
-                display: none;
+            .paging {
+                width: 100%;
             }
         }
     </style>


### PR DESCRIPTION
**Changes**
Play all and shuffle buttons are no longer are hidden on mobile.
It looks like this was done so it would fit better on the smaller screen, so my proposed solution is to move the pagination controls above the buttons on mobile.

![Example of what it looks like](https://user-images.githubusercontent.com/1357212/64468181-86ca9600-d160-11e9-8f68-3c835033cbd6.png)