### PR TITLE
Remove suffix for duration of tasks on scheduled tasks page

### DIFF
--- a/src/controllers/dashboard/scheduledtasks/scheduledtasks.js
+++ b/src/controllers/dashboard/scheduledtasks/scheduledtasks.js
@@ -69,7 +69,7 @@ define(["jQuery", "loading", "events", "globalize", "serverNotifications", "date
                 var endtime = Date.parse(task.LastExecutionResult.EndTimeUtc);
                 var starttime = Date.parse(task.LastExecutionResult.StartTimeUtc);
                 html += globalize.translate("LabelScheduledTaskLastRan", datefns.formatDistanceToNow(endtime, dfnshelper.localeWithSuffix),
-                    datefns.formatDistance(starttime, endtime, dfnshelper.localeWithSuffix));
+                    datefns.formatDistance(starttime, endtime, {locale: dfnshelper.getLocale()}));
                 if (task.LastExecutionResult.Status === "Failed") {
                     html += " <span style='color:#FF0000;'>(" + globalize.translate("LabelFailed") + ")</span>";
                 } else if (task.LastExecutionResult.Status === "Cancelled") {

--- a/src/controllers/dashboard/scheduledtasks/scheduledtasks.js
+++ b/src/controllers/dashboard/scheduledtasks/scheduledtasks.js
@@ -69,7 +69,7 @@ define(["jQuery", "loading", "events", "globalize", "serverNotifications", "date
                 var endtime = Date.parse(task.LastExecutionResult.EndTimeUtc);
                 var starttime = Date.parse(task.LastExecutionResult.StartTimeUtc);
                 html += globalize.translate("LabelScheduledTaskLastRan", datefns.formatDistanceToNow(endtime, dfnshelper.localeWithSuffix),
-                    datefns.formatDistance(starttime, endtime, {locale: dfnshelper.getLocale()}));
+                    datefns.formatDistance(starttime, endtime, { locale: dfnshelper.getLocale() }));
                 if (task.LastExecutionResult.Status === "Failed") {
                     html += " <span style='color:#FF0000;'>(" + globalize.translate("LabelFailed") + ")</span>";
                 } else if (task.LastExecutionResult.Status === "Cancelled") {


### PR DESCRIPTION
**Changes**
Removes suffix 'ago' from scheduled tasks page. Previously, completed tasks would say "Last ran 8 minutes ago, taking less than a **minute ago**".

**Issues**
Fixes [jellyfin/jellyfin#2766](https://github.com/jellyfin/jellyfin/issues/2766)
