### PR TITLE
reset subtitle offset on next episode play

### DIFF
--- a/src/components/htmlvideoplayer/plugin.js
+++ b/src/components/htmlvideoplayer/plugin.js
@@ -280,6 +280,8 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
 
             self._currentTime = null;
 
+            self.resetSubtitleOffset();
+
             return createMediaElement(options).then(function (elem) {
 
                 return updateVideoUrl(options, options.mediaSource).then(function () {
@@ -555,6 +557,15 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
 
             setCurrentTrackElement(index);
         };
+
+        self.resetSubtitleOffset = function() {
+            if (currentTrackOffset) {
+                currentTrackOffset = 0;
+            }
+            if (showTrackOffset) {
+                showTrackOffset = false;
+            }
+        }
 
         self.enableShowingSubtitleOffset = function() {
             showTrackOffset = true;

--- a/src/components/htmlvideoplayer/plugin.js
+++ b/src/components/htmlvideoplayer/plugin.js
@@ -188,7 +188,7 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
         var currentAssRenderer;
         var customTrackIndex = -1;
 
-        var showTrackOffset = false;
+        var showTrackOffset;
         var currentTrackOffset;
 
         var videoSubtitlesElem;
@@ -559,12 +559,8 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
         };
 
         self.resetSubtitleOffset = function() {
-            if (currentTrackOffset) {
-                currentTrackOffset = 0;
-            }
-            if (showTrackOffset) {
-                showTrackOffset = false;
-            }
+            currentTrackOffset = 0;
+            showTrackOffset = false;
         }
 
         self.enableShowingSubtitleOffset = function() {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->
Reset the subtitle offset (and the flag to display the subtitle offset slifing bar) when next episode is automatically played.

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
To avoid playing the next episode with subtitle offset from the previous episode, when the current htmlvideoplayer start to play a new stream:

* subtitleOffset (current subtitle offset) is set to **0**.
* showTrackOffset (flag to show the sliding bar) is set to **false**.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
#560 