### PR TITLE
Fix semicolons and throw error in ESLint if missing

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -74,7 +74,7 @@ rules:
   no-multiple-empty-lines: ["error", { "max": 1 }]
   no-trailing-spaces: ["error"]
   one-var: ["error", "never"]
-  semi: ["warn"]
+  semi: ["error"]
   space-before-blocks: ["error"]
   # TODO: Fix warnings and remove these rules
   no-redeclare: ["warn"]

--- a/src/bundle.js
+++ b/src/bundle.js
@@ -13,7 +13,7 @@ _define("document-register-element", function() {
 // fetch
 var fetch = require("whatwg-fetch");
 _define("fetch", function() {
-    return fetch
+    return fetch;
 });
 
 // query-string

--- a/src/components/activitylog.js
+++ b/src/components/activitylog.js
@@ -16,7 +16,7 @@ define(["events", "globalize", "dom", "date-fns", "dfnshelper", "userSettings", 
             html += '<i class="listItemIcon material-icons" style="width:2em!important;height:2em!important;padding:0;color:transparent;background-color:' + color + ";background-image:url('" + apiClient.getUserImageUrl(entry.UserId, {
                 type: "Primary",
                 tag: entry.UserPrimaryImageTag
-            }) + "');background-repeat:no-repeat;background-position:center center;background-size: cover;\">dvr</i>"
+            }) + "');background-repeat:no-repeat;background-position:center center;background-size: cover;\">dvr</i>";
         } else {
             html += '<i class="listItemIcon material-icons" style="background-color:' + color + '">' + icon + '</i>';
         }

--- a/src/components/appRouter.js
+++ b/src/components/appRouter.js
@@ -577,8 +577,8 @@ define(['loading', 'globalize', 'events', 'viewManager', 'layoutManager', 'skinM
 
     function showDirect(path) {
         return new Promise(function(resolve, reject) {
-            resolveOnNextShow = resolve, page.show(baseUrl()+path)
-        })
+            resolveOnNextShow = resolve, page.show(baseUrl()+path);
+        });
     }
 
     function show(path, options) {

--- a/src/components/apphost.js
+++ b/src/components/apphost.js
@@ -279,8 +279,8 @@ define(["appSettings", "browser", "events", "htmlMediaHelper", "webSettings"], f
         features.push("screensaver");
 
         webSettings.enableMultiServer().then(enabled => {
-            if (enabled) features.push("multiserver")
-        })
+            if (enabled) features.push("multiserver");
+        });
 
         if (!browser.orsay && !browser.msie && (browser.firefox || browser.ps4 || browser.edge || supportsCue())) {
             features.push("subtitleappearancesettings");
@@ -383,7 +383,7 @@ define(["appSettings", "browser", "events", "htmlMediaHelper", "webSettings"], f
                 return window.NativeShell.AppHost.getDefaultLayout();
             }
 
-            return getDefaultLayout()
+            return getDefaultLayout();
         },
         getDeviceProfile: getDeviceProfile,
         init: function () {

--- a/src/components/backdropscreensaver/plugin.js
+++ b/src/components/backdropscreensaver/plugin.js
@@ -52,5 +52,5 @@ define(["connectionManager"], function (connectionManager) {
                 currentSlideshow = null;
             }
         };
-    }
+    };
 });

