### PR TITLE
Set autocaptialize to 'off' on the login username form

### DIFF
--- a/src/assets/css/librarybrowser.css
+++ b/src/assets/css/librarybrowser.css
@@ -314,7 +314,6 @@
 
     .dashboardDocument .mainDrawer-scrollContainer {
         margin-top: 4.6em !important;
-
     }
 }
 

--- a/src/assets/css/librarybrowser.css
+++ b/src/assets/css/librarybrowser.css
@@ -242,7 +242,7 @@
 }
 
 .mainDrawer-scrollContainer {
-    padding-bottom: 10vh;
+    margin-bottom: 10vh;
 }
 
 @media all and (min-width: 40em) {
@@ -314,6 +314,7 @@
 
     .dashboardDocument .mainDrawer-scrollContainer {
         margin-top: 4.6em !important;
+
     }
 }
 

--- a/src/login.html
+++ b/src/login.html
@@ -8,7 +8,7 @@
             </div>
 
             <div class="inputContainer">
-                <input is="emby-input" type="text" id="txtManualName" required="required" label="${LabelUser}" autocomplete="username" />
+                <input is="emby-input" type="text" id="txtManualName" required="required" label="${LabelUser}" autocomplete="username" autocapitalize="off" />
             </div>
 
             <div class="inputContainer">


### PR DESCRIPTION
Set autocaptialize to 'off' on the login username form to improve mobile UX


**Changes**
Set the autocapitalize switch to off on the login form as user names are case sensitive and mobile keyboards default to autocapitalizing the start of sentences. 