### PR TITLE
Freeze lockfile by default

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+--frozen-lockfile true


### PR DESCRIPTION
**Changes**

Makes builds more reproducible by freezing the lockfile by default.

Should make dependency versions more consistent across builds.

**Issues**