--- a/src/components/chromecast/chromecasthelpers.js
+++ b/src/components/chromecast/chromecasthelpers.js
@@ -188,9 +188,9 @@ define(['events'], function (events) {
         return apiClient.getEndpointInfo().then(function (endpoint) {
             if (endpoint.IsInNetwork) {
                 return apiClient.getPublicSystemInfo().then(function (info) {
-                    var localAddress = info.LocalAddress
+                    var localAddress = info.LocalAddress;
                     if (!localAddress) {
-                        console.debug("No valid local address returned, defaulting to external one")
+                        console.debug("No valid local address returned, defaulting to external one");
                         localAddress = serverAddress;
                     }
                     addToCache(serverAddress, localAddress);

--- a/src/components/directorybrowser/directorybrowser.js
+++ b/src/components/directorybrowser/directorybrowser.js
@@ -7,11 +7,11 @@ define(['loading', 'dialogHelper', 'dom', 'listViewStyle', 'emby-input', 'paper-
                 systemInfo = info;
                 return info;
             }
-        )
+        );
     }
 
     function onDialogClosed() {
-        loading.hide()
+        loading.hide();
     }
 
     function refreshDirectoryBrowser(page, path, fileOptions, updatePathOnError) {
@@ -24,7 +24,7 @@ define(['loading', 'dialogHelper', 'dom', 'listViewStyle', 'emby-input', 'paper-
         var promises = [];
 
         if ("Network" === path) {
-            promises.push(ApiClient.getNetworkDevices())
+            promises.push(ApiClient.getNetworkDevices());
         } else {
             if (path) {
                 promises.push(ApiClient.getDirectoryContents(path, fileOptions));
@@ -101,7 +101,7 @@ define(['loading', 'dialogHelper', 'dom', 'listViewStyle', 'emby-input', 'paper-
                 html += Globalize.translate("MessageDirectoryPickerLinuxInstruction");
                 html += "<br/>";
             }
-            html += "</div>"
+            html += "</div>";
         }
         html += '<form style="margin:auto;">';
         html += '<div class="inputContainer" style="display: flex; align-items: center;">';
@@ -144,13 +144,13 @@ define(['loading', 'dialogHelper', 'dom', 'listViewStyle', 'emby-input', 'paper-
     function alertText(text) {
         alertTextWithOptions({
             text: text
-        })
+        });
     }
 
     function alertTextWithOptions(options) {
         require(["alert"], function(alert) {
-            alert(options)
-        })
+            alert(options);
+        });
     }
 
     function validatePath(path, validateWriteable, apiClient) {
@@ -171,12 +171,12 @@ define(['loading', 'dialogHelper', 'dom', 'listViewStyle', 'emby-input', 'paper-
                     if (validateWriteable) {
                         alertText(Globalize.translate("WriteAccessRequired"));
                     } else {
-                        alertText(Globalize.translate("PathNotFound"))
+                        alertText(Globalize.translate("PathNotFound"));
                     }
-                    return Promise.reject()
+                    return Promise.reject();
                 }
             }
-            return Promise.resolve()
+            return Promise.resolve();
         });
     }
 
@@ -188,7 +188,7 @@ define(['loading', 'dialogHelper', 'dom', 'listViewStyle', 'emby-input', 'paper-
                 if (lnkPath.classList.contains("lnkFile")) {
                     content.querySelector("#txtDirectoryPickerPath").value = path;
                 } else {
-                    refreshDirectoryBrowser(content, path, fileOptions, true)
+                    refreshDirectoryBrowser(content, path, fileOptions, true);
                 }
             }
         });
@@ -275,7 +275,7 @@ define(['loading', 'dialogHelper', 'dom', 'listViewStyle', 'emby-input', 'paper-
                     dlg.addEventListener("close", onDialogClosed);
                     dialogHelper.open(dlg);
                     dlg.querySelector(".btnCloseDialog").addEventListener("click", function() {
-                        dialogHelper.close(dlg)
+                        dialogHelper.close(dlg);
                     });
                     currentDialog = dlg;
                     dlg.querySelector("#txtDirectoryPickerPath").value = initialPath;
@@ -293,9 +293,9 @@ define(['loading', 'dialogHelper', 'dom', 'listViewStyle', 'emby-input', 'paper-
             if (currentDialog) {
                 dialogHelper.close(currentDialog);
             }
-        }
+        };
     }
 
     var systemInfo;
-    return directoryBrowser
+    return directoryBrowser;
 });

--- a/src/components/filedownloader.js
+++ b/src/components/filedownloader.js
@@ -1,4 +1,4 @@
-import multiDownload from "multi-download"
+import multiDownload from "multi-download";
 
 export function download(items) {
 

--- a/src/components/homesections/homesections.js
+++ b/src/components/homesections/homesections.js
@@ -64,18 +64,18 @@ define(['connectionManager', 'cardBuilder', 'appSettings', 'dom', 'apphost', 'la
             } else {
                 var noLibDescription;
                 if (user['Policy'] && user['Policy']['IsAdministrator']) {
-                    noLibDescription = Globalize.translate("NoCreatedLibraries", '<a id="button-createLibrary" class="button-link">', '</a>')
+                    noLibDescription = Globalize.translate("NoCreatedLibraries", '<a id="button-createLibrary" class="button-link">', '</a>');
                 } else {
                     noLibDescription = Globalize.translate("AskAdminToCreateLibrary");
                 }
 
                 html += '<div class="centerMessage padded-left padded-right">';
                 html += '<h2>' + Globalize.translate("MessageNothingHere") + '</h2>';
-                html += '<p>' + noLibDescription + '</p>'
+                html += '<p>' + noLibDescription + '</p>';
                 html += '</div>';
                 elem.innerHTML = html;
 
-                var createNowLink = elem.querySelector("#button-createLibrary")
+                var createNowLink = elem.querySelector("#button-createLibrary");
                 if (createNowLink) {
                     createNowLink.addEventListener("click", function () {
                         Dashboard.navigate("library.html");
@@ -640,7 +640,7 @@ define(['connectionManager', 'cardBuilder', 'appSettings', 'dom', 'apphost', 'la
 
                 if (enableScrollX()) {
                     html += '<div is="emby-scroller" class="padded-top-focusscale padded-bottom-focusscale" data-centerfocus="true">';
-                    html += '<div is="emby-itemscontainer" class="itemsContainer scrollSlider focuscontainer-x">'
+                    html += '<div is="emby-itemscontainer" class="itemsContainer scrollSlider focuscontainer-x">';
                 } else {
                     html += '<div is="emby-itemscontainer" class="itemsContainer padded-left padded-right vertical-wrap focuscontainer-x">';
                 }
@@ -714,7 +714,7 @@ define(['connectionManager', 'cardBuilder', 'appSettings', 'dom', 'apphost', 'la
 
         if (enableScrollX()) {
             html += '<div is="emby-scroller" class="padded-top-focusscale padded-bottom-focusscale" data-centerfocus="true">';
-            html += '<div is="emby-itemscontainer" class="itemsContainer scrollSlider focuscontainer-x" data-monitor="videoplayback,markplayed">'
+            html += '<div is="emby-itemscontainer" class="itemsContainer scrollSlider focuscontainer-x" data-monitor="videoplayback,markplayed">';
         } else {
             html += '<div is="emby-itemscontainer" class="itemsContainer padded-left padded-right vertical-wrap focuscontainer-x" data-monitor="videoplayback,markplayed">';
         }
@@ -786,7 +786,7 @@ define(['connectionManager', 'cardBuilder', 'appSettings', 'dom', 'apphost', 'la
 
         if (enableScrollX()) {
             html += '<div is="emby-scroller" class="padded-top-focusscale padded-bottom-focusscale" data-centerfocus="true">';
-            html += '<div is="emby-itemscontainer" class="itemsContainer scrollSlider focuscontainer-x">'
+            html += '<div is="emby-itemscontainer" class="itemsContainer scrollSlider focuscontainer-x">';
         } else {
             html += '<div is="emby-itemscontainer" class="itemsContainer padded-left padded-right vertical-wrap focuscontainer-x">';
         }

--- a/src/components/htmlvideoplayer/plugin.js
+++ b/src/components/htmlvideoplayer/plugin.js
@@ -567,19 +567,19 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
         self.resetSubtitleOffset = function() {
             currentTrackOffset = 0;
             showTrackOffset = false;
-        }
+        };
 
         self.enableShowingSubtitleOffset = function() {
             showTrackOffset = true;
-        }
+        };
 
         self.disableShowingSubtitleOffset = function() {
             showTrackOffset = false;
-        }
+        };
 
         self.isShowingSubtitleOffsetEnabled = function() {
             return showTrackOffset;
-        }
+        };
 
         function getTextTrack() {
             var videoElement = self._mediaElement;
@@ -651,7 +651,7 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
 
         self.getSubtitleOffset = function() {
             return currentTrackOffset;
-        }
+        };
 
         function isAudioStreamSupported(stream, deviceProfile) {
 
@@ -1019,7 +1019,7 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
                 xhr.onerror = function (e) {
                     reject(e);
                     decrementFetchQueue();
-                }
+                };
 
                 xhr.send();
             });
@@ -1428,11 +1428,11 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
         }
 
         if (browser.safari || browser.iOS || browser.iPad) {
-            list.push('AirPlay')
+            list.push('AirPlay');
         }
 
         list.push('SetBrightness');
-        list.push("SetAspectRatio")
+        list.push("SetAspectRatio");
 
         return list;
     }
@@ -1555,11 +1555,11 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
             if (video) {
                 if (isEnabled) {
                     video.requestAirPlay().catch(function(err) {
-                        console.error("Error requesting AirPlay", err)
+                        console.error("Error requesting AirPlay", err);
                     });
                 } else {
                     document.exitAirPLay().catch(function(err) {
-                        console.error("Error exiting AirPlay", err)
+                        console.error("Error exiting AirPlay", err);
                     });
                 }
             }
@@ -1692,12 +1692,12 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
         var mediaElement = this._mediaElement;
         if (mediaElement) {
             if ("auto" === val) {
-                mediaElement.style.removeProperty("object-fit")
+                mediaElement.style.removeProperty("object-fit");
             } else {
-                mediaElement.style["object-fit"] = val
+                mediaElement.style["object-fit"] = val;
             }
         }
-        this._currentAspectRatio = val
+        this._currentAspectRatio = val;
     };
 
     HtmlVideoPlayer.prototype.getAspectRatio = function () {
@@ -1714,7 +1714,7 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
         }, {
             name: "Fill",
             id: "fill"
-        }]
+        }];
     };
 
     HtmlVideoPlayer.prototype.togglePictureInPicture = function () {

--- a/src/components/itemMediaInfo/itemMediaInfo.js
+++ b/src/components/itemMediaInfo/itemMediaInfo.js
@@ -116,7 +116,7 @@ define(["dialogHelper", "require", "layoutManager", "globalize", "userSettings",
     }
 
     function createAttribute(label, value) {
-        return '<span class="mediaInfoLabel">' + label + '</span><span class="mediaInfoAttribute">' + value + "</span>"
+        return '<span class="mediaInfoLabel">' + label + '</span><span class="mediaInfoAttribute">' + value + "</span>";
     }
 
     function showMediaInfoMore(itemId, serverId, template) {

--- a/src/components/libraryoptionseditor/libraryoptionseditor.js
+++ b/src/components/libraryoptionseditor/libraryoptionseditor.js
@@ -36,7 +36,7 @@ define(["globalize", "dom", "emby-checkbox", "emby-select", "emby-input"], funct
                 html += "<option value='" + culture.TwoLetterISORegionName + "'>" + culture.DisplayName + "</option>";
             }
             select.innerHTML = html;
-        })
+        });
     }
 
     function populateRefreshInterval(select) {
@@ -120,7 +120,7 @@ define(["globalize", "dom", "emby-checkbox", "emby-select", "emby-input"], funct
             html += plugin.Name;
             html += "</h3>";
             html += "</div>";
-            i > 0 ? html += '<button type="button" is="paper-icon-button-light" title="' + globalize.translate("ButtonUp") + '" class="btnSortableMoveUp btnSortable" data-pluginindex="' + i + '"><i class="material-icons keyboard_arrow_up"></i></button>' : plugins.length > 1 && (html += '<button type="button" is="paper-icon-button-light" title="' + globalize.translate("ButtonDown") + '" class="btnSortableMoveDown btnSortable" data-pluginindex="' + i + '"><i class="material-icons keyboard_arrow_down"></i></button>'), html += "</div>"
+            i > 0 ? html += '<button type="button" is="paper-icon-button-light" title="' + globalize.translate("ButtonUp") + '" class="btnSortableMoveUp btnSortable" data-pluginindex="' + i + '"><i class="material-icons keyboard_arrow_up"></i></button>' : plugins.length > 1 && (html += '<button type="button" is="paper-icon-button-light" title="' + globalize.translate("ButtonDown") + '" class="btnSortableMoveDown btnSortable" data-pluginindex="' + i + '"><i class="material-icons keyboard_arrow_down"></i></button>'), html += "</div>";
         }
         html += "</div>";
         html += '<div class="fieldDescription">' + globalize.translate("LabelMetadataDownloadersHelp") + "</div>";
@@ -265,10 +265,10 @@ define(["globalize", "dom", "emby-checkbox", "emby-select", "emby-input"], funct
             renderMetadataFetchers(parent, availableOptions, {});
             renderSubtitleFetchers(parent, availableOptions, {});
             renderImageFetchers(parent, availableOptions, {});
-            availableOptions.SubtitleFetchers.length ? parent.querySelector(".subtitleDownloadSettings").classList.remove("hide") : parent.querySelector(".subtitleDownloadSettings").classList.add("hide")
+            availableOptions.SubtitleFetchers.length ? parent.querySelector(".subtitleDownloadSettings").classList.remove("hide") : parent.querySelector(".subtitleDownloadSettings").classList.add("hide");
         }).catch(function() {
             return Promise.resolve();
-        })
+        });
     }
 
     function adjustSortableListElement(elem) {
@@ -296,8 +296,8 @@ define(["globalize", "dom", "emby-checkbox", "emby-select", "emby-input"], funct
                 Type: type
             }, currentLibraryOptions.TypeOptions.push(typeOptions));
             var availableOptions = getTypeOptions(currentAvailableOptions || {}, type);
