### PR TITLE
Fix dropdown not properly aligned for long subtitles

### DIFF
--- a/src/itemdetails.html
+++ b/src/itemdetails.html
@@ -136,7 +136,7 @@
                             <div class="selectContainer selectAudioContainer hide trackSelectionFieldContainer flex-shrink-zero">
                                 <select is="emby-select" class="selectAudio detailTrackSelect" label=""></select>
                             </div>
-                            <div class="selectContainer selectSubtitlesContainer hide trackSelectionFieldContainer">
+                            <div class="selectContainer selectSubtitlesContainer hide trackSelectionFieldContainer flex-shrink-zero">
                                 <select is="emby-select" class="selectSubtitles detailTrackSelect" label=""></select>
                             </div>
                         </form>


### PR DESCRIPTION
**Changes**
This is an easy fix, but I guess there might be a reason the class was not used in the first place?

**Issues**
Fixes #1098