### PR TITLE
Show missing indicator in ListView

### DIFF
--- a/src/components/listview/listview.css
+++ b/src/components/listview/listview.css
@@ -238,13 +238,6 @@
     background-color: transparent !important;
 }
 
-.listItemMediaInfo {
-    /* Don't display if flex not supported */
-    display: none;
-    align-items: center;
-    margin-right: 1em;
-}
-
 .listGroupHeader-first {
     margin-top: 0;
 }


### PR DESCRIPTION
**Changes**

For some reason, the "missing" indicator was hidden in ListViews, making it more difficult than necessary to see what's missing in a TV show season.

The entire block of CSS was removed since it did pretty much nothing visible.

![Screenshot_2020-03-17 Jellyfin](https://user-images.githubusercontent.com/19396809/76831503-bea94900-6827-11ea-8735-dd5e2315e4d6.png)

**Issues**