-            (new ImageOptionsEditor).show(type, typeOptions, availableOptions)
-        })
+            (new ImageOptionsEditor).show(type, typeOptions, availableOptions);
+        });
     }
 
     function onImageFetchersContainerClick(e) {
@@ -315,12 +315,12 @@ define(["globalize", "dom", "emby-checkbox", "emby-select", "emby-input"], funct
             var list = dom.parentWithClass(li, "paperList");
             if (btnSortable.classList.contains("btnSortableMoveDown")) {
                 var next = li.nextSibling;
-                next && (li.parentNode.removeChild(li), next.parentNode.insertBefore(li, next.nextSibling))
+                next && (li.parentNode.removeChild(li), next.parentNode.insertBefore(li, next.nextSibling));
             } else {
                 var prev = li.previousSibling;
-                prev && (li.parentNode.removeChild(li), prev.parentNode.insertBefore(li, prev))
+                prev && (li.parentNode.removeChild(li), prev.parentNode.insertBefore(li, prev));
             }
-            Array.prototype.forEach.call(list.querySelectorAll(".sortableOption"), adjustSortableListElement)
+            Array.prototype.forEach.call(list.querySelectorAll(".sortableOption"), adjustSortableListElement);
         }
     }
 
@@ -407,13 +407,13 @@ define(["globalize", "dom", "emby-checkbox", "emby-select", "emby-input"], funct
 
     function setSubtitleFetchersIntoOptions(parent, options) {
         options.DisabledSubtitleFetchers = Array.prototype.map.call(Array.prototype.filter.call(parent.querySelectorAll(".chkSubtitleFetcher"), function(elem) {
-            return !elem.checked
+            return !elem.checked;
         }), function(elem) {
-            return elem.getAttribute("data-pluginname")
+            return elem.getAttribute("data-pluginname");
         });
 
         options.SubtitleFetcherOrder = Array.prototype.map.call(parent.querySelectorAll(".subtitleFetcherItem"), function(elem) {
-            return elem.getAttribute("data-pluginname")
+            return elem.getAttribute("data-pluginname");
         });
     }
 
@@ -455,13 +455,13 @@ define(["globalize", "dom", "emby-checkbox", "emby-select", "emby-input"], funct
             }
 
             typeOptions.ImageFetchers = Array.prototype.map.call(Array.prototype.filter.call(section.querySelectorAll(".chkImageFetcher"), function(elem) {
-                return elem.checked
+                return elem.checked;
             }), function(elem) {
-                return elem.getAttribute("data-pluginname")
+                return elem.getAttribute("data-pluginname");
             });
 
             typeOptions.ImageFetcherOrder = Array.prototype.map.call(section.querySelectorAll(".imageFetcherItem"), function(elem) {
-                return elem.getAttribute("data-pluginname")
+                return elem.getAttribute("data-pluginname");
             });
         }
     }
