### PR TITLE
Details page artwork ribbon revamp

### DIFF
--- a/src/assets/css/fonts.css
+++ b/src/assets/css/fonts.css
@@ -29,7 +29,7 @@ h3 {
 }
 
 .layout-tv {
-    font-size: 2.5vh;
+    font-size: 130%;
 }
 
 .layout-mobile {

--- a/src/assets/css/librarybrowser.css
+++ b/src/assets/css/librarybrowser.css
@@ -439,8 +439,19 @@
     background-size: cover;
     background-repeat: no-repeat;
     background-position: center;
+    background-attachment: fixed;
     height: 50vh;
     position: relative;
+}
+
+.layout-desktop .itemBackdrop::after,
+.layout-tv .itemBackdrop::after {
+    content: "";
+    width: 100%;
+    height: 100%;
+    background: #000000ad;
+    background: rgba(0, 0, 0, 0.65);
+    display: block;
 }
 
 .itemBackdrop.noBackdrop {
@@ -525,8 +536,6 @@
     display: flex;
     align-items: center;
     align-content: center;
-    position: sticky;
-    top: 3.85em;
     z-index: 2;
 }
 
@@ -536,13 +545,19 @@
     top: 0;
 }
 
-.layout-tv .detailPagePrimaryContainer {
+.layout-tv .detailPagePrimaryContainer:not(.noBackdrop),
+.layout-desktop .detailPagePrimaryContainer:not(.noBackdrop) {
     position: relative;
     top: 0;
+    padding-left: 32.45vw;
 }
 
 .detailSticky {
-    background-color: #101010;
+    margin-top: -7.3em;
+}
+
+.detailSticky.noBackdrop {
+    margin-top: 0;
 }
 
 .infoWrapper {
@@ -572,15 +587,15 @@
 }
 
 .detailImageContainer {
-    position: sticky;
-    top: 25%;
+    position: relative;
+    margin-top: -25vh;
     float: left;
-    width: 22.786458333333332vw;
+    width: 25vw;
+    z-index: 3;
 }
 
-.layout-mobile .detailImageContainer,
-.layout-tv .detailImageContainer {
-    position: relative;
+.detailImageContainer.noBackdrop {
+    margin-top: 0;
 }
 
 .detailPagePrimaryContent {
@@ -588,11 +603,11 @@
 }
 
 .detailLogo {
-    width: 25em;
-    height: 9.375em;
+    width: 67.25vw;
+    height: 14.5vh;
     position: absolute;
-    top: 14.5%;
-    right: 10.5%;
+    top: 15vh;
+    right: 0;
     -webkit-background-size: contain;
     background-size: contain;
 }
@@ -623,8 +638,8 @@
 
 .itemDetailImage {
     width: 100% !important;
-    box-shadow: 0 0.0725em 0.29em 0 rgba(0, 0, 0, 0.37);
-    -webkit-box-shadow: 0 0.0725em 0.29em 0 rgba(0, 0, 0, 0.37);
+    -webkit-box-shadow: 0 0.1em 0.5em 0 rgba(0, 0, 0, 0.75);
+    box-shadow: 0 0.1em 0.5em 0 rgba(0, 0, 0, 0.75);
 }
 
 div.itemDetailGalleryLink.defaultCardBackground {
@@ -863,6 +878,10 @@ div.itemDetailGalleryLink.defaultCardBackground {
 .detailPageWrapperContainer {
     border-spacing: 0;
     border-collapse: collapse;
+}
+
+.detailPageWrapperContainer.noBackdrop {
+    margin-top: 4em;
 }
 
 .mediaInfoStream {

--- a/src/assets/css/librarybrowser.css
+++ b/src/assets/css/librarybrowser.css
@@ -449,7 +449,6 @@
     content: "";
     width: 100%;
     height: 100%;
-    background: #000000ad;
     background: rgba(0, 0, 0, 0.65);
     display: block;
 }
@@ -898,7 +897,7 @@ div.itemDetailGalleryLink.defaultCardBackground {
 
 .layout-desktop .noBackdrop .detailPageWrapperContainer,
 .layout-tv .noBackdrop .detailPageWrapperContainer {
-    margin-top: 4em;
+    margin-top: 3.8em;
 }
 
 .mediaInfoStream {

--- a/src/assets/css/librarybrowser.css
+++ b/src/assets/css/librarybrowser.css
@@ -443,6 +443,22 @@
     position: relative;
 }
 
+.itemBackdrop.noBackdrop {
+    display: none;
+}
+
+.detailPageContent.noBackdrop {
+    margin-top: 6.75em;
+}
+
+.layout-desktop .detailImageContainer.noBackdrop img {
+    margin-top: -2.5em;
+}
+
+.layout-tv .detailImageContainer.noBackdrop img {
+    margin-top: 0;
+}
+
 .personBackdrop {
     background-size: contain;
 }

--- a/src/assets/css/librarybrowser.css
+++ b/src/assets/css/librarybrowser.css
@@ -459,6 +459,13 @@
     display: none;
 }
 
+.detailPageContent {
+    display: flex;
+    flex-direction: column;
+    padding-left: 2%;
+    padding-right: 2%;
+}
+
 .layout-desktop .noBackdrop .detailPageContent,
 .layout-tv .noBackdrop .detailPageContent {
     margin-top: 2.5em;
@@ -578,13 +585,6 @@
 
 .detailPageSecondaryContainer {
     margin: 1.25em 0;
-}
-
-.detailPageContent {
-    display: flex;
-    flex-direction: column;
-    padding-left: 2%;
-    padding-right: 2%;
 }
 
 .detailImageContainer {

--- a/src/assets/css/librarybrowser.css
+++ b/src/assets/css/librarybrowser.css
@@ -454,19 +454,18 @@
     display: block;
 }
 
-.itemBackdrop.noBackdrop {
+.layout-desktop .noBackdrop .itemBackdrop,
+.layout-tv .noBackdrop .itemBackdrop {
     display: none;
 }
 
-.detailPageContent.noBackdrop {
-    margin-top: 6.75em;
+.layout-desktop .noBackdrop .detailPageContent,
+.layout-tv .noBackdrop .detailPageContent {
+    margin-top: 2.5em;
 }
 
-.layout-desktop .detailImageContainer.noBackdrop img {
-    margin-top: -2.5em;
-}
-
-.layout-tv .detailImageContainer.noBackdrop img {
+.layout-desktop .noBackdrop .detailImageContainer img,
+.layout-tv .noBackdrop .detailImageContainer img {
     margin-top: 0;
 }
 
@@ -545,18 +544,20 @@
     top: 0;
 }
 
-.layout-tv .detailPagePrimaryContainer:not(.noBackdrop),
-.layout-desktop .detailPagePrimaryContainer:not(.noBackdrop) {
+.layout-tv #itemDetailPage:not(.noBackdrop) .detailPagePrimaryContainer,
+.layout-desktop #itemDetailPage:not(.noBackdrop) .detailPagePrimaryContainer {
     position: relative;
     top: 0;
     padding-left: 32.45vw;
 }
 
-.detailSticky {
-    margin-top: -7.3em;
+.layout-desktop .detailSticky,
+.layout-tv .detailSticky {
+    margin-top: -7.2em;
 }
 
-.detailSticky.noBackdrop {
+.layout-desktop .noBackdrop .detailSticky,
+.layout-tv .noBackdrop .detailSticky {
     margin-top: 0;
 }
 
@@ -594,7 +595,8 @@
     z-index: 3;
 }
 
-.detailImageContainer.noBackdrop {
+.layout-desktop .noBackdrop .detailImageContainer,
+.layout-tv .noBackdrop .detailImageContainer {
     margin-top: 0;
 }
 
@@ -610,6 +612,10 @@
     right: 0;
     -webkit-background-size: contain;
     background-size: contain;
+}
+
+.noBackdrop .detailLogo {
+    display: none;
 }
 
 @media all and (max-width: 87.5em) {
@@ -664,6 +670,16 @@ div.itemDetailGalleryLink.defaultCardBackground {
 @media all and (max-width: 62.5em) {
     .detailPageWrapperContainer {
         position: relative;
+    }
+
+    .layout-desktop .detailPageWrapperContainer,
+    .layout-tv .detailPageWrapperContainer {
+        margin-top: 7.2em;
+    }
+
+    .layout-tv #itemDetailPage:not(.noBackdrop) .detailPagePrimaryContainer,
+    .layout-desktop #itemDetailPage:not(.noBackdrop) .detailPagePrimaryContainer {
+        padding-left: 3.3%;
     }
 
     .btnPlaySimple {
@@ -880,7 +896,8 @@ div.itemDetailGalleryLink.defaultCardBackground {
     border-collapse: collapse;
 }
 
-.detailPageWrapperContainer.noBackdrop {
+.layout-desktop .noBackdrop .detailPageWrapperContainer,
+.layout-tv .noBackdrop .detailPageWrapperContainer {
     margin-top: 4em;
 }
 

--- a/src/controllers/itemdetailpage.js
+++ b/src/controllers/itemdetailpage.js
@@ -1,4 +1,4 @@
-define(["loading", "appRouter", "layoutManager", "connectionManager", "cardBuilder", "datetime", "mediaInfo", "backdrop", "listView", "itemContextMenu", "itemHelper", "dom", "indicators", "apphost", "imageLoader", "libraryMenu", "globalize", "browser", "events", "scrollHelper", "playbackManager", "libraryBrowser", "scrollStyles", "emby-itemscontainer", "emby-checkbox", "emby-button", "emby-playstatebutton", "emby-ratingbutton", "emby-scroller", "emby-select"], function (loading, appRouter, layoutManager, connectionManager, cardBuilder, datetime, mediaInfo, backdrop, listView, itemContextMenu, itemHelper, dom, indicators, appHost, imageLoader, libraryMenu, globalize, browser, events, scrollHelper, playbackManager, libraryBrowser) {
+define(["loading", "appRouter", "layoutManager", "connectionManager", "userSettings", "cardBuilder", "datetime", "mediaInfo", "backdrop", "listView", "itemContextMenu", "itemHelper", "dom", "indicators", "apphost", "imageLoader", "libraryMenu", "globalize", "browser", "events", "scrollHelper", "playbackManager", "libraryBrowser", "scrollStyles", "emby-itemscontainer", "emby-checkbox", "emby-button", "emby-playstatebutton", "emby-ratingbutton", "emby-scroller", "emby-select"], function (loading, appRouter, layoutManager, connectionManager, userSettings, cardBuilder, datetime, mediaInfo, backdrop, listView, itemContextMenu, itemHelper, dom, indicators, appHost, imageLoader, libraryMenu, globalize, browser, events, scrollHelper, playbackManager, libraryBrowser) {
     "use strict";
 
     function getPromise(apiClient, params) {
@@ -464,6 +464,10 @@ define(["loading", "appRouter", "layoutManager", "connectionManager", "cardBuild
             item.Type === "MusicArtist" ||
             item.Type === "Person";
 
+        if (!layoutManager.mobile && !userSettings.enableBackdrops()) {
+            return hasbackdrop;
+        }
+
         if ("Program" === item.Type && item.ImageTags && item.ImageTags.Thumb) {
             imgUrl = apiClient.getScaledImageUrl(item.Id, {
                 type: "Thumb",
@@ -663,7 +667,9 @@ define(["loading", "appRouter", "layoutManager", "connectionManager", "cardBuild
         });
         var detailLogo = page.querySelector(".detailLogo");
 
-        if (url) {
+        if (!layoutManager.mobile && !userSettings.enableBackdrops()) {
+            detailLogo.classList.add("hide");
+        } else if (url) {
             detailLogo.classList.remove("hide");
             detailLogo.classList.add("lazy");
             detailLogo.setAttribute("data-src", url);
@@ -836,6 +842,10 @@ define(["loading", "appRouter", "layoutManager", "connectionManager", "cardBuild
             } else if (item.PrimaryImageAspectRatio >= 0.85 && item.PrimaryImageAspectRatio <= 1.34) {
                 shape = "square";
             }
+        }
+
+        if (!layoutManager.mobile && !userSettings.enableBackdrops()) {
+            elem.classList.add("noBackdrop");
         }
 
         if ("thumb" == shape) {
@@ -1047,6 +1057,11 @@ define(["loading", "appRouter", "layoutManager", "connectionManager", "cardBuild
     }
 
     function renderDetails(page, item, apiClient, context, isStatic) {
+        var taglineElement = page.querySelector(".detailPageContent");
+        if (!layoutManager.mobile && !userSettings.enableBackdrops()) {
+            taglineElement.classList.add("noBackdrop");
+        }
+
         renderSimilarItems(page, item, context);
         renderMoreFromSeason(page, item, apiClient);
         renderMoreFromArtist(page, item, apiClient);

--- a/src/controllers/itemdetailpage.js
+++ b/src/controllers/itemdetailpage.js
@@ -516,6 +516,7 @@ define(["loading", "appRouter", "layoutManager", "connectionManager", "userSetti
         }
 
         if ("Person" === item.Type) {
+            // FIXME: This hides the backdrop on all persons to fix a margin issue. Ideally, a proper fix should be made.
             page.classList.add('noBackdrop');
             itemBackdropElement.classList.add("personBackdrop");
         } else {

--- a/src/controllers/itemdetailpage.js
+++ b/src/controllers/itemdetailpage.js
@@ -457,6 +457,7 @@ define(["loading", "appRouter", "layoutManager", "connectionManager", "userSetti
         var imgUrl;
         var screenWidth = screen.availWidth;
         var hasbackdrop = false;
+        console.debug(page);
         var itemBackdropElement = page.querySelector("#itemBackdrop");
         var usePrimaryImage = item.MediaType === "Video" && item.Type !== "Movie" && item.Type !== "Trailer" ||
             item.MediaType && item.MediaType !== "Video" ||
@@ -474,7 +475,7 @@ define(["loading", "appRouter", "layoutManager", "connectionManager", "userSetti
                 index: 0,
                 tag: item.ImageTags.Thumb
             });
-            itemBackdropElement.classList.remove("noBackdrop");
+            page.classList.remove("noBackdrop");
             imageLoader.lazyImage(itemBackdropElement, imgUrl, false);
             hasbackdrop = true;
         } else if (usePrimaryImage && item.ImageTags && item.ImageTags.Primary) {
@@ -483,7 +484,7 @@ define(["loading", "appRouter", "layoutManager", "connectionManager", "userSetti
                 index: 0,
                 tag: item.ImageTags.Primary
             });
-            itemBackdropElement.classList.remove("noBackdrop");
+            page.classList.remove("noBackdrop");
             imageLoader.lazyImage(itemBackdropElement, imgUrl, false);
             hasbackdrop = true;
         } else if (item.BackdropImageTags && item.BackdropImageTags.length) {
@@ -492,7 +493,7 @@ define(["loading", "appRouter", "layoutManager", "connectionManager", "userSetti
                 index: 0,
                 tag: item.BackdropImageTags[0]
             });
-            itemBackdropElement.classList.remove("noBackdrop");
+            page.classList.remove("noBackdrop");
             imageLoader.lazyImage(itemBackdropElement, imgUrl, false);
             hasbackdrop = true;
         } else if (item.ParentBackdropItemId && item.ParentBackdropImageTags && item.ParentBackdropImageTags.length) {
@@ -501,7 +502,7 @@ define(["loading", "appRouter", "layoutManager", "connectionManager", "userSetti
                 index: 0,
                 tag: item.ParentBackdropImageTags[0]
             });
-            itemBackdropElement.classList.remove("noBackdrop");
+            page.classList.remove("noBackdrop");
             imageLoader.lazyImage(itemBackdropElement, imgUrl, false);
             hasbackdrop = true;
         } else if (item.ImageTags && item.ImageTags.Thumb) {
@@ -510,16 +511,15 @@ define(["loading", "appRouter", "layoutManager", "connectionManager", "userSetti
                 index: 0,
                 tag: item.ImageTags.Thumb
             });
-            itemBackdropElement.classList.remove("noBackdrop");
+            page.classList.remove("noBackdrop");
             imageLoader.lazyImage(itemBackdropElement, imgUrl, false);
             hasbackdrop = true;
         } else {
-            itemBackdropElement.classList.add("noBackdrop");
-            page.querySelector(".detailPageWrapperContainer").add("noBackdrop");
             itemBackdropElement.style.backgroundImage = "";
         }
 
         if ("Person" === item.Type) {
+            page.classList.add('noBackdrop');
             itemBackdropElement.classList.add("personBackdrop");
         } else {
             itemBackdropElement.classList.remove("personBackdrop");
@@ -531,10 +531,6 @@ define(["loading", "appRouter", "layoutManager", "connectionManager", "userSetti
     function reloadFromItem(instance, page, params, item, user) {
         var context = params.context;
         page.querySelector(".detailPagePrimaryContainer").classList.add("detailSticky");
-
-        if (!layoutManager.mobile && !userSettings.enableBackdrops()) {
-            page.querySelector(".detailSticky").classList.add("noBackdrop");
-        }
 
         renderName(item, page.querySelector(".nameContainer"), false, context);
         var apiClient = connectionManager.getApiClient(item.ServerId);
@@ -850,10 +846,6 @@ define(["loading", "appRouter", "layoutManager", "connectionManager", "userSetti
             }
         }
 
-        if (!layoutManager.mobile && !userSettings.enableBackdrops()) {
-            elem.classList.add("noBackdrop");
-        }
-
         if ("thumb" == shape) {
             elem.classList.add("thumbDetailImageContainer");
             elem.classList.remove("portraitDetailImageContainer");
@@ -1064,9 +1056,6 @@ define(["loading", "appRouter", "layoutManager", "connectionManager", "userSetti
 
     function renderDetails(page, item, apiClient, context, isStatic) {
         var taglineElement = page.querySelector(".detailPageContent");
-        if (!layoutManager.mobile && !userSettings.enableBackdrops()) {
-            taglineElement.classList.add("noBackdrop");
-        }
 
         renderSimilarItems(page, item, context);
         renderMoreFromSeason(page, item, apiClient);

--- a/src/controllers/itemdetailpage.js
+++ b/src/controllers/itemdetailpage.js
@@ -515,6 +515,7 @@ define(["loading", "appRouter", "layoutManager", "connectionManager", "userSetti
             hasbackdrop = true;
         } else {
             itemBackdropElement.classList.add("noBackdrop");
+            page.querySelector(".detailPageWrapperContainer").add("noBackdrop");
             itemBackdropElement.style.backgroundImage = "";
         }
 
@@ -530,6 +531,11 @@ define(["loading", "appRouter", "layoutManager", "connectionManager", "userSetti
     function reloadFromItem(instance, page, params, item, user) {
         var context = params.context;
         page.querySelector(".detailPagePrimaryContainer").classList.add("detailSticky");
+
+        if (!layoutManager.mobile && !userSettings.enableBackdrops()) {
+            page.querySelector(".detailSticky").classList.add("noBackdrop");
+        }
+
         renderName(item, page.querySelector(".nameContainer"), false, context);
         var apiClient = connectionManager.getApiClient(item.ServerId);
         renderSeriesTimerEditor(page, item, apiClient, user);

--- a/src/controllers/itemdetailpage.js
+++ b/src/controllers/itemdetailpage.js
@@ -463,7 +463,7 @@ define(["loading", "appRouter", "layoutManager", "connectionManager", "userSetti
             item.Type === "Person";
 
         if (!layoutManager.mobile && !userSettings.enableBackdrops()) {
-            return hasbackdrop;
+            return false;
         }
 
         if ("Program" === item.Type && item.ImageTags && item.ImageTags.Thumb) {

--- a/src/itemdetails.html
+++ b/src/itemdetails.html
@@ -1,5 +1,5 @@
-<div id="itemDetailPage" data-role="page" class="page libraryPage itemDetailPage noSecondaryNavPage selfBackdropPage" data-backbutton="true">
-    <div id="itemBackdrop" class="itemBackdrop noBackdrop">
+<div id="itemDetailPage" data-role="page" class="page libraryPage itemDetailPage noSecondaryNavPage selfBackdropPage noBackdrop" data-backbutton="true">
+    <div id="itemBackdrop" class="itemBackdrop">
         <button is="emby-button" type="button" class="btnPlay detailFloatingButton hide fab autoSize" title="${ButtonPlay}" data-mode="resume">
             <i class="material-icons play_arrow"></i>
         </button>

--- a/src/themes/appletv/theme.css
+++ b/src/themes/appletv/theme.css
@@ -112,7 +112,7 @@ html {
 .inputLabelFocused,
 .selectLabelFocused,
 .textareaLabelFocused {
-    color: green;
+    color: #00a4dc;
 }
 
 .checkboxOutline {

--- a/src/themes/dark/theme.css
+++ b/src/themes/dark/theme.css
@@ -201,6 +201,10 @@ html {
 }
 
 .detailSticky {
+    background: rgba(32, 32, 32, 0.8);
+}
+
+.noBackdrop .detailSticky {
     background: #202020;
 }
 

--- a/src/themes/light/theme.css
+++ b/src/themes/light/theme.css
@@ -105,7 +105,7 @@ html {
 .inputLabelFocused,
 .selectLabelFocused,
 .textareaLabelFocused {
-    color: green;
+    color: #00a4dc;
 }
 
 .checkboxOutline {


### PR DESCRIPTION
**Changes**

Rework of the artwork on the details page.

ded19b1 - Hides the artwork ribbon (backdrop and logo) if the user has disabled the backdrops. Adjusts the position of the details and the poster to compensate for the backdrop ribbon not being shown.

e0dc32c  - Moves the poster and sticky bar, removes the stickyness.

Further commits fix up the layout when no backdrop is there.

![image](https://user-images.githubusercontent.com/19396809/75613903-0430fb00-5b33-11ea-8834-b17d1e3ec701.png)

![image](https://user-images.githubusercontent.com/19396809/75613908-14e17100-5b33-11ea-80d7-886a78bfbc5a.png)

**Issues**

Fixes #820 
