### PR TITLE
Make header icons bigger

### DIFF
--- a/src/assets/css/librarybrowser.css
+++ b/src/assets/css/librarybrowser.css
@@ -95,6 +95,10 @@
     justify-content: flex-start;
 }
 
+.headerLeft > button {
+    transform: scale(1.2);
+}
+
 .headerRight {
     display: -webkit-box;
     display: -webkit-flex;
@@ -109,6 +113,10 @@
 .noHeaderRight .headerRight,
 .noHomeButtonHeader .headerHomeButton {
     display: none !important;
+}
+
+.headerRight > * {
+    transform: scale(1.2);
 }
 
 .pageTitle {


### PR DESCRIPTION
I think that the icons should be bigger in the header for the sake of accessibility, as currently there is a lot of wasted space imo.

**Before**
*Desktop*
![before](https://user-images.githubusercontent.com/10274099/77015295-ad218780-6974-11ea-86a8-6441765bdd04.png)
*Mobile*
![mobile_before](https://user-images.githubusercontent.com/10274099/77015299-b0b50e80-6974-11ea-9b75-e02b59af3629.png)

**After**
*Desktop*
![after](https://user-images.githubusercontent.com/10274099/77015307-b874b300-6974-11ea-88bd-8640e0db0c5d.png)
*Mobile*
![mobile_after](https://user-images.githubusercontent.com/10274099/77015306-b7dc1c80-6974-11ea-9858-60bb9a23e849.png)
