### PR TITLE
add 700ms timer for 'mousemove' and 'touchmove' volume listeners

### DIFF
--- a/src/controllers/videoosd.js
+++ b/src/controllers/videoosd.js
@@ -1209,7 +1209,7 @@ define(["playbackManager", "dom", "inputmanager", "datetime", "itemHelper", "med
         var programEndDateMs = 0;
         var playbackStartTimeTicks = 0;
         var subtitleSyncOverlay;
-        var volumeSliderTimer = 0;
+        var volumeSliderTimer;
         var nowPlayingVolumeSlider = view.querySelector(".osdVolumeSlider");
         var nowPlayingVolumeSliderContainer = view.querySelector(".osdVolumeSliderContainer");
         var nowPlayingPositionSlider = view.querySelector(".osdPositionSlider");
@@ -1332,20 +1332,33 @@ define(["playbackManager", "dom", "inputmanager", "datetime", "itemHelper", "med
             playbackManager.toggleMute(currentPlayer);
         });
         nowPlayingVolumeSlider.addEventListener("change", function () {
+            if(volumeSliderTimer){
+                // interupt and remove existing timer
+                clearTimeout(volumeSliderTimer);
+                volumeSliderTimer = null;
+            }
             playbackManager.setVolume(this.value, currentPlayer);
         });
         nowPlayingVolumeSlider.addEventListener("mousemove", function () {
-            var now = new Date().getTime();
-            if ((now - volumeSliderTimer) > 700) {
-                volumeSliderTimer = now;
-                playbackManager.setVolume(this.value, currentPlayer);
+            if(!volumeSliderTimer){
+                var that = this;
+                // register new timer
+                volumeSliderTimer = setTimeout(function(){
+                    playbackManager.setVolume(that.value, currentPlayer);
+                    // delete timer after completion
+                    volumeSliderTimer = null;
+                }, 700);
             }
         });
         nowPlayingVolumeSlider.addEventListener("touchmove", function () {
-            var now = new Date().getTime();
-            if ((now - volumeSliderTimer) > 700) {
-                volumeSliderTimer = now;
-                playbackManager.setVolume(this.value, currentPlayer);
+            if(!volumeSliderTimer){
+                var that = this;
+                // register new timer
+                volumeSliderTimer = setTimeout(function(){
+                    playbackManager.setVolume(that.value, currentPlayer);
+                    // delete timer after completion
+                    volumeSliderTimer = null;
+                }, 700);
             }
         });
 

--- a/src/controllers/videoosd.js
+++ b/src/controllers/videoosd.js
@@ -1209,6 +1209,7 @@ define(["playbackManager", "dom", "inputmanager", "datetime", "itemHelper", "med
         var programEndDateMs = 0;
         var playbackStartTimeTicks = 0;
         var subtitleSyncOverlay;
+        var volumeSliderTimer = 0;
         var nowPlayingVolumeSlider = view.querySelector(".osdVolumeSlider");
         var nowPlayingVolumeSliderContainer = view.querySelector(".osdVolumeSliderContainer");
         var nowPlayingPositionSlider = view.querySelector(".osdPositionSlider");
@@ -1334,10 +1335,18 @@ define(["playbackManager", "dom", "inputmanager", "datetime", "itemHelper", "med
             playbackManager.setVolume(this.value, currentPlayer);
         });
         nowPlayingVolumeSlider.addEventListener("mousemove", function () {
-            playbackManager.setVolume(this.value, currentPlayer);
+            var now = new Date().getTime();
+            if ((now - volumeSliderTimer) > 700) {
+                volumeSliderTimer = now;
+                playbackManager.setVolume(this.value, currentPlayer);
+            }
         });
         nowPlayingVolumeSlider.addEventListener("touchmove", function () {
-            playbackManager.setVolume(this.value, currentPlayer);
+            var now = new Date().getTime();
+            if ((now - volumeSliderTimer) > 700) {
+                volumeSliderTimer = now;
+                playbackManager.setVolume(this.value, currentPlayer);
+            }
         });
 
         nowPlayingPositionSlider.addEventListener("change", function () {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
This PR is a proposal for #453 (Volume slider generates hundreds of Playback requests) : 

The 'mousemove' and 'touchmove' volume slider listeners make a server request for each increment when moving the slider. 
This PR set a timer on those two listeners to limit the number of requests.

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
* When 'mousemove' or 'touchmove' listeners are triggered, a new request is sent to the server only if 700ms elapsed since the last one.
* The timer's limit of 700ms is arbitrary (same as onTimeUpdate(e) limit in videoosd.js). 
* 700ms seems to me a good compromise between responsiveness and number requests limitation, but it could be changed.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Possibly #453