### PR TITLE
Add check for funky Promise faced on WebOS 2

### DIFF
--- a/src/scripts/apploader.js
+++ b/src/scripts/apploader.js
@@ -29,6 +29,16 @@
         );
     }
 
+    try {
+        Promise.resolve();
+    } catch (ex) {
+        // this checks for several cases actually, typical is
+        // Promise() being missing on some legacy browser, and a funky one
+        // is Promise() present but buggy on WebOS 2
+        window.Promise = undefined;
+        self.Promise = undefined;
+    }
+
     if (!self.Promise) {
         // Load Promise polyfill if they are not natively supported
         injectScriptElement(


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->
I have faced a buggy `Promise()` on WebOS2 - for once, it doesn't understand `Promise.resolve()` throwing a `TypeError`, and `new Promise(function (resolve, reject))` passed `undefined` as `reject` and some funny object as`resolve`.

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Force to use a Promise polyfill if missing or buggy `Promise` is detected.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
