### PR TITLE
Limit rate of timeupdate playback report

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -2959,7 +2959,7 @@ define(['events', 'datetime', 'appSettings', 'itemHelper', 'pluginManager', 'pla
 
         function onPlayerProgressInterval() {
             var player = this;
-            sendProgressUpdate(player, 'timeupdate');
+            sendProgressUpdateDelayed(player, 'timeupdate');
         }
 
         function startPlaybackProgressTimer(player) {
@@ -3267,7 +3267,7 @@ define(['events', 'datetime', 'appSettings', 'itemHelper', 'pluginManager', 'pla
 
         function onPlaybackTimeUpdate(e) {
             var player = this;
-            sendProgressUpdate(player, 'timeupdate');
+            sendProgressUpdateDelayed(player, 'timeupdate');
         }
 
         function onPlaybackPause(e) {
@@ -3381,7 +3381,7 @@ define(['events', 'datetime', 'appSettings', 'itemHelper', 'pluginManager', 'pla
         var sendProgressUpdateTimer;
 
         /** Delay time in ms for sendProgressUpdate */
-        var sendProgressUpdateDelay = 700;
+        var sendProgressUpdateDelay = 3000;
 
         function sendProgressUpdate(player, progressEventName, reportPlaylist) {
             clearTimeout(sendProgressUpdateTimer);


### PR DESCRIPTION
PlaybackManager has two ways for `timeupdate` report:
* player event `timeupdate` (every 250ms)
* interval (every 10s)

**Changes**
Add delay for player and interval `timeupdate` to limit report rate to 1 per 3s.

Volume update rate will also be limited to 1 per 3s, but this applies only to server notifications, and actual volume will be set instantly.

This part may also be delayed, but Live (M3U) works OK so dunno.
https://github.com/jellyfin/jellyfin-web/blob/54a80f8ab668c7f93f67407ca9df678d88829b65/src/components/playback/playbackmanager.js#L3405-L3410