### PR TITLE
Fix filter dialog size for TV

### DIFF
--- a/src/components/filterdialog/style.css
+++ b/src/components/filterdialog/style.css
@@ -28,8 +28,8 @@
 
 @media all and (min-width:400px) {
     .dynamicFilterDialog {
-        width: 300px;
-        margin-left: -150px !important;
+        width: 20.16em;
+        margin-left: -10.08em !important;
         left: 50% !important
     }
 }


### PR DESCRIPTION
Fix #537

Changed units based on font size on desktop (14.88px). Screen resolution is 1920x1200 24"

On desktop, visually no change (in web inspector width is 300.05px).
On TV, the proportions are slightly different due to the lack of a scrollbar.

Firefox 72 (before)
![filter-firefox-before](https://user-images.githubusercontent.com/56478732/72520219-05031b80-386a-11ea-9b5b-e201e6842961.png)
Firefox 72 (after)
![filter-firefox-after](https://user-images.githubusercontent.com/56478732/72520234-0cc2c000-386a-11ea-8a28-011770912c6e.png)

WebOS 3 (before)
![filter-webos-before](https://user-images.githubusercontent.com/56478732/72520382-632ffe80-386a-11ea-893b-a52c05b69a29.png)
WebOS 3 (after)
![filter-webos-after](https://user-images.githubusercontent.com/56478732/72520396-69be7600-386a-11ea-9bc5-9bd12f4ce112.png)
