### PR TITLE
Force ratings to 1 decimal place

### DIFF
--- a/src/components/mediainfo/mediainfo.js
+++ b/src/components/mediainfo/mediainfo.js
@@ -385,16 +385,13 @@ define(['datetime', 'globalize', 'appRouter', 'itemHelper', 'indicators', 'mater
     }
 
     function getStarIconsHtml(item) {
-
         var html = '';
 
-        var rating = item.CommunityRating;
-
-        if (rating) {
+        if (item.CommunityRating) {
             html += '<div class="starRatingContainer mediaInfoItem">';
 
             html += '<i class="material-icons starIcon">star</i>';
-            html += rating;
+            html += item.CommunityRating.toFixed(1);
             html += '</div>';
         }
 


### PR DESCRIPTION
**Changes**

In some cases, ratings don't respect the X.Y format and include more decimal places than necessary.

It should probably be fixed server-side to make sure all clients act the same, but this forces ratings to use only one decimal place (with proper rounding, as we're using toFixed()).

**Issues**

Fixes #768 