### PR TITLE
Changed to non-blocking subtitles

### DIFF
--- a/src/controllers/videoosd.js
+++ b/src/controllers/videoosd.js
@@ -603,6 +603,14 @@ define(["playbackManager", "dom", "inputmanager", "datetime", "itemHelper", "med
             }, state);
         }
 
+        function onBeginFetch() {
+            document.querySelector(".osdMediaStatus").classList.remove("hide");
+        }
+
+        function onEndFetch() {
+            document.querySelector(".osdMediaStatus").classList.add("hide");
+        }
+
         function bindToPlayer(player) {
             if (player !== currentPlayer) {
                 releaseCurrentPlayer();
@@ -621,7 +629,13 @@ define(["playbackManager", "dom", "inputmanager", "datetime", "itemHelper", "med
             events.on(player, "timeupdate", onTimeUpdate);
             events.on(player, "fullscreenchange", updateFullscreenIcon);
             events.on(player, "mediastreamschange", onMediaStreamsChanged);
+            events.on(player, "beginFetch", onBeginFetch);
+            events.on(player, "endFetch", onEndFetch);
             resetUpNextDialog();
+
+            if (player.isFetching) {
+                onBeginFetch();
+            }
         }
 
         function releaseCurrentPlayer() {

--- a/src/css/videoosd.css
+++ b/src/css/videoosd.css
@@ -214,6 +214,19 @@
     align-items: baseline
 }
 
+.osdMediaStatus {
+    margin-left: auto;
+}
+
+@-moz-keyframes spin { 100% { -moz-transform: rotate(360deg); } }
+@-webkit-keyframes spin { 100% { -webkit-transform: rotate(360deg); } }
+@keyframes spin { 100% { -webkit-transform: rotate(360deg); transform:rotate(360deg); } }
+.osdMediaStatus .animate {
+    -webkit-animation:spin 4s linear infinite;
+    -moz-animation:spin 4s linear infinite;
+    animation:spin 4s linear infinite;
+}
+
 .pageContainer {
     top: 0;
     position: fixed
@@ -236,7 +249,8 @@
 }
 
 @media all and (max-width:43em) {
-    .videoOsdBottom .volumeButtons {
+    .videoOsdBottom .volumeButtons,
+    .osdMediaStatus span {
         display: none !important
     }
 }

--- a/src/strings/de.json
+++ b/src/strings/de.json
@@ -238,6 +238,7 @@
     "FastForward": "Vorwärts spulen",
     "Favorite": "Favorit",
     "Favorites": "Favoriten",
+    "FetchingData": "Lade zusätzliche Daten",
     "File": "Datei",
     "FileNotFound": "Datei nicht gefunden.",
     "FileReadCancelled": "Dateiimport wurde abgebrochen.",

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -250,6 +250,7 @@
     "Favorite": "Favorite",
     "Favorites": "Favorites",
     "Features": "Features",
+    "FetchingData": "Fetching additional data",
     "File": "File",
     "FileNotFound": "File not found.",
     "FileReadCancelled": "The file read has been canceled.",

--- a/src/videoosd.html
+++ b/src/videoosd.html
@@ -15,6 +15,9 @@
             <div class="osdTextContainer osdMainTextContainer">
                 <h3 class="osdTitle"></h3>
                 <div class="osdMediaInfo"></div>
+                <div class="osdMediaStatus hide">
+                    <i class="md-icon animate">autorenew</i> <span>${FetchingData}</span>
+                </div>
             </div>
 
             <div class="osdTextContainer osdSecondaryMediaInfo">


### PR DESCRIPTION
_Behavior before_:   
When the user starts the video playback, for every `SUBRIP` a `<track />` element was created inside the main `<video />` tag. The propper playback started after all tracks were loaded.

In my case most of the subtitles are embedded, so jellyfin extracted the subtitles on-the-fly which took (depending on the file size) quite a while - even if I don't want to display a subtitle.

--> For a few minutes the `playing` event wasn't triggered, the `videoosd` interface was not shown and depending on the webbrowser the `<video/>` element behaved very strange.

**Changes** (_Behavior after_)
No tracks are added anymore. Jellyfin uses either the custom element (Firefox) to render the subtitle, or uses the TextTrackCue method (Chrome). These are loaded asynchronos while the playback starts. A little text indicates, that additional data is loading. Only the selected subtitle is loaded.

**Notes**
I am surprised that nobody has reported this behavior as a bug yet. While waiting for subtitles the first few seconds of the video were played in permanent loop (Chrome). Was hard for me to figure out that the mistake is in the subtitles.

Actually there were 3 ways to display subtitles (excluding the server-side burning):
(1) Using the trackCueObject
(2) Using the custom `videoSubtitles` event
(3) Using native `<tracks/>`

I think due to a bug, method (1) was never used. I eliminated method (3) and stick with (1) and (2).
We could use blobs for method (3) to enable asnychronous loading, but I do not see any advantages in using this method.

But may I'm wrong and this waiting-for-subtitles behavior is intended. For my use case this behavior was ... anoying :D
