### PR TITLE
Fix inputManager trigger

### DIFF
--- a/src/scripts/inputManager.js
+++ b/src/scripts/inputManager.js
@@ -235,6 +235,9 @@ import appHost from 'apphost';
         }
     }
 
+    // Alias for backward compatibility
+    export const trigger = handleCommand;
+
     dom.addEventListener(document, 'click', notify, {
         passive: true
     });


### PR DESCRIPTION
ES6 `inputManager` has `trigger` only in default export.

**Changes**
Add `trigger` as an alias for `handleCommand`, as it was before.

**Issues**
Error on `Search` from  the header.

As an alternative, we could leave only one of them.
