### PR TITLE
Switched OS media controls

### DIFF
--- a/src/components/playback/mediasession.js
+++ b/src/components/playback/mediasession.js
@@ -97,11 +97,8 @@ define(['playbackManager', 'nowPlayingHelper', 'events', 'connectionManager'], f
     }
 
     function updatePlayerState(player, state, eventName) {
-        var now = new Date().getTime();
-        lastUpdateTime = now;
-
         // Don't go crazy reporting position changes
-        if (eventName == 'timeupdate' && (now - lastUpdateTime) < 5000) {
+        if (eventName == 'timeupdate') {
             // Only report if this item hasn't been reported yet, or if there's an actual playback change.
             // Don't report on simple time updates
             return;

--- a/src/components/playback/mediasession.js
+++ b/src/components/playback/mediasession.js
@@ -160,8 +160,8 @@ define(['playbackManager', 'nowPlayingHelper', 'events', 'connectionManager'], f
 
         if (navigator.mediaSession) {
             navigator.mediaSession.metadata = new MediaMetadata({
-                title: title,
-                artist: artist,
+                title: artist,
+                artist: title,
                 album: album,
                 artwork: getImageUrls(item),
                 albumArtist: albumArtist,
@@ -185,8 +185,8 @@ define(['playbackManager', 'nowPlayingHelper', 'events', 'connectionManager'], f
                 action: eventName,
                 isLocalPlayer: isLocalPlayer,
                 itemId: itemId,
-                title: title,
-                artist: artist,
+                title: artist,
+                artist: title,
                 album: album,
                 duration: duration,
                 position: currentTime,

--- a/src/components/playback/mediasession.js
+++ b/src/components/playback/mediasession.js
@@ -97,6 +97,15 @@ define(['playbackManager', 'nowPlayingHelper', 'events', 'connectionManager'], f
     }
 
     function updatePlayerState(player, state, eventName) {
+        var now = new Date().getTime();
+        lastUpdateTime = now;
+
+        // Don't go crazy reporting position changes
+        if (eventName == 'timeupdate' && (now - lastUpdateTime) < 5000) {
+            // Only report if this item hasn't been reported yet, or if there's an actual playback change.
+            // Don't report on simple time updates
+            return;
+        }
 
         var item = state.NowPlayingItem;
 
@@ -118,19 +127,9 @@ define(['playbackManager', 'nowPlayingHelper', 'events', 'connectionManager'], f
         }
 
         var playState = state.PlayState || {};
-
         var parts = nowPlayingHelper.getNowPlayingNames(item);
-
-        var artist = parts.length === 1 ? '' : parts[0].text;
-        var title = parts[parts.length - 1].text;
-
-        // Switch these two around for video
-        if (isVideo && parts.length > 1) {
-            var temp = artist;
-            artist = title;
-            title = temp;
-        }
-
+        var artist = parts[parts.length - 1].text;
+        var title = parts.length === 1 ? '' : parts[0].text;
         var albumArtist;
 
         if (item.AlbumArtists && item.AlbumArtists[0]) {
@@ -147,21 +146,10 @@ define(['playbackManager', 'nowPlayingHelper', 'events', 'connectionManager'], f
         var isPaused = playState.IsPaused || false;
         var canSeek = playState.CanSeek || false;
 
-        var now = new Date().getTime();
-
-        // Don't go crazy reporting position changes
-        if (eventName == 'timeupdate' && (now - lastUpdateTime) < 5000) {
-            // Only report if this item hasn't been reported yet, or if there's an actual playback change.
-            // Don't report on simple time updates
-            return;
-        }
-
-        lastUpdateTime = now;
-
         if (navigator.mediaSession) {
             navigator.mediaSession.metadata = new MediaMetadata({
-                title: artist,
-                artist: title,
+                title: title,
+                artist: artist,
                 album: album,
                 artwork: getImageUrls(item),
                 albumArtist: albumArtist,
@@ -185,8 +173,8 @@ define(['playbackManager', 'nowPlayingHelper', 'events', 'connectionManager'], f
                 action: eventName,
                 isLocalPlayer: isLocalPlayer,
                 itemId: itemId,
-                title: artist,
-                artist: title,
+                title: title,
+                artist: artist,
                 album: album,
                 duration: duration,
                 position: currentTime,


### PR DESCRIPTION
Jellyfin was the only app I knew that displayed the artist's name as the title of the item in the OS media controls of all the devices I have. I don't know if that was intended that way, but how I left it makes much more sense to me:

* **Before**

![Screenshot_20200126_000327_com android chrome](https://user-images.githubusercontent.com/10274099/73128507-ba537300-3fd0-11ea-9fa5-b81290c6b1c6.jpg)
![Screenshot_20200126_000332_com android keyguard](https://user-images.githubusercontent.com/10274099/73128508-ba537300-3fd0-11ea-8ede-e61e54250a10.jpg)
![media_controls2](https://user-images.githubusercontent.com/10274099/73128513-c17a8100-3fd0-11ea-8324-cdc434dc918b.png)

* **After**

![Screenshot_20200126_000150_com huawei android launcher](https://user-images.githubusercontent.com/10274099/73128517-d7884180-3fd0-11ea-81ef-6611b0fcb55b.jpg)
![Screenshot_20200126_000155_com android keyguard](https://user-images.githubusercontent.com/10274099/73128518-d7884180-3fd0-11ea-82d2-edb7eed34856.jpg)
![media_controls](https://user-images.githubusercontent.com/10274099/73128521-de16b900-3fd0-11ea-841c-92db7aa18023.png)
