### PR TITLE
Fix subtitle sync firefox

### DIFF
--- a/src/components/htmlvideoplayer/plugin.js
+++ b/src/components/htmlvideoplayer/plugin.js
@@ -579,10 +579,10 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
             var videoElement = self._mediaElement;
             if (videoElement) {
                 return Array.from(videoElement.textTracks)
-                .find(function(trackElement) {
-                    // get showing .vtt textTack
-                    return trackElement.mode === 'showing';
-                });
+                    .find(function(trackElement) {
+                        // get showing .vtt textTack
+                        return trackElement.mode === 'showing';
+                    });
             } else {
                 // get track events
                 return currentTrackEvents;
@@ -603,7 +603,7 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
                     offsetValue = updateCurrentTrackOffset(offsetValue);
                     setVttSubtitleOffset(trackElement, offsetValue);
                 } else {
-                    console.log("No available track, cannot apply offset : " + offsetValue);
+                    console.log("No available track, cannot apply offset : ", offsetValue);
                 }
             }
         };
@@ -1022,6 +1022,7 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
                 return;
             }
 
+            self.resetSubtitleOffset();
             var item = self._currentPlayOptions.item;
 
             destroyCustomTrack(videoElement);

--- a/src/components/htmlvideoplayer/plugin.js
+++ b/src/components/htmlvideoplayer/plugin.js
@@ -603,7 +603,7 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
                     offsetValue = updateCurrentTrackOffset(offsetValue);
                     setVttSubtitleOffset(trackElement, offsetValue);
                 } else {
-                    console.log("No available track, cannot apply offset : ", offsetValue);
+                    console.log("No available track, cannot apply offset: ", offsetValue);
                 }
             }
         };

--- a/src/components/htmlvideoplayer/plugin.js
+++ b/src/components/htmlvideoplayer/plugin.js
@@ -584,8 +584,7 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
                         return trackElement.mode === 'showing';
                     });
             } else {
-                // get track events
-                return currentTrackEvents;
+                return null;
             }
         }
 
@@ -600,8 +599,9 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
                 var trackElement = getTextTrack();
                 // if .vtt currently rendering
                 if (trackElement) {
-                    offsetValue = updateCurrentTrackOffset(offsetValue);
-                    setVttSubtitleOffset(trackElement, offsetValue);
+                    setTextTrackSubtitleOffset(trackElement, offsetValue);
+                } else if (currentTrackEvents) {
+                    setTrackEventsSubtitleOffset(currentTrackEvents, offsetValue);
                 } else {
                     console.log("No available track, cannot apply offset: ", offsetValue);
                 }
@@ -620,16 +620,23 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
             return relativeOffset;
         }
 
-        function setVttSubtitleOffset(currentTrack, offsetValue) {
+        function setTextTrackSubtitleOffset(currentTrack, offsetValue) {
 
             if (currentTrack.cues) {
+                offsetValue = updateCurrentTrackOffset(offsetValue);
                 Array.from(currentTrack.cues)
                     .forEach(function(cue) {
                         cue.startTime -= offsetValue;
                         cue.endTime -= offsetValue;
                     });
-            } else if (Array.isArray(currentTrack)) {
-                currentTrack.forEach(function(trackEvent) {
+            }
+        }
+
+        function setTrackEventsSubtitleOffset(trackEvents, offsetValue) {
+
+            if (Array.isArray(trackEvents)) {
+                offsetValue = updateCurrentTrackOffset(offsetValue);
+                trackEvents.forEach(function(trackEvent) {
                     trackEvent.StartPositionTicks -= offsetValue;
                     trackEvent.EndPositionTicks -= offsetValue;
                 });


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->
After 10.4.0 upgrade the subtitle sync didn't worked. This was partially solved in #507 for ass subtitles (chrome and firefox) and vtt subtitles (chrome only).

This PR allow vtt subtitles offset to work on firefox as well.

This PR will also reset the subtitle-offset on track changes to fix the following bug:

1. play a video with multiple subtitle tracks.
2. select a track, set an offset.
3. select a second track (track play without offset but the previous offset is still displayed).
4. change the second track offset (offset is applied by substracting the displayed offset, wrong offset is applied).

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
* vtt subtitle offset mechanism in ```setSubtitleOffset``` function is simplified with:
   * unncessary ```customTrackIndex``` check is removed.
   * the vtt subtitle offset is applied to ```_mediaElement.textTracks``` for chrome and chromium-based web browsers.
  * the vtt subtitle offset is applied to ```currentTrackEvents``` for firefox-based web browsers.
* reset subtitle offset on subtitle-track changes (when switching subtitle on the same video).

**Tested on**

* Brave 1.0.1
* Chrome 78.0.3904.108
* Firefox 70.0.1

**Issues**

#669 