### PR TITLE
Fix subtitle settings in Tizen

### DIFF
--- a/src/components/apphost.js
+++ b/src/components/apphost.js
@@ -280,11 +280,11 @@ define(["appSettings", "browser", "events", "htmlMediaHelper"], function (appSet
         //features.push("multiserver");
         features.push("screensaver");
 
-        if (!browser.orsay && !browser.tizen && !browser.msie && (browser.firefox || browser.ps4 || browser.edge || supportsCue())) {
+        if (!browser.orsay && !browser.msie && (browser.firefox || browser.ps4 || browser.edge || supportsCue())) {
             features.push("subtitleappearancesettings");
         }
 
-        if (!browser.orsay && !browser.tizen) {
+        if (!browser.orsay) {
             features.push("subtitleburnsettings");
         }
 

--- a/src/components/subtitlesync/subtitlesync.js
+++ b/src/components/subtitlesync/subtitlesync.js
@@ -1,4 +1,4 @@
-define(['playbackManager', 'text!./subtitlesync.template.html', 'css!./subtitlesync'], function (playbackManager, template, css) {
+define(['playbackManager', 'layoutManager', 'text!./subtitlesync.template.html', 'css!./subtitlesync'], function (playbackManager, layoutManager, template, css) {
     "use strict";
 
     var player;
@@ -10,12 +10,21 @@ define(['playbackManager', 'text!./subtitlesync.template.html', 'css!./subtitles
     function init(instance) {
 
         var parent = document.createElement('div');
+        document.body.appendChild(parent);
         parent.innerHTML = template;
 
         subtitleSyncSlider = parent.querySelector(".subtitleSyncSlider");
         subtitleSyncTextField = parent.querySelector(".subtitleSyncTextField");
         subtitleSyncCloseButton = parent.querySelector(".subtitleSync-closeButton");
         subtitleSyncContainer = parent.querySelector(".subtitleSyncContainer");
+
+        if (layoutManager.tv) {
+            subtitleSyncSlider.classList.add("focusable");
+            // HACK: Delay to give time for registered element attach (Firefox)
+            setTimeout(function () {
+                subtitleSyncSlider.enableKeyboardDragging();
+            }, 0);
+        }
 
         subtitleSyncContainer.classList.add("hide");
 
@@ -86,8 +95,6 @@ define(['playbackManager', 'text!./subtitlesync.template.html', 'css!./subtitles
             playbackManager.disableShowingSubtitleOffset(player);
             SubtitleSync.prototype.toggle("forceToHide");
         });
-
-        document.body.appendChild(parent);
 
         instance.element = parent;
     }


### PR DESCRIPTION
Why were subtitle settings turned off for Tizen? :confused: 
At least Tizen 3 supports font settings.

**Changes**
* Enable subtitle settings on Tizen
* Enable subtitle sync slider focus and keyboard dragging

**Issues**
#988
