### PR TITLE
Fix cast sender api path

### DIFF
--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -415,7 +415,7 @@ var AppInfo = {};
         define("fileDownloader", [componentsPath + "/filedownloader"], returnFirstDependency);
         define("localassetmanager", [bowerPath + "/apiclient/localassetmanager"], returnFirstDependency);
 
-        define("castSenderApiLoader", [componentsPath + "castSenderApi"], returnFirstDependency);
+        define("castSenderApiLoader", [componentsPath + "/castSenderApi"], returnFirstDependency);
 
         define("transfermanager", [bowerPath + "/apiclient/sync/transfermanager"], returnFirstDependency);
         define("filerepository", [bowerPath + "/apiclient/sync/filerepository"], returnFirstDependency);


### PR DESCRIPTION
In the latest nightly I get following error by launching the web app:
![image](https://user-images.githubusercontent.com/14938497/77335298-43afc900-6d26-11ea-9696-91e6bd062f94.png)

I'm not 100% sure but I think it should fix it