### PR TITLE
Update issue template and stalebot config for new labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a bug report
 title: ''
-labels: bug
+labels: "Type: Bug"
 assignees: ''
 
 ---

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -4,13 +4,12 @@ daysUntilStale: 90
 daysUntilClose: 14
 # Issues with these labels will never be considered stale
 exemptLabels:
-  - regression
-  - future
-  - feature
-  - enhancement
-  - confirmed
+  - "Type: Regression"
+  - "Type: Discussion"
+  - "Type: Enhancement"
+  - "Status: Confirmed"
 # Label to use when marking an issue as stale
-staleLabel: stale
+staleLabel: "Status: Stale"
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   Issues go stale after 90d of inactivity. Mark the issue as fresh by adding a comment or commit. Stale issues close after an additional 14d of inactivity.


### PR DESCRIPTION
**Changes**

To make issues and PRs easier to navigate for new users and easier to manage for us, jellyfin-web will be using a new set of labels, that describe everything in more detail and allow better filtering.

As a result, Stalebot and the issue template need updating to take these new labels into account.

**Issues**
