### PR TITLE
Fix radiobutton and checkbox

### DIFF
--- a/src/elements/emby-checkbox/emby-checkbox.js
+++ b/src/elements/emby-checkbox/emby-checkbox.js
@@ -5,7 +5,8 @@ define(['browser', 'dom', 'css!./emby-checkbox', 'registerElement'], function (b
 
     function onKeyDown(e) {
         // Don't submit form on enter
-        if (e.keyCode === 13) {
+        // Real (non-emulator) Tizen does nothing on Space
+        if (e.keyCode === 13 || e.keyCode === 32) {
             e.preventDefault();
 
             this.checked = !this.checked;

--- a/src/elements/emby-radio/emby-radio.js
+++ b/src/elements/emby-radio/emby-radio.js
@@ -9,7 +9,13 @@ define(['css!./emby-radio', 'registerElement'], function () {
         if (e.keyCode === 13) {
             e.preventDefault();
 
-            this.checked = true;
+            if (!this.checked) {
+                this.checked = true;
+
+                this.dispatchEvent(new CustomEvent('change', {
+                    bubbles: true
+                }));
+            }
 
             return false;
         }

--- a/src/elements/emby-radio/emby-radio.js
+++ b/src/elements/emby-radio/emby-radio.js
@@ -6,7 +6,8 @@ define(['css!./emby-radio', 'registerElement'], function () {
     function onKeyDown(e) {
 
         // Don't submit form on enter
-        if (e.keyCode === 13) {
+        // Real (non-emulator) Tizen does nothing on Space
+        if (e.keyCode === 13 || e.keyCode === 32) {
             e.preventDefault();
 
             if (!this.checked) {


### PR DESCRIPTION
**Changes**
* Add radiobutton change notification
* Fix radiobutton and checkbox on Tizen

**Issues**
* Triggering radiobutton with `Enter` doesn't fire event.
* Everything is fine in Tizen emulator, but not in real one: `OK` button  on remote control is `Space`, but for unknown reason it doesn't toggle checkbox.

**Notes**
Not sure if I should check only Tizen for `Space` triggering.