### PR TITLE
Fix require of 'export default'

### DIFF
--- a/src/bundle.js
+++ b/src/bundle.js
@@ -17,7 +17,7 @@ _define("fetch", function() {
 });
 
 // flvjs
-var flvjs = require("flv.js");
+var flvjs = require("flv.js").default;
 _define("flvjs", function() {
     return flvjs;
 });
@@ -54,7 +54,7 @@ _define("native-promise-only", function() {
 });
 
 // resize-observer-polyfill
-var resize = require("resize-observer-polyfill");
+var resize = require("resize-observer-polyfill").default;
 _define("resize-observer-polyfill", function() {
     return resize;
 });
@@ -73,7 +73,7 @@ _define("swiper", function() {
 });
 
 // sortable
-var sortable = require("sortablejs");
+var sortable = require("sortablejs").default;
 _define("sortable", function() {
     return sortable;
 });


### PR DESCRIPTION
Fix second error mentioned in https://github.com/jellyfin/jellyfin-web/issues/608#issuecomment-562735856

There are more modules with the same error.
<details>
  <summary>Code to find them all</summary>

Add to the end of `init()` in `site.js`.

```javascript
require(["document-register-element"], function (obj) { console.log("document-register-element" + " " + ("default" in obj)); });
require(["fetch"], function (obj) { console.log("fetch" + " " + ("default" in obj)); });
require(["flvjs"], function (obj) { console.log("flvjs" + " " + ("default" in obj)); });
require(["jstree"], function (obj) { console.log("jstree" + " " + ("default" in obj)); });
require(["jQuery"], function (obj) { console.log("jQuery" + " " + ("default" in obj)); });
require(["hlsjs"], function (obj) { console.log("hlsjs" + " " + ("default" in obj)); });
require(["howler"], function (obj) { console.log("howler" + " " + ("default" in obj)); });
require(["native-promise-only"], function (obj) { console.log("native-promise-only" + " " + ("default" in obj)); });
require(["resize-observer-polyfill"], function (obj) { console.log("resize-observer-polyfill" + " " + ("default" in obj)); });
require(["shaka"], function (obj) { console.log("shaka" + " " + ("default" in obj)); });
require(["swiper"], function (obj) { console.log("swiper" + " " + ("default" in obj)); });
require(["sortable"], function (obj) { console.log("sortable" + " " + ("default" in obj)); });
require(["webcomponents"], function (obj) { console.log("webcomponents" + " " + ("default" in obj)); });
require(["libjass"], function (obj) { console.log("libjass" + " " + ("default" in obj)); });
```
</details>

* `sortable`
Checked on `nowplaying` page in Firefox 71 and Chrome 79.

* `flv.js`
To check this, I have to hack jellyfin to load it (it is loaded but not work due to incompatible stream source) _(maybe someone could check it in proper way)_
