### PR TITLE
Fix video osd header styles

### DIFF
--- a/src/css/videoosd.css
+++ b/src/css/videoosd.css
@@ -19,10 +19,10 @@
     transition: opacity .3s ease-out;
     position: relative;
     z-index: 1;
-    background-color: rgba(0, 0, 0, 0.7) !important;
+    background: rgba(0, 0, 0, 0.7) !important;
     -webkit-backdrop-filter: none !important;
     backdrop-filter: none !important;
-    color: #eee
+    color: #eee !important;
 }
 
 .osdHeader-hidden {


### PR DESCRIPTION
**Changes**
* Uses `background` to override theme setting for video osd header color.
* Adds `!important` to font color to override theme.

***Before:***
![Screenshot_2019-09-25 Jellyfin](https://user-images.githubusercontent.com/3450688/65569313-1dea6880-df2b-11e9-99d0-ac723ede42d0.jpg)

***After:***
![Screenshot_2019-09-25 Jellyfin(1)](https://user-images.githubusercontent.com/3450688/65569304-14610080-df2b-11e9-88cb-195391845035.jpg)

**Issues**
Fixes: #454 
