### PR TITLE
Fix browsers that do not support Promises

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "libjass": "^0.11.0",
     "material-design-icons-iconfont": "^5.0.1",
     "native-promise-only": "^0.8.0-a",
-    "requirejs": "^2.3.5",
     "resize-observer-polyfill": "^1.5.1",
     "shaka-player": "^2.5.9",
     "sortablejs": "^1.10.2",

--- a/src/bundle.js
+++ b/src/bundle.js
@@ -47,12 +47,6 @@ _define("howler", function() {
     return howler;
 });
 
-// native-promise-only
-var nativePromise = require("native-promise-only");
-_define("native-promise-only", function() {
-    return nativePromise;
-});
-
 // resize-observer-polyfill
 var resize = require("resize-observer-polyfill").default;
 _define("resize-observer-polyfill", function() {

--- a/src/scripts/apploader.js
+++ b/src/scripts/apploader.js
@@ -19,11 +19,23 @@
         document.head.appendChild(script);
     }
 
-    injectScriptElement(
-        self.Promise ? "./libraries/alameda.js" : "./libraries/require.js",
-        function() {
-            // onload of require library
-            injectScriptElement("./scripts/site.js");
-        }
-    );
+    function loadSite() {
+        injectScriptElement(
+            "./libraries/alameda.js",
+            function() {
+                // onload of require library
+                injectScriptElement("./scripts/site.js");
+            }
+        );
+    }
+
+    if (!self.Promise) {
+        // Load Promise polyfill if they are not natively supported
+        injectScriptElement(
+            "./libraries/npo.js",
+            loadSite
+        );
+    } else {
+        loadSite();
+    }
 })();

--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -671,11 +671,7 @@ var AppInfo = {};
             AppInfo.isNativeApp = true;
         }
 
-        if (!window.Promise || browser.web0s) {
-            require(["native-promise-only"], init);
-        } else {
-            init();
-        }
+        init();
     }
 
     var localApiClient;

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -5,7 +5,7 @@ const CopyPlugin = require("copy-webpack-plugin");
 
 const Assets = [
     "alameda/alameda.js",
-    "requirejs/require.js",
+    "native-promise-only/npo.js",
     "libass-wasm/dist/subtitles-octopus-worker.js",
     "libass-wasm/dist/subtitles-octopus-worker.data",
     "libass-wasm/dist/subtitles-octopus-worker.wasm"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5415,11 +5415,6 @@ require-main-filename@^2.0.0:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
-requirejs@^2.3.5:
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/requirejs/-/requirejs-2.3.6.tgz#e5093d9601c2829251258c0b9445d4d19fa9e7c9"
-  integrity sha512-ipEzlWQe6RK3jkzikgCupiTbTvm4S0/CAU5GlgptkN5SO6F3u0UD0K18wy6ErDqiCyP4J4YYe1HuAShvsxePLg==
-
 requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
@@ -5633,11 +5628,6 @@ send@0.17.1:
     on-finished "~2.3.0"
     range-parser "~1.2.1"
     statuses "~1.5.0"
-
-serialize-javascript@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
-  integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
 
 serialize-javascript@^2.1.2:
   version "2.1.2"


### PR DESCRIPTION
**Changes**
Support for browsers that do not natively support Promises was broken because we are using `require('script').then()` syntax which is not supported with standard require.js.

* Removes require.js
* Loads Promise polyfill before alameda
* Removes Promise polyfill from bundle

**Issues**
N/A
