### PR TITLE
Refactor document.registerElement

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "eslint": "^5.16.0",
     "file-loader": "^3.0.1",
     "html-webpack-plugin": "^3.2.0",
+    "jasmine": "^3.5.0",
     "postcss-loader": "^3.0.0",
     "style-loader": "^0.23.1",
     "webpack": "^4.41.0",
@@ -28,6 +29,7 @@
     "howler": "^2.1.2",
     "jquery": "^3.4.1",
     "jstree": "^3.3.7",
+    "libass-wasm": "^2.1.1",
     "libjass": "^0.11.0",
     "native-promise-only": "^0.8.0-a",
     "requirejs": "^2.3.5",
@@ -35,7 +37,6 @@
     "shaka-player": "^2.5.5",
     "sortablejs": "^1.9.0",
     "swiper": "^3.4.2",
-    "libass-wasm": "^2.1.1",
     "webcomponents.js": "^0.7.24",
     "whatwg-fetch": "^1.1.1"
   },

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,0 +1,6 @@
+{
+    "spec_dir": "src",
+    "spec_files": [
+        "**/__tests__/**/*.[jt]s?(x)"
+    ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2842,6 +2842,19 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
+jasmine-core@~3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-3.5.0.tgz#132c23e645af96d85c8bca13c8758b18429fc1e4"
+  integrity sha512-nCeAiw37MIMA9w9IXso7bRaLl+c/ef3wnxsoSAlYrzS+Ot0zTG6nU8G/cIfGkqpkjX2wNaIW9RFG0TwIFnG6bA==
+
+jasmine@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/jasmine/-/jasmine-3.5.0.tgz#7101eabfd043a1fc82ac24e0ab6ec56081357f9e"
+  integrity sha512-DYypSryORqzsGoMazemIHUfMkXM7I7easFaxAvNM3Mr6Xz3Fy36TupTrAOxZWN8MVKEU5xECv22J4tUQf3uBzQ==
+  dependencies:
+    glob "^7.1.4"
+    jasmine-core "~3.5.0"
+
 jquery@>=1.9.1, jquery@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"


### PR DESCRIPTION
This draft is to secure commitment to tagged issue.

**Changes**
- Removes dependency document.registerElement, in favour of CustomElementRegistry.define
https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define
- Adds unit testing framework with initial tests covering custom element wrapper.

**Issues**
Fixes #124 
