### PR TITLE
Fix keyboard navigation on remotecontrol page

### DIFF
--- a/src/nowplaying.html
+++ b/src/nowplaying.html
@@ -26,9 +26,9 @@
                     <div class="runtime"></div>
                 </div>
                 
-                <div class="nowPlayingButtonsContainer">
+                <div class="nowPlayingButtonsContainer focuscontainer-x">
                 
-                    <div class="nowPlayingInfoButtons focuscontainer-x">
+                    <div class="nowPlayingInfoButtons">
                     
                         <button is="paper-icon-button-light" class="btnRewind btnNowPlayingRewind btnPlayStateCommand autoSize" title="${Rewind}">
                             <i class="material-icons replay_10"></i>


### PR DESCRIPTION
Class `focuscontainer-x` tells `focusManager` to stay within container using left/right keys, and allows to leave container on up/down keys.
This broke when button container was split to support wrapping.

Since we use keyboard navigation mostly (only) on TV, container will be single-line. It seems that this also works when container is wrapped.

**Changes**
Move `focuscontainer-x` to parent `div`.

**Issues**
Keyboard navigation cannot reach playback buttons.