### PR TITLE
Add initial AirPlay support

### DIFF
--- a/src/components/htmlvideoplayer/plugin.js
+++ b/src/components/htmlvideoplayer/plugin.js
@@ -1640,7 +1640,7 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
         if (document.AirPlayEnabled) {
             return document.AirplayElement ? true : false;
         }
-        
+
         return false;
     };
 

--- a/src/components/htmlvideoplayer/plugin.js
+++ b/src/components/htmlvideoplayer/plugin.js
@@ -1658,7 +1658,6 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
             }
         } else {
             video.webkitShowPlaybackTargetPicker();
-
         }
     };
 

--- a/src/components/htmlvideoplayer/plugin.js
+++ b/src/components/htmlvideoplayer/plugin.js
@@ -1639,14 +1639,8 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
 
         if (document.AirPlayEnabled) {
             return document.AirplayElement ? true : false;
-        } else {
-            var video = this._mediaElement;
-            if (video) {
-                return video.webkitShowPlaybackTargetPicker();
-
-            }
         }
-
+        
         return false;
     };
 

--- a/src/components/htmlvideoplayer/plugin.js
+++ b/src/components/htmlvideoplayer/plugin.js
@@ -1522,7 +1522,7 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
                 list.push('PictureInPicture');
             }
         }
-        
+
         if (browser.safari || browser.iOS || browser.iPad) {
             list.push('AirPlay')
         }
@@ -1643,33 +1643,30 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
             var video = this._mediaElement;
             if (video) {
                 return video.webkitShowPlaybackTargetPicker();
-                
+
             }
         }
 
         return false;
     };
 
