### PR TITLE
Add autofocus on page load

### DIFF
--- a/src/components/autoFocuser.js
+++ b/src/components/autoFocuser.js
@@ -29,6 +29,13 @@ define(["focusManager", "layoutManager"], function (focusManager, layoutManager)
     }
 
     /**
+     * Create an array from some source.
+     */
+    var arrayFrom = Array.prototype.from || function (src) {
+        return Array.prototype.slice.call(src);
+    }
+
+    /**
      * Set focus on a suitable element, taking into account the previously selected.
      */
     function autoFocus(container) {
@@ -55,8 +62,8 @@ define(["focusManager", "layoutManager"], function (focusManager, layoutManager)
             candidates.push(activeElement);
         }
 
-        candidates = candidates.concat(Array.from(container.querySelectorAll(".btnResume")));
-        candidates = candidates.concat(Array.from(container.querySelectorAll(".btnPlay")));
+        candidates = candidates.concat(arrayFrom(container.querySelectorAll(".btnResume")));
+        candidates = candidates.concat(arrayFrom(container.querySelectorAll(".btnPlay")));
 
         var notFound = candidates.every(function (element) {
             if (focusManager.isCurrentlyFocusable(element)) {

--- a/src/components/autoFocuser.js
+++ b/src/components/autoFocuser.js
@@ -53,6 +53,15 @@ define(["focusManager"], function (focusManager) {
         });
 
         if (notFound) {
+            // FIXME: Multiple itemsContainers
+            var itemsContainer = container.querySelector(".itemsContainer");
+
+            if (itemsContainer) {
+                notFound = !focusManager.autoFocus(itemsContainer);
+            }
+        }
+
+        if (notFound) {
             focusManager.autoFocus(container);
         }
     }

--- a/src/components/autoFocuser.js
+++ b/src/components/autoFocuser.js
@@ -65,27 +65,32 @@ define(["focusManager", "layoutManager"], function (focusManager, layoutManager)
         candidates = candidates.concat(arrayFrom(container.querySelectorAll(".btnResume")));
         candidates = candidates.concat(arrayFrom(container.querySelectorAll(".btnPlay")));
 
-        var notFound = candidates.every(function (element) {
+        var focusedElement;
+
+        candidates.every(function (element) {
             if (focusManager.isCurrentlyFocusable(element)) {
                 focusManager.focus(element);
+                focusedElement = element;
                 return false;
             }
 
             return true;
         });
 
-        if (notFound) {
+        if (!focusedElement) {
             // FIXME: Multiple itemsContainers
             var itemsContainer = container.querySelector(".itemsContainer");
 
             if (itemsContainer) {
-                notFound = !focusManager.autoFocus(itemsContainer);
+                focusedElement = focusManager.autoFocus(itemsContainer);
             }
         }
 
-        if (notFound) {
-            focusManager.autoFocus(container);
+        if (!focusedElement) {
+            focusedElement = focusManager.autoFocus(container);
         }
+
+        return focusedElement;
     }
 
     return {

--- a/src/components/autoFocuser.js
+++ b/src/components/autoFocuser.js
@@ -1,4 +1,4 @@
-define(["focusManager"], function (focusManager) {
+define(["focusManager", "layoutManager"], function (focusManager, layoutManager) {
     "use strict";
 
     /**
@@ -7,9 +7,20 @@ define(["focusManager"], function (focusManager) {
     var activeElement;
 
     /**
+     * Returns true if AutoFocuser is enabled.
+     */
+    function isEnabled() {
+        return layoutManager.tv;
+    };
+
+    /**
      * Start AutoFocuser
      */
     function enable() {
+        if (!isEnabled()) {
+            return;
+        }
+
         window.addEventListener("focusin", function (e) {
             activeElement = e.target;
         });
@@ -21,6 +32,10 @@ define(["focusManager"], function (focusManager) {
      * Set focus on a suitable element, taking into account the previously selected.
      */
     function autoFocus(container) {
+        if (!isEnabled()) {
+            return;
+        }
+
         container = container || document.body;
 
         var candidates = [];
@@ -67,6 +82,7 @@ define(["focusManager"], function (focusManager) {
     }
 
     return {
+        isEnabled: isEnabled,
         enable: enable,
         autoFocus: autoFocus
     };

--- a/src/components/autoFocuser.js
+++ b/src/components/autoFocuser.js
@@ -1,0 +1,64 @@
+define(["focusManager"], function (focusManager) {
+    "use strict";
+
+    /**
+     * Previously selected element.
+     */
+    var activeElement;
+
+    /**
+     * Start AutoFocuser
+     */
+    function enable() {
+        window.addEventListener("focusin", function (e) {
+            activeElement = e.target;
+        });
+
+        console.log("AutoFocuser enabled");
+    }
+
+    /**
+     * Set focus on a suitable element, taking into account the previously selected.
+     */
+    function autoFocus(container) {
+        container = container || document.body;
+
+        var candidates = [];
+
+        if (activeElement) {
+            // These elements are recreated
+            if (activeElement.classList.contains("btnPreviousPage")) {
+                candidates.push(container.querySelector(".btnPreviousPage"));
+                candidates.push(container.querySelector(".btnNextPage"));
+            } else if (activeElement.classList.contains("btnNextPage")) {
+                candidates.push(container.querySelector(".btnNextPage"));
+                candidates.push(container.querySelector(".btnPreviousPage"));
+            } else if (activeElement.classList.contains("btnSelectView")) {
+                candidates.push(container.querySelector(".btnSelectView"));
+            }
+
+            candidates.push(activeElement);
+        }
+
+        candidates = candidates.concat(Array.from(container.querySelectorAll(".btnResume")));
+        candidates = candidates.concat(Array.from(container.querySelectorAll(".btnPlay")));
+
+        var notFound = candidates.every(function (element) {
+            if (focusManager.isCurrentlyFocusable(element)) {
+                focusManager.focus(element);
+                return false;
+            }
+
+            return true;
+        });
+
+        if (notFound) {
+            focusManager.autoFocus(container);
+        }
+    }
+
+    return {
+        enable: enable,
+        autoFocus: autoFocus
+    };
+});

--- a/src/components/autoFocuser.js
+++ b/src/components/autoFocuser.js
@@ -11,7 +11,7 @@ define(["focusManager", "layoutManager"], function (focusManager, layoutManager)
      */
     function isEnabled() {
         return layoutManager.tv;
-    };
+    }
 
     /**
      * Start AutoFocuser

--- a/src/controllers/addserver.js
+++ b/src/controllers/addserver.js
@@ -46,6 +46,10 @@ define(["appSettings", "loading", "browser", "emby-button"], function(appSetting
         view.querySelector(".addServerForm").addEventListener("submit", onServerSubmit);
         view.querySelector(".btnCancel").addEventListener("click", goBack);
 
+        require(["autoFocuser"], function (autoFocuser) {
+            autoFocuser.autoFocus(view);
+        });
+
         function onServerSubmit(e) {
             submitServer(view);
             e.preventDefault();

--- a/src/controllers/itemdetailpage.js
+++ b/src/controllers/itemdetailpage.js
@@ -1715,6 +1715,12 @@ define(["loading", "appRouter", "layoutManager", "connectionManager", "cardBuild
             hideAll(page, "btnPlay", false);
             hideAll(page, "btnShuffle", false);
         }
+
+        // HACK: Call autoFocuser again because btnPlay may be hidden, but focused by reloadFromItem
+        // FIXME: Sometimes focus does not move until all (?) sections are loaded
+        require(["autoFocuser"], function (autoFocuser) {
+            autoFocuser.autoFocus(page);
+        });
     }
 
     function renderCollectionItemType(page, parentItem, type, items) {

--- a/src/controllers/itemdetailpage.js
+++ b/src/controllers/itemdetailpage.js
@@ -617,24 +617,9 @@ define(["loading", "appRouter", "layoutManager", "connectionManager", "cardBuild
             hideAll(page, "btnDownload", true);
         }
 
-        try {
-            require(["focusManager"], function (focusManager) {
-                [".btnResume", ".btnPlay"].every(function (cls) {
-                    var elems = page.querySelectorAll(cls);
-
-                    for (var i = 0; i < elems.length; i++) {
-                        if (focusManager.isCurrentlyFocusable(elems[i])) {
-                            focusManager.focus(elems[i]);
-                            return false;
-                        }
-                    }
-
-                    return true;
-                });
-            });
-        } catch (e) {
-            console.log(e);
-        }
+        require(["autoFocuser"], function (autoFocuser) {
+            autoFocuser.autoFocus(page);
+        });
     }
 
     function logoImageUrl(item, apiClient, options) {

--- a/src/controllers/livetv/livetvchannels.js
+++ b/src/controllers/livetv/livetvchannels.js
@@ -102,6 +102,10 @@ define(["cardBuilder", "imageLoader", "libraryBrowser", "loading", "events", "em
                 renderChannels(context, result);
                 loading.hide();
                 isLoading = false;
+
+                require(["autoFocuser"], function (autoFocuser) {
+                    autoFocuser.autoFocus(view);
+                });
             });
         }
 

--- a/src/controllers/livetv/livetvsuggested.js
+++ b/src/controllers/livetv/livetvsuggested.js
@@ -49,6 +49,10 @@ define(["layoutManager", "userSettings", "inputManager", "loading", "globalize",
                 showAirEndTime: true
             });
             loading.hide();
+
+            require(["autoFocuser"], function (autoFocuser) {
+                autoFocuser.autoFocus(page);
+            });
         });
     }
 

--- a/src/controllers/loginpage.js
+++ b/src/controllers/loginpage.js
@@ -116,6 +116,10 @@ define(["apphost", "appSettings", "dom", "connectionManager", "loading", "layout
             view.querySelector(".visualLoginForm").classList.remove("hide");
             view.querySelector(".manualLoginForm").classList.add("hide");
             view.querySelector(".btnManual").classList.remove("hide");
+
+            require(["autoFocuser"], function (autoFocuser) {
+                autoFocuser.autoFocus(view);
+            });
         }
 
         view.querySelector("#divUsers").addEventListener("click", function(e) {

--- a/src/controllers/movies/moviecollections.js
+++ b/src/controllers/movies/moviecollections.js
@@ -172,6 +172,10 @@ define(["loading", "events", "libraryBrowser", "imageLoader", "listView", "cardB
                 libraryBrowser.saveQueryValues(getSavedQueryKey(page), query);
                 loading.hide();
                 isLoading = false;
+
+                require(["autoFocuser"], function (autoFocuser) {
+                    autoFocuser.autoFocus(page);
+                });
             });
         }
 

--- a/src/controllers/movies/movies.js
+++ b/src/controllers/movies/movies.js
@@ -77,6 +77,10 @@ define(["loading", "layoutManager", "userSettings", "events", "libraryBrowser", 
 
             isLoading = false;
             loading.hide();
+
+            require(["autoFocuser"], function (autoFocuser) {
+                autoFocuser.autoFocus(tabContent);
+            });
         }
 
         function getItemsHtml(items) {

--- a/src/controllers/movies/moviesrecommended.js
+++ b/src/controllers/movies/moviesrecommended.js
@@ -36,6 +36,9 @@ define(["events", "layoutManager", "inputManager", "userSettings", "libraryMenu"
                 showYear: true,
                 centerText: true
             });
+
+            // FIXME: Wait for all sections to load
+            autoFocus(page);
         });
     }
 
@@ -76,6 +79,9 @@ define(["events", "layoutManager", "inputManager", "userSettings", "libraryMenu"
                 showYear: true,
                 centerText: true
             });
+
+            // FIXME: Wait for all sections to load
+            autoFocus(page);
         });
     }
 
@@ -147,6 +153,15 @@ define(["events", "layoutManager", "inputManager", "userSettings", "libraryMenu"
             var recs = page.querySelector(".recommendations");
             recs.innerHTML = html;
             imageLoader.lazyChildren(recs);
+
+            // FIXME: Wait for all sections to load
+            autoFocus(page);
+        });
+    }
+
+    function autoFocus(page) {
+        require(["autoFocuser"], function (autoFocuser) {
+            autoFocuser.autoFocus(page);
         });
     }
 

--- a/src/controllers/music/musicalbums.js
+++ b/src/controllers/music/musicalbums.js
@@ -160,6 +160,10 @@ define(["layoutManager", "playbackManager", "loading", "events", "libraryBrowser
                 libraryBrowser.saveQueryValues(getSavedQueryKey(), query);
                 loading.hide();
                 isLoading = false;
+
+                require(["autoFocuser"], function (autoFocuser) {
+                    autoFocuser.autoFocus(tabContent);
+                });
             });
         }
 

--- a/src/controllers/music/musicartists.js
+++ b/src/controllers/music/musicartists.js
@@ -144,6 +144,10 @@ define(["layoutManager", "loading", "events", "libraryBrowser", "imageLoader", "
                 libraryBrowser.saveQueryValues(getSavedQueryKey(page), query);
                 loading.hide();
                 isLoading = false;
+
+                require(["autoFocuser"], function (autoFocuser) {
+                    autoFocuser.autoFocus(tabContent);
+                });
             });
         }
 

--- a/src/controllers/music/musicgenres.js
+++ b/src/controllers/music/musicgenres.js
@@ -87,6 +87,10 @@ define(["libraryBrowser", "cardBuilder", "apphost", "imageLoader", "loading"], f
                 imageLoader.lazyChildren(elem);
                 libraryBrowser.saveQueryValues(getSavedQueryKey(), query);
                 loading.hide();
+
+                require(["autoFocuser"], function (autoFocuser) {
+                    autoFocuser.autoFocus(context);
+                });
             });
         }
 

--- a/src/controllers/music/musicplaylists.js
+++ b/src/controllers/music/musicplaylists.js
@@ -58,6 +58,10 @@ define(["libraryBrowser", "cardBuilder", "apphost", "imageLoader", "loading"], f
                 imageLoader.lazyChildren(elem);
                 libraryBrowser.saveQueryValues(getSavedQueryKey(), query);
                 loading.hide();
+
+                require(["autoFocuser"], function (autoFocuser) {
+                    autoFocuser.autoFocus(context);
+                });
             });
         }
 

--- a/src/controllers/music/musicrecommended.js
+++ b/src/controllers/music/musicrecommended.js
@@ -59,6 +59,10 @@ define(["browser", "layoutManager", "userSettings", "inputManager", "loading", "
             });
             imageLoader.lazyChildren(elem);
             loading.hide();
+
+            require(["autoFocuser"], function (autoFocuser) {
+                autoFocuser.autoFocus(page);
+            });
         });
     }
 

--- a/src/controllers/music/songs.js
+++ b/src/controllers/music/songs.js
@@ -104,6 +104,10 @@ define(["events", "libraryBrowser", "imageLoader", "listView", "loading", "emby-
                 libraryBrowser.saveQueryValues(getSavedQueryKey(page), query);
                 loading.hide();
                 isLoading = false;
+
+                require(["autoFocuser"], function (autoFocuser) {
+                    autoFocuser.autoFocus(page);
+                });
             });
         }
 

--- a/src/controllers/shows/episodes.js
+++ b/src/controllers/shows/episodes.js
@@ -144,6 +144,10 @@ define(["loading", "events", "libraryBrowser", "imageLoader", "listView", "cardB
                 libraryBrowser.saveQueryValues(getSavedQueryKey(page), query);
                 loading.hide();
                 isLoading = false;
+
+                require(["autoFocuser"], function (autoFocuser) {
+                    autoFocuser.autoFocus(page);
+                });
             });
         }
 

--- a/src/controllers/shows/tvlatest.js
+++ b/src/controllers/shows/tvlatest.js
@@ -40,6 +40,10 @@ define(["loading", "components/groupedcards", "cardBuilder", "apphost", "imageLo
             elem.innerHTML = html;
             imageLoader.lazyChildren(elem);
             loading.hide();
+
+            require(["autoFocuser"], function (autoFocuser) {
+                autoFocuser.autoFocus(context);
+            });
         });
     }
 

--- a/src/controllers/shows/tvrecommended.js
+++ b/src/controllers/shows/tvrecommended.js
@@ -97,6 +97,10 @@ define(["events", "inputManager", "libraryMenu", "layoutManager", "loading", "do
                     cardLayout: false
                 });
                 loading.hide();
+
+                require(["autoFocuser"], function (autoFocuser) {
+                    autoFocuser.autoFocus(view);
+                });
             });
         }
 

--- a/src/controllers/shows/tvshows.js
+++ b/src/controllers/shows/tvshows.js
@@ -172,6 +172,10 @@ define(["layoutManager", "loading", "events", "libraryBrowser", "imageLoader", "
                 libraryBrowser.saveQueryValues(getSavedQueryKey(page), query);
                 loading.hide();
                 isLoading = false;
+
+                require(["autoFocuser"], function (autoFocuser) {
+                    autoFocuser.autoFocus(page);
+                });
             });
         }
 

--- a/src/controllers/shows/tvstudios.js
+++ b/src/controllers/shows/tvstudios.js
@@ -46,6 +46,10 @@ define(["loading", "libraryBrowser", "cardBuilder", "apphost"], function (loadin
                 context: "tvshows"
             });
             loading.hide();
+
+            require(["autoFocuser"], function (autoFocuser) {
+                autoFocuser.autoFocus(context);
+            });
         });
     }
 

--- a/src/controllers/user/display.js
+++ b/src/controllers/user/display.js
@@ -1,4 +1,4 @@
-define(["displaySettings", "userSettingsBuilder", "userSettings"], function (DisplaySettings, userSettingsBuilder, currentUserSettings) {
+define(["displaySettings", "userSettingsBuilder", "userSettings", "autoFocuser"], function (DisplaySettings, userSettingsBuilder, currentUserSettings, autoFocuser) {
     "use strict";
 
     return function (view, params) {
@@ -25,7 +25,7 @@ define(["displaySettings", "userSettingsBuilder", "userSettings"], function (Dis
                     userSettings: userSettings,
                     enableSaveButton: false,
                     enableSaveConfirmation: false,
-                    autoFocus: true
+                    autoFocus: autoFocuser.isEnabled()
                 });
             }
         });

--- a/src/controllers/user/display.js
+++ b/src/controllers/user/display.js
@@ -24,7 +24,8 @@ define(["displaySettings", "userSettingsBuilder", "userSettings"], function (Dis
                     element: view.querySelector(".settingsContainer"),
                     userSettings: userSettings,
                     enableSaveButton: false,
-                    enableSaveConfirmation: false
+                    enableSaveConfirmation: false,
+                    autoFocus: true
                 });
             }
         });

--- a/src/controllers/user/home.js
+++ b/src/controllers/user/home.js
@@ -1,4 +1,4 @@
-define(["homescreenSettings", "userSettingsBuilder", "dom", "globalize", "loading", "userSettings", "listViewStyle"], function (HomescreenSettings, userSettingsBuilder, dom, globalize, loading, currentUserSettings) {
+define(["homescreenSettings", "userSettingsBuilder", "dom", "globalize", "loading", "userSettings", "autoFocuser", "listViewStyle"], function (HomescreenSettings, userSettingsBuilder, dom, globalize, loading, currentUserSettings, autoFocuser) {
     "use strict";
 
     return function (view, params) {
@@ -25,7 +25,7 @@ define(["homescreenSettings", "userSettingsBuilder", "dom", "globalize", "loadin
                     userSettings: userSettings,
                     enableSaveButton: false,
                     enableSaveConfirmation: false,
-                    autoFocus: true
+                    autoFocus: autoFocuser.isEnabled()
                 });
             }
         });

--- a/src/controllers/user/home.js
+++ b/src/controllers/user/home.js
@@ -24,7 +24,8 @@ define(["homescreenSettings", "userSettingsBuilder", "dom", "globalize", "loadin
                     element: view.querySelector(".homeScreenSettingsContainer"),
                     userSettings: userSettings,
                     enableSaveButton: false,
-                    enableSaveConfirmation: false
+                    enableSaveConfirmation: false,
+                    autoFocus: true
                 });
             }
         });

--- a/src/controllers/user/menu.js
+++ b/src/controllers/user/menu.js
@@ -35,6 +35,10 @@ define(["apphost", "connectionManager", "listViewStyle", "emby-button"], functio
                     page.querySelector(".adminSection").classList.add("hide");
                 }
             });
+
+            require(["autoFocuser"], function (autoFocuser) {
+                autoFocuser.autoFocus(view);
+            });
         });
     };
 });

--- a/src/controllers/user/playback.js
+++ b/src/controllers/user/playback.js
@@ -24,7 +24,8 @@ define(["playbackSettings", "userSettingsBuilder", "dom", "globalize", "loading"
                     element: view.querySelector(".settingsContainer"),
                     userSettings: userSettings,
                     enableSaveButton: false,
-                    enableSaveConfirmation: false
+                    enableSaveConfirmation: false,
+                    autoFocus: true
                 });
             }
         });

--- a/src/controllers/user/playback.js
+++ b/src/controllers/user/playback.js
@@ -1,4 +1,4 @@
-define(["playbackSettings", "userSettingsBuilder", "dom", "globalize", "loading", "userSettings", "listViewStyle"], function (PlaybackSettings, userSettingsBuilder, dom, globalize, loading, currentUserSettings) {
+define(["playbackSettings", "userSettingsBuilder", "dom", "globalize", "loading", "userSettings", "autoFocuser", "listViewStyle"], function (PlaybackSettings, userSettingsBuilder, dom, globalize, loading, currentUserSettings, autoFocuser) {
     "use strict";
 
     return function (view, params) {
@@ -25,7 +25,7 @@ define(["playbackSettings", "userSettingsBuilder", "dom", "globalize", "loading"
                     userSettings: userSettings,
                     enableSaveButton: false,
                     enableSaveConfirmation: false,
-                    autoFocus: true
+                    autoFocus: autoFocuser.isEnabled()
                 });
             }
         });

--- a/src/controllers/user/subtitles.js
+++ b/src/controllers/user/subtitles.js
@@ -24,7 +24,8 @@ define(["subtitleSettings", "userSettingsBuilder", "userSettings"], function (Su
                     element: view.querySelector(".settingsContainer"),
                     userSettings: userSettings,
                     enableSaveButton: false,
-                    enableSaveConfirmation: false
+                    enableSaveConfirmation: false,
+                    autoFocus: true
                 });
             }
         });

--- a/src/controllers/user/subtitles.js
+++ b/src/controllers/user/subtitles.js
@@ -1,4 +1,4 @@
-define(["subtitleSettings", "userSettingsBuilder", "userSettings"], function (SubtitleSettings, userSettingsBuilder, currentUserSettings) {
+define(["subtitleSettings", "userSettingsBuilder", "userSettings", "autoFocuser"], function (SubtitleSettings, userSettingsBuilder, currentUserSettings, autoFocuser) {
     "use strict";
 
     return function (view, params) {
@@ -25,7 +25,7 @@ define(["subtitleSettings", "userSettingsBuilder", "userSettings"], function (Su
                     userSettings: userSettings,
                     enableSaveButton: false,
                     enableSaveConfirmation: false,
-                    autoFocus: true
+                    autoFocus: autoFocuser.isEnabled()
                 });
             }
         });

--- a/src/controllers/userpasswordpage.js
+++ b/src/controllers/userpasswordpage.js
@@ -47,6 +47,10 @@ define(["loading", "libraryMenu", "emby-button"], function (loading, libraryMenu
                 }
 
                 page.querySelector(".chkEnableLocalEasyPassword").checked = user.Configuration.EnableLocalPassword;
+
+                require(["autoFocuser"], function (autoFocuser) {
+                    autoFocuser.autoFocus(page);
+                });
             });
         });
         page.querySelector("#txtCurrentPassword").value = "";

--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -477,6 +477,9 @@ var AppInfo = {};
                 require(["keyboardnavigation"], function(keyboardnavigation) {
                     keyboardnavigation.enable();
                 });
+                require(["autoFocuser"], function(autoFocuser) {
+                    autoFocuser.enable();
+                });
             });
         });
     }
@@ -858,6 +861,7 @@ var AppInfo = {};
         define("serverNotifications", [componentsPath + "/serverNotifications/serverNotifications"], returnFirstDependency);
         define("skinManager", [componentsPath + "/skinManager"], returnFirstDependency);
         define("keyboardnavigation", [componentsPath + "/keyboardnavigation"], returnFirstDependency);
+        define("autoFocuser", [componentsPath + "/autoFocuser"], returnFirstDependency);
         define("connectionManager", [], function () {
             return ConnectionManager;
         });


### PR DESCRIPTION
As continue of #314 (#303 as main goal).

When view/page is loaded, focus usually is on `body`. When navigating with the keyboard, focus moves to the element at the bottom of the current view (at least it looks like this). To fix focus after page is loaded, I added `AutoFocuser`. :rofl:

**Detailed description**
In Tizen App, I fix focus in the function `onPageLoad` watching for style of loading element (https://github.com/dmitrylyzo/jellyfin-tizen/blob/ea271573c1342276f63f13b9ee04aa5cadd5d54f/tizen.js#L82-L128). In my first PR, we slightly discuss this approach (https://github.com/jellyfin/jellyfin-web/pull/522#discussion_r334903850), ended with the need for some event. At some point, event will be useful, but for now I decided to use some shared module directly.

Actually, `FocusManager` is the best candidate because focus is its duty (`ViewManager` or `loading` could be used for event emitting). But I decided not to clog `FocusManger` with some site specific classes (`btnPlay`, `btnNextPage`, etc.) and logic, and extracted feature in a separate module, `AutoFocuser`. If you think that it should be integrated into `FocusManager`, it will be integrated.

* For now, focus is fixed on pages which I can check somehow.
* `AutoFocuser` restores navigating buttons (`btnPreviousPage`, `btnNextPage`) for "unstoppable" library navigating.
* Play/Resume focus moved to it too.

**Issues**
1. Not all pages are fixed. Maybe some of them do not require it.
* `moviegenres` and `tvgenres` - could not find a place to call `AutoFocuser.autoFocus`.
* `livetv` group, `movietrailers` and `tvupcoming` - skipped due to no examples for check.

2. In pages with item listing, `FocusManager.autoFocus` moves focus on the "toolbuttons" (`btnNextPage`, `btnSelectView`) since they are not `noautofocus`. In my first PR, I have to mark all "toolbuttons" with `noautofocus` and swap alphaPicker (maybe `noautofocus` on each letter helps too).

3. Some pages do not use `AutoFocuser`:
* Settings loaded by the helper object - `autoFocus` option on it.

4. On "Profile" page, `AutoFocuser.autoFocus` called by UserPasswordPage.