### PR TITLE
Fix variable definition place

### DIFF
--- a/src/components/itemcontextmenu.js
+++ b/src/components/itemcontextmenu.js
@@ -3,10 +3,11 @@ define(["apphost", "globalize", "connectionManager", "itemHelper", "appRouter", 
 
     function getCommands(options) {
         var item = options.item;
+        var user = options.user;
+
         var canPlay = playbackManager.canPlay(item);
         var restrictOptions = (browser.operaTv || browser.web0s) && !user.Policy.IsAdministrator;
 
-        var user = options.user;
         var commands = [];
 
         if (canPlay && item.MediaType !== "Photo") {


### PR DESCRIPTION
Fix error introduced in 5fda5a873858632d4f3aa9762aee620294072bd1
`itemcontextmenu.js?v=10.5.0:7 Uncaught (in promise) TypeError: Cannot read property 'Policy' of undefined(…)`
(mentioned in https://github.com/jellyfin/jellyfin-web/issues/608#issuecomment-562735856)