### PR TITLE
Add delay on play/pause to prevent hiccup when entering/exiting fullscreen

### DIFF
--- a/src/controllers/playback/videoosd.js
+++ b/src/controllers/playback/videoosd.js
@@ -1230,7 +1230,7 @@ define(["playbackManager", "dom", "inputManager", "datetime", "itemHelper", "med
                     shell.disableFullscreen();
                 });
 
-                if(playerPauseClickTimeout) {
+                if (playerPauseClickTimeout) {
                     clearTimeout(playerPauseClickTimeout);
                 }
                 var player = currentPlayer;
@@ -1392,9 +1392,9 @@ define(["playbackManager", "dom", "inputManager", "datetime", "itemHelper", "med
 
                 case "mouse":
                     if (!e.button) {
-                        if(playerPauseClickTimeout){
+                        if (playerPauseClickTimeout) {
                             clearTimeout(playerPauseClickTimeout);
-                            playerPauseClickTimeout = 0;   
+                            playerPauseClickTimeout = 0;
                         } else {
                             playerPauseClickTimeout = setTimeout(() => {
                                 playbackManager.playPause(currentPlayer);

--- a/src/controllers/playback/videoosd.js
+++ b/src/controllers/playback/videoosd.js
@@ -1230,6 +1230,9 @@ define(["playbackManager", "dom", "inputManager", "datetime", "itemHelper", "med
                     shell.disableFullscreen();
                 });
 
+                if(playerPauseClickTimeout) {
+                    clearTimeout(playerPauseClickTimeout);
+                }
                 var player = currentPlayer;
                 view.removeEventListener("viewbeforehide", onViewHideStopPlayback);
                 releaseCurrentPlayer();
@@ -1369,6 +1372,7 @@ define(["playbackManager", "dom", "inputManager", "datetime", "itemHelper", "med
             destroySubtitleSync();
         });
         var lastPointerDown = 0;
+        let playerPauseClickTimeout;
         dom.addEventListener(view, window.PointerEvent ? "pointerdown" : "click", function (e) {
             if (dom.parentWithClass(e.target, ["videoOsdBottom", "upNextContainer"])) {
                 return void showOsd();
@@ -1388,8 +1392,16 @@ define(["playbackManager", "dom", "inputManager", "datetime", "itemHelper", "med
 
                 case "mouse":
                     if (!e.button) {
-                        playbackManager.playPause(currentPlayer);
-                        showOsd();
+                        if(playerPauseClickTimeout){
+                            clearTimeout(playerPauseClickTimeout);
+                            playerPauseClickTimeout = 0;   
+                        } else {
+                            playerPauseClickTimeout = setTimeout(() => {
+                                playbackManager.playPause(currentPlayer);
+                                showOsd();
+                                playerPauseClickTimeout = 0;
+                            }, 300);
+                        }
                     }
 
                     break;

--- a/src/controllers/playback/videoosd.js
+++ b/src/controllers/playback/videoosd.js
@@ -1223,14 +1223,14 @@ define(["playbackManager", "dom", "inputManager", "datetime", "itemHelper", "med
 
             return null;
         }
-        
+
         let playPauseClickTimeout;
         function onViewHideStopPlayback() {
             if (playbackManager.isPlayingVideo()) {
                 require(['shell'], function (shell) {
                     shell.disableFullscreen();
                 });
-                
+
                 clearTimeout(playPauseClickTimeout);
                 var player = currentPlayer;
                 view.removeEventListener("viewbeforehide", onViewHideStopPlayback);

--- a/src/controllers/playback/videoosd.js
+++ b/src/controllers/playback/videoosd.js
@@ -1223,15 +1223,16 @@ define(["playbackManager", "dom", "inputManager", "datetime", "itemHelper", "med
 
             return null;
         }
-
+        
+        let playPauseClickTimeout;
         function onViewHideStopPlayback() {
             if (playbackManager.isPlayingVideo()) {
                 require(['shell'], function (shell) {
                     shell.disableFullscreen();
                 });
-
-                if (playerPauseClickTimeout) {
-                    clearTimeout(playerPauseClickTimeout);
+                
+                if (playPauseClickTimeout) {
+                    clearTimeout(playPauseClickTimeout);
                 }
                 var player = currentPlayer;
                 view.removeEventListener("viewbeforehide", onViewHideStopPlayback);
@@ -1372,7 +1373,6 @@ define(["playbackManager", "dom", "inputManager", "datetime", "itemHelper", "med
             destroySubtitleSync();
         });
         var lastPointerDown = 0;
-        let playerPauseClickTimeout;
         dom.addEventListener(view, window.PointerEvent ? "pointerdown" : "click", function (e) {
             if (dom.parentWithClass(e.target, ["videoOsdBottom", "upNextContainer"])) {
                 return void showOsd();
@@ -1392,14 +1392,14 @@ define(["playbackManager", "dom", "inputManager", "datetime", "itemHelper", "med
 
                 case "mouse":
                     if (!e.button) {
-                        if (playerPauseClickTimeout) {
-                            clearTimeout(playerPauseClickTimeout);
-                            playerPauseClickTimeout = 0;
+                        if (playPauseClickTimeout) {
+                            clearTimeout(playPauseClickTimeout);
+                            playPauseClickTimeout = 0;
                         } else {
-                            playerPauseClickTimeout = setTimeout(() => {
+                            playPauseClickTimeout = setTimeout(() => {
                                 playbackManager.playPause(currentPlayer);
                                 showOsd();
-                                playerPauseClickTimeout = 0;
+                                playPauseClickTimeout = 0;
                             }, 300);
                         }
                     }

--- a/src/controllers/playback/videoosd.js
+++ b/src/controllers/playback/videoosd.js
@@ -1231,9 +1231,7 @@ define(["playbackManager", "dom", "inputManager", "datetime", "itemHelper", "med
                     shell.disableFullscreen();
                 });
                 
-                if (playPauseClickTimeout) {
-                    clearTimeout(playPauseClickTimeout);
-                }
+                clearTimeout(playPauseClickTimeout);
                 var player = currentPlayer;
                 view.removeEventListener("viewbeforehide", onViewHideStopPlayback);
                 releaseCurrentPlayer();


### PR DESCRIPTION
**To Discuss**
I found 300ms to be the optimal delay for me but some might like a longer delay

**Changes**
Adds a 300ms delay before pause/unpause when left-clicking on the player. This allows for uninterrupted playback when toggling fullscreen. Does not affect pausing via the OSD button or media keys.

**Issues**
Resolves: #589