### PR TITLE
Add basic playback speed control

### DIFF
--- a/src/controllers/playback/videoosd.js
+++ b/src/controllers/playback/videoosd.js
@@ -1081,6 +1081,15 @@ define(["playbackManager", "dom", "inputManager", "datetime", "itemHelper", "med
             }
         }
 
+        function setPlaybackSpeed() {
+            if (document.querySelector('video').playbackRate >= 2) {
+                document.querySelector('video').playbackRate = 0.5;
+            } else {
+                document.querySelector('video').playbackRate = document.querySelector('video').playbackRate + 0.25;
+            }
+            view.querySelector(".btnSetPlaybackSpeed").textContent = document.querySelector('video').playbackRate + "x";
+        }
+
         /**
          * Clicked element.
          * To skip 'click' handling on Firefox/Edge.
@@ -1509,6 +1518,7 @@ define(["playbackManager", "dom", "inputManager", "datetime", "itemHelper", "med
         });
         view.querySelector(".btnAudio").addEventListener("click", showAudioTrackSelection);
         view.querySelector(".btnSubtitles").addEventListener("click", showSubtitleTrackSelection);
+        view.querySelector(".btnSetPlaybackSpeed").addEventListener("click", setPlaybackSpeed);
 
         if (browser.touch) {
             (function () {

--- a/src/videoosd.html
+++ b/src/videoosd.html
@@ -68,6 +68,8 @@
                     <i class="xlargePaperIconButton material-icons">airplay</i>
                 </button>
 
+                <button is="paper-icon-button-light" class="btnSetPlaybackSpeed">1x</button>
+
                 <div class="osdTimeText">
                     <span class="osdPositionText"></span>
                     <span class="osdDurationText"></span>


### PR DESCRIPTION
**Changes**
Add basic playback speed control on web client.
(https://features.jellyfin.org/posts/176/playback-speed)
It change 1x -> 1.25x -> 1.5x -> 1.75x -> 2x -> 0.5x -> 0.75x (0.25x step) playbackRate value(HTML 5 Video – DOM Attribute).
Add button and change value when it clicked.
And playbackRate shows on OSD button itself.


**Issues**
No popup selection. (Only loop value change.)
