### PR TITLE
[WIP] Fix horizontal scrolling of scrollbutton items

### DIFF
--- a/src/components/emby-scrollbuttons/emby-scrollbuttons.js
+++ b/src/components/emby-scrollbuttons/emby-scrollbuttons.js
@@ -54,14 +54,21 @@ define(['layoutManager', 'dom', 'css!./emby-scrollbuttons', 'registerElement', '
     }
 
     function onScroll(e) {
-        var scrollButtons = this;
-        var scroller = this.scroller;
+        // Only handle horizontal scrolls
+        if (!e.deltaX) return;
 
+        var scroller = this.scroller;
         var scrollSize = getScrollSize(scroller);
         var scrollPos = getScrollPosition(scroller);
         var scrollWidth = getScrollWidth(scroller);
 
-        updateScrollButtons(scrollButtons, scrollSize, scrollPos, scrollWidth);
+        // Get the width of the first item in the scroller
+        var itemWidth = scroller.children[0].children[0].offsetWidth;
+        var newPos = Math.max(0, scrollPos + (itemWidth * e.deltaX));
+
+        scroller.scrollToPosition(newPos, false);
+        // Disable buttons when at start / end
+        updateScrollButtons(this, scrollSize, newPos, scrollWidth);
     }
 
     function getStyleValue(style, name) {

--- a/src/components/emby-scrollbuttons/emby-scrollbuttons.js
+++ b/src/components/emby-scrollbuttons/emby-scrollbuttons.js
@@ -121,9 +121,8 @@ define(['layoutManager', 'dom', 'css!./emby-scrollbuttons', 'registerElement', '
     }
 
     function onScrollButtonClick(e) {
-        var scroller = this.parentNode.nextSibling;
-
-        var direction = this.getAttribute('data-direction');
+        var scroller = this.scroller;
+        var direction = e.currentTarget.getAttribute('data-direction');
         var scrollSize = getScrollSize(scroller);
         var scrollPos = getScrollPosition(scroller);
         var scrollWidth = getScrollWidth(scroller);
@@ -136,6 +135,7 @@ define(['layoutManager', 'dom', 'css!./emby-scrollbuttons', 'registerElement', '
         }
 
         scroller.scrollToPosition(newPos, false);
+        updateScrollButtons(this, scrollSize, newPos, scrollWidth);
     }
 
     EmbyScrollButtonsPrototype.attachedCallback = function () {
@@ -148,9 +148,10 @@ define(['layoutManager', 'dom', 'css!./emby-scrollbuttons', 'registerElement', '
         this.innerHTML = getScrollButtonHtml('left') + getScrollButtonHtml('right');
 
         var buttons = this.querySelectorAll('.emby-scrollbuttons-button');
-        buttons[0].addEventListener('click', onScrollButtonClick);
-        buttons[1].addEventListener('click', onScrollButtonClick);
+        buttons[0].addEventListener('click', onScrollButtonClick.bind(this));
+        buttons[1].addEventListener('click', onScrollButtonClick.bind(this));
         this.scrollButtonsLeft = buttons[0];
+        this.scrollButtonsLeft.disabled = true;
         this.scrollButtonsRight = buttons[1];
 
         var scrollHandler = onScroll.bind(this);

--- a/src/components/scroller.js
+++ b/src/components/scroller.js
@@ -213,7 +213,8 @@ define(['browser', 'layoutManager', 'dom', 'focusManager', 'ResizeObserver', 'sc
         };
 
         self.getScrollEventName = function () {
-            return transform ? 'scrollanimate' : 'scroll';
+            // Scroll event is not triggered when overflow is hidden, so use wheel instead
+            return 'wheel';
         };
 
         self.getScrollSlider = function () {


### PR DESCRIPTION
**Changes**
* Fix horizontal scrolling of scrollbutton items
* Update button state when clicking the scrollbuttons
* Disable the left button by default since we always start at the beginning of the list

There is still an issue where the scroll button should be hidden initially if they are not needed. When the buttons are initialized, the data has not been fetched yet though, so we would need a callback somehow once the data is populated.

**Issues**
#487 
