### PR TITLE
sort items to play in the correct order when sending to Chromecast

### DIFF
--- a/src/components/chromecast/chromecastplayer.js
+++ b/src/components/chromecast/chromecastplayer.js
@@ -686,6 +686,13 @@ define(['appSettings', 'userSettings', 'playbackManager', 'connectionManager', '
             });
         }
 
+        if (options.items.length > 1 && options && options.ids) {
+            // Use the original request id array for sorting the result in the proper order
+            options.items.sort(function (a, b) {
+                return options.ids.indexOf(a.Id) - options.ids.indexOf(b.Id);
+            });
+        }
+
         return this._castPlayer.loadMedia(options, command);
     };
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Copies the relevant segment of `translateItemsForPlayback` in `playbackmanager.js` to play items in the correct order instead of the order returned by the server.

It seems like the rest of the functionality of `translateItemsForPlayback` is best implemented on the `jellyfin-chromecast` side here, so there's no need to do anything more complicated than this.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #692.