### PR TITLE
Hide Cast button on TV layout

### DIFF
--- a/src/scripts/librarymenu.js
+++ b/src/scripts/librarymenu.js
@@ -47,7 +47,9 @@ define(["dom", "layoutManager", "inputManager", "connectionManager", "events", "
                 headerSearchButton.classList.remove("hide");
             }
 
-            headerCastButton.classList.remove("hide");
+            if (!layoutManager.tv) {
+                headerCastButton.classList.remove("hide");
+            }
         } else {
             headerHomeButton.classList.add("hide");
             headerCastButton.classList.add("hide");

--- a/src/scripts/librarymenu.js
+++ b/src/scripts/librarymenu.js
@@ -103,7 +103,10 @@ define(["dom", "layoutManager", "inputManager", "connectionManager", "events", "
 
         headerUserButton.addEventListener("click", onHeaderUserButtonClick);
         headerHomeButton.addEventListener("click", onHeaderHomeButtonClick);
-        headerCastButton.addEventListener("click", onCastButtonClicked);
+
+        if (!layoutManager.tv) {
+            headerCastButton.addEventListener("click", onCastButtonClicked);
+        }
 
         initHeadRoom(skinHeader);
     }


### PR DESCRIPTION
**Changes**

I fail to see a proper use case for the Cast button on the TV UI, since it'll mainly be used on TVs (Either directly on the TV or on a box connected to it). So this commit keeps the cast button hidden in the TV Layout.

**Issues**

None
