### PR TITLE
If item EndYear is the same as ProductionYear only display ProductionYear

### DIFF
--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -892,7 +892,8 @@ define(['datetime', 'imageLoader', 'connectionManager', 'itemHelper', 'focusMana
                         } else {
 
                             if (item.EndDate && item.ProductionYear) {
-                                lines.push(item.ProductionYear + ' - ' + datetime.parseISO8601Date(item.EndDate).getFullYear());
+                                var endYear = datetime.parseISO8601Date(item.EndDate).getFullYear();
+                                lines.push(item.ProductionYear + (endYear === item.ProductionYear) ? '' : (' - ' + endYear));
                             } else {
                                 lines.push(item.ProductionYear || '');
                             }


### PR DESCRIPTION
cardBuilder: When ProductionYear is the same as EndDate.Year only display one value.
Example:
![example](https://user-images.githubusercontent.com/3680212/71207081-54bfe880-22a6-11ea-9b11-8006add61e28.PNG)
![example_2](https://user-images.githubusercontent.com/3680212/71207082-54bfe880-22a6-11ea-841e-827b8609835c.PNG)
