### PR TITLE
Fix headerLeft justify-content (WebOS 3/4, Tizen 4)

### DIFF
--- a/src/assets/css/librarybrowser.css
+++ b/src/assets/css/librarybrowser.css
@@ -137,7 +137,7 @@
     align-items: center;
     flex-grow: 1;
     overflow: hidden;
-    justify-content: left;
+    justify-content: flex-start;
 }
 
 .sectionTabs {


### PR DESCRIPTION
WebOS 3/4 and Tizen 4 do not support `left` for `justify-content`.
I changed `left` to `flex-start`.

Before (WebOS 4)
![header-before](https://user-images.githubusercontent.com/56478732/72464495-700b0e80-37e6-11ea-9509-bb9e8b22611b.png)

After (WebOS 4)
![header-after](https://user-images.githubusercontent.com/56478732/72464501-739e9580-37e6-11ea-91ce-a68713448b99.png)

Firefox 72.0.1, Chrome 79.0.3945.79, iPhone 5S, iPad Pro 11 - no difference.

_I believe that WebOS 2 also doesn’t support `left`, but it failed to load even transpiled to ES2015 (`bundle.js` and `components/htmlvideoplayer/plugin.js` only, because full transpile doesn't work)._
<details>
<summary>TypeError: Expected at least one argument    alameda.js:131</summary>

```
TypeError: Expected at least one argument alameda.js:131
resolve alameda.js:131
newContext alameda.js:131
(anonymous function) alameda.js:1242

131:     asyncResolve = Promise.resolve();
```
</details>