### PR TITLE
Fix for card image scaling problem

### DIFF
--- a/src/components/cardbuilder/card.css
+++ b/src/components/cardbuilder/card.css
@@ -247,7 +247,7 @@ button {
 }
 
 .coveredImage {
-    background-size: 100% 100%;
+    background-size: cover;
     background-position: center center;
 }
 


### PR DESCRIPTION
Card images were losing aspect, change to "background-size: cover" to fix.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
