### PR TITLE
Fix cropping of scaled card (TV layout)

### DIFF
--- a/src/controllers/movies/moviegenres.js
+++ b/src/controllers/movies/moviegenres.js
@@ -152,7 +152,7 @@ define(["layoutManager", "loading", "libraryBrowser", "cardBuilder", "lazyLoader
                         var scrollXClass = "scrollX hiddenScrollX";
 
                         if (layoutManager.tv) {
-                            scrollXClass += "smoothScrollX";
+                            scrollXClass += "smoothScrollX padded-top-focusscale padded-bottom-focusscale";
                         }
 
                         html += '<div is="emby-itemscontainer" class="itemsContainer ' + scrollXClass + ' lazy padded-left padded-right" data-id="' + item.Id + '">';

--- a/src/controllers/movies/moviesrecommended.js
+++ b/src/controllers/movies/moviesrecommended.js
@@ -178,6 +178,8 @@ define(["events", "layoutManager", "inputManager", "userSettings", "libraryMenu"
 
             if (layoutManager.tv) {
                 elem.classList.add("smoothScrollX");
+                elem.classList.add("padded-top-focusscale");
+                elem.classList.add("padded-bottom-focusscale");
             }
 
             elem.classList.add("scrollX");

--- a/src/controllers/shows/tvgenres.js
+++ b/src/controllers/shows/tvgenres.js
@@ -147,7 +147,7 @@ define(["layoutManager", "loading", "libraryBrowser", "cardBuilder", "lazyLoader
                     if (enableScrollX()) {
                         var scrollXClass = "scrollX hiddenScrollX";
                         if (layoutManager.tv) {
-                            scrollXClass += "smoothScrollX";
+                            scrollXClass += "smoothScrollX padded-top-focusscale padded-bottom-focusscale";
                         }
                         html += '<div is="emby-itemscontainer" class="itemsContainer ' + scrollXClass + ' lazy padded-left padded-right" data-id="' + item.Id + '">';
                     } else {


### PR DESCRIPTION
**Changes**
Append padding classes to item containers.
* Movies/Suggestions
* Movies/Genres
* TV Shows/Genres

**Issues**
Fixes #569

In fact, these classes can be added regardless of layout.
https://github.com/jellyfin/jellyfin-web/blob/7a9fbb3edf5a6e1998badc0ba0d564ddc65f2a77/src/assets/css/librarybrowser.css#L1017-L1025