### PR TITLE
Resolves missing policy error on user creation

### DIFF
--- a/src/bower_components/apiclient/apiclientcore.js
+++ b/src/bower_components/apiclient/apiclientcore.js
@@ -1195,7 +1195,7 @@ define(["events", "appStorage"], function(events, appStorage) {
         return this.ajax({
             type: "POST",
             url: url,
-            data: {
+            data: user,
                     Name: user.Name,
                     Password: user.Password
                 },

--- a/src/bower_components/apiclient/apiclientcore.js
+++ b/src/bower_components/apiclient/apiclientcore.js
@@ -1198,7 +1198,6 @@ define(["events", "appStorage"], function(events, appStorage) {
             data: {
                     Name: user.Name,
                     Password: user.Password
-
                 },
             dataType: "json"
         })

--- a/src/bower_components/apiclient/apiclientcore.js
+++ b/src/bower_components/apiclient/apiclientcore.js
@@ -1196,9 +1196,6 @@ define(["events", "appStorage"], function(events, appStorage) {
             type: "POST",
             url: url,
             data: user,
-                    Name: user.Name,
-                    Password: user.Password
-                },
             dataType: "json"
         })
     }, ApiClient.prototype.updateUser = function(user) {

--- a/src/bower_components/apiclient/apiclientcore.js
+++ b/src/bower_components/apiclient/apiclientcore.js
@@ -1195,8 +1195,12 @@ define(["events", "appStorage"], function(events, appStorage) {
         return this.ajax({
             type: "POST",
             url: url,
-            data: JSON.stringify(user),
-            contentType: "application/json"
+            data: {
+                    Name: user.Name,
+                    Password: user.Password
+
+                },
+            dataType: "json"
         })
     }, ApiClient.prototype.updateUser = function(user) {
         if (!user) throw new Error("null user");


### PR DESCRIPTION
Restores the previous method of posting the Users/New request, but adds the password field as well.


**Note**
I'm sure this isn't right, but this does fix the problem here.
