### PR TITLE
Fix inconsistent value in drop down list on library page

### DIFF
--- a/src/controllers/librarydisplay.js
+++ b/src/controllers/librarydisplay.js
@@ -27,12 +27,8 @@ define(["globalize", "loading", "libraryMenu", "emby-checkbox", "emby-button", "
                 view.querySelector("#chkSaveMetadataHidden").checked = config.SaveMetadataHidden;
             });
             ApiClient.getNamedConfiguration("metadata").then(function(metadata) {
-                loadMetadataConfig(this, metadata);
+                view.querySelector("#selectDateAdded").selectedIndex = metadata.UseFileCreationTimeForDateAdded ? 1 : 0;
             });
-        }
-
-        function loadMetadataConfig(page, config) {
-            $("#selectDateAdded", page).val(config.UseFileCreationTimeForDateAdded ? "1" : "0");
         }
 
         view.querySelector("form").addEventListener("submit", function(e) {


### PR DESCRIPTION
**Changes**
Modifies how the drop down value for Libraries' date-added behavior is loaded, so that it consistently causes a change in the UI. Previously, the selected value would be correctly loaded, but UI would sometimes not update.

**Issues**
Fixes #1019 
