### PR TITLE
Set "Resume" action on season item on TV

### DIFF
--- a/src/controllers/itemdetailpage.js
+++ b/src/controllers/itemdetailpage.js
@@ -818,7 +818,7 @@ define(["loading", "appRouter", "layoutManager", "connectionManager", "cardBuild
                     imageSize: "large",
                     enableSideMediaInfo: !1,
                     highlight: !1,
-                    action: "none",
+                    action: layoutManager.tv ? "resume" : "none",
                     infoButton: !0,
                     imagePlayButton: !0,
                     includeParentInfoInTitle: !1


### PR DESCRIPTION
Made to be able to play/resume an episode of a TV season on the TV ^_^. Prior to this, there was no action at all. I have doubts about where the action is specified, but it works.