### PR TITLE
Fix parameters for POST to backend to set language in setup wizard

### DIFF
--- a/src/controllers/wizard/settings.js
+++ b/src/controllers/wizard/settings.js
@@ -5,8 +5,8 @@ define(["loading", "emby-checkbox", "emby-button", "emby-select"], function (loa
         loading.show();
         var apiClient = ApiClient;
         apiClient.getJSON(apiClient.getUrl("Startup/Configuration")).then(function (config) {
-            config.PreferredMetadataLanguage = page.querySelector("#selectLanguage").value;
-            config.MetadataCountryCode = page.querySelector("#selectCountry").value;
+            config.preferredMetadataLanguage = page.querySelector("#selectLanguage").value;
+            config.metadataCountryCode = page.querySelector("#selectCountry").value;
             apiClient.ajax({
                 type: "POST",
                 data: config,

--- a/src/controllers/wizard/start.js
+++ b/src/controllers/wizard/start.js
@@ -12,7 +12,7 @@ define(["jQuery", "loading", "emby-button", "emby-select"], function ($, loading
         loading.show();
         var apiClient = ApiClient;
         apiClient.getJSON(apiClient.getUrl("Startup/Configuration")).then(function (config) {
-            config.UICulture = $("#selectLocalizationLanguage", page).val();
+            config.uiCulture = $("#selectLocalizationLanguage", page).val();
             apiClient.ajax({
                 type: "POST",
                 data: config,


### PR DESCRIPTION
**Changes**
Modifies parameters sent to backend from wizard to be camel-case, necessary to properly set language(metadata & display) in startup wizard.

**Issues**
Fixes [jellyfin/jellyfin#2812](https://github.com/jellyfin/jellyfin/issues/2812)
