### PR TITLE
Fix coveredImage not being cover-sized

### DIFF
--- a/src/components/cardbuilder/card.css
+++ b/src/components/cardbuilder/card.css
@@ -247,7 +247,7 @@ button {
 }
 
 .coveredImage {
-    background-size: 100% 100%;
+    background-size: cover;
     background-position: center center;
 }
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**

Changed a background-size property for coveredImage from "100% 100%" to "cover".

Most of these had been fixed a year ago, but I noticed some of my posters being deformed and tracked it down to this. Turns out one background-size property hadn't been changed.

**Issues**
 
n/a

