### PR TITLE
Fix for live tv channel thumbnails and horizontal scroll on trackpad

### DIFF
--- a/src/components/cardbuilder/card.css
+++ b/src/components/cardbuilder/card.css
@@ -36,6 +36,11 @@ button {
     margin-right: -0.6em;
 }
 
+.itemsContainer.scrollSlider.focuscontainer-x.animatedScrollX {
+    overflow-x: scroll;
+    margin-bottom: -15px
+}
+
 /* TODO replace this with a proper fix */
 /* doesnt work on mobile devices */
 /* negative margin fixes annoying misalignment with cards and title */
@@ -216,6 +221,7 @@ button {
 .visualCardBox .cardContent {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
+    background-size: contain;
 }
 
 .cardContent-shadow {


### PR DESCRIPTION
'smushed'/bad aspect ratio images on the live tv channel thumbnails
horizontal scrolling through containers on trackpads.

without my fix: https://i.imgur.com/dMxt4zr.png - with my fix: https://i.imgur.com/qrLh6E1.png 

[css.mp4.zip](https://github.com/jellyfin/jellyfin-web/files/4110869/css.mp4.zip)


<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
