### PR TITLE
Fix schedules direct buttons being hidden by default

### DIFF
--- a/src/components/tvproviders/schedulesdirect.js
+++ b/src/components/tvproviders/schedulesdirect.js
@@ -264,18 +264,20 @@ define(["jQuery", "loading", "emby-checkbox", "listViewStyle", "emby-input", "em
         self.init = function () {
             options = options || {};
 
-            // Show cancel button by default
-            if (options.showCancelButton !== false) {
-                page.querySelector(".btnCancel").classList.remove("hide");
-            } else {
+            // Only hide the button if explicitly set to false; default to showing if undefined or null
+            // FIXME: rename this option to clarify logic
+            if (options.showCancelButton === false) {
                 page.querySelector(".btnCancel").classList.add("hide");
+            } else {
+                page.querySelector(".btnCancel").classList.remove("hide");
             }
 
-            // Show submit button by default
-            if (options.showSubmitButton !== false) {
-                page.querySelector(".btnSubmitListings").classList.remove("hide");
-            } else {
+            // Only hide the button if explicitly set to false; default to showing if undefined or null
+            // FIXME: rename this option to clarify logic
+            if (options.showSubmitButton === false) {
                 page.querySelector(".btnSubmitListings").classList.add("hide");
+            } else {
+                page.querySelector(".btnSubmitListings").classList.remove("hide");
             }
 
             $(".formLogin", page).on("submit", function () {

--- a/src/components/tvproviders/schedulesdirect.js
+++ b/src/components/tvproviders/schedulesdirect.js
@@ -264,13 +264,15 @@ define(["jQuery", "loading", "emby-checkbox", "listViewStyle", "emby-input", "em
         self.init = function () {
             options = options || {};
 
-            if (options.showCancelButton) {
+            // Show cancel button by default
+            if (options.showCancelButton !== false) {
                 page.querySelector(".btnCancel").classList.remove("hide");
             } else {
                 page.querySelector(".btnCancel").classList.add("hide");
             }
 
-            if (options.showSubmitButton) {
+            // Show submit button by default
+            if (options.showSubmitButton !== false) {
                 page.querySelector(".btnSubmitListings").classList.remove("hide");
             } else {
                 page.querySelector(".btnSubmitListings").classList.add("hide");

--- a/src/components/tvproviders/schedulesdirect.js
+++ b/src/components/tvproviders/schedulesdirect.js
@@ -264,21 +264,13 @@ define(["jQuery", "loading", "emby-checkbox", "listViewStyle", "emby-input", "em
         self.init = function () {
             options = options || {};
 
-            // Only hide the button if explicitly set to false; default to showing if undefined or null
+            // Only hide the buttons if explicitly set to false; default to showing if undefined or null
             // FIXME: rename this option to clarify logic
-            if (options.showCancelButton === false) {
-                page.querySelector(".btnCancel").classList.add("hide");
-            } else {
-                page.querySelector(".btnCancel").classList.remove("hide");
-            }
+            var hideCancelButton = options.showCancelButton === false;
+            page.querySelector(".btnCancel").classList.toggle("hide", hideCancelButton);
 
-            // Only hide the button if explicitly set to false; default to showing if undefined or null
-            // FIXME: rename this option to clarify logic
-            if (options.showSubmitButton === false) {
-                page.querySelector(".btnSubmitListings").classList.add("hide");
-            } else {
-                page.querySelector(".btnSubmitListings").classList.remove("hide");
-            }
+            var hideSubmitButton = options.showSubmitButton === false;
+            page.querySelector(".btnSubmitListings").classList.toggle("hide", hideSubmitButton);
 
             $(".formLogin", page).on("submit", function () {
                 submitLoginForm();

--- a/src/components/tvproviders/xmltv.js
+++ b/src/components/tvproviders/xmltv.js
@@ -163,16 +163,20 @@ define(["jQuery", "loading", "emby-checkbox", "emby-input", "listViewStyle", "pa
         self.init = function () {
             options = options || {};
 
-            if (false !== options.showCancelButton) {
-                page.querySelector(".btnCancel").classList.remove("hide");
-            } else {
+            // Only hide the button if explicitly set to false; default to showing if undefined or null
+            // FIXME: rename this option to clarify logic
+            if (options.showCancelButton === false) {
                 page.querySelector(".btnCancel").classList.add("hide");
+            } else {
+                page.querySelector(".btnCancel").classList.remove("hide");
             }
 
-            if (false !== options.showSubmitButton) {
-                page.querySelector(".btnSubmitListings").classList.remove("hide");
-            } else {
+            // Only hide the button if explicitly set to false; default to showing if undefined or null
+            // FIXME: rename this option to clarify logic
+            if (options.showSubmitButton === false) {
                 page.querySelector(".btnSubmitListings").classList.add("hide");
+            } else {
+                page.querySelector(".btnSubmitListings").classList.remove("hide");
             }
 
             $("form", page).on("submit", function () {

--- a/src/components/tvproviders/xmltv.js
+++ b/src/components/tvproviders/xmltv.js
@@ -163,21 +163,13 @@ define(["jQuery", "loading", "emby-checkbox", "emby-input", "listViewStyle", "pa
         self.init = function () {
             options = options || {};
 
-            // Only hide the button if explicitly set to false; default to showing if undefined or null
+            // Only hide the buttons if explicitly set to false; default to showing if undefined or null
             // FIXME: rename this option to clarify logic
-            if (options.showCancelButton === false) {
-                page.querySelector(".btnCancel").classList.add("hide");
-            } else {
-                page.querySelector(".btnCancel").classList.remove("hide");
-            }
+            var hideCancelButton = options.showCancelButton === false;
+            page.querySelector(".btnCancel").classList.toggle("hide", hideCancelButton);
 
-            // Only hide the button if explicitly set to false; default to showing if undefined or null
-            // FIXME: rename this option to clarify logic
-            if (options.showSubmitButton === false) {
-                page.querySelector(".btnSubmitListings").classList.add("hide");
-            } else {
-                page.querySelector(".btnSubmitListings").classList.remove("hide");
-            }
+            var hideSubmitButton = options.showSubmitButton === false;
+            page.querySelector(".btnSubmitListings").classList.toggle("hide", hideSubmitButton);
 
             $("form", page).on("submit", function () {
                 submitListingsForm();


### PR DESCRIPTION
**Changes**
Fixes an issue reported on [Reddit](https://old.reddit.com/r/jellyfin/comments/fiprd5/guide_data_for_live_tv/) where the submit and cancel buttons were hidden by default when adding Schedules Direct guide provider.

![can't see me](https://user-images.githubusercontent.com/3450688/76795612-03899d00-67a0-11ea-89d9-38c0734cab5c.gif)

**Issues**
N/A
