### PR TITLE
Fix focus of library order item after change

### DIFF
--- a/src/components/homescreensettings/homescreensettings.js
+++ b/src/components/homescreensettings/homescreensettings.js
@@ -330,6 +330,7 @@ define(['require', 'apphost', 'layoutManager', 'focusManager', 'globalize', 'loa
                     if (next) {
                         viewItem.parentNode.removeChild(viewItem);
                         next.parentNode.insertBefore(viewItem, next.nextSibling);
+                        focusManager.focus(e.target);
                     }
 
                 } else {
@@ -339,6 +340,7 @@ define(['require', 'apphost', 'layoutManager', 'focusManager', 'globalize', 'loa
                     if (prev) {
                         viewItem.parentNode.removeChild(viewItem);
                         prev.parentNode.insertBefore(viewItem, prev);
+                        focusManager.focus(e.target);
                     }
                 }
             }


### PR DESCRIPTION
Focus is lost when the library is reordered due to the removal of the focused element from the tree. Just restore focus on it after putting it back into the tree.