### PR TITLE
Fix: Not all players support xxxSubtitleOffset

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -1643,7 +1643,9 @@ define(['events', 'datetime', 'appSettings', 'itemHelper', 'pluginManager', 'pla
 
         self.disableShowingSubtitleOffset = function(player) {
             player = player || self._currentPlayer;
-            player.disableShowingSubtitleOffset();
+            if (player.disableShowingSubtitleOffset) {
+                player.disableShowingSubtitleOffset();
+            }            
         }
 
         self.isShowingSubtitleOffsetEnabled = function(player) {
@@ -1658,12 +1660,16 @@ define(['events', 'datetime', 'appSettings', 'itemHelper', 'pluginManager', 'pla
 
         self.setSubtitleOffset = function (value, player) {
             player = player || self._currentPlayer;
-            player.setSubtitleOffset(value);
+            if (player.setSubtitleOffset) {
+                player.setSubtitleOffset(value);
+            }
         };
 
         self.getPlayerSubtitleOffset = function(player) {
             player = player || self._currentPlayer;
-            return player.getSubtitleOffset();
+            if (player.getPlayerSubtitleOffset) {
+                return player.getSubtitleOffset();
+            }
         }
 
         self.canHandleOffsetOnCurrentSubtitle = function(player) {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->

Not all players support the function `xxxSubtitleOffset`, i.e. the youtube player does not have it. This resulted in errors when playing a trailer (which uses the youtube player).

**Changes**
Added if conditions for `xxxSubtitleOffset` functions in `playbackmanager.js`.
