### PR TITLE
Revert "Allow card text to continue through line breaks"

### DIFF
--- a/src/components/cardbuilder/card.css
+++ b/src/components/cardbuilder/card.css
@@ -267,7 +267,6 @@ button {
 
 .cardFooter {
     padding: .3em .3em .5em .3em;
-    height: 3.5em;
     position: relative;
 }
 
@@ -298,6 +297,7 @@ button {
 
 .cardText {
     padding: .06em .5em;
+    white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
     text-align: left;
@@ -309,11 +309,6 @@ button {
 
 .cardText-first {
     padding-top: .24em;
-    display: -webkit-box;
-    line-height: 16px; /* fallback */
-    max-height: 32px; /* fallback */
-    -webkit-line-clamp: 2; /* number of lines to show */
-    -webkit-box-orient: vertical;
 }
 
 .cardText > .textActionButton {


### PR DESCRIPTION
**Changes**
Reverts changes to allow multiline text in card footers.

**Issues**
Fixes #485
