### PR TITLE
Fix "Copy Stream URL" for iOS.

### DIFF
--- a/src/components/itemcontextmenu.js
+++ b/src/components/itemcontextmenu.js
@@ -346,7 +346,7 @@ define(["apphost", "globalize", "connectionManager", "itemHelper", "appRouter", 
                     break;
                 case "copy-stream":
                     var downloadHref = apiClient.getItemDownloadUrl(itemId);
-                    var textareaCopy = function () {
+                    var textAreaCopy = function () {
                         var textArea = document.createElement("textarea");
                         textArea.value = downloadHref;
                         document.body.appendChild(textArea);

--- a/src/components/itemcontextmenu.js
+++ b/src/components/itemcontextmenu.js
@@ -346,11 +346,7 @@ define(["apphost", "globalize", "connectionManager", "itemHelper", "appRouter", 
                     break;
                 case "copy-stream":
                     var downloadHref = apiClient.getItemDownloadUrl(itemId);
-                    navigator.clipboard.writeText(downloadHref).then(function () {
-                        require(["toast"], function (toast) {
-                            toast(globalize.translate("CopyStreamURLSuccess"));
-                        });
-                    }, function () {
+                    var textareaCopy = function () {
                         var textArea = document.createElement("textarea");
                         textArea.value = downloadHref;
                         document.body.appendChild(textArea);
@@ -364,7 +360,16 @@ define(["apphost", "globalize", "connectionManager", "itemHelper", "appRouter", 
                             prompt(globalize.translate("CopyStreamURL"), downloadHref);
                         }
                         document.body.removeChild(textArea);
-                    });
+                    };
+                    if (navigator.clipboard === undefined) {
+                        textareaCopy();
+                    } else {
+                        navigator.clipboard.writeText(downloadHref).then(function () {
+                            require(["toast"], function (toast) {
+                                toast(globalize.translate("CopyStreamURLSuccess"));
+                            });
+                        }, textareaCopy);
+                    }
                     getResolveFunction(resolve, id)();
                     break;
                 case "editsubtitles":

--- a/src/components/itemcontextmenu.js
+++ b/src/components/itemcontextmenu.js
@@ -362,13 +362,13 @@ define(["apphost", "globalize", "connectionManager", "itemHelper", "appRouter", 
                         document.body.removeChild(textArea);
                     };
                     if (navigator.clipboard === undefined) {
-                        textareaCopy();
+                        textAreaCopy();
                     } else {
                         navigator.clipboard.writeText(downloadHref).then(function () {
                             require(["toast"], function (toast) {
                                 toast(globalize.translate("CopyStreamURLSuccess"));
                             });
-                        }, textareaCopy);
+                        }, textAreaCopy);
                     }
                     getResolveFunction(resolve, id)();
                     break;


### PR DESCRIPTION
`navigator.clipboard` is `undefined` on iOS safari so the fallback code inside `navigator.clipboard.writeText`  will not trigger on iOS.

**Changes**
Added checking `undefined` `navigator.clipboard` and then running the clipboard copy fallback code there as well.
**Issues**
Fixes #935 
