### PR TITLE
Fix XviD playback on Tizen

### DIFF
--- a/src/scripts/browser.js
+++ b/src/scripts/browser.js
@@ -271,6 +271,9 @@ define([], function () {
 
     if (!browser.tizen) {
         browser.orsay = userAgent.toLowerCase().indexOf('smarthub') !== -1;
+    } else {
+        var v = (navigator.appVersion).match(/Tizen (\d+).(\d+)/);
+        browser.tizenVersion = parseInt(v[1]);
     }
 
     if (browser.edgeUwp) {

--- a/src/scripts/browserdeviceprofile.js
+++ b/src/scripts/browserdeviceprofile.js
@@ -216,7 +216,7 @@ define(['browser'], function (browser) {
                 supported = browser.tizen || browser.orsay || browser.web0s || browser.edgeUwp;
                 // New Samsung TV don't support XviD/DivX
                 // Explicitly add supported codecs to make other codecs be transcoded
-                if (browser.tizen) {
+                if (browser.tizenVersion >= 4) {
                     videoCodecs.push('h264');
                     if (canPlayH265(videoTestElement, options)) {
                         videoCodecs.push('h265');

--- a/src/scripts/browserdeviceprofile.js
+++ b/src/scripts/browserdeviceprofile.js
@@ -215,6 +215,7 @@ define(['browser'], function (browser) {
             case 'avi':
                 supported = browser.tizen || browser.orsay || browser.web0s || browser.edgeUwp;
                 // New Samsung TV don't support XviD/DivX
+                // Explicitly add supported codecs to make other codecs be transcoded
                 if (browser.tizen) {
                     videoCodecs.push('h264');
                     if (canPlayH265(videoTestElement, options)) {

--- a/src/scripts/browserdeviceprofile.js
+++ b/src/scripts/browserdeviceprofile.js
@@ -214,6 +214,14 @@ define(['browser'], function (browser) {
                 break;
             case 'avi':
                 supported = browser.tizen || browser.orsay || browser.web0s || browser.edgeUwp;
+                // New Samsung TV don't support XviD/DivX
+                if (browser.tizen) {
+                    videoCodecs.push('h264');
+                    if (canPlayH265(videoTestElement, options)) {
+                        videoCodecs.push('h265');
+                        videoCodecs.push('hevc');
+                    }
+                }
                 break;
             case 'mpg':
             case 'mpeg':


### PR DESCRIPTION
I received a message from Tizen user https://github.com/dmitrylyzo/jellyfin-tizen/issues/5

I can reproduce this with
```
General
Complete name                            : xvid_test.avi
Format                                   : AVI
Format/Info                              : Audio Video Interleave
File size                                : 44.1 MiB
Duration                                 : 5 min 0 s
Overall bit rate                         : 1 233 kb/s
Writing application                      : Lavf58.20.100

Video
ID                                       : 0
Format                                   : xvid
Codec ID                                 : xvid
Duration                                 : 5 min 0 s
Bit rate                                 : 1 092 kb/s
Width                                    : 1 280 pixels
Height                                   : 720 pixels
Display aspect ratio                     : 16:9
Frame rate                               : 29.970 (30000/1001) FPS
Scan type                                : Progressive
Bits/(Pixel*Frame)                       : 0.040
Stream size                              : 39.1 MiB (89%)

Audio
ID                                       : 1
Format                                   : MPEG Audio
Format version                           : Version 1
Format profile                           : Layer 3
Format settings                          : Joint stereo / MS Stereo
Codec ID                                 : 55
Codec ID/Hint                            : MP3
Duration                                 : 5 min 0 s
Bit rate mode                            : Constant
Bit rate                                 : 128 kb/s
Channel(s)                               : 2 channels
Sampling rate                            : 44.1 kHz
Compression mode                         : Lossy
Stream size                              : 4.58 MiB (10%)
Alignment                                : Aligned on interleaves
Interleave, duration                     : 26  ms (0.78 video frame)
Writing library                          : LAME3.100
```

Currently `avi` uses `DirectPlay` but new Samsung TV don't support XviD - this can be verified with video-file on USB-flash.
On play, I got just black screen with no errors anywhere, and webui just borked.

**Changes**
Explicitly add supported codecs for 'avi' for Tizen to make other codecs be transcoded.

**Issues**
https://github.com/dmitrylyzo/jellyfin-tizen/issues/5