### PR TITLE
Fix iOS platform detection #572

### DIFF
--- a/src/scripts/browser.js
+++ b/src/scripts/browser.js
@@ -122,7 +122,7 @@ define([], function () {
     }
 
     function iOSversion() {
-        if (/iP(hone|od|ad)/.test(navigator.platform)) {
+        if (/iP(hone|od|ad)|MacIntel/.test(navigator.platform)) {
             // supports iOS 2.0 and later: <http://bit.ly/TJjs1V>
             var v = (navigator.appVersion).match(/OS (\d+)_(\d+)_?(\d+)?/);
             return [parseInt(v[1], 10), parseInt(v[2], 10), parseInt(v[3] || 0, 10)];

--- a/src/scripts/browser.js
+++ b/src/scripts/browser.js
@@ -122,6 +122,7 @@ define([], function () {
     }
 
     function iOSversion() {
+        // MacIntel: Apple iPad Pro 11 iOS 13.1
         if (/iP(hone|od|ad)|MacIntel/.test(navigator.platform)) {
             // supports iOS 2.0 and later: <http://bit.ly/TJjs1V>
             var v = (navigator.appVersion).match(/OS (\d+)_(\d+)_?(\d+)?/);
@@ -301,7 +302,10 @@ define([], function () {
 
     if (browser.iOS) {
         browser.iOSVersion = iOSversion();
-        browser.iOSVersion = browser.iOSVersion[0] + (browser.iOSVersion[1] / 10);
+
+        if (browser.iOSVersion && browser.iOSVersion.length >= 2) {
+            browser.iOSVersion = browser.iOSVersion[0] + (browser.iOSVersion[1] / 10);
+        }
     }
 
     browser.chromecast = browser.chrome && userAgent.toLowerCase().indexOf('crkey') !== -1;


### PR DESCRIPTION
Fix #572 

Apple iPad Pro 11
iOS 13.1.?
Chrome 78.0.3904.84
```
userAgent: Mozilla/5.0 (iPad; CPU OS 13_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/78.0.3904.84 Mobile/15E148 Safari/604.1
platform: MacIntel
appVersion: 5.0 (iPad; CPU OS 13_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/78.0.3904.84 Mobile/15E148 Safari/604.1
```

It seems that there are more Apple platforms [(What is the list of possible values for navigator.platform as of today?).](https://stackoverflow.com/questions/19877924/what-is-the-list-of-possible-values-for-navigator-platform-as-of-today), and this is a pretty old question.