### PR TITLE
update apphost appVersion to 10.4.0

### DIFF
--- a/src/components/apphost.js
+++ b/src/components/apphost.js
@@ -313,7 +313,7 @@ define(["appSettings", "browser", "events", "htmlMediaHelper"], function (appSet
     var deviceId;
     var deviceName;
     var appName = "Jellyfin Web";
-    var appVersion = "10.3.6";
+    var appVersion = "10.4.0";
     var visibilityChange;
     var visibilityState;
 


### PR DESCRIPTION
The only place I saw this appear was in a log entry, so not sure what else this will impact (or if it's deliberately being held back).  It looks like it is also passed in when the ApiClient is created.
```
[13:23:15] [INF] Playback stopped reported by app Jellyfin Web 10.3.6 playing cam-basement. Stopped at 29411 ms
```

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
- Change appVersion string from 10.3.6 to 10.4.0 in apphost.js

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
