### PR TITLE
Restore prepare script

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -29,6 +29,10 @@ jobs:
       displayName: 'Install dependencies'
 
     - script: |
+        test -d dist
+      displayName: 'Check dist directory'
+
+    - script: |
         yarn pack --filename jellyfin-web.tgz
       displayName: 'Build package'
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "scripts": {
     "serve": "webpack-dev-server --config webpack.dev.js --open",
     "build": "webpack --config webpack.prod.js",
-    "lint": "eslint \"src\""
+    "lint": "eslint \"src\"",
+    "prepare": "webpack --config webpack.prod.js"
   }
 }


### PR DESCRIPTION
**Changes**
* Adds CI check for `dist` directory creation on install. See: https://dev.azure.com/jellyfin-project/jellyfin/_build/results?buildId=1006
* Restores `prepare` script in `package.json`.

**Issues**
N/A
