### PR TITLE
Tizen: Remove tab activation by focus

### DIFF
--- a/src/components/emby-tabs/emby-tabs.js
+++ b/src/components/emby-tabs/emby-tabs.js
@@ -10,23 +10,6 @@ define(['dom', 'scroller', 'browser', 'layoutManager', 'focusManager', 'register
         newButton.classList.add(activeButtonClass);
     }
 
-    function getFocusCallback(tabs, e) {
-        return function () {
-            onClick.call(tabs, e);
-        };
-    }
-
-    function onFocus(e) {
-
-        if (layoutManager.tv) {
-
-            if (this.focusTimeout) {
-                clearTimeout(this.focusTimeout);
-            }
-            this.focusTimeout = setTimeout(getFocusCallback(this, e), 700);
-        }
-    }
-
     function getTabPanel(tabs, index) {
 
         return null;
@@ -86,10 +69,6 @@ define(['dom', 'scroller', 'browser', 'layoutManager', 'focusManager', 'register
     }
 
     function onClick(e) {
-
-        if (this.focusTimeout) {
-            clearTimeout(this.focusTimeout);
-        }
 
         var tabs = this;
 
@@ -177,10 +156,6 @@ define(['dom', 'scroller', 'browser', 'layoutManager', 'focusManager', 'register
         dom.addEventListener(this, 'click', onClick, {
             passive: true
         });
-        dom.addEventListener(this, 'focus', onFocus, {
-            passive: true,
-            capture: true
-        });
     };
 
     EmbyTabs.focus = function () {
@@ -236,10 +211,6 @@ define(['dom', 'scroller', 'browser', 'layoutManager', 'focusManager', 'register
 
         dom.removeEventListener(this, 'click', onClick, {
             passive: true
-        });
-        dom.removeEventListener(this, 'focus', onFocus, {
-            passive: true,
-            capture: true
         });
     };
 


### PR DESCRIPTION
When navigating the top menu (on TV), the tab is activated by focus, sometimes losing focus. This behavior has been removed to make the top menu navigation "smoother".