### PR TITLE
Add a warning to user wizard reflecting the importance of usernames

### DIFF
--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1282,6 +1282,7 @@
     "SearchForMissingMetadata": "Search for missing metadata",
     "SearchForSubtitles": "Search for Subtitles",
     "SearchResults": "Search Results",
+    "SelectAdminUsername": "Please select a username for the admin account.",
     "SendMessage": "Send message",
     "Series": "Series",
     "SeriesCancelled": "Series cancelled.",

--- a/src/wizarduser.html
+++ b/src/wizarduser.html
@@ -7,8 +7,8 @@
                     <p style="margin-top:2em;">${UserProfilesIntro}</p>
                     <br />
                     <div class="inputContainer">
-                        <input is="emby-input" type="text" id="txtUsername" label="${LabelYourFirstName}" required="required" />
-                        <div class="fieldDescription">${MoreUsersCanBeAddedLater}</div>
+                        <input is="emby-input" type="text" id="txtUsername" label="${LabelUsername}" required="required" />
+                        <div class="fieldDescription">${SelectAdminUsername}</div>
                     </div>
                     <div class="inputContainer">
                         <input is="emby-input" id="txtManualPassword" type="password" label="${LabelPassword}" />
@@ -17,6 +17,7 @@
                     <div class="inputContainer">
                         <input is="emby-input" id="txtPasswordConfirm" type="password" label="${LabelPasswordConfirm}" />
                     </div>
+                    <p>${MoreUsersCanBeAddedLater}</p>
                 </div>
 
                 <div class="wizardNavigation">


### PR DESCRIPTION
Me and @sparky8251 discussed the importance of this earlier in matrix but decided to move the discussion to a pr. Personally I think the red text might be a little over the top but I do believe the other changes are positive for the user experience

**Changes**
Replace "Your first name:" with "Username:"
Replace original username description with one more relevant to the field
Move original username description to bottom
![userwizard-text-edit](https://user-images.githubusercontent.com/6439218/71025650-c1e94780-2107-11ea-92c4-7062627cf4a2.png)

**Issues**
Resolves: #591
