### PR TITLE
More accurate jump to time on slide bar

### DIFF
--- a/src/components/emby-slider/emby-slider.css
+++ b/src/components/emby-slider/emby-slider.css
@@ -84,7 +84,10 @@ _:-ms-input-placeholder {
 }
 
 .mdl-slider:hover::-webkit-slider-thumb {
-    transform: scale(1.6);
+    transform: scale(0);
+    transition: 0.4s;
+    width: 0;
+    height: 0;
 }
 
 .mdl-slider.show-focus:focus::-webkit-slider-thumb {


### PR DESCRIPTION
Hello. I notice that it is difficult to do a precise jump to time if the slider icon displays right under the cursor, which often happens when you just want to skip or go back a few seconds.
It seems that the slider icon covers the control bar so that the cursor clicks on the icon, not the bar. I try to fix it by scaling down the size of the slider to 0 while hovering and it works, though it may not look fancy.
I have checked some streaming sites like youtube and twitch and found that they did not have such problem. But I failed to figure out how they make it, as I am really new to web coding. It would be much better if someone else can fix it elegantly.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
