### PR TITLE
Fix subtitle sync

### DIFF
--- a/src/components/htmlvideoplayer/plugin.js
+++ b/src/components/htmlvideoplayer/plugin.js
@@ -580,18 +580,15 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
 
             Array.from(videoElement.textTracks)
             .filter(function(trackElement) {
-                if (customTrackIndex === -1 ) {
-                    // get showing .vtt textTacks
-                    return trackElement.mode === 'showing';
-                } else {
-                    // get current .ass textTrack
-                    return ("textTrack" + customTrackIndex) === trackElement.id;
-                }
+                // get showing .vtt textTacks
+                return (trackElement.mode === 'showing') ||
+                // get current .ass textTrack
+                (("textTrack" + customTrackIndex) === trackElement.id);
             })
             .forEach(function(trackElement) {
 
-                var track = mediaStreamTextTracks.filter(function(stream) {
-                    return ("textTrack" + stream.Index) === trackElement.id;
+                var track = customTrackIndex === -1 ? null : mediaStreamTextTracks.filter(function (t) {
+                    return t.Index === customTrackIndex;
                 })[0];
 
                 if(track) {

--- a/src/components/htmlvideoplayer/plugin.js
+++ b/src/components/htmlvideoplayer/plugin.js
@@ -577,7 +577,7 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
             var offsetValue = parseFloat(offset);
 
             // if .ass currently rendering
-            if(currentAssRenderer){
+            if (currentAssRenderer){
                 updateCurrentTrackOffset(offsetValue);
             } else {
                 var videoElement = self._mediaElement;

--- a/src/components/htmlvideoplayer/plugin.js
+++ b/src/components/htmlvideoplayer/plugin.js
@@ -575,35 +575,34 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
         self.setSubtitleOffset = function(offset) {
 
             var offsetValue = parseFloat(offset);
-            var videoElement = self._mediaElement;
-            var mediaStreamTextTracks = getMediaStreamTextTracks(self._currentPlayOptions.mediaSource);
 
-            Array.from(videoElement.textTracks)
-            .filter(function(trackElement) {
-                // get showing .vtt textTacks
-                var isVttTrackShowing = trackElement.mode === 'showing';
-                // get current .ass textTrack
-                var isAssTrackShowing = ("textTrack" + customTrackIndex) === trackElement.id;
-                
-                return isVttTrackShowing || isAssTrackShowing;
-            })
-            .forEach(function(trackElement) {
+            // if .ass currently rendering
+            if(currentAssRenderer){
+                updateCurrentTrackOffset(offsetValue);
+            } else {
+                var videoElement = self._mediaElement;
+                var mediaStreamTextTracks = getMediaStreamTextTracks(self._currentPlayOptions.mediaSource);
 
-                var track = customTrackIndex === -1 ? null : mediaStreamTextTracks.filter(function (t) {
-                    return t.Index === customTrackIndex;
-                })[0];
+                Array.from(videoElement.textTracks)
+                .filter(function(trackElement) {
+                    // get showing .vtt textTacks
+                    return trackElement.mode === 'showing';
+                })
+                .forEach(function(trackElement) {
 
-                if(track) {
-                    offsetValue = updateCurrentTrackOffset(offsetValue);
-                    var format = (track.Codec || '').toLowerCase();
-                    if (format !== 'ass' && format !== 'ssa') {
+                    var track = customTrackIndex === -1 ? null : mediaStreamTextTracks.filter(function (t) {
+                        return t.Index === customTrackIndex;
+                    })[0];
+
+                    if(track) {
+                        offsetValue = updateCurrentTrackOffset(offsetValue);
                         setVttSubtitleOffset(trackElement, offsetValue);
+                    } else {
+                        console.log("No available track, cannot apply offset : " + offsetValue);
                     }
-                } else {
-                    console.log("No available track, cannot apply offset : " + offsetValue);
-                }
 
-            });
+                });
+            }
         };
 
         function updateCurrentTrackOffset(offsetValue) {

--- a/src/components/htmlvideoplayer/plugin.js
+++ b/src/components/htmlvideoplayer/plugin.js
@@ -584,7 +584,7 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
                 var mediaStreamTextTracks = getMediaStreamTextTracks(self._currentPlayOptions.mediaSource);
 
                 Array.from(videoElement.textTracks)
-                .filter(function(trackElement) {
+                    .filter(function(trackElement) {
                     // get showing .vtt textTacks
                     return trackElement.mode === 'showing';
                 })

--- a/src/components/htmlvideoplayer/plugin.js
+++ b/src/components/htmlvideoplayer/plugin.js
@@ -581,9 +581,11 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
             Array.from(videoElement.textTracks)
             .filter(function(trackElement) {
                 // get showing .vtt textTacks
-                return (trackElement.mode === 'showing') ||
+                var isVttTrackShowing = trackElement.mode === 'showing';
                 // get current .ass textTrack
-                (("textTrack" + customTrackIndex) === trackElement.id);
+                var isAssTrackShowing = ("textTrack" + customTrackIndex) === trackElement.id;
+                
+                return isVttTrackShowing || isAssTrackShowing;
             })
             .forEach(function(trackElement) {
 

--- a/src/components/htmlvideoplayer/plugin.js
+++ b/src/components/htmlvideoplayer/plugin.js
@@ -594,7 +594,7 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
                         return t.Index === customTrackIndex;
                     })[0];
 
-                    if(track) {
+                    if (track) {
                         offsetValue = updateCurrentTrackOffset(offsetValue);
                         setVttSubtitleOffset(trackElement, offsetValue);
                     } else {

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -1667,7 +1667,7 @@ define(['events', 'datetime', 'appSettings', 'itemHelper', 'pluginManager', 'pla
 
         self.getPlayerSubtitleOffset = function(player) {
             player = player || self._currentPlayer;
-            if (player.getPlayerSubtitleOffset) {
+            if (player.getSubtitleOffset) {
                 return player.getSubtitleOffset();
             }
         }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->
Quick PR to fix two problems I've experienced since 10.4.0 upgrade:

* Moving subtitle-sync slider doesn't apply offset to vtt subtitles.
* After closing or fading, subtitle-sync doesn't recover previous subtitle offset.

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
* Update code to recover subtitle-track.
* The wrong function was tested in "getPlayerSubtitleOffset" in playbackmanager.js (test if actual player support subtitle-sync): it always returned false and subtitleOffset was interpreted as 0.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
