### PR TITLE
Repositioned 'played on' message on item details

### DIFF
--- a/src/assets/css/librarybrowser.css
+++ b/src/assets/css/librarybrowser.css
@@ -28,6 +28,10 @@
     padding-top: 0 !important;
 }
 
+.itemLastPlayed {
+    text-align: right;
+}
+
 .standalonePage {
     padding-top: 4.5em !important;
 }
@@ -854,7 +858,7 @@ div.itemDetailGalleryLink.defaultCardBackground {
         width: auto;
         align-items: center;
         justify-content: center;
-        margin-top: -4.2em;
+        margin-top: -4.3em;
         position: relative;
     }
 

--- a/src/itemdetails.html
+++ b/src/itemdetails.html
@@ -113,6 +113,7 @@
                 <div class="detailPagePrimaryContent padded-left padded-right">
                     <div class="detailSection" style="margin-bottom: 0;">
                         <div class="itemMiscInfo nativeName hide"></div>
+                        <div class="itemLastPlayed hide"></div>
                         <div class="genres hide" style="margin: .7em 0;font-size:92%;"></div>
                         <div class="directors hide" style="margin: .7em 0;font-size:92%;"></div>
 
@@ -133,7 +134,6 @@
 
                         <div class="recordingFields hide" style="margin: .5em 0 1.5em;"></div>
                         <div class="detailSectionContent">
-                            <div class="itemLastPlayed hide"></div>
 
                             <p class="itemGenres"></p>
                             <h3 class="tagline"></h3>


### PR DESCRIPTION
Changes the position of the "Played on" message on item details to the upper right corner, in a position where fits better imo.

**Before**
![OLD](https://user-images.githubusercontent.com/10274099/75967622-6049a580-5ecc-11ea-8dca-c38c82b2d78d.PNG)

**After**
![image](https://user-images.githubusercontent.com/10274099/75967604-59229780-5ecc-11ea-9162-f7f5177284e0.png)

I placed it in the right corner to avoid loosing it in the crowd of all the text, so it's more relevant and noticeable for users. However, I think that it's also good just at the top, without the  ``text-align: right``.

I leave that for discussion :D
