### PR TITLE
Fix hover buttons layout on portraitCard

### DIFF
--- a/src/components/cardbuilder/card.css
+++ b/src/components/cardbuilder/card.css
@@ -784,7 +784,7 @@ button::-moz-focus-inner {
     opacity: 0;
     transition: 0.2s;
     background: transparent;
-    padding: 0.5em;
+    padding: 0.25em;
 }
 
 .cardOverlayButtonIcon-hover {


### PR DESCRIPTION
In the collection screen, the hover buttons for movies was not inline (on a 1080 screen)

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

I have reduced the padding by 0.05 em on the cardOverlayButton-hover so the icons will fit on one line at the bottom of the postcard

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
From this:
![image](https://user-images.githubusercontent.com/41705642/75608916-7f32eb00-5b0c-11ea-9b96-5cd7bd38487b.png)

To this:
![image](https://user-images.githubusercontent.com/41705642/75608923-8ce87080-5b0c-11ea-82e6-0addbc5bfb28.png)
