### PR TITLE
Disable keyboard navigation for non-TV

### DIFF
--- a/src/components/keyboardnavigation.js
+++ b/src/components/keyboardnavigation.js
@@ -36,6 +36,11 @@ define(["inputManager", "layoutManager"], function (inputManager, layoutManager)
         10252: "MediaPlayPause"
     };
 
+    /**
+     * Keys used for keyboard navigation.
+     */
+    var NavigationKeys = ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"];
+
     var hasFieldKey = false;
     try {
         hasFieldKey = "key" in new KeyboardEvent("keydown");
@@ -60,11 +65,28 @@ define(["inputManager", "layoutManager"], function (inputManager, layoutManager)
         return KeyNames[event.keyCode] || event.key;
     }
 
+    /**
+     * Returns _true_ if key is used for navigation.
+     *
+     * @param {string} key name
+     * @return {boolean} _true_ if key is used for navigation
+     */
+    function isNavigationKey(key) {
+        return NavigationKeys.indexOf(key) != -1;
+    }
+
     function enable() {
         document.addEventListener("keydown", function (e) {
+            var key = getKeyName(e);
+
+            // Ignore navigation keys for non-TV
+            if (!layoutManager.tv && isNavigationKey(key)) {
+                return;
+            }
+
             var capture = true;
 
-            switch (getKeyName(e)) {
+            switch (key) {
                 case "ArrowLeft":
                     inputManager.handle("left");
                     break;
@@ -128,6 +150,7 @@ define(["inputManager", "layoutManager"], function (inputManager, layoutManager)
 
     return {
         enable: enable,
-        getKeyName: getKeyName
+        getKeyName: getKeyName,
+        isNavigationKey: isNavigationKey
     };
 });

--- a/src/controllers/playback/videoosd.js
+++ b/src/controllers/playback/videoosd.js
@@ -1088,11 +1088,6 @@ define(["playbackManager", "dom", "inputManager", "datetime", "itemHelper", "med
         }
 
         /**
-         * Keys used for keyboard navigation.
-         */
-        var NavigationKeys = ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"];
-
-        /**
          * Clicked element.
          * To skip 'click' handling on Firefox/Edge.
          */
@@ -1109,7 +1104,7 @@ define(["playbackManager", "dom", "inputManager", "datetime", "itemHelper", "med
                 return;
             }
 
-            if (layoutManager.tv && NavigationKeys.indexOf(key) != -1) {
+            if (layoutManager.tv && keyboardnavigation.isNavigationKey(key)) {
                 showOsd();
                 return;
             }


### PR DESCRIPTION
I asked about disabling the keyboard on non-TV "between this and then", and I can’t say for sure what we decided.

I look at it like this.

**Desktop layout**
This is mostly for browsers on PC (with mouse and keyboard) - just leave them to do the job in their own way. There is no focus indication, so users will be disoriented.

**Mobile layout**
This is for those with a touch screen - I can hardly imagine using a physical keyboard. And, like previous, there is no focus indication, so users will be disoriented too.

**TV layout**
Most TV users are doomed to use the keyboard/remote - this is our "clients".

**Changes**
Disable keyboard navigation for non-TV.

**Issues**
Partially fixes #504 (at least for `Desktop`/`Mobile` users).
Partially fixes #682 (at least for `Desktop`/`Mobile` users).

For TV users (as I am), I tried (a little luck) to grab keyboard by `emby-input` like [here](https://github.com/jellyfin/jellyfin-web/issues/504#issuecomment-574233711), but this is for another PR.

Also, I heard that you are back to single-quotes. Should I change to single-quotes the touched files? Or touched lines?