### PR TITLE
Fix text centering on multi-line titles

### DIFF
--- a/src/assets/css/librarybrowser.css
+++ b/src/assets/css/librarybrowser.css
@@ -539,6 +539,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    text-align: center;
 }
 
 .detailPagePrimaryContainer {


### PR DESCRIPTION
**Changes**
Fixes item titles that span multiple lines not being centered on mobile. (Ignore the backdrop change as nightly does not have that fix yet.)

**Before**
![Screenshot_2020-03-04 Jellyfin](https://user-images.githubusercontent.com/3450688/75895195-5019c380-5e03-11ea-817c-09f69d74ee43.png)

**After**
![Screenshot_2020-03-04 Jellyfin(1)](https://user-images.githubusercontent.com/3450688/75895279-6889de00-5e03-11ea-8a34-370b88295f81.png)

**Issues**
N/A
