### PR TITLE
Add appropriate focuscontainer classes to menus

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -98,8 +98,8 @@
 <body>
     <div class="backdropContainer"></div>
     <div class="backgroundContainer"></div>
-    <div class="mainDrawer hide"><div class="mainDrawer-scrollContainer scrollContainer"></div></div>
-    <div class="skinHeader"></div>
+    <div class="mainDrawer hide"><div class="mainDrawer-scrollContainer scrollContainer focuscontainer-y"></div></div>
+    <div class="skinHeader focuscontainer-x"></div>
     <div class="mainAnimatedPages skinBody"></div>
     <div class="mainDrawerHandle"></div>
 </body>


### PR DESCRIPTION
Set the appropriate focuscontainer direction classes so that the keyboard navigation is bound to the menu. Without this, focus can jump from the top menu to an item below the space in the menu. The same for the side menu (it is not used on TV, but for uniformity; I made it visible for the test).