### PR TITLE
Fix view restoring

### DIFF
--- a/src/components/appRouter.js
+++ b/src/components/appRouter.js
@@ -511,9 +511,16 @@ define(['loading', 'globalize', 'events', 'viewManager', 'layoutManager', 'skinM
         return baseRoute;
     }
 
+    var popstateOccurred = false;
+    window.addEventListener('popstate', function () {
+        popstateOccurred = true;
+    });
+
     function getHandler(route) {
         return function (ctx, next) {
+            ctx.isBack = popstateOccurred;
             handleRoute(ctx, next, route);
+            popstateOccurred = false;
         };
     }
 


### PR DESCRIPTION
Old (customized) `page.js` set `ctx.isBack` on `popstate`. In fact, `ctx.isBack` is more "restore" or "back to view".
New `page.js` does not have such feature, and `viewManager` always opens a new view.

**Changes**
Set `ctx.isBack` on `popstate` event to restore view instead of creating a new one.

**Issues**
Fixes #947

Didn't see if `page.js` has any built-in option to detect navigation back.
