### PR TITLE
Fixed broken links described by #925

### DIFF
--- a/src/dlnasettings.html
+++ b/src/dlnasettings.html
@@ -8,7 +8,7 @@
                 <div class="verticalSection">
                     <div class="sectionTitleContainer flex align-items-center">
                         <h2 class="sectionTitle">${TabSettings}</h2>
-                        <a is="emby-linkbutton" class="raised button-alt headerHelpButton" target="_blank" href="https://docs.jellyfin.org/general/administration/connectivity.html#DLNA">${Help}</a>
+                        <a is="emby-linkbutton" class="raised button-alt headerHelpButton" target="_blank" href="https://docs.jellyfin.org/general/networking/dlna.html">${Help}</a>
                     </div>
                 </div>
 

--- a/src/networking.html
+++ b/src/networking.html
@@ -5,7 +5,7 @@
                 <div class="verticalSection verticalSection-extrabottompadding">
                     <div class="sectionTitleContainer flex align-items-center">
                         <h2 class="sectionTitle">${TabNetworking}</h2>
-                        <a is="emby-linkbutton" class="raised button-alt headerHelpButton" target="_blank" href="https://docs.jellyfin.org/general/administration/networking.html">${Help}</a>
+                        <a is="emby-linkbutton" class="raised button-alt headerHelpButton" target="_blank" href="https://docs.jellyfin.org/general/networking/index.html">${Help}</a>
                     </div>
 
                     <div class="inputContainer">


### PR DESCRIPTION
#925 reported two broken links in DLNA and Networking help buttons. They are now fixed.

**Issues**
#925 

**More on that**
I've noticed links in source code (https://docs.jellyfin.org/general/networking/dlna.html) redirect to the main domain (https://jellyfin.org/docs/general/networking/dlna.html). Is it how it should be or should we use the main domain? Thanks!