### PR TITLE
Fix radio style

### DIFF
--- a/src/elements/emby-checkbox/emby-checkbox.css
+++ b/src/elements/emby-checkbox/emby-checkbox.css
@@ -55,7 +55,7 @@
     height: 1.83em;
     margin: 0;
     overflow: hidden;
-    border: 2px solid currentcolor;
+    border: 0.14em solid currentcolor;
     border-radius: 0.14em;
     z-index: 2;
     display: flex;

--- a/src/elements/emby-radio/emby-radio.css
+++ b/src/elements/emby-radio/emby-radio.css
@@ -46,6 +46,7 @@
     top: 0;
     left: 0;
     z-index: 1;
+    overflow: visible;
 }
 
 .mdl-radio__button:disabled + .mdl-radio__circles {

--- a/src/elements/emby-radio/emby-radio.css
+++ b/src/elements/emby-radio/emby-radio.css
@@ -4,7 +4,6 @@
     display: inline-block;
     box-sizing: border-box;
     margin: 0;
-    padding-left: 24px;
 }
 
 .radio-label-block {
@@ -31,67 +30,81 @@
     border: none;
 }
 
-.mdl-radio__outer-circle {
-    position: absolute;
-    top: 4px;
-    left: 0;
-    display: inline-block;
-    box-sizing: border-box;
-    width: 16px;
-    height: 16px;
-    margin: 0;
-    cursor: pointer;
-    border: 2px solid currentcolor;
+.mdl-radio__circles {
+    position: relative;
+    margin-right: 0.54em;
+    width: 1.08em;
+    height: 1.08em;
     border-radius: 50%;
-    z-index: 2;
+    cursor: pointer;
 }
 
-.mdl-radio__button:checked + .mdl-radio__label + .mdl-radio__outer-circle {
-    border: 2px solid #00a4dc;
+.mdl-radio__circles svg {
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 1;
 }
 
-.mdl-radio__button:disabled + .mdl-radio__label + .mdl-radio__outer-circle {
-    border: 2px solid rgba(0, 0, 0, 0.26);
+.mdl-radio__button:disabled + .mdl-radio__circles {
     cursor: auto;
+}
+
+.mdl-radio__button:focus + .mdl-radio__circles .mdl-radio__outer-circle {
+    color: #00a4dc;
+}
+
+.mdl-radio__button:disabled + .mdl-radio__circles .mdl-radio__outer-circle {
+    color: rgba(0, 0, 0, 0.26);
 }
 
 .mdl-radio__inner-circle {
-    position: absolute;
-    z-index: 1;
-    margin: 0;
-    top: 8px;
-    left: 4px;
-    box-sizing: border-box;
-    width: 8px;
-    height: 8px;
-    cursor: pointer;
-    transition-duration: 0.28s;
-    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    transition-duration: 0.2s;
     transition-property: -webkit-transform;
     transition-property: transform;
     transition-property: transform, -webkit-transform;
-    -webkit-transform: scale3d(0, 0, 0);
-    transform: scale3d(0, 0, 0);
+    -webkit-transform: scale(0);
+    transform: scale(0);
+    transform-origin: 50% 50%;
+}
+
+.mdl-radio__button:checked + .mdl-radio__circles .mdl-radio__inner-circle {
+    -webkit-transform: scale(1);
+    transform: scale(1);
+}
+
+.mdl-radio__button:disabled + .mdl-radio__circles .mdl-radio__inner-circle {
+    color: rgba(0, 0, 0, 0.26);
+}
+
+.mdl-radio__button:focus + .mdl-radio__circles .mdl-radio__inner-circle {
+    color: #00a4dc;
+}
+
+.mdl-radio__focus-circle {
+    position: absolute;
+    top: 0;
+    left: 0;
+    box-sizing: border-box;
+    width: 100%;
+    height: 100%;
+    margin: 0;
     border-radius: 50%;
     background: #00a4dc;
+    opacity: 0.26;
+    transition-duration: 0.2s;
+    transition-property: -webkit-transform;
+    transition-property: transform;
+    transition-property: transform, -webkit-transform;
+    -webkit-transform: scale(0);
+    transform: scale(0);
 }
 
-.mdl-radio__button:checked + .mdl-radio__label + .mdl-radio__outer-circle + .mdl-radio__inner-circle {
-    -webkit-transform: scale3d(1, 1, 1);
-    transform: scale3d(1, 1, 1);
-}
-
-.mdl-radio__button:disabled + .mdl-radio__label + .mdl-radio__outer-circle + .mdl-radio__inner-circle {
-    background: rgba(0, 0, 0, 0.26);
-    cursor: auto;
-}
-
-.mdl-radio__button:focus + .mdl-radio__label + .mdl-radio__outer-circle + .mdl-radio__inner-circle {
-    box-shadow: 0 0 0 10px rgba(255, 255, 255, 0.76);
-}
-
-.mdl-radio__button:checked:focus + .mdl-radio__label + .mdl-radio__outer-circle + .mdl-radio__inner-circle {
-    box-shadow: 0 0 0 10px rgba(0, 164, 220, 0.26);
+.mdl-radio__button:focus + .mdl-radio__circles .mdl-radio__focus-circle {
+    -webkit-transform: scale(1.75);
+    transform: scale(1.75);
 }
 
 .mdl-radio__label {

--- a/src/elements/emby-radio/emby-radio.css
+++ b/src/elements/emby-radio/emby-radio.css
@@ -53,7 +53,7 @@
     cursor: auto;
 }
 
-.mdl-radio__button:focus + .mdl-radio__circles .mdl-radio__outer-circle {
+.mdl-radio.show-focus .mdl-radio__button:focus + .mdl-radio__circles .mdl-radio__outer-circle {
     color: #00a4dc;
 }
 
@@ -80,7 +80,7 @@
     color: rgba(0, 0, 0, 0.26);
 }
 
-.mdl-radio__button:focus + .mdl-radio__circles .mdl-radio__inner-circle {
+.mdl-radio.show-focus .mdl-radio__button:focus + .mdl-radio__circles .mdl-radio__inner-circle {
     color: #00a4dc;
 }
 
@@ -103,7 +103,7 @@
     transform: scale(0);
 }
 
-.mdl-radio__button:focus + .mdl-radio__circles .mdl-radio__focus-circle {
+.mdl-radio.show-focus .mdl-radio__button:focus + .mdl-radio__circles .mdl-radio__focus-circle {
     -webkit-transform: scale(1.75);
     transform: scale(1.75);
 }

--- a/src/elements/emby-radio/emby-radio.css
+++ b/src/elements/emby-radio/emby-radio.css
@@ -53,12 +53,12 @@
     cursor: auto;
 }
 
-.mdl-radio.show-focus .mdl-radio__button:focus + .mdl-radio__circles .mdl-radio__outer-circle {
-    color: #00a4dc;
-}
-
 .mdl-radio__button:disabled + .mdl-radio__circles .mdl-radio__outer-circle {
     color: rgba(0, 0, 0, 0.26);
+}
+
+.mdl-radio.show-focus .mdl-radio__button:focus + .mdl-radio__circles .mdl-radio__outer-circle {
+    color: #00a4dc;
 }
 
 .mdl-radio__inner-circle {

--- a/src/elements/emby-radio/emby-radio.js
+++ b/src/elements/emby-radio/emby-radio.js
@@ -43,7 +43,25 @@ define(['css!./emby-radio', 'registerElement'], function () {
         labelTextElement.classList.add('radioButtonLabel');
         labelTextElement.classList.add('mdl-radio__label');
 
-        labelElement.insertAdjacentHTML('beforeend', '<span class="mdl-radio__outer-circle"></span><span class="mdl-radio__inner-circle"></span>');
+        var html = '';
+
+        html += '<div class="mdl-radio__circles">';
+
+        html += '<svg>';
+        html += '<defs>';
+        html += '<clipPath id="cutoff">';
+        html += '<circle cx="50%" cy="50%" r="50%" />';
+        html += '</clipPath>';
+        html += '</defs>';
+        html += '<circle class="mdl-radio__outer-circle" cx="50%" cy="50%" r="50%" fill="none" stroke="currentcolor" stroke-width="0.26em" clip-path="url(#cutoff)" />';
+        html += '<circle class="mdl-radio__inner-circle" cx="50%" cy="50%" r="25%" fill="currentcolor" />';
+        html += '</svg>';
+
+        html += '<div class="mdl-radio__focus-circle"></div>';
+
+        html += '</div>';
+
+        this.insertAdjacentHTML('afterend', html);
 
         this.addEventListener('keydown', onKeyDown);
     };

--- a/src/elements/emby-radio/emby-radio.js
+++ b/src/elements/emby-radio/emby-radio.js
@@ -1,4 +1,4 @@
-define(['css!./emby-radio', 'registerElement'], function () {
+define(['layoutManager', 'css!./emby-radio', 'registerElement'], function (layoutManager) {
     'use strict';
 
     var EmbyRadioPrototype = Object.create(HTMLInputElement.prototype);
@@ -23,6 +23,7 @@ define(['css!./emby-radio', 'registerElement'], function () {
     }
 
     EmbyRadioPrototype.attachedCallback = function () {
+        var showFocus = !layoutManager.mobile;
 
         if (this.getAttribute('data-radio') === 'true') {
             return;
@@ -37,6 +38,9 @@ define(['css!./emby-radio', 'registerElement'], function () {
         labelElement.classList.add('mdl-radio');
         labelElement.classList.add('mdl-js-radio');
         labelElement.classList.add('mdl-js-ripple-effect');
+        if (showFocus) {
+            labelElement.classList.add('show-focus');
+        }
 
         var labelTextElement = labelElement.querySelector('span');
 
@@ -57,7 +61,9 @@ define(['css!./emby-radio', 'registerElement'], function () {
         html += '<circle class="mdl-radio__inner-circle" cx="50%" cy="50%" r="25%" fill="currentcolor" />';
         html += '</svg>';
 
-        html += '<div class="mdl-radio__focus-circle"></div>';
+        if (showFocus) {
+            html += '<div class="mdl-radio__focus-circle"></div>';
+        }
 
         html += '</div>';
 

--- a/src/themes/purplehaze/theme.css
+++ b/src/themes/purplehaze/theme.css
@@ -438,12 +438,12 @@ a[data-role=button] {
     color: #f8f8fe;
 }
 
-.mdl-radio__button:focus + .mdl-radio__circles svg .mdl-radio__outer-circle,
-.mdl-radio__button:focus + .mdl-radio__circles svg .mdl-radio__inner-circle {
+.mdl-radio.show-focus .mdl-radio__button:focus + .mdl-radio__circles svg .mdl-radio__outer-circle,
+.mdl-radio.show-focus .mdl-radio__button:focus + .mdl-radio__circles svg .mdl-radio__inner-circle {
     color: #ff77f1;
 }
 
-.mdl-radio__button:focus + .mdl-radio__circles .mdl-radio__focus-circle {
+.mdl-radio.show-focus .mdl-radio__button:focus + .mdl-radio__circles .mdl-radio__focus-circle {
     background: #00a4dc;
 }
 

--- a/src/themes/purplehaze/theme.css
+++ b/src/themes/purplehaze/theme.css
@@ -382,7 +382,7 @@ a[data-role=button] {
 
 .emby-checkbox:checked + span + .checkboxOutline {
     background-color: #030322;
-    border: 2px solid rgb(72, 195, 200);
+    border: 0.14em solid rgb(72, 195, 200);
 }
 
 .emby-checkbox:checked + span + .checkboxOutline > .checkboxIcon-checked {
@@ -394,7 +394,7 @@ a[data-role=button] {
 }
 
 .emby-checkbox:focus:not(:checked) + span + .checkboxOutline {
-    border: 2px solid #ff77f1;
+    border: 0.14em solid #ff77f1;
 }
 
 .itemProgressBarForeground {

--- a/src/themes/purplehaze/theme.css
+++ b/src/themes/purplehaze/theme.css
@@ -438,6 +438,15 @@ a[data-role=button] {
     color: #f8f8fe;
 }
 
+.mdl-radio__button:focus + .mdl-radio__circles svg .mdl-radio__outer-circle,
+.mdl-radio__button:focus + .mdl-radio__circles svg .mdl-radio__inner-circle {
+    color: #ff77f1;
+}
+
+.mdl-radio__button:focus + .mdl-radio__circles .mdl-radio__focus-circle {
+    background: #00a4dc;
+}
+
 .emby-tab-button {
     color: #999;
 }


### PR DESCRIPTION
:radio: :notes: 

I tried to use `em` units, but due to rounding errors, inner circle was off-centered. So I turned to inline SVG. There is still some warping (Desktop NEW "Parental rating"), but centered at least.

I had to place focus circle outside because WebOS 3 does not support `overflow` for SVG.

Desktop
![radio](https://user-images.githubusercontent.com/56478732/76508497-8a1c4280-645f-11ea-9b9c-2b81003c83ae.png)

TV
![radio_tv](https://user-images.githubusercontent.com/56478732/76508506-8e486000-645f-11ea-9d46-3f5ada1cb0c1.png)

Checkbox (TV)
![checkbox](https://user-images.githubusercontent.com/56478732/76510419-9e157380-6462-11ea-9a18-e4c1492d9e40.png)

**Changes**
* Fix radiobutton focus marker
* Fix checkbox border on TV (_just `em` units_)

**Issues**
Fixes #536
