### PR TITLE
Add playback control from TV remote

### DIFF
--- a/src/components/keyboardnavigation.js
+++ b/src/components/keyboardnavigation.js
@@ -1,35 +1,108 @@
-define(['inputManager', 'focusManager'], function(inputManager, focusManager) {
-    'use strict';
+define(["inputManager", "layoutManager"], function (inputManager, layoutManager) {
+    "use strict";
 
     console.log("keyboardnavigation");
 
+    /**
+     * Key name mapping.
+     */
+    // Add more to support old browsers
+    var KeyNames = {
+        13: "Enter",
+        19: "Pause",
+        27: "Escape",
+        32: "Space",
+        37: "ArrowLeft",
+        38: "ArrowUp",
+        39: "ArrowRight",
+        40: "ArrowDown",
+        412: "MediaRewind", // MediaRewind (Tizen/WebOS)
+        413: "MediaStop", // MediaStop (Tizen/WebOS)
+        415: "MediaPlay", // MediaPlay (Tizen/WebOS)
+        417: "MediaFastForward", // MediaFastForward (Tizen/WebOS)
+        461: "Back", // Back (WebOS)
+        10009: "Back", // Back (Tizen)
+        10232: "MediaTrackPrevious", // MediaTrackPrevious (Tizen)
+        10233: "MediaTrackNext", // MediaTrackNext (Tizen)
+        10252: "MediaPlayPause" // MediaPlayPause (Tizen)
+    };
+
+    /**
+     * Returns key name from event.
+     *
+     * @param {KeyboardEvent} keyboard event
+     * @return {string} key name
+     */
+    function getKeyName(event) {
+        return KeyNames[event.keyCode] || event.key;
+    }
+
     function enable() {
-        document.addEventListener('keydown', function(e) {
+        document.addEventListener("keydown", function (e) {
             var capture = true;
 
-            switch (e.keyCode) {
-                case 37: // ArrowLeft
-                    inputManager.handle('left');
+            switch (getKeyName(e)) {
+                case "ArrowLeft":
+                    inputManager.handle("left");
                     break;
-                case 38: // ArrowUp
-                    inputManager.handle('up');
+                case "ArrowUp":
+                    inputManager.handle("up");
                     break;
-                case 39: // ArrowRight
-                    inputManager.handle('right');
+                case "ArrowRight":
+                    inputManager.handle("right");
                     break;
-                case 40: // ArrowDown
-                    inputManager.handle('down');
+                case "ArrowDown":
+                    inputManager.handle("down");
                     break;
+
+                case "Back":
+                    inputManager.handle("back");
+                    break;
+
+                case "Escape":
+                    if (layoutManager.tv) {
+                        inputManager.handle("back");
+                    } else {
+                        capture = false;
+                    }
+                    break;
+
+                case "MediaPlay":
+                    inputManager.handle("play");
+                    break;
+                case "Pause":
+                    inputManager.handle("pause");
+                    break;
+                case "MediaPlayPause":
+                    inputManager.handle("playpause");
+                    break;
+                case "MediaRewind":
+                    inputManager.handle("rewind");
+                    break;
+                case "MediaFastForward":
+                    inputManager.handle("fastforward");
+                    break;
+                case "MediaStop":
+                    inputManager.handle("stop");
+                    break;
+                case "MediaTrackPrevious":
+                    inputManager.handle("previoustrack");
+                    break;
+                case "MediaTrackNext":
+                    inputManager.handle("nexttrack");
+                    break;
+
                 default:
                     capture = false;
             }
+
             if (capture) {
                 console.log("Disabling default event handling");
                 e.preventDefault();
             }
         });
-
     }
+
     return {
         enable: enable
     };

--- a/src/components/keyboardnavigation.js
+++ b/src/components/keyboardnavigation.js
@@ -27,6 +27,20 @@ define(["inputManager", "layoutManager"], function (inputManager, layoutManager)
         10252: "MediaPlayPause" // MediaPlayPause (Tizen)
     };
 
+    var hasFieldKey = false;
+    try {
+        hasFieldKey = "key" in new KeyboardEvent("keydown");
+    } catch (e) {
+        console.log("error checking 'key' field");
+    }
+
+    if (!hasFieldKey) {
+        // Add [a..z]
+        for (var i = 65; i <= 90; i++) {
+            KeyNames[i] = String.fromCharCode(i).toLowerCase();
+        }
+    }
+
     /**
      * Returns key name from event.
      *
@@ -104,6 +118,7 @@ define(["inputManager", "layoutManager"], function (inputManager, layoutManager)
     }
 
     return {
-        enable: enable
+        enable: enable,
+        getKeyName: getKeyName
     };
 });

--- a/src/components/keyboardnavigation.js
+++ b/src/components/keyboardnavigation.js
@@ -16,15 +16,24 @@ define(["inputManager", "layoutManager"], function (inputManager, layoutManager)
         38: "ArrowUp",
         39: "ArrowRight",
         40: "ArrowDown",
-        412: "MediaRewind", // MediaRewind (Tizen/WebOS)
-        413: "MediaStop", // MediaStop (Tizen/WebOS)
-        415: "MediaPlay", // MediaPlay (Tizen/WebOS)
-        417: "MediaFastForward", // MediaFastForward (Tizen/WebOS)
-        461: "Back", // Back (WebOS)
-        10009: "Back", // Back (Tizen)
-        10232: "MediaTrackPrevious", // MediaTrackPrevious (Tizen)
-        10233: "MediaTrackNext", // MediaTrackNext (Tizen)
-        10252: "MediaPlayPause" // MediaPlayPause (Tizen)
+        // MediaRewind (Tizen/WebOS)
+        412: "MediaRewind",
+        // MediaStop (Tizen/WebOS)
+        413: "MediaStop",
+        // MediaPlay (Tizen/WebOS)
+        415: "MediaPlay",
+        // MediaFastForward (Tizen/WebOS)
+        417: "MediaFastForward",
+        // Back (WebOS)
+        461: "Back",
+        // Back (Tizen)
+        10009: "Back",
+        // MediaTrackPrevious (Tizen)
+        10232: "MediaTrackPrevious",
+        // MediaTrackNext (Tizen)
+        10233: "MediaTrackNext",
+        // MediaPlayPause (Tizen)
+        10252: "MediaPlayPause"
     };
 
     var hasFieldKey = false;

--- a/src/controllers/playback/videoosd.js
+++ b/src/controllers/playback/videoosd.js
@@ -1105,7 +1105,6 @@ define(["playbackManager", "dom", "inputManager", "datetime", "itemHelper", "med
                 case "Enter":
                     showOsd();
                     break;
-
                 case "Escape":
                 case "Back":
                     // Ignore key when some dialog is opened
@@ -1114,52 +1113,45 @@ define(["playbackManager", "dom", "inputManager", "datetime", "itemHelper", "med
                         e.stopPropagation();
                     }
                     break;
-
                 case "k":
                     playbackManager.playPause(currentPlayer);
                     showOsd();
                     break;
-
                 case "l":
                 case "ArrowRight":
                 case "Right":
                     playbackManager.fastForward(currentPlayer);
                     showOsd();
                     break;
-
                 case "j":
                 case "ArrowLeft":
                 case "Left":
                     playbackManager.rewind(currentPlayer);
                     showOsd();
                     break;
-
                 case "f":
                     if (!e.ctrlKey && !e.metaKey) {
                         playbackManager.toggleFullscreen(currentPlayer);
                         showOsd();
                     }
                     break;
-
                 case "m":
                     playbackManager.toggleMute(currentPlayer);
                     showOsd();
                     break;
-
                 case "NavigationLeft":
                 case "GamepadDPadLeft":
                 case "GamepadLeftThumbstickLeft":
-                // Ignores gamepad events that are always triggered, even when not focused.
+                    // Ignores gamepad events that are always triggered, even when not focused.
                     if (document.hasFocus()) {
                         playbackManager.rewind(currentPlayer);
                         showOsd();
                     }
                     break;
-
                 case "NavigationRight":
                 case "GamepadDPadRight":
                 case "GamepadLeftThumbstickRight":
-                // Ignores gamepad events that are always triggered, even when not focused.
+                    // Ignores gamepad events that are always triggered, even when not focused.
                     if (document.hasFocus()) {
                         playbackManager.fastForward(currentPlayer);
                         showOsd();

--- a/src/controllers/playback/videoosd.js
+++ b/src/controllers/playback/videoosd.js
@@ -1100,6 +1100,20 @@ define(["playbackManager", "dom", "inputManager", "datetime", "itemHelper", "med
             }
 
             switch (e.key) {
+                case "Enter":
+                    showOsd();
+                    break;
+
+                case "Escape":
+                case "RCUBack": // WebOS back
+                case "XF86Back": // Tizen back
+                    // Ignore key when some dialog is opened
+                    if (currentVisibleMenu === "osd" && !document.querySelector(".dialogContainer")) {
+                        hideOsd();
+                        e.stopPropagation();
+                    }
+                    break;
+
                 case "k":
                     playbackManager.playPause(currentPlayer);
                     showOsd();
@@ -1280,7 +1294,7 @@ define(["playbackManager", "dom", "inputManager", "datetime", "itemHelper", "med
                 showOsd();
                 inputManager.on(window, onInputCommand);
                 dom.addEventListener(window, "keydown", onWindowKeyDown, {
-                    passive: true
+                    capture: true
                 });
             } catch (e) {
                 require(['appRouter'], function(appRouter) {
@@ -1294,7 +1308,7 @@ define(["playbackManager", "dom", "inputManager", "datetime", "itemHelper", "med
             }
 
             dom.removeEventListener(window, "keydown", onWindowKeyDown, {
-                passive: true
+                capture: true
             });
             stopOsdHideTimer();
             headerElement.classList.remove("osdHeader");

--- a/src/controllers/playback/videoosd.js
+++ b/src/controllers/playback/videoosd.js
@@ -1,4 +1,4 @@
-define(["playbackManager", "dom", "inputManager", "datetime", "itemHelper", "mediaInfo", "focusManager", "imageLoader", "scrollHelper", "events", "connectionManager", "browser", "globalize", "apphost", "layoutManager", "userSettings", "scrollStyles", "emby-slider", "paper-icon-button-light", "css!assets/css/videoosd"], function (playbackManager, dom, inputManager, datetime, itemHelper, mediaInfo, focusManager, imageLoader, scrollHelper, events, connectionManager, browser, globalize, appHost, layoutManager, userSettings) {
+define(["playbackManager", "dom", "inputManager", "datetime", "itemHelper", "mediaInfo", "focusManager", "imageLoader", "scrollHelper", "events", "connectionManager", "browser", "globalize", "apphost", "layoutManager", "userSettings", "keyboardnavigation", "scrollStyles", "emby-slider", "paper-icon-button-light", "css!assets/css/videoosd"], function (playbackManager, dom, inputManager, datetime, itemHelper, mediaInfo, focusManager, imageLoader, scrollHelper, events, connectionManager, browser, globalize, appHost, layoutManager, userSettings, keyboardnavigation) {
     "use strict";
 
     function seriesImageUrl(item, options) {
@@ -1088,25 +1088,26 @@ define(["playbackManager", "dom", "inputManager", "datetime", "itemHelper", "med
         var NavigationKeys = ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"];
 
         function onWindowKeyDown(e) {
+            var key = keyboardnavigation.getKeyName(e);
+
             if (!currentVisibleMenu && 32 === e.keyCode) {
                 playbackManager.playPause(currentPlayer);
                 showOsd();
                 return;
             }
 
-            if (layoutManager.tv && NavigationKeys.indexOf(e.key) != -1) {
+            if (layoutManager.tv && NavigationKeys.indexOf(key) != -1) {
                 showOsd();
                 return;
             }
 
-            switch (e.key) {
+            switch (key) {
                 case "Enter":
                     showOsd();
                     break;
 
                 case "Escape":
-                case "RCUBack": // WebOS back
-                case "XF86Back": // Tizen back
+                case "Back":
                     // Ignore key when some dialog is opened
                     if (currentVisibleMenu === "osd" && !document.querySelector(".dialogContainer")) {
                         hideOsd();

--- a/src/elements/emby-slider/emby-slider.js
+++ b/src/elements/emby-slider/emby-slider.js
@@ -1,4 +1,4 @@
-define(['browser', 'dom', 'layoutManager', 'css!./emby-slider', 'registerElement', 'emby-input'], function (browser, dom, layoutManager) {
+define(['browser', 'dom', 'layoutManager', 'keyboardnavigation', 'css!./emby-slider', 'registerElement', 'emby-input'], function (browser, dom, layoutManager, keyboardnavigation) {
     'use strict';
 
     var EmbySliderPrototype = Object.create(HTMLInputElement.prototype);
@@ -250,7 +250,7 @@ define(['browser', 'dom', 'layoutManager', 'css!./emby-slider', 'registerElement
      * Handle KeyDown event
      */
     function onKeyDown(e) {
-        switch (e.key) {
+        switch (keyboardnavigation.getKeyName(e)) {
             case 'ArrowLeft':
             case 'Left':
                 stepKeyboard(this, -this.keyboardStepDown || -1);

--- a/src/scripts/inputManager.js
+++ b/src/scripts/inputManager.js
@@ -22,9 +22,7 @@ define(['playbackManager', 'focusManager', 'appRouter', 'dom'], function (playba
 
     var eventListenerCount = 0;
     function on(scope, fn) {
-        if (eventListenerCount) {
-            eventListenerCount++;
-        }
+        eventListenerCount++;
         dom.addEventListener(scope, 'command', fn, {});
     }
 


### PR DESCRIPTION
Fix event subscription in `inputManager` (required by next change). (#623)

Add key handling to support LG and Samsung remotes (#303):
* Play
* Pause
* PlayPause
* Stop
* Rewind
* FastForward
* Previous Track
* Next Track
* Back _(Tizen app do not handle "Back" by default; for WebOS app it is better to disable built-in handling)_

Add shortcuts to video playback (#621):
* `Enter` - show OSD
* `Escape`/`Back` - hide OSD / go to back
* I left `Space` as is - pause and show OSD only if the latter is hidden

In addition, `Escape` on TV is now "Go to Back".

**Remarks**
I found out how to disable `Back` built-in handling in WebOS.
Need to add `disableBackHistoryAPI: true` to `appinfo.json` of `jellyfin-webos`.
[http://webostv.developer.lge.com/develop/app-developer-guide/back-button/](http://webostv.developer.lge.com/develop/app-developer-guide/back-button/)

**Limitations**
In TV browser (at least Tizen 4), `Back` and `Escape` are handled as "Go to Back" by browser itself - webapp doesn't receive event. So, `Back`/`Escape` functionality doesn't work in TV browser.
