### PR TITLE
Fix Swiper on WebOS by importing ES5 version

### DIFF
--- a/src/bundle.js
+++ b/src/bundle.js
@@ -66,7 +66,7 @@ _define("shaka", function() {
 });
 
 // swiper
-var swiper = require("swiper");
+var swiper = require("swiper/js/swiper");
 require("swiper/css/swiper.min.css");
 _define("swiper", function() {
     return swiper;


### PR DESCRIPTION
**Changes**

Explicitly import the ES5 version of Swiper to prevent older WebOS versions from crashing.

**Issues**

I thought there was an issue on this, couldn't find it.