### PR TITLE
Use posters for latest TV shows

### DIFF
--- a/src/components/homesections/homesections.js
+++ b/src/components/homesections/homesections.js
@@ -243,7 +243,7 @@ define(['connectionManager', 'cardBuilder', 'appSettings', 'dom', 'apphost', 'la
         return function (items) {
             var cardLayout = false;
             var shape;
-            if (itemType === 'Channel' || viewType === 'movies' || viewType === 'books') {
+            if (itemType === 'Channel' || viewType === 'movies' || viewType === 'books' || viewType === 'tvshows') {
                 shape = getPortraitShape();
             } else if (viewType === 'music') {
                 shape = getSquareShape();

--- a/src/components/homesections/homesections.js
+++ b/src/components/homesections/homesections.js
@@ -243,8 +243,6 @@ define(['connectionManager', 'cardBuilder', 'appSettings', 'dom', 'apphost', 'la
         return function (items) {
             var cardLayout = false;
             var shape;
-            console.warn(viewType);
-            console.warn(itemType);
             if (itemType === 'Channel' || viewType === 'movies' || viewType === 'books' || viewType === 'tvshows') {
                 shape = getPortraitShape();
             } else if (viewType === 'music' || viewType === 'homevideos') {

--- a/src/components/homesections/homesections.js
+++ b/src/components/homesections/homesections.js
@@ -243,9 +243,11 @@ define(['connectionManager', 'cardBuilder', 'appSettings', 'dom', 'apphost', 'la
         return function (items) {
             var cardLayout = false;
             var shape;
+            console.warn(viewType);
+            console.warn(itemType);
             if (itemType === 'Channel' || viewType === 'movies' || viewType === 'books' || viewType === 'tvshows') {
                 shape = getPortraitShape();
-            } else if (viewType === 'music') {
+            } else if (viewType === 'music' || viewType === 'homevideos') {
                 shape = getSquareShape();
             } else {
                 shape = getThumbShape();


### PR DESCRIPTION
**Changes**

Use the poster for Latest sections containing TV shows on the home page.

This brings it in line with other media types, which use their Primary images for the Latest sections.

![image](https://user-images.githubusercontent.com/19396809/80301745-31ea9700-87a6-11ea-806f-426200e06fa5.png)

It also switches Photo libraries to using square cards, to be more consistent with how these items appear in their libraries.

**Issues**

Fixes #956 