### PR TITLE
Rearrange and add metadata button in top-right

### DIFF
--- a/src/scripts/librarymenu.js
+++ b/src/scripts/librarymenu.js
@@ -890,13 +890,13 @@ define(["dom", "layoutManager", "inputManager", "connectionManager", "events", "
         html += '<span class="headerSelectedPlayer"></span>';
         html += '<button is="paper-icon-button-light" class="headerCastButton castButton headerButton headerButtonRight hide"><i class="md-icon">&#xE307;</i></button>';
         html += '<button type="button" is="paper-icon-button-light" class="headerButton headerButtonRight headerSearchButton hide"><i class="md-icon">&#xE8B6;</i></button>';
-        html += '<button is="paper-icon-button-light" class="headerButton headerButtonRight headerUserButton hide"><i class="md-icon">&#xE7FD;</i></button>';
 
         if (!layoutManager.mobile) {
             html += '<button is="paper-icon-button-light" class="headerButton headerButtonRight headerMetadataEditorButton hide"><i class="md-icon">mode_edit</i></button>';
             html += '<button is="paper-icon-button-light" class="headerButton headerButtonRight headerSettingsButton hide"><i class="md-icon">dashboard</i></button>';
         }
 
+        html += '<button is="paper-icon-button-light" class="headerButton headerButtonRight headerUserButton hide"><i class="md-icon">&#xE7FD;</i></button>';
         html += "</div>";
         html += "</div>";
         html += '<div class="headerTabs sectionTabs hide">';

--- a/src/scripts/librarymenu.js
+++ b/src/scripts/librarymenu.js
@@ -52,6 +52,13 @@ define(["dom", "layoutManager", "inputManager", "connectionManager", "events", "
                 headerSearchButton.classList.remove("hide");
             }
 
+            if (headerMetadataEditorButton) {
+                if (user.localUser.Policy.IsAdministrator) {
+                    headerMetadataEditorButton.classList.remove("hide");
+                } else {
+                    headerMetadataEditorButton.classList.add("hide");
+                }
+            }
             if (headerSettingsButton) {
                 if (user.localUser.Policy.IsAdministrator) {
                     headerSettingsButton.classList.remove("hide");
@@ -69,6 +76,9 @@ define(["dom", "layoutManager", "inputManager", "connectionManager", "events", "
                 headerSearchButton.classList.add("hide");
             }
 
+            if (headerMetadataEditorButton) {
+                headerMetadataEditorButton.classList.add("hide");
+            }
             if (headerSettingsButton) {
                 headerSettingsButton.classList.add("hide");
             }
@@ -93,6 +103,10 @@ define(["dom", "layoutManager", "inputManager", "connectionManager", "events", "
 
     function onHeaderUserButtonClick(e) {
         Dashboard.navigate("mypreferencesmenu.html");
+    }
+
+    function onMetadataEditorClick(e) {
+        Dashboard.navigate("edititemmetadata.html");
     }
 
     function onSettingsClick(e) {
@@ -124,6 +138,9 @@ define(["dom", "layoutManager", "inputManager", "connectionManager", "events", "
         initHeadRoom(skinHeader);
         headerCastButton.addEventListener("click", onCastButtonClicked);
 
+        if (headerMetadataEditorButton) {
+            headerMetadataEditorButton.addEventListener("click", onMetadataEditorClick);
+        }
         if (headerSettingsButton) {
             headerSettingsButton.addEventListener("click", onSettingsClick);
         }
@@ -747,6 +764,7 @@ define(["dom", "layoutManager", "inputManager", "connectionManager", "events", "
     var headerBackButton;
     var headerUserButton;
     var currentUser;
+    var headerMetadataEditorButton;
     var headerSettingsButton;
     var headerCastButton;
     var headerSearchButton;
@@ -875,6 +893,7 @@ define(["dom", "layoutManager", "inputManager", "connectionManager", "events", "
         html += '<button is="paper-icon-button-light" class="headerButton headerButtonRight headerUserButton hide"><i class="md-icon">&#xE7FD;</i></button>';
 
         if (!layoutManager.mobile) {
+            html += '<button is="paper-icon-button-light" class="headerButton headerButtonRight headerMetadataEditorButton hide"><i class="md-icon">mode_edit</i></button>';
             html += '<button is="paper-icon-button-light" class="headerButton headerButtonRight headerSettingsButton hide"><i class="md-icon">dashboard</i></button>';
         }
 
@@ -886,6 +905,7 @@ define(["dom", "layoutManager", "inputManager", "connectionManager", "events", "
         skinHeader.innerHTML = html;
         headerHomeButton = skinHeader.querySelector(".headerHomeButton");
         headerUserButton = skinHeader.querySelector(".headerUserButton");
+        headerMetadataEditorButton = skinHeader.querySelector(".headerMetadataEditorButton");
         headerSettingsButton = skinHeader.querySelector(".headerSettingsButton");
         headerCastButton = skinHeader.querySelector(".headerCastButton");
         headerSearchButton = skinHeader.querySelector(".headerSearchButton");


### PR DESCRIPTION
**Changes**
1. Adds a Metadata editor button on the top right menu, to match the dashboard button. Avoids this visually being hidden away in the user menu. IMO if we have a dashboard button here, this probably should be too.
2. Move the User button to the end. IMO this is visually nicer as it's the "main" button.

**Issues**
N/A

**Visual**

![Screenshot from 2019-10-08 19-07-58](https://user-images.githubusercontent.com/4031396/66439888-2482e080-e9ff-11e9-90e0-c09ded15ced7.png)
