### PR TITLE
Add title attributes to card title buttons

### DIFF
--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -1018,7 +1018,7 @@ define(['datetime', 'imageLoader', 'connectionManager', 'itemHelper', 'focusMana
                 return text;
             }
 
-            var html = '<button ' + itemShortcuts.getShortcutAttributesHtml(item, serverId) + ' type="button" class="itemAction textActionButton" data-action="link">';
+            var html = '<button ' + itemShortcuts.getShortcutAttributesHtml(item, serverId) + ' type="button" class="itemAction textActionButton" title="' + text + '" data-action="link">';
             html += text;
             html += '</button>';
 


### PR DESCRIPTION
**Changes**
Add `title` attributes to card title `button` elements to allow full titles to be viewed.

![Screenshot from 2020-01-26 01-45-00](https://user-images.githubusercontent.com/3450688/73131717-45873580-3fde-11ea-9f6e-adf9c7c5f948.png)

**Issues**
N/A
