### PR TITLE
Fix action icons in lists wrapping to multiple lines

### DIFF
--- a/src/assets/css/librarybrowser.css
+++ b/src/assets/css/librarybrowser.css
@@ -875,12 +875,9 @@
     }
 }
 
-@media all and (max-width: 75em) {
-    .listViewUserDataButtons {
-        display: flex;
-        align-items: center;
-        font-size: 65%;
-    }
+.listViewUserDataButtons {
+    display: flex;
+    align-items: center;
 }
 
 .bulletSeparator {


### PR DESCRIPTION
**Changes**

An unnecessary media query was preventing action buttons on list items from staying on one line.  
This removes said media query.

**Issues**

Fixes #777 
