### PR TITLE
Disable animations in editor sidebar

### DIFF
--- a/src/scripts/editorsidebar.js
+++ b/src/scripts/editorsidebar.js
@@ -241,6 +241,8 @@ define(["datetime", "jQuery", "material-icons"], function (datetime, $) {
         $(".libraryTree", page).jstree({
             "plugins": ["wholerow"],
             core: {
+                // Disable animations because jQuery slim does not support them
+                animation: false,
                 check_callback: true,
                 data: function (node, callback) {
                     loadNode(page, this, node, openItems, selectedId, currentUser, callback);


### PR DESCRIPTION
**Changes**
Fixes the editor sidebar not expanding because it tries to use jQuery animations which are not supported in the version of jQuery slim included here.

This was removed in https://github.com/jellyfin/jellyfin-web/commit/2ffbc14cd7170cb7757954f10dbceb69c930759e#diff-2d0ce3ffff473ca542608d32ede5c576

**Issues**
N/A
