### PR TITLE
Disable scrollManager on emby-scroller in "native mode"

### DIFF
--- a/src/components/scrollManager.js
+++ b/src/components/scrollManager.js
@@ -158,11 +158,20 @@ define(["dom", "browser", "layoutManager"], function (dom, browser, layoutManage
      */
     function getScrollableParent(element, vertical) {
         if (element) {
+            var nameScroll = "scrollWidth";
+            var nameClient = "clientWidth";
+            var nameClass = "scrollX";
+
+            if (vertical) {
+                nameScroll = "scrollHeight";
+                nameClient = "clientHeight";
+                nameClass = "scrollY";
+            }
+
             var parent = element.parentElement;
 
             while (parent) {
-                if ((!vertical && parent.scrollWidth > parent.clientWidth && parent.classList.contains("scrollX")) ||
-                    (vertical && parent.scrollHeight > parent.clientHeight && parent.classList.contains("scrollY"))) {
+                if (parent[nameScroll] > parent[nameClient] && parent.classList.contains(nameClass)) {
                     return parent;
                 }
 

--- a/src/components/scrollManager.js
+++ b/src/components/scrollManager.js
@@ -171,7 +171,9 @@ define(["dom", "browser", "layoutManager"], function (dom, browser, layoutManage
             var parent = element.parentElement;
 
             while (parent) {
-                if (parent[nameScroll] > parent[nameClient] && parent.classList.contains(nameClass)) {
+                // Skip 'emby-scroller' because it scrolls by itself
+                if (!parent.classList.contains("emby-scroller") &&
+                    parent[nameScroll] > parent[nameClient] && parent.classList.contains(nameClass)) {
                     return parent;
                 }
 


### PR DESCRIPTION
When `emby-scroller` goes to native scrolling mechanism (_on webOS 3_), it gets `scrollX` class, and `scrollManager` tries to scroll it - we get some jitter.

**Changes**
Disable scrollManager on emby-scroller.
