### PR TITLE
Make card buttons be positioned properly

### DIFF
--- a/src/components/cardbuilder/card.css
+++ b/src/components/cardbuilder/card.css
@@ -429,6 +429,12 @@ button::-moz-focus-inner {
     font-size: 1.66956521739130434em !important;
 }
 
+.cardOverlayButtonIcon.material-icons {
+    /* material-icons override display, so we need to
+       make a better matching selector to set it to flex */
+    display: flex;
+}
+
 .cardOverlayButton-centered {
     bottom: initial;
     right: initial;


### PR DESCRIPTION

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Implement a more specific selector to force `display: flex` on card buttons regardless of order of loading of `card.css` and material icons package.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #842