### PR TITLE
Make item detail overview expandable (Fix #888)

### DIFF
--- a/src/assets/css/librarybrowser.css
+++ b/src/assets/css/librarybrowser.css
@@ -1145,6 +1145,11 @@ div:not(.sectionTitleContainer-cards) > .sectionTitle-cards {
     font-size: 1.4em;
 }
 
+.overview-controls {
+    display: flex;
+    justify-content: flex-end;
+}
+
 .detail-clamp-text {
     overflow: hidden;
     display: -webkit-box;

--- a/src/assets/css/librarybrowser.css
+++ b/src/assets/css/librarybrowser.css
@@ -1150,16 +1150,10 @@ div:not(.sectionTitleContainer-cards) > .sectionTitle-cards {
     display: -webkit-box;
     -webkit-line-clamp: 12;
     -webkit-box-orient: vertical;
-
-    /* Fallback for older browsers: line-height * number of lines */
-    max-height: calc(1.35 * 12em);
 }
 
 @media all and (min-width: 40em) {
     .detail-clamp-text {
         -webkit-line-clamp: 6;
-
-        /* Fallback for older browsers: line-height * number of lines */
-        max-height: calc(1.35 * 6em);
     }
 }

--- a/src/assets/css/librarybrowser.css
+++ b/src/assets/css/librarybrowser.css
@@ -1144,3 +1144,22 @@ div:not(.sectionTitleContainer-cards) > .sectionTitle-cards {
     margin-top: 0;
     font-size: 1.4em;
 }
+
+.detail-clamp-text {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 12;
+    -webkit-box-orient: vertical;
+
+    /* Fallback for older browsers: line-height * number of lines */
+    max-height: calc(1.35 * 12em);
+}
+
+@media all and (min-width: 40em) {
+    .detail-clamp-text {
+        -webkit-line-clamp: 6;
+
+        /* Fallback for older browsers: line-height * number of lines */
+        max-height: calc(1.35 * 6em);
+    }
+}

--- a/src/controllers/itemDetails.js
+++ b/src/controllers/itemDetails.js
@@ -972,14 +972,16 @@ define(['loading', 'appRouter', 'layoutManager', 'connectionManager', 'userSetti
         }
     }
 
-    function toggleLineClamp(e) {
-        var target = e.target;
+    function toggleLineClamp(clampTarget, e) {
+        var expandButton = e.target;
         var clampClassName = 'detail-clamp-text';
 
-        if (target.classList.contains(clampClassName)) {
-            target.classList.remove(clampClassName);
+        if (clampTarget.classList.contains(clampClassName)) {
+            clampTarget.classList.remove(clampClassName);
+            expandButton.innerHTML = 'Show Less';
         } else {
-            target.classList.add(clampClassName);
+            clampTarget.classList.add(clampClassName);
+            expandButton.innerHTML = 'Show More';
         }
     }
 
@@ -991,9 +993,20 @@ define(['loading', 'appRouter', 'layoutManager', 'connectionManager', 'userSetti
             if (overview) {
                 elem.innerHTML = overview;
                 elem.classList.remove('hide');
-
                 elem.classList.add('detail-clamp-text');
-                elem.addEventListener('click', toggleLineClamp);
+
+                // Grab the sibling element to control the expand state
+                var expandButton = elem.parentElement.querySelector('.overview-expand');
+
+                // Detect if we have overflow of text. Based on this StackOverflow answer
+                // https://stackoverflow.com/a/35157976
+                if (Math.abs(elem.scrollHeight - elem.offsetHeight) > 2) {
+                    expandButton.classList.remove('hide');
+                } else {
+                    expandButton.classList.add('hide');
+                }
+
+                expandButton.addEventListener('click', toggleLineClamp.bind(null, elem));
 
                 var anchors = elem.querySelectorAll('a');
 

--- a/src/controllers/itemDetails.js
+++ b/src/controllers/itemDetails.js
@@ -978,10 +978,10 @@ define(['loading', 'appRouter', 'layoutManager', 'connectionManager', 'userSetti
 
         if (clampTarget.classList.contains(clampClassName)) {
             clampTarget.classList.remove(clampClassName);
-            expandButton.innerHTML = globalize.translate('Show Less');
+            expandButton.innerHTML = globalize.translate('ShowLess');
         } else {
             clampTarget.classList.add(clampClassName);
-            expandButton.innerHTML = globalize.translate('Show More');
+            expandButton.innerHTML = globalize.translate('ShowMore');
         }
     }
 

--- a/src/controllers/itemDetails.js
+++ b/src/controllers/itemDetails.js
@@ -978,10 +978,10 @@ define(['loading', 'appRouter', 'layoutManager', 'connectionManager', 'userSetti
 
         if (clampTarget.classList.contains(clampClassName)) {
             clampTarget.classList.remove(clampClassName);
-            expandButton.innerHTML = 'Show Less';
+            expandButton.innerHTML = globalize.translate('Show Less');
         } else {
             clampTarget.classList.add(clampClassName);
-            expandButton.innerHTML = 'Show More';
+            expandButton.innerHTML = globalize.translate('Show More');
         }
     }
 

--- a/src/controllers/itemDetails.js
+++ b/src/controllers/itemDetails.js
@@ -972,6 +972,17 @@ define(['loading', 'appRouter', 'layoutManager', 'connectionManager', 'userSetti
         }
     }
 
+    function toggleLineClamp(e) {
+        var target = e.target;
+        var clampClassName = 'detail-clamp-text';
+
+        if (target.classList.contains(clampClassName)) {
+            target.classList.remove(clampClassName);
+        } else {
+            target.classList.add(clampClassName);
+        }
+    }
+
     function renderOverview(elems, item) {
         for (var i = 0, length = elems.length; i < length; i++) {
             var elem = elems[i];
@@ -980,6 +991,10 @@ define(['loading', 'appRouter', 'layoutManager', 'connectionManager', 'userSetti
             if (overview) {
                 elem.innerHTML = overview;
                 elem.classList.remove('hide');
+
+                elem.classList.add('detail-clamp-text');
+                elem.addEventListener('click', toggleLineClamp);
+
                 var anchors = elem.querySelectorAll('a');
 
                 for (var j = 0, length2 = anchors.length; j < length2; j++) {

--- a/src/itemdetails.html
+++ b/src/itemdetails.html
@@ -149,7 +149,7 @@
                             <h3 class="tagline"></h3>
                             <p class="overview"></p>
                             <div class="overview-controls">
-                                <a class="overview-expand hide" is="emby-linkbutton">Show More</a>
+                                <a class="overview-expand hide" is="emby-linkbutton" href="#">${ShowMore}</a>
                             </div>
                             <p id="itemBirthday"></p>
                             <p id="itemBirthLocation"></p>

--- a/src/itemdetails.html
+++ b/src/itemdetails.html
@@ -148,6 +148,9 @@
                             <p class="itemGenres"></p>
                             <h3 class="tagline"></h3>
                             <p class="overview"></p>
+                            <div class="overview-controls">
+                                <a class="overview-expand hide" is="emby-linkbutton">Show More</a>
+                            </div>
                             <p id="itemBirthday"></p>
                             <p id="itemBirthLocation"></p>
                             <p id="itemDeathDate"></p>

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1373,6 +1373,7 @@
     "Share": "Share",
     "ShowAdvancedSettings": "Show advanced settings",
     "ShowIndicatorsFor": "Show indicators for:",
+    "ShowLess": "Show less",
     "ShowMore": "Show more",
     "ShowTitle": "Show title",
     "ShowYear": "Show year",

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1373,6 +1373,7 @@
     "Share": "Share",
     "ShowAdvancedSettings": "Show advanced settings",
     "ShowIndicatorsFor": "Show indicators for:",
+    "ShowMore": "Show more",
     "ShowTitle": "Show title",
     "ShowYear": "Show year",
     "Shows": "Shows",


### PR DESCRIPTION
**Changes**
Adds a `onClick` action that toggles expanding the item detail Overview. By default it crops the text to 12 lines on mobile, 6 on larger viewports.

**Issues**
Fixes #888

**Notes**
This is my first PR for jellyfin, so any additional feedback is welcome :)

I would love some guidance on the location of the callback or CSS classes.

`-webkit-line-clamp` is supported on all Webkit browsers and Firefox as of 3/2020. A fallback with max-height is provided as well, just missing the ellipsis. This might be confusing without a better UX or hints.

**Collapsed Screenshot**
![image](https://user-images.githubusercontent.com/108104/80926273-40b3e980-8d64-11ea-8c66-8ce2cc503155.png)

**Expanded Screenshot**
![image](https://user-images.githubusercontent.com/108104/80926295-62ad6c00-8d64-11ea-882a-b33666122c86.png)

**Known issues**
1) Show More / Show Less does not dynamically change visibility after a window resize event. This might be problematic.