### PR TITLE
Reduced OSD timeout from 5 seconds to 3

### DIFF
--- a/src/controllers/playback/videoosd.js
+++ b/src/controllers/playback/videoosd.js
@@ -376,7 +376,7 @@ define(["playbackManager", "dom", "inputManager", "datetime", "itemHelper", "med
 
         function startOsdHideTimer() {
             stopOsdHideTimer();
-            osdHideTimeout = setTimeout(hideOsd, 5e3);
+            osdHideTimeout = setTimeout(hideOsd, 3e3);
         }
 
         function stopOsdHideTimer() {


### PR DESCRIPTION
Dropped the video OSD timeout down from 5 seconds to 3.

Youtube uses a 4 second timeout and their OSD is much smaller. Our OSD tends to obscure any onscreen subtitles and we can't fix the problem for burned in subs. This is an attempt at mitigating that frustration without introducing usability issues.