@@ -505,20 +505,20 @@ define(["globalize", "dom", "emby-checkbox", "emby-select", "emby-input"], funct
             SaveSubtitlesWithMedia: parent.querySelector("#chkSaveSubtitlesLocally").checked,
             RequirePerfectSubtitleMatch: parent.querySelector("#chkRequirePerfectMatch").checked,
             MetadataSavers: Array.prototype.map.call(Array.prototype.filter.call(parent.querySelectorAll(".chkMetadataSaver"), function(elem) {
-                return elem.checked
+                return elem.checked;
             }), function(elem) {
-                return elem.getAttribute("data-pluginname")
+                return elem.getAttribute("data-pluginname");
             }),
             TypeOptions: []
         };
 
         options.LocalMetadataReaderOrder = Array.prototype.map.call(parent.querySelectorAll(".localReaderOption"), function(elem) {
-            return elem.getAttribute("data-pluginname")
+            return elem.getAttribute("data-pluginname");
         });
         options.SubtitleDownloadLanguages = Array.prototype.map.call(Array.prototype.filter.call(parent.querySelectorAll(".chkSubtitleLanguage"), function(elem) {
-            return elem.checked
+            return elem.checked;
         }), function(elem) {
-            return elem.getAttribute("data-lang")
+            return elem.getAttribute("data-lang");
         });
         setSubtitleFetchersIntoOptions(parent, options);
         setMetadataFetchersIntoOptions(parent, options);
