### PR TITLE
Babel query-string to support older browsers

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-env"]
+}

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -13,7 +13,7 @@ module.exports = merge(common, {
         rules: [
             {
                 test: /\.js$/,
-                exclude: /node_modules/,
+                exclude: /node_modules[\\/](?!query-string)/,
                 loader: "babel-loader"
             },
             {

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -8,7 +8,7 @@ module.exports = merge(common, {
         rules: [
             {
                 test: /\.js$/,
-                exclude: /node_modules/,
+                exclude: /node_modules[\\/](?!query-string)/,
                 loader: "babel-loader"
             },
             {


### PR DESCRIPTION
Babel `query-string` to support older browsers (Tizen 3 ~ Chrome 47).

**Changes**
- Include `query-string` for "babeling".
- Make global babel config.

_If there is a more correct way to do this, feel free to replace this PR_