### PR TITLE
Make navigation and playback control TV-friendly

### DIFF
--- a/src/components/emby-slider/emby-slider.css
+++ b/src/components/emby-slider/emby-slider.css
@@ -87,6 +87,10 @@ _:-ms-input-placeholder {
     transform: scale(1.6);
 }
 
+.mdl-slider.show-focus:focus::-webkit-slider-thumb {
+    transform: scale(1.6);
+}
+
 .slider-no-webkit-thumb::-webkit-slider-thumb {
     opacity: 0 !important;
 }

--- a/src/components/emby-slider/emby-slider.js
+++ b/src/components/emby-slider/emby-slider.js
@@ -250,7 +250,6 @@ define(['browser', 'dom', 'layoutManager', 'css!./emby-slider', 'registerElement
      * Handle KeyDown event
      */
     function onKeyDown(e) {
-
         switch (e.key) {
             case 'ArrowLeft':
             case 'Left':
@@ -258,7 +257,6 @@ define(['browser', 'dom', 'layoutManager', 'css!./emby-slider', 'registerElement
                 e.preventDefault();
                 e.stopPropagation();
                 break;
-
             case 'ArrowRight':
             case 'Right':
                 stepKeyboard(this, this.keyboardStepUp || 1);

--- a/src/components/emby-slider/emby-slider.js
+++ b/src/components/emby-slider/emby-slider.js
@@ -19,6 +19,11 @@ define(['browser', 'dom', 'layoutManager', 'css!./emby-slider', 'registerElement
 
     function updateValues() {
 
+        // Do not update values when dragging with keyboard to keep current progress for reference
+        if (!!this.keyboardDragging) {
+            return;
+        }
+
         var range = this;
         var value = range.value;
 
@@ -81,6 +86,9 @@ define(['browser', 'dom', 'layoutManager', 'css!./emby-slider', 'registerElement
         }
         if (!layoutManager.mobile) {
             this.classList.add('mdl-slider-hoverthumb');
+        }
+        if (layoutManager.tv) {
+            this.classList.add('show-focus');
         }
 
         var containerElement = this.parentNode;
@@ -176,6 +184,116 @@ define(['browser', 'dom', 'layoutManager', 'css!./emby-slider', 'registerElement
             }
         }
     };
+
+    /**
+     * Keyboard dragging timeout.
+     * After this delay "change" event will be fired.
+     */
+    var KeyboardDraggingTimeout = 1000;
+
+    /**
+     * Keyboard dragging timer.
+     */
+    var keyboardDraggingTimer;
+
+    /**
+     * Start keyboard dragging.
+     *
+     * @param {Object} elem slider itself
+     */
+    function startKeyboardDragging(elem) {
+
+        elem.keyboardDragging = true;
+
+        clearTimeout(keyboardDraggingTimer);
+
+        keyboardDraggingTimer = setTimeout(function () {
+            finishKeyboardDragging(elem);
+        }, KeyboardDraggingTimeout);
+    }
+
+    /**
+     * Finish keyboard dragging.
+     *
+     * @param {Object} elem slider itself
+     */
+    function finishKeyboardDragging(elem) {
+
+        clearTimeout(keyboardDraggingTimer);
+        keyboardDraggingTimer = undefined;
+
+        elem.keyboardDragging = false;
+
+        var event = new Event('change', {
+            bubbles: true,
+            cancelable: false
+        });
+        elem.dispatchEvent(event);
+    }
+
+    /**
+     * Do step by delta.
+     *
+     * @param {Object} elem slider itself
+     * @param {number} delta step amount
+     */
+    function stepKeyboard(elem, delta) {
+
+        startKeyboardDragging(elem);
+
+        elem.value = Math.max(elem.min, Math.min(elem.max, parseFloat(elem.value) + delta));
+
+        var event = new Event('input', {
+            bubbles: true,
+            cancelable: false
+        });
+        elem.dispatchEvent(event);
+    }
+
+    /**
+     * Handle KeyDown event
+     */
+    function onKeyDown(e) {
+
+        switch (e.key) {
+            case 'ArrowLeft':
+            case 'Left':
+                stepKeyboard(this, -this.keyboardStepDown || -1);
+                e.preventDefault();
+                e.stopPropagation();
+            break;
+
+            case 'ArrowRight':
+            case 'Right':
+                stepKeyboard(this, this.keyboardStepUp || 1);
+                e.preventDefault();
+                e.stopPropagation();
+            break;
+        }
+    }
+
+    /**
+     * Enable keyboard dragging.
+     */
+    EmbySliderPrototype.enableKeyboardDragging = function () {
+
+        if (!this.keyboardDraggingEnabled) {
+            this.addEventListener('keydown', onKeyDown);
+            this.keyboardDraggingEnabled = true;
+        }
+    }
+
+    /**
+     * Set steps for keyboard input.
+     *
+     * @param {number} stepDown step to reduce
+     * @param {number} stepUp step to increase
+     */
+    EmbySliderPrototype.setKeyboardSteps = function (stepDown, stepUp) {
+
+        this.keyboardStepDown = stepDown || stepUp || 1;
+        this.keyboardStepUp = stepUp || stepDown || 1;
+    }
 
     function setRange(elem, startPercent, endPercent) {
 

--- a/src/components/emby-slider/emby-slider.js
+++ b/src/components/emby-slider/emby-slider.js
@@ -202,11 +202,9 @@ define(['browser', 'dom', 'layoutManager', 'css!./emby-slider', 'registerElement
      * @param {Object} elem slider itself
      */
     function startKeyboardDragging(elem) {
-
         elem.keyboardDragging = true;
 
         clearTimeout(keyboardDraggingTimer);
-
         keyboardDraggingTimer = setTimeout(function () {
             finishKeyboardDragging(elem);
         }, KeyboardDraggingTimeout);
@@ -218,7 +216,6 @@ define(['browser', 'dom', 'layoutManager', 'css!./emby-slider', 'registerElement
      * @param {Object} elem slider itself
      */
     function finishKeyboardDragging(elem) {
-
         clearTimeout(keyboardDraggingTimer);
         keyboardDraggingTimer = undefined;
 
@@ -238,7 +235,6 @@ define(['browser', 'dom', 'layoutManager', 'css!./emby-slider', 'registerElement
      * @param {number} delta step amount
      */
     function stepKeyboard(elem, delta) {
-
         startKeyboardDragging(elem);
 
         elem.value = Math.max(elem.min, Math.min(elem.max, parseFloat(elem.value) + delta));
@@ -261,14 +257,14 @@ define(['browser', 'dom', 'layoutManager', 'css!./emby-slider', 'registerElement
                 stepKeyboard(this, -this.keyboardStepDown || -1);
                 e.preventDefault();
                 e.stopPropagation();
-            break;
+                break;
 
             case 'ArrowRight':
             case 'Right':
                 stepKeyboard(this, this.keyboardStepUp || 1);
                 e.preventDefault();
                 e.stopPropagation();
-            break;
+                break;
         }
     }
 
@@ -276,7 +272,6 @@ define(['browser', 'dom', 'layoutManager', 'css!./emby-slider', 'registerElement
      * Enable keyboard dragging.
      */
     EmbySliderPrototype.enableKeyboardDragging = function () {
-
         if (!this.keyboardDraggingEnabled) {
             this.addEventListener('keydown', onKeyDown);
             this.keyboardDraggingEnabled = true;
@@ -290,7 +285,6 @@ define(['browser', 'dom', 'layoutManager', 'css!./emby-slider', 'registerElement
      * @param {number} stepUp step to increase
      */
     EmbySliderPrototype.setKeyboardSteps = function (stepDown, stepUp) {
-
         this.keyboardStepDown = stepDown || stepUp || 1;
         this.keyboardStepUp = stepUp || stepDown || 1;
     }

--- a/src/controllers/videoosd.js
+++ b/src/controllers/videoosd.js
@@ -1083,11 +1083,13 @@ define(["playbackManager", "dom", "inputManager", "datetime", "itemHelper", "med
         function onWindowKeyDown(e) {
             if (!currentVisibleMenu && 32 === e.keyCode) {
                 playbackManager.playPause(currentPlayer);
-                return void showOsd();
+                showOsd();
+                return;
             }
 
             if (layoutManager.tv && NavigationKeys.indexOf(e.key) != -1) {
-                return void showOsd();
+                showOsd();
+                return;
             }
 
             switch (e.key) {

--- a/src/controllers/videoosd.js
+++ b/src/controllers/videoosd.js
@@ -770,6 +770,10 @@ define(["playbackManager", "dom", "inputManager", "datetime", "itemHelper", "med
             var isProgressClear = state.MediaSource && null == state.MediaSource.RunTimeTicks;
             nowPlayingPositionSlider.setIsClear(isProgressClear);
 
+            if (nowPlayingItem.RunTimeTicks) {
+                nowPlayingPositionSlider.setKeyboardSteps(userSettings.skipBackLength() * 1000000 / nowPlayingItem.RunTimeTicks, userSettings.skipForwardLength() * 1000000 / nowPlayingItem.RunTimeTicks);
+            }
+
             if (-1 === supportedCommands.indexOf("ToggleFullscreen") || player.isLocalPlayer && layoutManager.tv && playbackManager.isFullscreen(player)) {
                 view.querySelector(".btnFullscreen").classList.add("hide");
             } else {
@@ -1070,9 +1074,18 @@ define(["playbackManager", "dom", "inputManager", "datetime", "itemHelper", "med
             }
         }
 
+        /**
+         * Keys used for keyboard navigation.
+         */
+        var NavigationKeys = ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"];
+
         function onWindowKeyDown(e) {
             if (!currentVisibleMenu && 32 === e.keyCode) {
                 playbackManager.playPause(currentPlayer);
+                return void showOsd();
+            }
+
+            if (layoutManager.tv && NavigationKeys.indexOf(e.key) != -1) {
                 return void showOsd();
             }
 
@@ -1237,6 +1250,12 @@ define(["playbackManager", "dom", "inputManager", "datetime", "itemHelper", "med
         var transitionEndEventName = dom.whichTransitionEvent();
         var headerElement = document.querySelector(".skinHeader");
         var osdBottomElement = document.querySelector(".videoOsdBottom-maincontrols");
+
+        if (layoutManager.tv) {
+            nowPlayingPositionSlider.classList.add("focusable");
+            nowPlayingPositionSlider.enableKeyboardDragging();
+        }
+
         view.addEventListener("viewbeforeshow", function (e) {
             headerElement.classList.add("osdHeader");
             Emby.Page.setTransparency("full");

--- a/src/controllers/videoosd.js
+++ b/src/controllers/videoosd.js
@@ -771,7 +771,8 @@ define(["playbackManager", "dom", "inputManager", "datetime", "itemHelper", "med
             nowPlayingPositionSlider.setIsClear(isProgressClear);
 
             if (nowPlayingItem.RunTimeTicks) {
-                nowPlayingPositionSlider.setKeyboardSteps(userSettings.skipBackLength() * 1000000 / nowPlayingItem.RunTimeTicks, userSettings.skipForwardLength() * 1000000 / nowPlayingItem.RunTimeTicks);
+                nowPlayingPositionSlider.setKeyboardSteps(userSettings.skipBackLength() * 1000000 / nowPlayingItem.RunTimeTicks,
+                    userSettings.skipForwardLength() * 1000000 / nowPlayingItem.RunTimeTicks);
             }
 
             if (-1 === supportedCommands.indexOf("ToggleFullscreen") || player.isLocalPlayer && layoutManager.tv && playbackManager.isFullscreen(player)) {

--- a/src/videoosd.html
+++ b/src/videoosd.html
@@ -31,7 +31,7 @@
                 <div class="osdTextContainer endTimeText" style="margin: 0 0 0 .25em;"></div>
             </div>
 
-            <div class="buttons">
+            <div class="buttons focuscontainer-x">
                 <button is="paper-icon-button-light" class="btnRecord autoSize hide">
                     <i class="xlargePaperIconButton md-icon">&#xE061;</i>
                 </button>


### PR DESCRIPTION
On the TV, keyboard navigation during playback is broken, because at the same time it controls playback.

* I left all the keys except the navigation ones as they are.
* Made possible to seek with the keyboard like with a mouse ("keyboard dragging"), when slider is focused (I made this the only focusable in TV mode).
* "Keyboard dragging" is allways enabled, even in Desktop mode (but this also works), because focus is set on click.
* There is a volume slider. I tried to make it focusable too, but then you are not be able to navigate from it horizontally.
* Cannot check video playback in webOS 4 emulator (not playing :disappointed:), but visually keyboard dragging works. In Tizen 4/5, good.
* **LiveTV is not tested.**