### PR TITLE
Added color while hovering over buttons in the new layout

### DIFF
--- a/src/elements/emby-button/emby-button.css
+++ b/src/elements/emby-button/emby-button.css
@@ -47,7 +47,7 @@
 }
 
 .button-flat:hover {
-    opacity: .5;
+    background-color: rgba(0,164,220, .4);
 }
 
 .button-link {


### PR DESCRIPTION
Probably this is pointless as I suppose the new layout is still a WIP and this was already planned, but hovering over buttons in the new layout used in item's details page needed some improvement in my opinion, as with 50% of the opacity texts were barely readable. The color used is the same used in the "Play" material icon that appears while hovering over a poster.

* **Before**

![old](https://user-images.githubusercontent.com/10274099/73139077-5bdad300-406a-11ea-999f-6f8b158c7e5b.png)

* **After**

![new](https://user-images.githubusercontent.com/10274099/73139074-53829800-406a-11ea-85f0-d4acf11a9a07.png)
