### PR TITLE
Fix slider positioning on click and (try to) make it look the same in different browsers

### DIFF
--- a/src/elements/emby-slider/emby-slider.css
+++ b/src/elements/emby-slider/emby-slider.css
@@ -29,6 +29,8 @@
     /* Disable webkit tap highlighting */
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
     display: block;
+
+    font-size: inherit; /* Chrome and Firefox override font size for 'input' */
 }
 
 .mdl-slider::-moz-focus-outer {
@@ -72,8 +74,8 @@
 
 .mdl-slider::-webkit-slider-thumb {
     -webkit-appearance: none;
-    width: 1.2em;
-    height: 1.2em;
+    width: 1.08em;
+    height: 1.08em;
     box-sizing: border-box;
     border-radius: 50%;
     background: #00a4dc;
@@ -100,8 +102,8 @@
 
 .mdl-slider::-moz-range-thumb {
     -moz-appearance: none;
-    width: 0.9em;
-    height: 0.9em;
+    width: 0.81em;
+    height: 0.81em;
     box-sizing: border-box;
     border-radius: 50%;
     background: #00a4dc;

--- a/src/elements/emby-slider/emby-slider.css
+++ b/src/elements/emby-slider/emby-slider.css
@@ -220,6 +220,13 @@
     bottom: 0;
 }
 
+.sliderBubbleTrack {
+    position: absolute;
+    left: 0;
+    right: 0;
+    margin: 0 0.54em; /* half of slider thumb size */
+}
+
 .sliderBubble {
     position: absolute;
     top: 0;

--- a/src/elements/emby-slider/emby-slider.css
+++ b/src/elements/emby-slider/emby-slider.css
@@ -158,7 +158,6 @@
 .mdl-slider-background-flex-container {
     width: 100%;
     box-sizing: border-box;
-    margin-top: -0.05em;
     top: 50%;
     left: 0;
     position: absolute;
@@ -168,7 +167,7 @@
 .mdl-slider-background-flex {
     background: #333;
     height: 0.2em;
-    margin-top: -0.08em;
+    margin-top: -0.1em;
     width: 100%;
     top: 50%;
     left: 0;

--- a/src/elements/emby-slider/emby-slider.css
+++ b/src/elements/emby-slider/emby-slider.css
@@ -146,14 +146,6 @@
     display: none;
 }
 
-.mdl-slider-ie-container {
-    height: 1.25em;
-    overflow: visible;
-    border: none;
-    margin: 0;
-    padding: 0;
-}
-
 .mdl-slider-container {
     height: 1.25em;
     position: relative;

--- a/src/elements/emby-slider/emby-slider.css
+++ b/src/elements/emby-slider/emby-slider.css
@@ -72,6 +72,12 @@
     display: none;
 }
 
+.slider-browser-edge {
+    margin-left: -0.16em;
+    margin-right: -0.16em;
+    width: 150%; /* need to occupy space */
+}
+
 .mdl-slider::-webkit-slider-thumb {
     -webkit-appearance: none;
     width: 1.08em;
@@ -114,22 +120,21 @@
 
 .mdl-slider::-ms-thumb {
     -webkit-appearance: none;
-    width: 1.8em;
-    height: 1.8em;
+    width: 1.4em;
+    height: 1.4em;
     box-sizing: border-box;
     border-radius: 50%;
     background: #00a4dc;
     border: none;
-    transform: scale(0.9, 0.9);
+    transform: scale(0.771429);
     transition: transform 300ms cubic-bezier(0.4, 0, 0.2, 1), border 0.18s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.18s cubic-bezier(0.4, 0, 0.2, 1), background 0.28s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.mdl-slider-hoverthumb::-ms-thumb {
-    margin-left: -0.4em;
-    transform: scale(0.5, 0.5);
+.mdl-slider:hover::-ms-thumb {
+    transform: none;
 }
 
-.mdl-slider:hover::-ms-thumb {
+.mdl-slider.show-focus:focus::-ms-thumb {
     transform: none;
 }
 

--- a/src/elements/emby-slider/emby-slider.css
+++ b/src/elements/emby-slider/emby-slider.css
@@ -227,7 +227,7 @@
     position: absolute;
     top: 0;
     left: 0;
-    transform: translate3d(-48%, -120%, 0);
+    transform: translate3d(-50%, -120%, 0);
     background: #282828;
     color: #fff;
     display: flex;

--- a/src/elements/emby-slider/emby-slider.css
+++ b/src/elements/emby-slider/emby-slider.css
@@ -167,6 +167,7 @@
     margin-top: -0.05em;
     top: 50%;
     position: absolute;
+    padding: 0 0.54em; /* half of slider thumb size */
 }
 
 .mdl-slider-background-flex {

--- a/src/elements/emby-slider/emby-slider.css
+++ b/src/elements/emby-slider/emby-slider.css
@@ -79,6 +79,7 @@
     background: #00a4dc;
     border: none;
     transition: transform 300ms cubic-bezier(0.4, 0, 0.2, 1), border 0.18s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.18s cubic-bezier(0.4, 0, 0.2, 1), background 0.28s cubic-bezier(0.4, 0, 0.2, 1);
+    pointer-events: none;
 }
 
 .mdl-slider-hoverthumb::-webkit-slider-thumb {

--- a/src/elements/emby-slider/emby-slider.css
+++ b/src/elements/emby-slider/emby-slider.css
@@ -79,11 +79,7 @@
     pointer-events: none;
 }
 
-.mdl-slider-hoverthumb::-webkit-slider-thumb {
-    transform: none;
-}
-
-.mdl-slider:hover::-webkit-slider-thumb {
+.mdl-slider-hoverthumb:hover::-webkit-slider-thumb {
     transform: scale(1.3);
 }
 
@@ -107,7 +103,7 @@
     transition: 0.2s;
 }
 
-.mdl-slider:hover::-moz-range-thumb {
+.mdl-slider-hoverthumb:hover::-moz-range-thumb {
     transform: scale(1.3);
 }
 
@@ -127,7 +123,7 @@
     transition: 0.2s;
 }
 
-.mdl-slider:hover::-ms-thumb {
+.mdl-slider-hoverthumb:hover::-ms-thumb {
     transform: none;
 }
 

--- a/src/elements/emby-slider/emby-slider.css
+++ b/src/elements/emby-slider/emby-slider.css
@@ -167,6 +167,7 @@
     box-sizing: border-box;
     margin-top: -0.05em;
     top: 50%;
+    left: 0;
     position: absolute;
     padding: 0 0.54em; /* half of slider thumb size */
 }

--- a/src/elements/emby-slider/emby-slider.css
+++ b/src/elements/emby-slider/emby-slider.css
@@ -45,17 +45,6 @@
     background: transparent;
 }
 
-.mdl-slider::-moz-range-track {
-    background: #444;
-    border: none;
-    width: calc(100% - 20px);
-}
-
-.mdl-slider::-moz-range-progress {
-    background: #00a4dc;
-    width: calc(100% - 20px);
-}
-
 .mdl-slider::-ms-track {
     background: none;
     color: transparent;
@@ -108,14 +97,21 @@
 
 .mdl-slider::-moz-range-thumb {
     -moz-appearance: none;
-    width: 0.81em;
-    height: 0.81em;
+    width: 1.08em;
+    height: 1.08em;
     box-sizing: border-box;
     border-radius: 50%;
     background: #00a4dc;
     background-image: none;
     border: none;
-    transform: scale(1.4, 1.4);
+}
+
+.mdl-slider:hover::-moz-range-thumb {
+    transform: scale(1.3);
+}
+
+.mdl-slider.show-focus:focus::-moz-range-thumb {
+    transform: scale(1.3);
 }
 
 .mdl-slider::-ms-thumb {

--- a/src/elements/emby-slider/emby-slider.css
+++ b/src/elements/emby-slider/emby-slider.css
@@ -75,7 +75,7 @@
     border-radius: 50%;
     background: #00a4dc;
     border: none;
-    transition: transform 300ms cubic-bezier(0.4, 0, 0.2, 1), border 0.18s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.18s cubic-bezier(0.4, 0, 0.2, 1), background 0.28s cubic-bezier(0.4, 0, 0.2, 1);
+    transition: 0.2s;
     pointer-events: none;
 }
 
@@ -104,6 +104,7 @@
     background: #00a4dc;
     background-image: none;
     border: none;
+    transition: 0.2s;
 }
 
 .mdl-slider:hover::-moz-range-thumb {
@@ -123,7 +124,7 @@
     background: #00a4dc;
     border: none;
     transform: scale(0.771429);
-    transition: transform 300ms cubic-bezier(0.4, 0, 0.2, 1), border 0.18s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.18s cubic-bezier(0.4, 0, 0.2, 1), background 0.28s cubic-bezier(0.4, 0, 0.2, 1);
+    transition: 0.2s;
 }
 
 .mdl-slider:hover::-ms-thumb {

--- a/src/elements/emby-slider/emby-slider.js
+++ b/src/elements/emby-slider/emby-slider.js
@@ -48,8 +48,13 @@ define(['browser', 'dom', 'layoutManager', 'keyboardnavigation', 'css!./emby-sli
     function updateBubble(range, value, bubble, bubbleText) {
 
         requestAnimationFrame(function () {
+            var bubbleTrackRect = range.sliderBubbleTrack.getBoundingClientRect();
+            var bubbleRect = bubble.getBoundingClientRect();
 
-            bubble.style.left = value + '%';
+            var bubblePos = bubbleTrackRect.width * value / 100;
+            bubblePos = Math.min(Math.max(bubblePos, bubbleRect.width / 2), bubbleTrackRect.width - bubbleRect.width / 2);
+
+            bubble.style.left = bubblePos + 'px';
 
             if (range.getBubbleHtml) {
                 value = range.getBubbleHtml(value);

--- a/src/elements/emby-slider/emby-slider.js
+++ b/src/elements/emby-slider/emby-slider.js
@@ -84,6 +84,9 @@ define(['browser', 'dom', 'layoutManager', 'keyboardnavigation', 'css!./emby-sli
         if (browser.noFlex) {
             this.classList.add('slider-no-webkit-thumb');
         }
+        if (browser.edge || browser.msie) {
+            this.classList.add('slider-browser-edge');
+        }
         if (!layoutManager.mobile) {
             this.classList.add('mdl-slider-hoverthumb');
         }

--- a/src/elements/emby-slider/emby-slider.js
+++ b/src/elements/emby-slider/emby-slider.js
@@ -115,10 +115,11 @@ define(['browser', 'dom', 'layoutManager', 'keyboardnavigation', 'css!./emby-sli
             htmlToInsert += '</div>';
         }
 
-        htmlToInsert += '<div class="sliderBubble hide"></div>';
+        htmlToInsert += '<div class="sliderBubbleTrack"><div class="sliderBubble hide"></div></div>';
 
         containerElement.insertAdjacentHTML('beforeend', htmlToInsert);
 
+        this.sliderBubbleTrack = containerElement.querySelector('.sliderBubbleTrack');
         this.backgroundLower = containerElement.querySelector('.mdl-slider-background-lower');
         this.backgroundUpper = containerElement.querySelector('.mdl-slider-background-upper');
         var sliderBubble = containerElement.querySelector('.sliderBubble');
@@ -152,10 +153,16 @@ define(['browser', 'dom', 'layoutManager', 'keyboardnavigation', 'css!./emby-sli
         dom.addEventListener(this, (window.PointerEvent ? 'pointermove' : 'mousemove'), function (e) {
 
             if (!this.dragging) {
-                var rect = this.getBoundingClientRect();
+                var rect = this.sliderBubbleTrack.getBoundingClientRect();
                 var clientX = e.clientX;
+
                 var bubbleValue = (clientX - rect.left) / rect.width;
                 bubbleValue *= 100;
+                if (this.step !== 0) {
+                    bubbleValue = Math.round(bubbleValue / this.step) * this.step;
+                }
+                bubbleValue = Math.min(Math.max(bubbleValue, 0), 100);
+
                 updateBubble(this, bubbleValue, sliderBubble);
 
                 if (hasHideClass) {

--- a/src/elements/emby-slider/emby-slider.js
+++ b/src/elements/emby-slider/emby-slider.js
@@ -3,7 +3,7 @@ define(['browser', 'dom', 'layoutManager', 'keyboardnavigation', 'css!./emby-sli
 
     var EmbySliderPrototype = Object.create(HTMLInputElement.prototype);
 
-    var supportsNativeProgressStyle = browser.firefox;
+    var supportsNativeProgressStyle = false;
     var supportsValueSetOverride = false;
 
     var enableWidthWithTransform;

--- a/src/elements/emby-slider/emby-slider.js
+++ b/src/elements/emby-slider/emby-slider.js
@@ -3,7 +3,6 @@ define(['browser', 'dom', 'layoutManager', 'keyboardnavigation', 'css!./emby-sli
 
     var EmbySliderPrototype = Object.create(HTMLInputElement.prototype);
 
-    var supportsNativeProgressStyle = false;
     var supportsValueSetOverride = false;
 
     var enableWidthWithTransform;
@@ -104,24 +103,22 @@ define(['browser', 'dom', 'layoutManager', 'keyboardnavigation', 'css!./emby-sli
 
         var htmlToInsert = '';
 
-        if (!supportsNativeProgressStyle) {
-            htmlToInsert += '<div class="mdl-slider-background-flex-container">';
-            htmlToInsert += '<div class="mdl-slider-background-flex">';
-            htmlToInsert += '<div class="mdl-slider-background-flex-inner">';
+        htmlToInsert += '<div class="mdl-slider-background-flex-container">';
+        htmlToInsert += '<div class="mdl-slider-background-flex">';
+        htmlToInsert += '<div class="mdl-slider-background-flex-inner">';
 
-            // the more of these, the more ranges we can display
-            htmlToInsert += '<div class="mdl-slider-background-upper"></div>';
+        // the more of these, the more ranges we can display
+        htmlToInsert += '<div class="mdl-slider-background-upper"></div>';
 
-            if (enableWidthWithTransform) {
-                htmlToInsert += '<div class="mdl-slider-background-lower mdl-slider-background-lower-withtransform"></div>';
-            } else {
-                htmlToInsert += '<div class="mdl-slider-background-lower"></div>';
-            }
-
-            htmlToInsert += '</div>';
-            htmlToInsert += '</div>';
-            htmlToInsert += '</div>';
+        if (enableWidthWithTransform) {
+            htmlToInsert += '<div class="mdl-slider-background-lower mdl-slider-background-lower-withtransform"></div>';
+        } else {
+            htmlToInsert += '<div class="mdl-slider-background-lower"></div>';
         }
+
+        htmlToInsert += '</div>';
+        htmlToInsert += '</div>';
+        htmlToInsert += '</div>';
 
         htmlToInsert += '<div class="sliderBubbleTrack"><div class="sliderBubble hide"></div></div>';
 
@@ -190,13 +187,10 @@ define(['browser', 'dom', 'layoutManager', 'keyboardnavigation', 'css!./emby-sli
             passive: true
         });
 
-        if (!supportsNativeProgressStyle) {
-
-            if (supportsValueSetOverride) {
-                this.addEventListener('valueset', updateValues);
-            } else {
-                startInterval(this);
-            }
+        if (supportsValueSetOverride) {
+            this.addEventListener('valueset', updateValues);
+        } else {
+            startInterval(this);
         }
     };
 


### PR DESCRIPTION
Option 1 from https://github.com/jellyfin/jellyfin-web/pull/644#issuecomment-583559307

**Changes**
* Make pointer click pass through.
* Fix font on `emby-input` (details below)
* Fix slider bubble range
* Fix progress bar range
* Make slider in Edge same as in Chrome
* Make slider in Firefox same as in Chrome
* Fix progress bar position on WebOS 3
* Limit slider bubble position to its track
* Fix vertical position of slider progress bar

**Font size**
In Firefox and Chrome, `font-size` goes from browser ignoring `fonts.css`. This makes hard to align progress bar and bubble to slider range. I use `font-size: inherit`, and this helps. But I am not sure that this will work everywhere.
In Edge, font goes from `fonts.css` as expected.

**Screenshots**
New slider structure (add bubble track)
![slider-structure](https://user-images.githubusercontent.com/56478732/74102694-fbae5b80-4b56-11ea-9938-7f3203dafff5.png)
yellowish background - slider container
red background - slider (`input` itself)
red line - `sliderBubble` track

Firefox before
![slider1-firefox-old](https://user-images.githubusercontent.com/56478732/74102624-73c85180-4b56-11ea-8925-aa523ec8cce5.png)
Firefox after
![slider1-firefox-new](https://user-images.githubusercontent.com/56478732/74102629-7a56c900-4b56-11ea-9006-6d4f730a6582.png)

Chrome before
![slider1-chrome-old](https://user-images.githubusercontent.com/56478732/74102632-82af0400-4b56-11ea-8200-9dbe18dea9ae.png)
Chrome after
![slider1-chrome-new](https://user-images.githubusercontent.com/56478732/74102637-8a6ea880-4b56-11ea-8ae0-a650351db08c.png)

Edge before
![slider1-edge-old](https://user-images.githubusercontent.com/56478732/74102642-95293d80-4b56-11ea-9ef2-12800a22a942.png)
Edge after
![slider1-edge-new](https://user-images.githubusercontent.com/56478732/74102644-9b1f1e80-4b56-11ea-8319-1e8741cbb563.png)

On TV, thumb became much bigger :smile: It was small due to uninherited font size.

Firefox TV before
![slider1-firefox_tv-old](https://user-images.githubusercontent.com/56478732/74102650-a8d4a400-4b56-11ea-8249-afc416c9d82e.png)
Firefox TV after
![slider1-firefox_tv-new](https://user-images.githubusercontent.com/56478732/74102655-aeca8500-4b56-11ea-971f-d41c92eebab4.png)

Chrome TV before
![slider1-chrome_tv-old](https://user-images.githubusercontent.com/56478732/74102660-b853ed00-4b56-11ea-8814-37f447b93588.png)
Chrome TV after
![slider1-chrome_tv-new](https://user-images.githubusercontent.com/56478732/74102663-bdb13780-4b56-11ea-9eb6-6ee3a607bcc4.png)

On iPad Pro 11, looks OK.
IE11 does not load - stop loading on random file with no errors :confused: 
Opera 66.0.3515.72 looks OK.

**To discuss**
- [x] 1. Bubble has no limits:
![simplescreenrecorder7-2020-02-09_15 49 27 mkv](https://user-images.githubusercontent.com/56478732/74103708-885d1780-4b5f-11ea-8d5d-644b78b51ca2.gif)
I can fix it (with JS, but maybe someone know how it could be fixed with plain CSS)
![simplescreenrecorder7-2020-02-09_15 50 23 mkv](https://user-images.githubusercontent.com/56478732/74103711-90b55280-4b5f-11ea-9dfc-4d5e2066fedb.gif)
Does it look good when bubble changes its size (being clamped)?
![simplescreenrecorder7-2020-02-09_15 51 31 mkv](https://user-images.githubusercontent.com/56478732/74103756-e8ec5480-4b5f-11ea-9581-72924aedefc0.gif)

- [x] 2. I left condition `supportsNativeProgressStyle`. Should I remove it?

- [x] 3. There is historical class `mdl-slider-ie-container`. No reference. I could switch to it instead of new `slider-browser-edge`. Or just remove it.

- [x] 4. I can set `transition: 0.2s` like `emby-button` has. There are much more "transitions" - historical.

- [x] 5. There is `mdl-slider-hoverthumb`. It is added for non-Mobile. Not sure about its purpose. We could use it to make thumb non-scalable on Mobile.

- [x] 6. `mdl-slider-background-flex-container` and `mdl-slider-background-flex` have negative `margin-top` (-0.13em in total). To be mathematically "perfect" it must be -0.1em. Also, this will be good for TV layout since it has bigger font. But due to rounding errors we will get:
Firefox
![slider1-firefox-new2](https://user-images.githubusercontent.com/56478732/74106210-b3526600-4b75-11ea-8af9-7d6a1044fe87.png)
Chrome - no change
Edge
![slider1-edge-new2](https://user-images.githubusercontent.com/56478732/74106184-78e8c900-4b75-11ea-9c44-1efeb45bbadf.png)
Firefox TV
![slider1-firefox_tv-new2](https://user-images.githubusercontent.com/56478732/74106187-7edeaa00-4b75-11ea-8d2c-14b5882b3fba.png)
Chrome TV - thicker volume bar
![slider1-chrome_tv-new2](https://user-images.githubusercontent.com/56478732/74106190-856d2180-4b75-11ea-929c-a37079861529.png)
