### PR TITLE
Fix admin drawer logo showing up everywhere

### DIFF
--- a/src/assets/css/dashboard.css
+++ b/src/assets/css/dashboard.css
@@ -63,6 +63,10 @@ progress[aria-valuenow]::before {
 }
 
 .adminDrawerLogo {
+    display: none;
+}
+
+.layout-mobile .adminDrawerLogo {
     padding: 1.5em 1em 1.2em;
     border-bottom: 1px solid #e0e0e0;
     margin-bottom: 1em;
@@ -161,7 +165,7 @@ div[data-role=controlgroup] a.ui-btn-active {
 
 @media all and (min-width: 40em) {
     .content-primary {
-        padding-top: 7em;
+        padding-top: 4.6em;
     }
 
     .withTabs .content-primary {

--- a/src/assets/css/librarybrowser.css
+++ b/src/assets/css/librarybrowser.css
@@ -313,7 +313,7 @@
     }
 
     .dashboardDocument .mainDrawer-scrollContainer {
-        margin-top: 6em !important;
+        margin-top: 4.6em !important;
     }
 }
 


### PR DESCRIPTION
**Changes**

The logo in the admin drawer apparently had nothing hiding it? No idea what changed compared to before, but this hides it everywhere except mobile.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
