### PR TITLE
Only inject appLoader if using standalone mode

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -183,6 +183,12 @@ function copy(query) {
         .pipe(browserSync.stream());
 }
 
+function copyIndex() {
+    return src(options.injectBundle.query, { base: './src/' })
+        .pipe(dest('dist/'))
+        .pipe(browserSync.stream());
+}
+
 function injectBundle() {
     return src(options.injectBundle.query, { base: './src/' })
         .pipe(inject(
@@ -193,9 +199,9 @@ function injectBundle() {
 }
 
 function build(standalone) {
-    return series(clean, parallel(javascript, apploader(standalone), webpack, css, html, images, copy), injectBundle);
+    return series(clean, parallel(javascript, apploader(standalone), webpack, css, html, images, copy));
 }
 
-exports.default = build(false);
-exports.standalone = build(true);
+exports.default = series(build(false), copyIndex);
+exports.standalone = series(build(true), injectBundle);
 exports.serve = series(exports.standalone, serve);


### PR DESCRIPTION
**Changes**

Removes the automatic embedding of appLoader into index.html when not building for standalone.

The server disables it anyway, but other wrapper clients might not.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