@@ -531,7 +531,7 @@ define(["globalize", "dom", "emby-checkbox", "emby-select", "emby-input"], funct
     function getOrderedPlugins(plugins, configuredOrder) {
         plugins = plugins.slice(0);
         plugins.sort(function(a, b) {
-            return a = configuredOrder.indexOf(a.Name), b = configuredOrder.indexOf(b.Name), a < b ? -1 : a > b ? 1 : 0
+            return a = configuredOrder.indexOf(a.Name), b = configuredOrder.indexOf(b.Name), a < b ? -1 : a > b ? 1 : 0;
         });
         return plugins;
     }
@@ -558,10 +558,10 @@ define(["globalize", "dom", "emby-checkbox", "emby-select", "emby-input"], funct
         parent.querySelector("#chkSkipIfAudioTrackPresent").checked = options.SkipSubtitlesIfAudioTrackMatches;
         parent.querySelector("#chkRequirePerfectMatch").checked = options.RequirePerfectSubtitleMatch;
         Array.prototype.forEach.call(parent.querySelectorAll(".chkMetadataSaver"), function(elem) {
-            elem.checked = options.MetadataSavers ? -1 !== options.MetadataSavers.indexOf(elem.getAttribute("data-pluginname")) : "true" === elem.getAttribute("data-defaultenabled")
+            elem.checked = options.MetadataSavers ? -1 !== options.MetadataSavers.indexOf(elem.getAttribute("data-pluginname")) : "true" === elem.getAttribute("data-defaultenabled");
         });
         Array.prototype.forEach.call(parent.querySelectorAll(".chkSubtitleLanguage"), function(elem) {
-            elem.checked = !!options.SubtitleDownloadLanguages && -1 !== options.SubtitleDownloadLanguages.indexOf(elem.getAttribute("data-lang"))
+            elem.checked = !!options.SubtitleDownloadLanguages && -1 !== options.SubtitleDownloadLanguages.indexOf(elem.getAttribute("data-lang"));
         });
         renderMetadataReaders(parent, getOrderedPlugins(parent.availableOptions.MetadataReaders, options.LocalMetadataReaderOrder || []));
         renderMetadataFetchers(parent, parent.availableOptions, options);
@@ -578,5 +578,5 @@ define(["globalize", "dom", "emby-checkbox", "emby-select", "emby-input"], funct
         getLibraryOptions: getLibraryOptions,
         setLibraryOptions: setLibraryOptions,
         setAdvancedVisible: setAdvancedVisible
-    }
+    };
 });

