### PR TITLE
Fix custom css precedence

### DIFF
--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -623,8 +623,25 @@ var AppInfo = {};
 
                 require(["playerSelectionMenu", "fullscreenManager"]);
 
-                if (!AppInfo.isNativeApp && window.ApiClient) {
-                    require(["css!" + ApiClient.getUrl("Branding/Css")]);
+                var apiClient = window.ConnectionManager && window.ConnectionManager.currentApiClient();
+                if (apiClient) {
+                    fetch(apiClient.getUrl("Branding/Css"))
+                        .then(function(response) {
+                            if (!response.ok) {
+                                throw new Error(response.status + ' ' + response.statusText);
+                            }
+                            return response.text();
+                        })
+                        .then(function(css) {
+                            // Inject the branding css as a dom element in body so it will take
+                            // precedence over other stylesheets
+                            var style = document.createElement('style');
+                            style.appendChild(document.createTextNode(css));
+                            document.body.appendChild(style);
+                        })
+                        .catch(function(err) {
+                            console.warn('Error applying custom css', err);
+                        });
                 }
             });
         });


### PR DESCRIPTION
**Changes**
* Adds support for custom css in native apps with web wrappers
* Injects custom css into the body so it will take precedence over themes

**Issues**
https://github.com/jellyfin/jellyfin-android/issues/153
#742 

![sunglasses](https://user-images.githubusercontent.com/3450688/73785532-70ebec00-4765-11ea-966b-7fc584b1f65c.gif)