### PR TITLE
Align the page title with other text and icons in the header

### DIFF
--- a/src/css/librarybrowser.css
+++ b/src/css/librarybrowser.css
@@ -93,7 +93,7 @@
     display: -webkit-inline-box;
     display: -webkit-inline-flex;
     display: inline-flex;
-    margin: 0 0 0 .5em;
+    margin: .3em 0 0 .5em;
     height: 1.7em;
     -webkit-box-align: center;
     -webkit-align-items: center;


### PR DESCRIPTION
**Changes**

Changes the top margin for pageTitle from 0 to .3em in order to properly align the baseline of the title with the other text and icons in the headers.

Before:
![Screenshot_2019-12-24 Jellyfin(2)](https://user-images.githubusercontent.com/19396809/71405549-0d36b500-2636-11ea-8421-1a9257ccddab.jpg)

After:
![Screenshot_2019-12-24 Jellyfin(3)](https://user-images.githubusercontent.com/19396809/71405561-158ef000-2636-11ea-8e85-6944ea828e46.jpg)

**Issues**

None