--- a/src/components/logoscreensaver/plugin.js
+++ b/src/components/logoscreensaver/plugin.js
@@ -188,5 +188,5 @@ define(["pluginManager"], function (pluginManager) {
                 }
             }
         };
-    }
+    };
 });

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -1633,29 +1633,29 @@ define(['events', 'datetime', 'appSettings', 'itemHelper', 'pluginManager', 'pla
         self.supportSubtitleOffset = function(player) {
             player = player || self._currentPlayer;
             return player && 'setSubtitleOffset' in player;
-        }
+        };
 
         self.enableShowingSubtitleOffset = function(player) {
             player = player || self._currentPlayer;
             player.enableShowingSubtitleOffset();
-        }
+        };
 
         self.disableShowingSubtitleOffset = function(player) {
             player = player || self._currentPlayer;
             if (player.disableShowingSubtitleOffset) {
                 player.disableShowingSubtitleOffset();
             }
-        }
+        };
 
         self.isShowingSubtitleOffsetEnabled = function(player) {
             player = player || self._currentPlayer;
             return player.isShowingSubtitleOffsetEnabled();
-        }
+        };
 
         self.isSubtitleStreamExternal = function(index, player) {
             var stream = getSubtitleStream(player, index);
             return stream ? getDeliveryMethod(stream) === 'External' : false;
-        }
+        };
 
         self.setSubtitleOffset = function (value, player) {
             player = player || self._currentPlayer;
@@ -1669,12 +1669,12 @@ define(['events', 'datetime', 'appSettings', 'itemHelper', 'pluginManager', 'pla
             if (player.getSubtitleOffset) {
                 return player.getSubtitleOffset();
             }
-        }
+        };
 
         self.canHandleOffsetOnCurrentSubtitle = function(player) {
             var index = self.getSubtitleStreamIndex(player);
             return index !== -1 && self.isSubtitleStreamExternal(index, player);
-        }
+        };
 
         self.seek = function (ticks, player) {
 

--- a/src/components/subtitlesync/subtitlesync.js
+++ b/src/components/subtitlesync/subtitlesync.js
@@ -30,7 +30,7 @@ define(['playbackManager', 'layoutManager', 'text!./subtitlesync.template.html',
 
         subtitleSyncTextField.updateOffset = function(offset) {
             this.textContent = offset + "s";
-        }
+        };
 
         subtitleSyncTextField.addEventListener("keypress", function(event) {
 
@@ -66,7 +66,7 @@ define(['playbackManager', 'layoutManager', 'text!./subtitlesync.template.html',
         subtitleSyncSlider.updateOffset = function(percent) {
             // default value is 0s = 50%
             this.value = percent === undefined ? 50 : percent;
-        }
+        };
 
         subtitleSyncSlider.addEventListener("change", function () {
             // set new offset
@@ -132,7 +132,7 @@ define(['playbackManager', 'layoutManager', 'text!./subtitlesync.template.html',
             elem.parentNode.removeChild(elem);
             this.element = null;
         }
-    }
+    };
 
     SubtitleSync.prototype.toggle = function(action) {
 
@@ -166,7 +166,7 @@ define(['playbackManager', 'layoutManager', 'text!./subtitlesync.template.html',
             }
             /* eslint-enable no-fallthrough */
         }
-    }
+    };
 
     return SubtitleSync;
 });

--- a/src/controllers/dashboard/logs.js
+++ b/src/controllers/dashboard/logs.js
@@ -29,5 +29,5 @@ define(["datetime", "loading", "apphost", "listViewStyle", "emby-button", "flexS
                 loading.hide();
             });
         });
-    }
+    };
 });

--- a/src/controllers/dashboard/notifications/notifications.js
+++ b/src/controllers/dashboard/notifications/notifications.js
@@ -49,12 +49,12 @@ define(["loading", "libraryMenu", "globalize", "listViewStyle", "emby-button"], 
             }
             page.querySelector(".notificationList").innerHTML = html;
             loading.hide();
-        })
+        });
     }
 
     return function(view, params) {
         view.addEventListener("viewshow", function() {
             reload(view);
         });
-    }
+    };
 });

