### PR TITLE
Checks if stream URL is successfully copied and displays an appropriate toast

### DIFF
--- a/src/components/itemcontextmenu.js
+++ b/src/components/itemcontextmenu.js
@@ -351,14 +351,15 @@ define(["apphost", "globalize", "connectionManager", "itemHelper", "appRouter", 
                     document.body.appendChild(textArea);
                     textArea.focus();
                     textArea.select();
-                    try {
-                        document.execCommand("copy");
-
+                    if (document.execCommand("copy")) {
                         require(["toast"], function (toast) {
                             toast(globalize.translate("CopyStreamURLSuccess"));
                         });
-                    } catch (err) {
+                    } else {
                         console.error("Failed to copy to clipboard");
+                        require(["toast"], function (toast) {
+                            toast(globalize.translate("CopyStreamURLError"));
+                        });
                     }
 
                     document.body.removeChild(textArea);

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -161,6 +161,7 @@
     "Continuing": "Continuing",
     "CopyStreamURL": "Copy Stream URL",
     "CopyStreamURLSuccess": "URL copied successfully.",
+    "CopyStreamURLError": "There was an error copying the URL.",
     "CriticRating": "Critic rating",
     "CustomDlnaProfilesHelp": "Create a custom profile to target a new device or override a system profile.",
     "DateAdded": "Date added",


### PR DESCRIPTION
**Changes**
Displays an error message in a toast when the browser fails copying the stream URL to the clipboard. It used to say it successfully copied the link.
**Issues**
#557 UX improvement for this issue