### PR TITLE
Fix a bug that hides children elements in the videoosd

### DIFF
--- a/src/controllers/videoosd.js
+++ b/src/controllers/videoosd.js
@@ -402,6 +402,8 @@ define(["playbackManager", "dom", "inputManager", "datetime", "itemHelper", "med
 
         function onHideAnimationComplete(e) {
             var elem = e.target;
+            if (elem != osdBottomElement)
+                return;
             elem.classList.add("hide");
             dom.removeEventListener(elem, transitionEndEventName, onHideAnimationComplete, {
                 once: true


### PR DESCRIPTION
This bug seems to be only present in the layout **mobile**
![2019-12-07_14-14-35](https://user-images.githubusercontent.com/30053032/70375338-f8031c00-18fc-11ea-9776-f6aa9cf1e445.gif)
the event `onHideAnimationComplete` in the file videoosd.js also seems to be triggered by children elements
![chrome_2019-12-07_13-11-01](https://user-images.githubusercontent.com/30053032/70375381-79f34500-18fd-11ea-9d08-f1c854aa1ff4.png)

**Changes**
checks that the element is the parent element

**Issues**
Fix #530 