### PR TITLE
Fix padding in itemdetails' selectors

### DIFF
--- a/src/elements/emby-select/emby-select.css
+++ b/src/elements/emby-select/emby-select.css
@@ -81,7 +81,7 @@
 }
 
 .trackSelections > .selectContainer {
-    margin: 0.4em;
+    margin: 0.4em 0;
 }
 
 .emby-select-withcolor {

--- a/src/elements/emby-select/emby-select.css
+++ b/src/elements/emby-select/emby-select.css
@@ -33,12 +33,12 @@
     border: 0;
 }
 
-.selectContainer-inline>.emby-select {
+.selectContainer-inline > .emby-select {
     padding: 0.3em 1.9em 0.3em 0.5em;
     font-size: inherit;
 }
 
-.selectContainer-inline>.emby-select[disabled] {
+.selectContainer-inline > .emby-select[disabled] {
     padding-left: 0;
     padding-right: 0;
 }
@@ -54,7 +54,7 @@
     z-index: 1;
 }
 
-.emby-select+.fieldDescription {
+.emby-select + .fieldDescription {
     margin-top: 0.25em;
 }
 
@@ -74,13 +74,13 @@
     margin-bottom: 0.25em;
 }
 
-.selectContainer-inline>.selectLabel {
+.selectContainer-inline > .selectLabel {
     margin-bottom: 0;
     margin-right: 0.5em;
     flex-shrink: 0;
 }
 
-.trackSelections>.selectContainer {
+.trackSelections > .selectContainer {
     margin: 0.4em;
 }
 
@@ -98,13 +98,13 @@
     pointer-events: none;
 }
 
-.selectContainer-inline>.selectArrowContainer {
+.selectContainer-inline > .selectArrowContainer {
     top: initial;
     bottom: 0.24em;
     font-size: 90%;
 }
 
-.emby-select[disabled]+.selectArrowContainer {
+.emby-select[disabled] + .selectArrowContainer {
     display: none;
 }
 

--- a/src/elements/emby-select/emby-select.css
+++ b/src/elements/emby-select/emby-select.css
@@ -33,12 +33,12 @@
     border: 0;
 }
 
-.selectContainer-inline > .emby-select {
+.selectContainer-inline>.emby-select {
     padding: 0.3em 1.9em 0.3em 0.5em;
     font-size: inherit;
 }
 
-.selectContainer-inline > .emby-select[disabled] {
+.selectContainer-inline>.emby-select[disabled] {
     padding-left: 0;
     padding-right: 0;
 }
@@ -54,7 +54,7 @@
     z-index: 1;
 }
 
-.emby-select + .fieldDescription {
+.emby-select+.fieldDescription {
     margin-top: 0.25em;
 }
 
@@ -74,10 +74,14 @@
     margin-bottom: 0.25em;
 }
 
-.selectContainer-inline > .selectLabel {
+.selectContainer-inline>.selectLabel {
     margin-bottom: 0;
     margin-right: 0.5em;
     flex-shrink: 0;
+}
+
+.trackSelections>.selectContainer {
+    margin: 0.4em;
 }
 
 .emby-select-withcolor {
@@ -94,13 +98,13 @@
     pointer-events: none;
 }
 
-.selectContainer-inline > .selectArrowContainer {
+.selectContainer-inline>.selectArrowContainer {
     top: initial;
     bottom: 0.24em;
     font-size: 90%;
 }
 
-.emby-select[disabled] + .selectArrowContainer {
+.emby-select[disabled]+.selectArrowContainer {
     display: none;
 }
 

--- a/src/itemdetails.html
+++ b/src/itemdetails.html
@@ -116,7 +116,7 @@
                         <div class="genres hide" style="margin: .7em 0;font-size:92%;"></div>
                         <div class="directors hide" style="margin: .7em 0;font-size:92%;"></div>
 
-                        <form class="trackSelections flex align-items-center flex-wrap-wrap hide focuscontainer-x" style="padding:1em 0">
+                        <form class="trackSelections flex align-items-center flex-wrap-wrap hide focuscontainer-x">
                             <div class="selectContainer selectContainer-inline selectSourceContainer hide trackSelectionFieldContainer flex-shrink-zero">
                                 <select is="emby-select" class="selectSource detailTrackSelect" label=""></select>
                             </div>

--- a/src/itemdetails.html
+++ b/src/itemdetails.html
@@ -120,7 +120,7 @@
                             <div class="selectContainer selectContainer-inline selectSourceContainer hide trackSelectionFieldContainer flex-shrink-zero" style="margin-right:1.5em;">
                                 <select is="emby-select" class="selectSource detailTrackSelect" label=""></select>
                             </div>
-                            <div class="selectContainer selectContainer-inline selectVideoContainer hide trackSelectionFieldContainer flex-shrink-zero" style="margin-right:1.5em;">
+                            <div class="selectContainer selectContainer-inline selectVideoContainer hide trackSelectionFieldContainer flex-shrink-zero" style="margin-right:1.5em;padding:1em 0">
                                 <select is="emby-select" class="selectVideo detailTrackSelect" label=""></select>
                             </div>
                             <div class="selectContainer selectContainer-inline selectAudioContainer hide trackSelectionFieldContainer flex-shrink-zero" style="margin-right:1.5em;">

--- a/src/itemdetails.html
+++ b/src/itemdetails.html
@@ -116,14 +116,14 @@
                         <div class="genres hide" style="margin: .7em 0;font-size:92%;"></div>
                         <div class="directors hide" style="margin: .7em 0;font-size:92%;"></div>
 
-                        <form class="trackSelections flex align-items-center flex-wrap-wrap hide focuscontainer-x" style="margin: .5em 0;font-size:92%; padding: 0;">
-                            <div class="selectContainer selectContainer-inline selectSourceContainer hide trackSelectionFieldContainer flex-shrink-zero" style="margin-right:1.5em;">
+                        <form class="trackSelections flex align-items-center flex-wrap-wrap hide focuscontainer-x" style="padding:1em 0">
+                            <div class="selectContainer selectContainer-inline selectSourceContainer hide trackSelectionFieldContainer flex-shrink-zero">
                                 <select is="emby-select" class="selectSource detailTrackSelect" label=""></select>
                             </div>
-                            <div class="selectContainer selectContainer-inline selectVideoContainer hide trackSelectionFieldContainer flex-shrink-zero" style="margin-right:1.5em;padding:1em 0">
+                            <div class="selectContainer selectContainer-inline selectVideoContainer hide trackSelectionFieldContainer flex-shrink-zero">
                                 <select is="emby-select" class="selectVideo detailTrackSelect" label=""></select>
                             </div>
-                            <div class="selectContainer selectContainer-inline selectAudioContainer hide trackSelectionFieldContainer flex-shrink-zero" style="margin-right:1.5em;">
+                            <div class="selectContainer selectContainer-inline selectAudioContainer hide trackSelectionFieldContainer flex-shrink-zero">
                                 <select is="emby-select" class="selectAudio detailTrackSelect" label=""></select>
                             </div>
                             <div class="selectContainer selectContainer-inline selectSubtitlesContainer hide trackSelectionFieldContainer">


### PR DESCRIPTION
Fixes the overlapping and the small separation between the selectors in the video elements (version, subtitles, audio, etc...)

**Before:**
![Sin título_old](https://user-images.githubusercontent.com/10274099/75928813-7b39fc80-5e6f-11ea-99b1-c9cddfc7620f.png)

**After:**
![Sin título](https://user-images.githubusercontent.com/10274099/75928827-83923780-5e6f-11ea-9c28-e4b9dcadd7a9.png)
