### PR TITLE
Remove es6 env until babel is added

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,5 +1,5 @@
 env:
-  es6: true
+  es6: false
   browser: true
   amd: true
 


### PR DESCRIPTION
**Changes**
Removes the es6 support in the eslint config. This should prevent adding code that uses features not supported in old browsers (WebOS for example). Once Babel support has been implemented we can revert this.

**Issues**
N/A

![no more tears](https://user-images.githubusercontent.com/3450688/75105041-668f7600-55de-11ea-8ff0-2fe707a72c69.jpg)