### PR TITLE
Add server select support for NativeShell

### DIFF
--- a/src/controllers/auth/login.js
+++ b/src/controllers/auth/login.js
@@ -187,6 +187,9 @@ define(["apphost", "appSettings", "dom", "connectionManager", "loading", "layout
             view.querySelector("#txtManualName").value = "";
             showManualForm(view, true);
         });
+        view.querySelector(".btnSelectServer").addEventListener("click", function () {
+            Dashboard.selectServer();
+        });
         view.addEventListener("viewshow", function (e) {
             loading.show();
 

--- a/src/controllers/user/menu.js
+++ b/src/controllers/user/menu.js
@@ -6,6 +6,10 @@ define(["apphost", "connectionManager", "listViewStyle", "emby-button"], functio
             Dashboard.logout();
         });
 
+        view.querySelector(".selectServer").addEventListener("click", function () {
+            Dashboard.selectServer();
+        });
+
         view.addEventListener("viewshow", function() {
             // this page can also be used by admins to change user preferences from the user edit page
             var userId = params.userId || Dashboard.getCurrentUserId();

--- a/src/login.html
+++ b/src/login.html
@@ -47,9 +47,9 @@
                 <span>${ButtonForgotPassword}</span>
             </button>
 
-            <a is="emby-linkbutton" href="selectserver.html" class="raised block btnSelectServer">
+            <button is="emby-button" type="button" class="raised block btnSelectServer">
                 <span>${ButtonChangeServer}</span>
-            </a>
+            </button>
 
             <p class="disclaimer" style="text-align: center; margin-top: 2em;"></p>
         </div>

--- a/src/mypreferencesmenu.html
+++ b/src/mypreferencesmenu.html
@@ -69,7 +69,7 @@
             </div>
             <div class="userSection verticalSection verticalSection-extrabottompadding">
                 <h2 class="sectionTitle" style="padding-left:.25em;">${HeaderUser}</h2>
-                <a is="emby-linkbutton" data-ripple="false" href="selectserver.html" style="display:block;padding:0;margin:0;" class="selectServer hide listItem-border">
+                <a is="emby-linkbutton" data-ripple="false" href="#" style="display:block;padding:0;margin:0;" class="selectServer hide listItem-border">
                     <div class="listItem">
                         <i class="material-icons listItemIcon listItemIcon-transparent">wifi</i>
                         <div class="listItemBody">

--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -221,6 +221,13 @@ var Dashboard = {
         };
         appHost.getPushTokenInfo();
         return capabilities = Object.assign(capabilities, appHost.getPushTokenInfo());
+    },
+    selectServer: function () {
+        if (window.NativeShell && typeof window.NativeShell.selectServer === "function") {
+            window.NativeShell.selectServer();
+        } else {
+            Dashboard.navigate("selectserver.html");
+        }
     }
 };
 


### PR DESCRIPTION
Idea is to give apps ability to change server their own way.
_webOS app on the way_

**Changes**
Add `selectServer` function to `Dashboard` (`site.js`) which calls `NativeShell.selectServer` or navigates to `selectserver.html` (as it was before).