### PR TITLE
Correct the url in the wizardstart.html to remove the administrator folder

### DIFF
--- a/src/wizardstart.html
+++ b/src/wizardstart.html
@@ -4,7 +4,7 @@
             <form class="wizardStartForm">
                 <div>
                     <h1 style="float:left;">${WelcomeToProject}</h1>
-                    <a is="emby-linkbutton" href="https://docs.jellyfin.org/general/administration/quick-start.html" target="_blank" class="raised raised-alt" style="float:right;margin-top:20px;">
+                    <a is="emby-linkbutton" href="https://docs.jellyfin.org/general/quick-start.html" target="_blank" class="raised raised-alt" style="float:right;margin-top:20px;">
                         <span>${ButtonQuickStartGuide}</span>
                     </a>
                 </div>


### PR DESCRIPTION
**Changes**
Swaps the link on the wizard start form from https://docs.jellyfin.org/general/administration/quick-start.html which 404's to
https://docs.jellyfin.org/general/quick-start.html

**Issues**
Fixes https://github.com/jellyfin/jellyfin/issues/2605