### PR TITLE
Handle 401 & 403 Server Responses Correctly

### DIFF
--- a/src/components/appRouter.js
+++ b/src/components/appRouter.js
@@ -200,7 +200,7 @@ define(['loading', 'globalize', 'events', 'viewManager', 'layoutManager', 'skinM
 
         var apiClient = this;
 
-        if (data.status === 401) {
+        if (data.status === 403) {
             if (data.errorCode === "ParentalControl") {
 
                 var isCurrentAllowed = currentRouteInfo ? (currentRouteInfo.route.anonymous || currentRouteInfo.route.startup) : true;

--- a/src/controllers/auth/login.js
+++ b/src/controllers/auth/login.js
@@ -26,7 +26,7 @@ define(["apphost", "appSettings", "dom", "connectionManager", "loading", "layout
 
             if (response.status === 401 || response.status === 403) {
                 require(["toast"], function (toast) {
-                    var messageKey = response.status === 401 ? "MessageInvalidUser" : "MessageUnauthorizedUser"
+                    var messageKey = response.status === 401 ? "MessageInvalidUser" : "MessageUnauthorizedUser";
                     toast(Globalize.translate(messageKey));
                 });
             } else {

--- a/src/controllers/auth/login.js
+++ b/src/controllers/auth/login.js
@@ -24,9 +24,10 @@ define(["apphost", "appSettings", "dom", "connectionManager", "loading", "layout
             page.querySelector("#txtManualPassword").value = "";
             loading.hide();
 
-            if (response.status === 401) {
+            if (response.status === 401 || response.status === 403) {
                 require(["toast"], function (toast) {
-                    toast(Globalize.translate("MessageInvalidUser"));
+                    var messageKey = response.status === 401 ? "MessageInvalidUser" : "MessageUnauthorizedUser"
+                    toast(Globalize.translate(messageKey));
                 });
             } else {
                 Dashboard.alert({

--- a/src/controllers/auth/login.js
+++ b/src/controllers/auth/login.js
@@ -24,9 +24,10 @@ define(["apphost", "appSettings", "dom", "connectionManager", "loading", "layout
             page.querySelector("#txtManualPassword").value = "";
             loading.hide();
 
-            if (response.status === 401 || response.status === 403) {
+            const UnauthorizedOrForbidden = [401, 403];
+            if (UnauthorizedOrForbidden.includes(response.status)) {
                 require(["toast"], function (toast) {
-                    var messageKey = response.status === 401 ? "MessageInvalidUser" : "MessageUnauthorizedUser";
+                    const messageKey = response.status === 401 ? "MessageInvalidUser" : "MessageUnauthorizedUser";
                     toast(Globalize.translate(messageKey));
                 });
             } else {

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -990,6 +990,7 @@
     "MessageInstallPluginFromApp": "This plugin must be installed from within the app you intend to use it in.",
     "MessageInvalidForgotPasswordPin": "An invalid or expired pin code was entered. Please try again.",
     "MessageInvalidUser": "Invalid username or password. Please try again.",
+    "MessageUnauthorizedUser": "You are not authorized to access the server at this time. Please contact your server administrator for more information.",
     "MessageItemSaved": "Item saved.",
     "MessageItemsAdded": "Items added.",
     "MessageLeaveEmptyToInherit": "Leave empty to inherit settings from a parent item or the global default value.",


### PR DESCRIPTION
* Update the login page to handle a 403 response from the server. A new message/translation string has been added to to display to the user in this case.
* Update to expect a 403 response for parental control limitations

The associated server updates are in https://github.com/jellyfin/jellyfin/pull/2861