### PR TITLE
Fix dom addEventListener/removeEventListener

### DIFF
--- a/src/components/dom.js
+++ b/src/components/dom.js
@@ -74,17 +74,17 @@ define([], function () {
     }
 
     function addEventListenerWithOptions(target, type, handler, options) {
-        var optionsOrCapture = options;
+        var optionsOrCapture = options || {};
         if (!supportsCaptureOption) {
-            optionsOrCapture = options.capture;
+            optionsOrCapture = optionsOrCapture.capture;
         }
         target.addEventListener(type, handler, optionsOrCapture);
     }
 
     function removeEventListenerWithOptions(target, type, handler, options) {
-        var optionsOrCapture = options;
+        var optionsOrCapture = options || {};
         if (!supportsCaptureOption) {
-            optionsOrCapture = options.capture;
+            optionsOrCapture = optionsOrCapture.capture;
         }
         target.removeEventListener(type, handler, optionsOrCapture);
     }


### PR DESCRIPTION
Here `addEventListener` is called without options (`{}` at least).
https://github.com/jellyfin/jellyfin-web/blob/63a05df3a8dd9a192819b5fede49d51e500bff64/src/components/dialogHelper/dialogHelper.js#L173-L180

**Changes**
Fix dom addEventListener/removeEventListener for case of undefined options 

**Issues**
Calling `addEventListener`/`removeEventListener` without options breaks dialogs on Tizen 3 (old browsers).
