### PR TITLE
Use forked version of JavascriptSubtitlesOctopus

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "jellyfin-noto": "https://github.com/jellyfin/jellyfin-noto",
     "jquery": "^3.4.1",
     "jstree": "^3.3.7",
-    "libass-wasm": "^2.1.1",
+    "libass-wasm": "https://github.com/jellyfin/JavascriptSubtitlesOctopus",
     "libjass": "^0.11.0",
     "material-design-icons-iconfont": "^5.0.1",
     "native-promise-only": "^0.8.0-a",

--- a/src/components/htmlvideoplayer/plugin.js
+++ b/src/components/htmlvideoplayer/plugin.js
@@ -1056,8 +1056,9 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
                     return i.DeliveryUrl;
                 }),
                 workerUrl: appRouter.baseUrl() + "/libraries/subtitles-octopus-worker.js",
+                legacyWorkerUrl: appRouter.baseUrl() + "/libraries/subtitles-octopus-worker-legacy.js",
                 onError: function() {
-                    htmlMediaHelper.onErrorInternal(self, 'mediadecodeerror')
+                    htmlMediaHelper.onErrorInternal(self, 'mediadecodeerror');
                 }
             };
             require(['JavascriptSubtitlesOctopus'], function(SubtitlesOctopus) {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -8,7 +8,10 @@ const Assets = [
     "native-promise-only/npo.js",
     "libass-wasm/dist/subtitles-octopus-worker.js",
     "libass-wasm/dist/subtitles-octopus-worker.data",
-    "libass-wasm/dist/subtitles-octopus-worker.wasm"
+    "libass-wasm/dist/subtitles-octopus-worker.wasm",
+    "libass-wasm/dist/subtitles-octopus-worker-legacy.js",
+    "libass-wasm/dist/subtitles-octopus-worker-legacy.data",
+    "libass-wasm/dist/subtitles-octopus-worker-legacy.js.mem"
 ];
 
 module.exports = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3683,10 +3683,9 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-libass-wasm@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/libass-wasm/-/libass-wasm-2.1.1.tgz#f12f4fdb9579dd422dcbc348bc3bd61097f4d07d"
-  integrity sha512-d45bHQ7tFVsLW3QstQDrDog2m+0D6Cja4GTrkGi70R9A5+aeLunPSUz3G4CVB+sKffNgiWjK4QI5NZLHQKZ9oQ==
+"libass-wasm@https://github.com/jellyfin/JavascriptSubtitlesOctopus":
+  version "3.0.2"
+  resolved "https://github.com/jellyfin/JavascriptSubtitlesOctopus#7f331237026db75af2441717a4132d2398e96735"
 
 libjass@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
Use the forked version, add the legacy assets to Webpack and add the legacyWorkerUrl parameter to the SubOctopus initialization.

**Issues**

Fixes #679 
