### PR TITLE
Move "hide watched media" checkbox

### DIFF
--- a/src/components/homescreensettings/homescreensettings.template.html
+++ b/src/components/homescreensettings/homescreensettings.template.html
@@ -10,6 +10,13 @@
             <div class="fieldDescription">${LabelPleaseRestart}</div>
         </div>
 
+        <div class="verticalSection verticalSection-extrabottompadding">
+            <label class="checkboxContainer">
+                <input class="chkHidePlayedFromLatest" type="checkbox" is="emby-checkbox" />
+                <span>${HideWatchedContentFromLatestMedia}</span>
+            </label>
+        </div>
+
         <div class="selectContainer">
             <select is="emby-select" id="selectHomeSection1" label="{section1label}">
                 <option value="smalllibrarytiles">${HeaderMyMedia}</option>
@@ -109,13 +116,6 @@
     </div>
 
     <div class="perLibrarySettings"></div>
-
-    <div class="verticalSection verticalSection-extrabottompadding">
-        <label class="checkboxContainer">
-            <input class="chkHidePlayedFromLatest" type="checkbox" is="emby-checkbox" />
-            <span>${HideWatchedContentFromLatestMedia}</span>
-        </label>
-    </div>
 
     <div class="verticalSection verticalSection-extrabottompadding">
         <h2 class="sectionTitle">${HeaderLibraryFolders}</h2>


### PR DESCRIPTION
This checkbox is located in a way that makes you think that it affects only an specific library, when it affects all the libraries, so I moved it to a more sensible way, where it's function is clear.

**Before**
![before](https://user-images.githubusercontent.com/10274099/79081336-ce2f8b00-7d1c-11ea-9f79-bf7135df121b.PNG)

**After**
![after](https://user-images.githubusercontent.com/10274099/79081340-d38cd580-7d1c-11ea-9787-dabbda35f721.PNG)
