### PR TITLE
Add label to exclude issue from Stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -8,6 +8,7 @@ exemptLabels:
   - future
   - feature
   - enhancement
+  - confirmed
 # Label to use when marking an issue as stale
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
Adds the `confirmed` label, to ask the bot to ignore confirmed issues.