### PR TITLE
Fix pointer missing in "create new lib" link

### DIFF
--- a/src/components/homesections/homesections.js
+++ b/src/components/homesections/homesections.js
@@ -64,7 +64,7 @@ define(['connectionManager', 'cardBuilder', 'appSettings', 'dom', 'apphost', 'la
             } else {
                 var noLibDescription;
                 if (user['Policy'] && user['Policy']['IsAdministrator']) {
-                    noLibDescription = Globalize.translate("NoCreatedLibraries", '<a id="button-createLibrary" class="button-link">', '</a>');
+                    noLibDescription = Globalize.translate("NoCreatedLibraries", '<br><a id="button-createLibrary" class="button-link">', '</a>');
                 } else {
                     noLibDescription = Globalize.translate("AskAdminToCreateLibrary");
                 }

--- a/src/elements/emby-button/emby-button.css
+++ b/src/elements/emby-button/emby-button.css
@@ -49,6 +49,7 @@
 
 .button-link {
     background: transparent;
+    cursor: pointer;
     margin: 0;
     padding: 0;
     vertical-align: initial;


### PR DESCRIPTION

**Changes**
Nothing too fancy. The link did not look "clickable" because the mouse pointer did not change, so I added the appropriate css rule. 

Also, added a new-line as it looks more polished like that.

Before:
![Screenshot_2020-04-25 Jellyfin(1)](https://user-images.githubusercontent.com/4193924/80277315-6a2e9e80-86ee-11ea-9707-5d39e5e3373e.png)

After:
![Screenshot_2020-04-25 Jellyfin](https://user-images.githubusercontent.com/4193924/80277318-74509d00-86ee-11ea-92c8-0eab6878caf4.png)


**Issues**
None.