### PR TITLE
Tweak poster size on home screen

### DIFF
--- a/src/components/cardbuilder/card.css
+++ b/src/components/cardbuilder/card.css
@@ -725,7 +725,7 @@ button::-moz-focus-inner {
 @media (min-width: 120em) {
     .overflowSquareCard,
     .overflowPortraitCard {
-        width: 10.3vw;
+        width: 10.41vw;
     }
 }
 

--- a/src/themes/blueradiance/theme.css
+++ b/src/themes/blueradiance/theme.css
@@ -1,3 +1,7 @@
+* {
+    scrollbar-color: #3b3b3b #202020;
+}
+
 .skinHeader,
 html {
     color: #ddd;

--- a/src/themes/dark/theme.css
+++ b/src/themes/dark/theme.css
@@ -1,3 +1,8 @@
+* {
+    scrollbar-width: thin;
+    scrollbar-color: #3b3b3b #202020;
+}
+
 .skinHeader,
 html {
     color: #ddd;
@@ -425,8 +430,7 @@ html {
 }
 
 .layout-desktop ::-webkit-scrollbar {
-    width: 1em;
-    height: 1em;
+    width: 0.4em;
 }
 
 ::-webkit-scrollbar-thumb:horizontal,

--- a/src/themes/wmc/theme.css
+++ b/src/themes/wmc/theme.css
@@ -1,3 +1,7 @@
+* {
+    scrollbar-color: #3b3b3b #202020;
+}
+
 html {
     color: #eee;
     color: rgba(255, 255, 255, 0.9);


### PR DESCRIPTION
**Changes**

Slightly tweaks the size of posters in the scrollers on the home page in order to prevent a few pixels from the first poster outside of the view from showing up.

Also enables cool colored scrollbars on Firefox, bringing it a bit more to parity with Chrome.

**Issues**

None
