### PR TITLE
Fix device images on main dashboard page

### DIFF
--- a/src/scripts/imagehelper.js
+++ b/src/scripts/imagehelper.js
@@ -3,7 +3,7 @@ define(["browser"], function (browser) {
 
     function getDeviceIcon(device) {
         var baseUrl = "assets/img/devices/";
-        switch (device.AppName) {
+        switch (device.AppName || device.Client) {
             case "Samsung Smart TV":
                 return baseUrl + "samsung.svg";
             case "Xbox One":
@@ -15,7 +15,7 @@ define(["browser"], function (browser) {
             case "Jellyfin Android":
                 return baseUrl + "android.svg";
             case "Jellyfin Web":
-                switch (device.Name) {
+                switch (device.Name || device.DeviceName) {
                     case "Opera":
                     case "Opera TV":
                         return baseUrl + "opera.svg";


### PR DESCRIPTION
**Changes**
Device images were falling back to the default for all clients on the main dashboard page due to inconsistent naming of the properties in the device object passed to this function. This allows both cases to be supported.

**Issues**
N/A

![doublemint](https://user-images.githubusercontent.com/3450688/73793227-f37ba800-4773-11ea-9099-12be7414d18e.gif)