--- a/src/controllers/dashboard/scheduledtasks/scheduledtasks.js
+++ b/src/controllers/dashboard/scheduledtasks/scheduledtasks.js
@@ -7,7 +7,7 @@ define(["jQuery", "loading", "events", "globalize", "serverNotifications", "date
         }).then(function(tasks) {
             populateList(page, tasks);
             loading.hide();
-        })
+        });
     }
 
     function populateList(page, tasks) {
@@ -155,7 +155,7 @@ define(["jQuery", "loading", "events", "globalize", "serverNotifications", "date
             ApiClient.startScheduledTask(id).then(function() {
                 updateTaskButton(button, "Running");
                 reloadList(view);
-            })
+            });
         });
 
         $(".divScheduledTasks", view).on("click", ".btnStopTask", function() {
@@ -164,7 +164,7 @@ define(["jQuery", "loading", "events", "globalize", "serverNotifications", "date
             ApiClient.stopScheduledTask(id).then(function() {
                 updateTaskButton(button, "");
                 reloadList(view);
-            })
+            });
         });
 
         view.addEventListener("viewbeforehide", function() {
@@ -178,5 +178,5 @@ define(["jQuery", "loading", "events", "globalize", "serverNotifications", "date
             reloadList(view);
             events.on(serverNotifications, "ScheduledTasksInfo", onScheduledTasksUpdate);
         });
-    }
+    };
 });

--- a/src/controllers/librarydisplay.js
+++ b/src/controllers/librarydisplay.js
@@ -14,7 +14,7 @@ define(["globalize", "loading", "libraryMenu", "emby-checkbox", "emby-button", "
         }, {
             href: "metadatanfo.html",
             name: Globalize.translate("TabNfoSettings")
-        }]
+        }];
     }
 
     return function(view, params) {
@@ -27,7 +27,7 @@ define(["globalize", "loading", "libraryMenu", "emby-checkbox", "emby-button", "
                 view.querySelector("#chkSaveMetadataHidden").checked = config.SaveMetadataHidden;
             });
             ApiClient.getNamedConfiguration("metadata").then(function(metadata) {
-                loadMetadataConfig(this, metadata)
+                loadMetadataConfig(this, metadata);
             });
         }
 
@@ -67,5 +67,5 @@ define(["globalize", "loading", "libraryMenu", "emby-checkbox", "emby-button", "
                 }
             });
         });
-    }
+    };
 });

--- a/src/controllers/livetv/livetvschedule.js
+++ b/src/controllers/livetv/livetvschedule.js
@@ -48,7 +48,7 @@ define(["layoutManager", "cardBuilder", "apphost", "imageLoader", "loading", "sc
     }
 
     function getBackdropShape() {
-        return enableScrollX() ? "overflowBackdrop" : "backdrop"
+        return enableScrollX() ? "overflowBackdrop" : "backdrop";
     }
 
     function renderActiveRecordings(context, promise) {

--- a/src/controllers/metadataimagespage.js
+++ b/src/controllers/metadataimagespage.js
@@ -7,10 +7,10 @@ define(["jQuery", "dom", "loading", "libraryMenu", "listViewStyle"], function($,
             html += "<option value=''></option>";
             for (var i = 0, length = languages.length; i < length; i++) {
                 var culture = languages[i];
-                html += "<option value='" + culture.TwoLetterISOLanguageName + "'>" + culture.DisplayName + "</option>"
+                html += "<option value='" + culture.TwoLetterISOLanguageName + "'>" + culture.DisplayName + "</option>";
             }
-            select.innerHTML = html
-        })
+            select.innerHTML = html;
+        });
     }
 
     function populateCountries(select) {
@@ -19,25 +19,25 @@ define(["jQuery", "dom", "loading", "libraryMenu", "listViewStyle"], function($,
             html += "<option value=''></option>";
             for (var i = 0, length = allCountries.length; i < length; i++) {
                 var culture = allCountries[i];
-                html += "<option value='" + culture.TwoLetterISORegionName + "'>" + culture.DisplayName + "</option>"
+                html += "<option value='" + culture.TwoLetterISORegionName + "'>" + culture.DisplayName + "</option>";
             }
-            select.innerHTML = html
-        })
+            select.innerHTML = html;
+        });
     }
 
     function loadPage(page) {
         var promises = [ApiClient.getServerConfiguration(), populateLanguages(page.querySelector("#selectLanguage")), populateCountries(page.querySelector("#selectCountry"))];
         Promise.all(promises).then(function(responses) {
             var config = responses[0];
-            page.querySelector("#selectLanguage").value = config.PreferredMetadataLanguage || "", page.querySelector("#selectCountry").value = config.MetadataCountryCode || "", loading.hide()
-        })
+            page.querySelector("#selectLanguage").value = config.PreferredMetadataLanguage || "", page.querySelector("#selectCountry").value = config.MetadataCountryCode || "", loading.hide();
+        });
     }
 
     function onSubmit() {
         var form = this;
         return loading.show(), ApiClient.getServerConfiguration().then(function(config) {
-            config.PreferredMetadataLanguage = form.querySelector("#selectLanguage").value, config.MetadataCountryCode = form.querySelector("#selectCountry").value, ApiClient.updateServerConfiguration(config).then(Dashboard.processServerConfigurationUpdateResult)
-        }), !1
+            config.PreferredMetadataLanguage = form.querySelector("#selectLanguage").value, config.MetadataCountryCode = form.querySelector("#selectCountry").value, ApiClient.updateServerConfiguration(config).then(Dashboard.processServerConfigurationUpdateResult);
+        }), !1;
     }
 
     function getTabs() {
@@ -53,12 +53,12 @@ define(["jQuery", "dom", "loading", "libraryMenu", "listViewStyle"], function($,
         }, {
             href: "metadatanfo.html",
             name: Globalize.translate("TabNfoSettings")
-        }]
+        }];
     }
 
     $(document).on("pageinit", "#metadataImagesConfigurationPage", function() {
-        $(".metadataImagesConfigurationForm").off("submit", onSubmit).on("submit", onSubmit)
+        $(".metadataImagesConfigurationForm").off("submit", onSubmit).on("submit", onSubmit);
     }).on("pageshow", "#metadataImagesConfigurationPage", function() {
-        libraryMenu.setTabs("metadata", 2, getTabs), loading.show(), loadPage(this)
-    })
+        libraryMenu.setTabs("metadata", 2, getTabs), loading.show(), loadPage(this);
+    });
 });

