### PR TITLE
Check appSettings for undefined

### DIFF
--- a/src/scripts/settings/appSettings.js
+++ b/src/scripts/settings/appSettings.js
@@ -12,7 +12,7 @@ import events from 'events';
     }
 
     export function enableAutoLogin(val) {
-        if (val !== undefined || val !== null) {
+        if (val !== undefined) {
             this.set('enableAutoLogin', val.toString());
         }
 
@@ -20,7 +20,7 @@ import events from 'events';
     }
 
     export function enableSystemExternalPlayers(val) {
-        if (val !== undefined || val !== null) {
+        if (val !== undefined) {
             this.set('enableSystemExternalPlayers', val.toString());
         }
 
@@ -29,7 +29,7 @@ import events from 'events';
 
     export function enableAutomaticBitrateDetection(isInNetwork, mediaType, val) {
         var key = 'enableautobitratebitrate-' + mediaType + '-' + isInNetwork;
-        if (val !== undefined || val !== null) {
+        if (val !== undefined) {
             if (isInNetwork && mediaType === 'Audio') {
                 val = true;
             }
@@ -46,7 +46,7 @@ import events from 'events';
 
     export function maxStreamingBitrate(isInNetwork, mediaType, val) {
         var key = 'maxbitrate-' + mediaType + '-' + isInNetwork;
-        if (val !== undefined || val !== null) {
+        if (val !== undefined) {
             if (isInNetwork && mediaType === 'Audio') {
                 //  nothing to do, this is always a max value
             } else {
@@ -63,7 +63,7 @@ import events from 'events';
     }
 
     export function maxStaticMusicBitrate(val) {
-        if (val !== undefined || val !== null) {
+        if (val !== undefined) {
             this.set('maxStaticMusicBitrate', val);
         }
 
@@ -72,7 +72,7 @@ import events from 'events';
     }
 
     export function maxChromecastBitrate(val) {
-        if (val !== undefined || val !== null) {
+        if (val !== undefined) {
             this.set('chromecastBitrate1', val);
         }
 
@@ -81,7 +81,7 @@ import events from 'events';
     }
 
     export function syncOnlyOnWifi(val) {
-        if (val !== undefined || val !== null) {
+        if (val !== undefined) {
             this.set('syncOnlyOnWifi', val.toString());
         }
 
@@ -89,7 +89,7 @@ import events from 'events';
     }
 
     export function syncPath(val) {
-        if (val !== undefined || val !== null) {
+        if (val !== undefined) {
             this.set('syncPath', val);
         }
 
@@ -97,7 +97,7 @@ import events from 'events';
     }
 
     export function cameraUploadServers(val) {
-        if (val !== undefined || val !== null) {
+        if (val !== undefined) {
             this.set('cameraUploadServers', val.join(','));
         }
 
@@ -110,7 +110,7 @@ import events from 'events';
     }
 
     export function runAtStartup(val) {
-        if (val !== undefined || val !== null) {
+        if (val !== undefined) {
             this.set('runatstartup', val.toString());
         }
 

--- a/src/scripts/settings/appSettings.js
+++ b/src/scripts/settings/appSettings.js
@@ -12,7 +12,7 @@ import events from 'events';
     }
 
     export function enableAutoLogin(val) {
-        if (val !== undefined || null) {
+        if (val !== undefined || val !== null) {
             this.set('enableAutoLogin', val.toString());
         }
 
@@ -20,7 +20,7 @@ import events from 'events';
     }
 
     export function enableSystemExternalPlayers(val) {
-        if (val !== undefined || null) {
+        if (val !== undefined || val !== null) {
             this.set('enableSystemExternalPlayers', val.toString());
         }
 
@@ -29,7 +29,7 @@ import events from 'events';
 
     export function enableAutomaticBitrateDetection(isInNetwork, mediaType, val) {
         var key = 'enableautobitratebitrate-' + mediaType + '-' + isInNetwork;
-        if (val !== undefined || null) {
+        if (val !== undefined || val !== null) {
             if (isInNetwork && mediaType === 'Audio') {
                 val = true;
             }
@@ -46,7 +46,7 @@ import events from 'events';
 
     export function maxStreamingBitrate(isInNetwork, mediaType, val) {
         var key = 'maxbitrate-' + mediaType + '-' + isInNetwork;
-        if (val !== undefined || null) {
+        if (val !== undefined || val !== null) {
             if (isInNetwork && mediaType === 'Audio') {
                 //  nothing to do, this is always a max value
             } else {
@@ -63,7 +63,7 @@ import events from 'events';
     }
 
     export function maxStaticMusicBitrate(val) {
-        if (val !== undefined || null) {
+        if (val !== undefined || val !== null) {
             this.set('maxStaticMusicBitrate', val);
         }
 
@@ -72,7 +72,7 @@ import events from 'events';
     }
 
     export function maxChromecastBitrate(val) {
-        if (val !== undefined || null) {
+        if (val !== undefined || val !== null) {
             this.set('chromecastBitrate1', val);
         }
 
@@ -81,7 +81,7 @@ import events from 'events';
     }
 
     export function syncOnlyOnWifi(val) {
-        if (val !== undefined || null) {
+        if (val !== undefined || val !== null) {
             this.set('syncOnlyOnWifi', val.toString());
         }
 
@@ -89,7 +89,7 @@ import events from 'events';
     }
 
     export function syncPath(val) {
-        if (val !== undefined || null) {
+        if (val !== undefined || val !== null) {
             this.set('syncPath', val);
         }
 
@@ -97,7 +97,7 @@ import events from 'events';
     }
 
     export function cameraUploadServers(val) {
-        if (val !== undefined || null) {
+        if (val !== undefined || val !== null) {
             this.set('cameraUploadServers', val.join(','));
         }
 
@@ -110,7 +110,7 @@ import events from 'events';
     }
 
     export function runAtStartup(val) {
-        if (val !== undefined || null) {
+        if (val !== undefined || val !== null) {
             this.set('runatstartup', val.toString());
         }
 

--- a/src/scripts/settings/appSettings.js
+++ b/src/scripts/settings/appSettings.js
@@ -12,7 +12,7 @@ import events from 'events';
     }
 
     export function enableAutoLogin(val) {
-        if (val != null) {
+        if (val !== undefined || null) {
             this.set('enableAutoLogin', val.toString());
         }
 
@@ -20,7 +20,7 @@ import events from 'events';
     }
 
     export function enableSystemExternalPlayers(val) {
-        if (val !== null) {
+        if (val !== undefined || null) {
             this.set('enableSystemExternalPlayers', val.toString());
         }
 
@@ -29,7 +29,7 @@ import events from 'events';
 
     export function enableAutomaticBitrateDetection(isInNetwork, mediaType, val) {
         var key = 'enableautobitratebitrate-' + mediaType + '-' + isInNetwork;
-        if (val != null) {
+        if (val !== undefined || null) {
             if (isInNetwork && mediaType === 'Audio') {
                 val = true;
             }
@@ -46,7 +46,7 @@ import events from 'events';
 
     export function maxStreamingBitrate(isInNetwork, mediaType, val) {
         var key = 'maxbitrate-' + mediaType + '-' + isInNetwork;
-        if (val != null) {
+        if (val !== undefined || null) {
             if (isInNetwork && mediaType === 'Audio') {
                 //  nothing to do, this is always a max value
             } else {
@@ -63,7 +63,7 @@ import events from 'events';
     }
 
     export function maxStaticMusicBitrate(val) {
-        if (val !== undefined) {
+        if (val !== undefined || null) {
             this.set('maxStaticMusicBitrate', val);
         }
 
@@ -72,7 +72,7 @@ import events from 'events';
     }
 
     export function maxChromecastBitrate(val) {
-        if (val != null) {
+        if (val !== undefined || null) {
             this.set('chromecastBitrate1', val);
         }
 
@@ -81,7 +81,7 @@ import events from 'events';
     }
 
     export function syncOnlyOnWifi(val) {
-        if (val != null) {
+        if (val !== undefined || null) {
             this.set('syncOnlyOnWifi', val.toString());
         }
 
@@ -89,7 +89,7 @@ import events from 'events';
     }
 
     export function syncPath(val) {
-        if (val != null) {
+        if (val !== undefined || null) {
             this.set('syncPath', val);
         }
 
@@ -97,7 +97,7 @@ import events from 'events';
     }
 
     export function cameraUploadServers(val) {
-        if (val != null) {
+        if (val !== undefined || null) {
             this.set('cameraUploadServers', val.join(','));
         }
 
@@ -110,7 +110,7 @@ import events from 'events';
     }
 
     export function runAtStartup(val) {
-        if (val != null) {
+        if (val !== undefined || null) {
             this.set('runatstartup', val.toString());
         }
 

--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -93,7 +93,7 @@ import events from 'events';
     }
 
     export function enableNextVideoInfoOverlay(val) {
-        if (val != null) {
+        if (val !== undefined || null) {
             return this.set('enableNextVideoInfoOverlay', val.toString());
         }
 
@@ -102,7 +102,7 @@ import events from 'events';
     }
 
     export function enableThemeSongs(val) {
-        if (val != null) {
+        if (val !== undefined || null) {
             return this.set('enableThemeSongs', val.toString(), false);
         }
 
@@ -111,7 +111,7 @@ import events from 'events';
     }
 
     export function enableThemeVideos(val) {
-        if (val != null) {
+        if (val !== undefined || null) {
             return this.set('enableThemeVideos', val.toString(), false);
         }
 
@@ -120,7 +120,7 @@ import events from 'events';
     }
 
     export function enableFastFadein(val) {
-        if (val != null) {
+        if (val !== undefined || null) {
             return this.set('fastFadein', val.toString(), false);
         }
 
@@ -129,7 +129,7 @@ import events from 'events';
     }
 
     export function enableBackdrops(val) {
-        if (val != null) {
+        if (val !== undefined || null) {
             return this.set('enableBackdrops', val.toString(), false);
         }
 
@@ -138,7 +138,7 @@ import events from 'events';
     }
 
     export function language(val) {
-        if (val != null) {
+        if (val !== undefined || null) {
             return this.set('language', val.toString(), false);
         }
 
@@ -146,7 +146,7 @@ import events from 'events';
     }
 
     export function dateTimeLocale(val) {
-        if (val != null) {
+        if (val !== undefined || null) {
             return this.set('datetimelocale', val.toString(), false);
         }
 
@@ -154,7 +154,7 @@ import events from 'events';
     }
 
     export function skipBackLength(val) {
-        if (val != null) {
+        if (val !== undefined || null) {
             return this.set('skipBackLength', val.toString());
         }
 
@@ -162,7 +162,7 @@ import events from 'events';
     }
 
     export function skipForwardLength(val) {
-        if (val != null) {
+        if (val !== undefined || null) {
             return this.set('skipForwardLength', val.toString());
         }
 
@@ -170,7 +170,7 @@ import events from 'events';
     }
 
     export function dashboardTheme(val) {
-        if (val != null) {
+        if (val !== undefined || null) {
             return this.set('dashboardTheme', val);
         }
 
@@ -178,7 +178,7 @@ import events from 'events';
     }
 
     export function skin(val) {
-        if (val != null) {
+        if (val !== undefined || null) {
             return this.set('skin', val, false);
         }
 
@@ -186,7 +186,7 @@ import events from 'events';
     }
 
     export function theme(val) {
-        if (val != null) {
+        if (val !== undefined || null) {
             return this.set('appTheme', val, false);
         }
 
@@ -194,7 +194,7 @@ import events from 'events';
     }
 
     export function screensaver(val) {
-        if (val != null) {
+        if (val !== undefined || null) {
             return this.set('screensaver', val, false);
         }
 
@@ -202,7 +202,7 @@ import events from 'events';
     }
 
     export function libraryPageSize(val) {
-        if (val != null) {
+        if (val !== undefined || null) {
             return this.set('libraryPageSize', parseInt(val, 10), false);
         }
 
@@ -216,7 +216,7 @@ import events from 'events';
     }
 
     export function soundEffects(val) {
-        if (val != null) {
+        if (val !== undefined || null) {
             return this.set('soundeffects', val, false);
         }
 

--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -84,7 +84,7 @@ import events from 'events';
     }
 
     export function enableCinemaMode(val) {
-        if (val != null) {
+        if (val !== undefined || val !== null) {
             return this.set('enableCinemaMode', val.toString(), false);
         }
 
@@ -93,7 +93,7 @@ import events from 'events';
     }
 
     export function enableNextVideoInfoOverlay(val) {
-        if (val !== undefined || null) {
+        if (val !== undefined || val !== null) {
             return this.set('enableNextVideoInfoOverlay', val.toString());
         }
 
@@ -102,7 +102,7 @@ import events from 'events';
     }
 
     export function enableThemeSongs(val) {
-        if (val !== undefined || null) {
+        if (val !== undefined || val !== null) {
             return this.set('enableThemeSongs', val.toString(), false);
         }
 
@@ -111,7 +111,7 @@ import events from 'events';
     }
 
     export function enableThemeVideos(val) {
-        if (val !== undefined || null) {
+        if (val !== undefined || val !== null) {
             return this.set('enableThemeVideos', val.toString(), false);
         }
 
@@ -120,7 +120,7 @@ import events from 'events';
     }
 
     export function enableFastFadein(val) {
-        if (val !== undefined || null) {
+        if (val !== undefined || val !== null) {
             return this.set('fastFadein', val.toString(), false);
         }
 
@@ -129,7 +129,7 @@ import events from 'events';
     }
 
     export function enableBackdrops(val) {
-        if (val !== undefined || null) {
+        if (val !== undefined || val !== null) {
             return this.set('enableBackdrops', val.toString(), false);
         }
 
@@ -138,7 +138,7 @@ import events from 'events';
     }
 
     export function language(val) {
-        if (val !== undefined || null) {
+        if (val !== undefined || val !== null) {
             return this.set('language', val.toString(), false);
         }
 
@@ -146,7 +146,7 @@ import events from 'events';
     }
 
     export function dateTimeLocale(val) {
-        if (val !== undefined || null) {
+        if (val !== undefined || val !== null) {
             return this.set('datetimelocale', val.toString(), false);
         }
 
@@ -154,7 +154,7 @@ import events from 'events';
     }
 
     export function skipBackLength(val) {
-        if (val !== undefined || null) {
+        if (val !== undefined || val !== null) {
             return this.set('skipBackLength', val.toString());
         }
 
@@ -162,7 +162,7 @@ import events from 'events';
     }
 
     export function skipForwardLength(val) {
-        if (val !== undefined || null) {
+        if (val !== undefined || val !== null) {
             return this.set('skipForwardLength', val.toString());
         }
 
@@ -170,7 +170,7 @@ import events from 'events';
     }
 
     export function dashboardTheme(val) {
-        if (val !== undefined || null) {
+        if (val !== undefined || val !== null) {
             return this.set('dashboardTheme', val);
         }
 
@@ -178,7 +178,7 @@ import events from 'events';
     }
 
     export function skin(val) {
-        if (val !== undefined || null) {
+        if (val !== undefined || val !== null) {
             return this.set('skin', val, false);
         }
 
@@ -186,7 +186,7 @@ import events from 'events';
     }
 
     export function theme(val) {
-        if (val !== undefined || null) {
+        if (val !== undefined || val !== null) {
             return this.set('appTheme', val, false);
         }
 
@@ -194,7 +194,7 @@ import events from 'events';
     }
 
     export function screensaver(val) {
-        if (val !== undefined || null) {
+        if (val !== undefined || val !== null) {
             return this.set('screensaver', val, false);
         }
 
@@ -202,7 +202,7 @@ import events from 'events';
     }
 
     export function libraryPageSize(val) {
-        if (val !== undefined || null) {
+        if (val !== undefined || val !== null) {
             return this.set('libraryPageSize', parseInt(val, 10), false);
         }
 
@@ -216,7 +216,7 @@ import events from 'events';
     }
 
     export function soundEffects(val) {
-        if (val !== undefined || null) {
+        if (val !== undefined || val !== null) {
             return this.set('soundeffects', val, false);
         }
 

--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -84,7 +84,7 @@ import events from 'events';
     }
 
     export function enableCinemaMode(val) {
-        if (val !== undefined || val !== null) {
+        if (val !== undefined) {
             return this.set('enableCinemaMode', val.toString(), false);
         }
 
@@ -93,7 +93,7 @@ import events from 'events';
     }
 
     export function enableNextVideoInfoOverlay(val) {
-        if (val !== undefined || val !== null) {
+        if (val !== undefined) {
             return this.set('enableNextVideoInfoOverlay', val.toString());
         }
 
@@ -102,7 +102,7 @@ import events from 'events';
     }
 
     export function enableThemeSongs(val) {
-        if (val !== undefined || val !== null) {
+        if (val !== undefined) {
             return this.set('enableThemeSongs', val.toString(), false);
         }
 
@@ -111,7 +111,7 @@ import events from 'events';
     }
 
     export function enableThemeVideos(val) {
-        if (val !== undefined || val !== null) {
+        if (val !== undefined) {
             return this.set('enableThemeVideos', val.toString(), false);
         }
 
@@ -120,7 +120,7 @@ import events from 'events';
     }
 
     export function enableFastFadein(val) {
-        if (val !== undefined || val !== null) {
+        if (val !== undefined) {
             return this.set('fastFadein', val.toString(), false);
         }
 
@@ -129,7 +129,7 @@ import events from 'events';
     }
 
     export function enableBackdrops(val) {
-        if (val !== undefined || val !== null) {
+        if (val !== undefined) {
             return this.set('enableBackdrops', val.toString(), false);
         }
 
@@ -138,7 +138,7 @@ import events from 'events';
     }
 
     export function language(val) {
-        if (val !== undefined || val !== null) {
+        if (val !== undefined) {
             return this.set('language', val.toString(), false);
         }
 
@@ -146,7 +146,7 @@ import events from 'events';
     }
 
     export function dateTimeLocale(val) {
-        if (val !== undefined || val !== null) {
+        if (val !== undefined) {
             return this.set('datetimelocale', val.toString(), false);
         }
 
@@ -154,7 +154,7 @@ import events from 'events';
     }
 
     export function skipBackLength(val) {
-        if (val !== undefined || val !== null) {
+        if (val !== undefined) {
             return this.set('skipBackLength', val.toString());
         }
 
@@ -162,7 +162,7 @@ import events from 'events';
     }
 
     export function skipForwardLength(val) {
-        if (val !== undefined || val !== null) {
+        if (val !== undefined) {
             return this.set('skipForwardLength', val.toString());
         }
 
@@ -170,7 +170,7 @@ import events from 'events';
     }
 
     export function dashboardTheme(val) {
-        if (val !== undefined || val !== null) {
+        if (val !== undefined) {
             return this.set('dashboardTheme', val);
         }
 
@@ -178,7 +178,7 @@ import events from 'events';
     }
 
     export function skin(val) {
-        if (val !== undefined || val !== null) {
+        if (val !== undefined) {
             return this.set('skin', val, false);
         }
 
@@ -186,7 +186,7 @@ import events from 'events';
     }
 
     export function theme(val) {
-        if (val !== undefined || val !== null) {
+        if (val !== undefined) {
             return this.set('appTheme', val, false);
         }
 
@@ -194,7 +194,7 @@ import events from 'events';
     }
 
     export function screensaver(val) {
-        if (val !== undefined || val !== null) {
+        if (val !== undefined) {
             return this.set('screensaver', val, false);
         }
 
@@ -202,7 +202,7 @@ import events from 'events';
     }
 
     export function libraryPageSize(val) {
-        if (val !== undefined || val !== null) {
+        if (val !== undefined) {
             return this.set('libraryPageSize', parseInt(val, 10), false);
         }
 
@@ -216,7 +216,7 @@ import events from 'events';
     }
 
     export function soundEffects(val) {
-        if (val !== undefined || val !== null) {
+        if (val !== undefined) {
             return this.set('soundeffects', val, false);
         }
 


### PR DESCRIPTION
**Changes**

Prevents the infinite loading on the Playback settings by strictly checking for undefined or null instead of loosely checking for null.

**Issues**

Fixes #1057
