### PR TITLE
Fix native hls resume

### DIFF
--- a/src/components/htmlMediaHelper.js
+++ b/src/components/htmlMediaHelper.js
@@ -171,13 +171,29 @@ define(['appSettings', 'browser', 'events'], function (appSettings, browser, eve
 
             // Appending #t=xxx to the query string doesn't seem to work with HLS
             // For plain video files, not all browsers support it either
-            var delay = browser.safari ? 2500 : 0;
-            if (delay) {
-                setTimeout(function () {
-                    setCurrentTimeIfNeeded(element, seconds);
-                }, delay);
-            } else {
+
+            if (element.duration >= seconds) {
+                // media is ready, seek immediately
                 setCurrentTimeIfNeeded(element, seconds);
+            } else {
+                // update video player position when media is ready to be sought
+                var events = ["durationchange", "loadeddata", "play", "loadedmetadata"];
+                var onMediaChange = function(e) {
+                    if (element.currentTime === 0 && element.duration >= seconds) {
+                        // seek only when video position is exactly zero,
+                        // as this is true only if video hasn't started yet or
+                        // user rewound to the very beginning
+                        // (but rewinding cannot happen as the first event with media of non-empty duration)
+                        console.log("seeking to " + seconds + " on " + e.type);
+                        setCurrentTimeIfNeeded(element, seconds);
+                        events.map(function(name) {
+                            element.removeEventListener(name, onMediaChange);
+                        });
+                    }
+                };
+                events.map(function (name) {
+                    element.addEventListener(name, onMediaChange);
+                });
             }
         }
     }

--- a/src/components/htmlMediaHelper.js
+++ b/src/components/htmlMediaHelper.js
@@ -184,7 +184,7 @@ define(['appSettings', 'browser', 'events'], function (appSettings, browser, eve
                         // as this is true only if video hasn't started yet or
                         // user rewound to the very beginning
                         // (but rewinding cannot happen as the first event with media of non-empty duration)
-                        console.log("seeking to " + seconds + " on " + e.type);
+                        console.debug(`seeking to ${seconds} on ${e.type} event`);
                         setCurrentTimeIfNeeded(element, seconds);
                         events.map(function(name) {
                             element.removeEventListener(name, onMediaChange);

--- a/src/components/htmlvideoplayer/plugin.js
+++ b/src/components/htmlvideoplayer/plugin.js
@@ -506,12 +506,6 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
             var seconds = (options.playerStartPositionTicks || 0) / 10000000;
             if (seconds) {
                 val += '#t=' + seconds;
-                // update video player position when file is ready
-                var onMetadataLoaded = function() {
-                    elem.removeEventListener("loadedmetadata", onMetadataLoaded);
-                    elem.currentTime = seconds;
-                };
-                elem.addEventListener("loadedmetadata", onMetadataLoaded);
             }
 
             htmlMediaHelper.destroyHlsPlayer(self);

--- a/src/components/htmlvideoplayer/plugin.js
+++ b/src/components/htmlvideoplayer/plugin.js
@@ -506,6 +506,12 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
             var seconds = (options.playerStartPositionTicks || 0) / 10000000;
             if (seconds) {
                 val += '#t=' + seconds;
+                // update video player position when file is ready
+                var onMetadataLoaded = function() {
+                    elem.removeEventListener("loadedmetadata", onMetadataLoaded);
+                    elem.currentTime = seconds;
+                };
+                elem.addEventListener("loadedmetadata", onMetadataLoaded);
             }
 
             htmlMediaHelper.destroyHlsPlayer(self);


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Remove the hack that was used to resume HLS from previous position on Safari (actually it was used to resume everything, even direct plays, so Safari should have played 2.5 seconds of the beginning always) and implement a proper event-driven way to seek the stream only when it's really ready to be sought (should usually be faster than 2.5 seconds, but in reality depends on the bandwidth and the server).

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes the broken resume of non-direct play on mobile Chrome and Android app:
* Fixes https://github.com/jellyfin/jellyfin-web/issues/899 (only the resuming part; in current design you're actually expected to _resume_ from mobile, there's no option to start from the beginning, it's starting from start prior to my fix due to the bug I'm fixing).
* Fixes https://github.com/jellyfin/jellyfin-web/issues/815