### PR TITLE
Switch to new version of JavascriptSubtitlesOctopus, enable new options

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "jellyfin-noto": "https://github.com/jellyfin/jellyfin-noto",
     "jquery": "^3.4.1",
     "jstree": "^3.3.7",
-    "libass-wasm": "https://github.com/jellyfin/JavascriptSubtitlesOctopus",
+    "libass-wasm": "https://github.com/jellyfin/JavascriptSubtitlesOctopus#4.0.0-jf",
     "material-design-icons-iconfont": "^5.0.1",
     "native-promise-only": "^0.8.0-a",
     "page": "^1.11.5",

--- a/src/components/htmlvideoplayer/plugin.js
+++ b/src/components/htmlvideoplayer/plugin.js
@@ -1058,7 +1058,19 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
                 legacyWorkerUrl: appRouter.baseUrl() + "/libraries/subtitles-octopus-worker-legacy.js",
                 onError: function() {
                     htmlMediaHelper.onErrorInternal(self, 'mediadecodeerror');
-                }
+                },
+
+                // new octopus options; override all, even defaults
+                renderMode: 'blend',
+                dropAllAnimations: false,
+                libassMemoryLimit: 40,
+                libassGlyphLimit: 40,
+                targetFps: 24,
+                prescaleTradeoff: 0.8,
+                softHeightLimit: 1080,
+                hardHeightLimit: 2160,
+                resizeVariation: 0.2,
+                renderAhead: 90
             };
             require(['JavascriptSubtitlesOctopus'], function(SubtitlesOctopus) {
                 currentSubtitlesOctopus = new SubtitlesOctopus(options);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6576,9 +6576,9 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-"libass-wasm@https://github.com/jellyfin/JavascriptSubtitlesOctopus":
+"libass-wasm@https://github.com/jellyfin/JavascriptSubtitlesOctopus#4.0.0-jf":
   version "4.0.0"
-  resolved "https://github.com/jellyfin/JavascriptSubtitlesOctopus#1d12af0b04fb2337570b57d706dd97db2f904b9d"
+  resolved "https://github.com/jellyfin/JavascriptSubtitlesOctopus#7e6b75dcab9f7dad12719983510d05242803707c"
 
 liftoff@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
First of all, this makes JavascriptSubtitlesOctopus be used from a fixed tag, so whatever happens later with `master` is irrelevant. Reproducibility yay!

Second, I'm updating it to our new version of renderer with vastly improved performance, but setting the limits relatively low (total memory consumption should stay around ~200 MiB at worst), should be fine even for heavy-animated subtitles on recent enough laptop/desktop clients but requires tuning for low-power devices like Smart TV. Current (pre-update) state is much worse though, as those animated subtitles would most likely hang those TVs to the point of unresponsiveness, so I'm not doing anything bad really :)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Not sure if there are any issues made, but this is to improve responsiveness of our web player when displaying subtitles. It also should make them more in sync with video.