### PR TITLE
Use dist versions in bundle.js

### DIFF
--- a/src/bundle.js
+++ b/src/bundle.js
@@ -17,7 +17,7 @@ _define("fetch", function() {
 });
 
 // flvjs
-var flvjs = require("flv.js").default;
+var flvjs = require("flv.js/dist/flv").default;
 _define("flvjs", function() {
     return flvjs;
 });


### PR DESCRIPTION
**Changes**

Use the transpiled version of flv.js and other libraries imported in bundle.js instead of the default.
This should fix any compatibility issue with unsupported keywords, since it's valid ES5 instead of ES6.

**Issues**

Should help with #646 until the Webpack migration is complete.
