### PR TITLE
Clear player data after stop

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -3162,7 +3162,8 @@ define(['events', 'datetime', 'appSettings', 'itemHelper', 'pluginManager', 'pla
 
             // User clicked stop or content ended
             var state = self.getPlayerState(player);
-            var streamInfo = getPlayerData(player).streamInfo;
+            var data = getPlayerData(player);
+            var streamInfo = data.streamInfo;
 
             var nextItem = self._playNextAfterEnded ? self._playQueueManager.getNextItemInfo() : null;
 
@@ -3210,6 +3211,9 @@ define(['events', 'datetime', 'appSettings', 'itemHelper', 'pluginManager', 'pla
                 showPlaybackInfoErrorMessage(self, displayErrorCode, nextItem);
             } else if (nextItem) {
                 self.nextTrack();
+            } else {
+                // Nothing more to play - clear data
+                data.streamInfo = null;
             }
         }
 

--- a/src/controllers/playback/videoosd.js
+++ b/src/controllers/playback/videoosd.js
@@ -665,7 +665,8 @@ define(["playbackManager", "dom", "inputManager", "datetime", "itemHelper", "med
         }
 
         function onTimeUpdate(e) {
-            if (isEnabled) {
+            // Test for 'currentItem' is required for Firefox since its player spams 'timeupdate' events even being at breakpoint
+            if (isEnabled && currentItem) {
                 var now = new Date().getTime();
 
                 if (!(now - lastUpdateTime < 700)) {


### PR DESCRIPTION
_**Some warning at the end**_

When player stops, `playerData` still keeps `streamInfo` of previous item.
`videoosd` updates on bind to player and on play start.

In case of LiveTV then local movie:
* [on bind]: async request of previous item is sent
https://github.com/jellyfin/jellyfin-web/blob/2a99df8365993c0d0f02f80f11f6bd20fb697829/src/controllers/playback/videoosd.js#L290
https://github.com/jellyfin/jellyfin-web/blob/2a99df8365993c0d0f02f80f11f6bd20fb697829/src/controllers/playback/videoosd.js#L112-L126
* [on play start]: update poster (and other data) with current item
https://github.com/jellyfin/jellyfin-web/blob/2a99df8365993c0d0f02f80f11f6bd20fb697829/src/controllers/playback/videoosd.js#L290
* then response of the first request overrides poster (and other data) with previous item

With this PR, there is no update on bind.

**Changes**
* Clear player data after stop

**Issues**
Fixes #800

**Warning**
During the test I set breakpoint at
https://github.com/jellyfin/jellyfin-web/blob/2a99df8365993c0d0f02f80f11f6bd20fb697829/src/controllers/playback/videoosd.js#L273
In Firefox, for LiveTV, I got a reference to `null` - `timeupdate` events are handled as if they were in a separate thread. :confused: 
In Chrome, everything is fine.