### PR TITLE
Remove the leading /web/ from the manifest to avoid PWA titles

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -4,7 +4,7 @@
     "description": "Jellyfin: the Free Software Media System.",
     "lang": "en-US",
     "short_name": "Jellyfin",
-    "start_url": "/web/index.html#!/home.html",
+    "start_url": "index.html#!/home.html",
     "theme_color": "#101010",
     "background_color": "#101010",
     "display": "standalone",


### PR DESCRIPTION
Remove the leading /web/ from the manifest URL to avoid PWA titles.

After this is added, whenever someone changes their base URL, they will have to make a new shortcut on their homescreen. Tested on iOS, have not tested on Android. Desktop Web remains unaffected.


**Changes**
Change the start url in manifest.json from:
```json
"start_url": "/web/index.html#!/home.html"
```
to
```json
"start_url": "index.html#!/home.html"
```
**Issues**
Fixes #575.