--- a/src/controllers/playbackconfiguration.js
+++ b/src/controllers/playbackconfiguration.js
@@ -36,7 +36,7 @@ define(["jQuery", "loading", "libraryMenu"], function ($, loading, libraryMenu) 
     }
 
     $(document).on("pageinit", "#playbackConfigurationPage", function () {
-        $(".playbackConfigurationForm").off("submit", onSubmit).on("submit", onSubmit)
+        $(".playbackConfigurationForm").off("submit", onSubmit).on("submit", onSubmit);
     }).on("pageshow", "#playbackConfigurationPage", function () {
         loading.show();
         libraryMenu.setTabs("playback", 1, getTabs);

--- a/src/elements/emby-slider/emby-slider.js
+++ b/src/elements/emby-slider/emby-slider.js
@@ -402,7 +402,7 @@ define(['browser', 'dom', 'layoutManager', 'keyboardnavigation', 'css!./emby-sli
             this.addEventListener('keydown', onKeyDown);
             this.keyboardDraggingEnabled = true;
         }
-    }
+    };
 
     /**
      * Set steps for keyboard input.
@@ -413,7 +413,7 @@ define(['browser', 'dom', 'layoutManager', 'keyboardnavigation', 'css!./emby-sli
     EmbySliderPrototype.setKeyboardSteps = function (stepDown, stepUp) {
         this.keyboardStepDown = stepDown || stepUp || 1;
         this.keyboardStepUp = stepUp || stepDown || 1;
-    }
+    };
 
     function setRange(elem, startPercent, endPercent) {
 

--- a/src/legacy/dashboard.js
+++ b/src/legacy/dashboard.js
@@ -2,19 +2,19 @@ Dashboard.confirm = function(message, title, callback) {
     "use strict";
     require(["confirm"], function(confirm) {
         confirm(message, title).then(function() {
-            callback(!0)
+            callback(!0);
         }, function() {
-            callback(!1)
-        })
-    })
+            callback(!1);
+        });
+    });
 }, Dashboard.showLoadingMsg = function() {
     "use strict";
     require(["loading"], function(loading) {
-        loading.show()
-    })
+        loading.show();
+    });
 }, Dashboard.hideLoadingMsg = function() {
     "use strict";
     require(["loading"], function(loading) {
-        loading.hide()
-    })
+        loading.hide();
+    });
 };

--- a/src/legacy/fnchecked.js
+++ b/src/legacy/fnchecked.js
@@ -2,9 +2,9 @@ define(["jQuery"], function($) {
     "use strict";
     $.fn.checked = function(value) {
         return !0 === value || !1 === value ? $(this).each(function() {
-            this.checked = value
-        }) : this.length && this[0].checked
+            this.checked = value;
+        }) : this.length && this[0].checked;
     }, $.fn.checkboxradio = function() {
-        return this
-    }
+        return this;
+    };
 });

--- a/src/legacy/selectmenu.js
+++ b/src/legacy/selectmenu.js
@@ -1,6 +1,6 @@
 define(["jQuery"], function($) {
     "use strict";
     $.fn.selectmenu = function() {
-        return this
-    }
+        return this;
+    };
 });

--- a/src/scripts/dfnshelper.js
+++ b/src/scripts/dfnshelper.js
@@ -101,4 +101,4 @@ export const localeWithSuffix = { addSuffix: true, locale: getLocale() };
 export default {
     getLocale: getLocale,
     localeWithSuffix: localeWithSuffix
-}
+};

--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -323,11 +323,11 @@ var AppInfo = {};
     }
 
     function getElementsPath() {
-        return "elements"
+        return "elements";
     }
 
     function getScriptsPath() {
-        return "scripts"
+        return "scripts";
     }
 
     function getPlaybackManager(playbackManager) {


### PR DESCRIPTION
**Changes**

Inconsistent semicolon usage is generating errors with Terser.

This auto-fixes the semicolons using ESLint and changes the "semi" rule from a warning to an error, thereby enforcing proper semicolon usage.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
