### PR TITLE
Fix slideshow 2

### DIFF
--- a/src/components/dialogHelper/dialogHelper.js
+++ b/src/components/dialogHelper/dialogHelper.js
@@ -242,9 +242,12 @@ define(['appRouter', 'focusManager', 'browser', 'layoutManager', 'inputManager',
 
         var onAnimationFinish = function () {
             focusManager.pushScope(dlg);
+
             if (dlg.getAttribute('data-autofocus') === 'true') {
                 focusManager.autoFocus(dlg);
-            } else if (document.activeElement && !dlg.contains(document.activeElement)) {
+            }
+
+            if (document.activeElement && !dlg.contains(document.activeElement)) {
                 // Blur foreign element to prevent triggering of an action from the previous scope
                 document.activeElement.blur();
             }

--- a/src/components/dialogHelper/dialogHelper.js
+++ b/src/components/dialogHelper/dialogHelper.js
@@ -244,6 +244,9 @@ define(['appRouter', 'focusManager', 'browser', 'layoutManager', 'inputManager',
             focusManager.pushScope(dlg);
             if (dlg.getAttribute('data-autofocus') === 'true') {
                 focusManager.autoFocus(dlg);
+            } else if (document.activeElement && !dlg.contains(document.activeElement)) {
+                // Blur foreign element to prevent triggering of an action from the previous scope
+                document.activeElement.blur();
             }
         };
 

--- a/src/components/slideshow/slideshow.js
+++ b/src/components/slideshow/slideshow.js
@@ -188,11 +188,6 @@ define(['dialogHelper', 'inputManager', 'connectionManager', 'layoutManager', 'f
                 stopInterval();
             });
 
-            // Blur foreign element to prevent starting of "nested" slideshow
-            if (document.activeElement && !dlg.contains(document.activeElement)) {
-                document.activeElement.blur();
-            }
-
             inputManager.on(window, onInputCommand);
             document.addEventListener((window.PointerEvent ? 'pointermove' : 'mousemove'), onPointerMove);
 

--- a/src/components/slideshow/slideshow.js
+++ b/src/components/slideshow/slideshow.js
@@ -188,6 +188,11 @@ define(['dialogHelper', 'inputManager', 'connectionManager', 'layoutManager', 'f
                 stopInterval();
             });
 
+            // Blur foreign element to prevent starting of "nested" slideshow
+            if (document.activeElement && !dlg.contains(document.activeElement)) {
+                document.activeElement.blur();
+            }
+
             inputManager.on(window, onInputCommand);
             document.addEventListener((window.PointerEvent ? 'pointermove' : 'mousemove'), onPointerMove);
 

--- a/src/scripts/inputManager.js
+++ b/src/scripts/inputManager.js
@@ -58,7 +58,7 @@ define(['playbackManager', 'focusManager', 'appRouter', 'dom', 'apphost'], funct
             sourceElement = focusManager.focusableParent(sourceElement);
         }
 
-        sourceElement = sourceElement || document.activeElement || window;
+        sourceElement = sourceElement || document.querySelector('.dialogContainer .dialog.opened') || document.activeElement || window;
 
         if (eventListenerCount) {
             var customEvent = new CustomEvent("command", {

--- a/src/scripts/inputManager.js
+++ b/src/scripts/inputManager.js
@@ -58,7 +58,15 @@ define(['playbackManager', 'focusManager', 'appRouter', 'dom', 'apphost'], funct
             sourceElement = focusManager.focusableParent(sourceElement);
         }
 
-        sourceElement = sourceElement || document.querySelector('.dialogContainer .dialog.opened') || document.activeElement || window;
+        if (!sourceElement) {
+            sourceElement = document.activeElement || window;
+
+            var dlg = document.querySelector('.dialogContainer .dialog.opened');
+
+            if (dlg && (!sourceElement || !dlg.contains(sourceElement))) {
+                sourceElement = dlg;
+            }
+        }
 
         if (eventListenerCount) {
             var customEvent = new CustomEvent("command", {


### PR DESCRIPTION
Another problems with slideshow.

**1. There is no escape**
* Turn on TV layout
* Run slideshow
* Wait for OSD (at bottom) disappeared
* Push `Escape` (in TV, it fires `back` command)
* `appRouter` goes back but slideshow is still on top

The problem is that `inputManager` sends events from activeElement which is `body` after OSD disappears.

**2. Nested slideshow**
* Turn on TV layout
* Run slideshow by keyboard (OSD should not appear)
* Push `Enter` again to run nested slideshow

The problem is that focus stays on card if OSD does not appear.

**Changes**
* Add opened dialog as inputManager event source
* Prevent nested slideshow
