### PR TITLE
Add Android icon for Android TV in devices page

### DIFF
--- a/src/scripts/imagehelper.js
+++ b/src/scripts/imagehelper.js
@@ -14,6 +14,7 @@ import browser from 'browser';
             case "Kodi":
                 return baseUrl + "kodi.svg";
             case "Jellyfin Android":
+            case "Android TV":
                 return baseUrl + "android.svg";
             case "Jellyfin Web":
                 switch (device.Name || device.DeviceName) {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- This PR adds the android icon for Android TV.

Before:  
![image](https://user-images.githubusercontent.com/2305178/79640296-1c1b1780-8191-11ea-9582-d6e33d436c24.png)

After: 
![image](https://user-images.githubusercontent.com/2305178/79640304-25a47f80-8191-11ea-931c-2fbde5748761.png)


**Issues**
- None
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
