### PR TITLE
Enable headroom only on mobile

### DIFF
--- a/src/components/emby-scroller/emby-scroller.js
+++ b/src/components/emby-scroller/emby-scroller.js
@@ -155,7 +155,7 @@ define(['scroller', 'dom', 'layoutManager', 'inputManager', 'focusManager', 'bro
             initCenterFocus(this, this.scroller);
         }
 
-        if (bindHeader) {
+        if (bindHeader && layoutManager.mobile) {
             initHeadroom(this);
         }
 

--- a/src/scripts/librarymenu.js
+++ b/src/scripts/librarymenu.js
@@ -103,7 +103,9 @@ define(["dom", "layoutManager", "inputManager", "connectionManager", "events", "
         headerHomeButton.addEventListener("click", onHeaderHomeButtonClick);
         headerCastButton.addEventListener("click", onCastButtonClicked);
 
-        initHeadRoom(skinHeader);
+        if (layoutManager.mobile) {
+            initHeadRoom(skinHeader);
+        }
     }
 
     function onCastButtonClicked() {


### PR DESCRIPTION
**Changes**

If using the desktop layout, don't make the header disappear on scroll.

Desktops should have way more than enough headroom nowadays for this not to be necessary, and it's actually pretty annoying to have part of the page disappear when scrolling, especially since it has the search button.

**Issues**

None