-HtmlVideoPlayer.prototype.setAirPlayEnabled = function (isEnabled) {
+    HtmlVideoPlayer.prototype.setAirPlayEnabled = function (isEnabled) {
 
-    var video = this._mediaElement;
+        var video = this._mediaElement;
 
-    if (document.AirPlayEnabled) {
-        if (video) {
-            if (isEnabled) {
-                video.requestAirPlay().catch(onAirPlayError);
-            } else {
-                document.exitAirPLay().catch(onAirPlayError);
+        if (document.AirPlayEnabled) {
+            if (video) {
+                if (isEnabled) {
+                    video.requestAirPlay().catch(onAirPlayError);
+                } else {
+                    document.exitAirPLay().catch(onAirPlayError);
+                }
             }
+        } else {
+            video.webkitShowPlaybackTargetPicker();
+
         }
-    } else {
-             video.webkitShowPlaybackTargetPicker();
-
-    }
-};
-
- 
-    
+    };
 
     HtmlVideoPlayer.prototype.setBrightness = function (val) {
 

--- a/src/components/htmlvideoplayer/plugin.js
+++ b/src/components/htmlvideoplayer/plugin.js
@@ -1645,7 +1645,6 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
     };
 
     HtmlVideoPlayer.prototype.setAirPlayEnabled = function (isEnabled) {
-
         var video = this._mediaElement;
 
         if (document.AirPlayEnabled) {

--- a/src/components/htmlvideoplayer/plugin.js
+++ b/src/components/htmlvideoplayer/plugin.js
@@ -1522,6 +1522,10 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
                 list.push('PictureInPicture');
             }
         }
+        
+        if (browser.safari || browser.iOS || browser.iPad) {
+            list.push('AirPlay')
+        }
 
         list.push('SetBrightness');
         list.push("SetAspectRatio")
@@ -1630,6 +1634,42 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
 
         return false;
     };
+
+    HtmlVideoPlayer.prototype.isAirPlayEnabled = function () {
+
+        if (document.AirPlayEnabled) {
+            return document.AirplayElement ? true : false;
+        } else {
+            var video = this._mediaElement;
+            if (video) {
+                return video.webkitShowPlaybackTargetPicker();
+                
+            }
+        }
+
+        return false;
+    };
+
+HtmlVideoPlayer.prototype.setAirPlayEnabled = function (isEnabled) {
+
+    var video = this._mediaElement;
+
+    if (document.AirPlayEnabled) {
+        if (video) {
+            if (isEnabled) {
+                video.requestAirPlay().catch(onAirPlayError);
+            } else {
+                document.exitAirPLay().catch(onAirPlayError);
+            }
+        }
+    } else {
+             video.webkitShowPlaybackTargetPicker();
+
+    }
+};
+
+ 
+    
 
     HtmlVideoPlayer.prototype.setBrightness = function (val) {
 
@@ -1782,6 +1822,10 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
 
     HtmlVideoPlayer.prototype.togglePictureInPicture = function () {
         return this.setPictureInPictureEnabled(!this.isPictureInPictureEnabled());
+    };
+
+    HtmlVideoPlayer.prototype.toggleAirPlay = function () {
+        return this.setAirPlayEnabled(!this.isAirPlayEnabled());
     };
 
     HtmlVideoPlayer.prototype.getBufferedRanges = function () {

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -1540,6 +1540,11 @@ define(['events', 'datetime', 'appSettings', 'itemHelper', 'pluginManager', 'pla
             return player.togglePictureInPicture();
         };
 
+        self.toggleAirPlay = function (player) {
+            player = player || self._currentPlayer;
+            return player.toggleAirPlay();
+        };
+
         self.getSubtitleStreamIndex = function (player) {
 
             player = player || self._currentPlayer;
@@ -3853,6 +3858,9 @@ define(['events', 'datetime', 'appSettings', 'itemHelper', 'pluginManager', 'pla
             if (player.supports) {
                 if (player.supports('PictureInPicture')) {
                     list.push('PictureInPicture');
+                }
+                if (player.supports('AirPlay')) {
+                    list.push('AirPlay');
                 }
                 if (player.supports('SetBrightness')) {
                     list.push('SetBrightness');

--- a/src/controllers/videoosd.js
+++ b/src/controllers/videoosd.js
@@ -789,6 +789,12 @@ define(["playbackManager", "dom", "inputManager", "datetime", "itemHelper", "med
                 view.querySelector(".btnPip").classList.remove("hide");
             }
 
+             if (-1 === supportedCommands.indexOf("AirPlay")) {
+                 view.querySelector(".btnAirPlay").classList.add("hide");
+             } else {
+                 view.querySelector(".btnAirPlay").classList.remove("hide");
+             }
+
             updateFullscreenIcon();
         }
 
@@ -1306,6 +1312,9 @@ define(["playbackManager", "dom", "inputManager", "datetime", "itemHelper", "med
         view.querySelector(".btnPip").addEventListener("click", function () {
             playbackManager.togglePictureInPicture(currentPlayer);
         });
+          view.querySelector(".btnAirPlay").addEventListener("click", function () {
+              playbackManager.toggleAirPlay(currentPlayer);
+          });
         view.querySelector(".btnVideoOsdSettings").addEventListener("click", onSettingsButtonClick);
         view.addEventListener("viewhide", function () {
             headerElement.classList.remove("hide");

--- a/src/controllers/videoosd.js
+++ b/src/controllers/videoosd.js
@@ -789,11 +789,11 @@ define(["playbackManager", "dom", "inputManager", "datetime", "itemHelper", "med
                 view.querySelector(".btnPip").classList.remove("hide");
             }
 
-             if (-1 === supportedCommands.indexOf("AirPlay")) {
-                 view.querySelector(".btnAirPlay").classList.add("hide");
-             } else {
-                 view.querySelector(".btnAirPlay").classList.remove("hide");
-             }
+            if (-1 === supportedCommands.indexOf("AirPlay")) {
+                view.querySelector(".btnAirPlay").classList.add("hide");
+            } else {
+                view.querySelector(".btnAirPlay").classList.remove("hide");
+            }
 
             updateFullscreenIcon();
         }
@@ -1312,9 +1312,9 @@ define(["playbackManager", "dom", "inputManager", "datetime", "itemHelper", "med
         view.querySelector(".btnPip").addEventListener("click", function () {
             playbackManager.togglePictureInPicture(currentPlayer);
         });
-          view.querySelector(".btnAirPlay").addEventListener("click", function () {
-              playbackManager.toggleAirPlay(currentPlayer);
-          });
+        view.querySelector(".btnAirPlay").addEventListener("click", function () {
+            playbackManager.toggleAirPlay(currentPlayer);
+        });
         view.querySelector(".btnVideoOsdSettings").addEventListener("click", onSettingsButtonClick);
         view.addEventListener("viewhide", function () {
             headerElement.classList.remove("hide");

--- a/src/videoosd.html
+++ b/src/videoosd.html
@@ -72,6 +72,9 @@
                 <button is="paper-icon-button-light" class="btnPip hide autoSize" title="${PictureInPicture}">
                     <i class="xlargePaperIconButton md-icon">picture_in_picture_alt</i>
                 </button>
+                <button is="paper-icon-button-light" class="btnAirPlay hide autoSize" title="${AirPlay}">
+                    <i class="xlargePaperIconButton md-icon">airplay</i>
+                </button>
 
                 <div class="osdTimeText"><span class="osdPositionText"></span><span class="osdDurationText"></span><span class="endsAtText"></span></div>
 


### PR DESCRIPTION
**Changes**
Adds an AirPlay button to the web OSD controls. When clicked, it will populate with all available AirPlay hardware that is in range, using a system picker.

**Issues**
#346, and the corresponding [Fider #132](https://features.jellyfin.org/posts/132/airplay-support
) (kind of).

**Notes**
The Apple doc reference is here: https://developer.apple.com/documentation/webkitjs/adding_an_airplay_button_to_your_safari_media_controls

I am not actually listening for availability as they recommend, instead, I'm just displaying the button. Improvements welcome.

If testing, you can't be using `localhost`, because the Apple TV can't reach that. Also, subtitles do not render at this point in time.