### PR TITLE
Fix some issues blocking WebOS 1.2 / 2.0

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -116,12 +116,12 @@ const pipelineJavascript = lazypipe()
             ]
         });
     })
-    .pipe(function () {
-        return terser({
-            keep_fnames: true,
-            mangle: false
-        });
-    })
+//    .pipe(function () {
+//        return terser({
+//            keep_fnames: true,
+//            mangle: false
+//        });
+//    })
     .pipe(function () {
         return mode.development(sourcemaps.write('.'));
     });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -116,12 +116,12 @@ const pipelineJavascript = lazypipe()
             ]
         });
     })
-//    .pipe(function () {
-//        return terser({
-//            keep_fnames: true,
-//            mangle: false
-//        });
-//    })
+    .pipe(function () {
+        return terser({
+            keep_fnames: true,
+            mangle: false
+        });
+    })
     .pipe(function () {
         return mode.development(sourcemaps.write('.'));
     });

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
           "src/components/cardbuilder/cardBuilder.js",
           "src/scripts/dom.js",
           "src/components/filedownloader.js",
-          "src/components/filesystem.js",
+          "src/scripts/filesystem.js",
           "src/scripts/keyboardnavigation.js",
           "src/components/sanatizefilename.js",
           "src/components/scrollManager.js",

--- a/src/components/apphost.js
+++ b/src/components/apphost.js
@@ -46,20 +46,9 @@ define(["appSettings", "browser", "events", "htmlMediaHelper", "webSettings"], f
                 if (window.NativeShell) {
                     profile = window.NativeShell.AppHost.getDeviceProfile(profileBuilder);
                 } else {
-                    profile = profileBuilder(getBaseProfileOptions(item));
-
-                    if (item && !options.isRetry && "allcomplexformats" !== appSettings.get("subtitleburnin")) {
-                        if (!browser.orsay && !browser.tizen) {
-                            profile.SubtitleProfiles.push({
-                                Format: "ass",
-                                Method: "External"
-                            });
-                            profile.SubtitleProfiles.push({
-                                Format: "ssa",
-                                Method: "External"
-                            });
-                        }
-                    }
+                    var builderOpts = getBaseProfileOptions(item);
+                    builderOpts.enableSsaRender = (item && !options.isRetry && "allcomplexformats" !== appSettings.get("subtitleburnin"));
+                    profile = profileBuilder(builderOpts);
                 }
 
                 resolve(profile);

--- a/src/components/maintabsmanager.js
+++ b/src/components/maintabsmanager.js
@@ -139,8 +139,18 @@ define(['dom', 'browser', 'events', 'emby-tabs', 'emby-button'], function (dom, 
 
             var index = 0;
 
-            var indexAttribute = selectedIndex == null ? '' : (' data-index="' + selectedIndex + '"');
-            var tabsHtml = '<div is="emby-tabs"' + indexAttribute + ' class="tabs-viewmenubar"><div class="emby-tabs-slider" style="white-space:nowrap;">' + getTabsFn().map(function (t) {
+            var tabsElement;
+            try {
+                tabsElement = document.createElement('div', {is: 'emby-tabs'});
+            } catch (err) {
+                // older browser not supporting options for createElement
+                tabsElement = document.createElement('div', 'emby-tabs');
+            }
+            if (selectedIndex != null) {
+                tabsElement.setAttribute('data-index', selectedIndex);
+            }
+            tabsElement.className = 'tabs-viewmenubar';
+            tabsElement.innerHTML = '<div class="emby-tabs-slider" style="white-space:nowrap;">' + getTabsFn().map(function (t) {
 
                 var tabClass = 'emby-tab-button';
 
@@ -163,9 +173,12 @@ define(['dom', 'browser', 'events', 'emby-tabs', 'emby-button'], function (dom, 
                 index++;
                 return tabHtml;
 
-            }).join('') + '</div></div>';
+            }).join('') + '</div>';
 
-            tabsContainerElem.innerHTML = tabsHtml;
+            while (tabsContainerElem.children.length != 0) {
+                tabsContainerElem.removeChild(tabsContainerElem.children[0]);
+            }
+            tabsContainerElem.appendChild(tabsElement);
 
             document.body.classList.add('withSectionTabs');
             tabOwnerView = view;

--- a/src/components/maintabsmanager.js
+++ b/src/components/maintabsmanager.js
@@ -139,19 +139,8 @@ define(['dom', 'browser', 'events', 'emby-tabs', 'emby-button'], function (dom, 
 
             var index = 0;
 
-            /*var tabsElement;
-            try {
-                tabsElement = document.createElement('div', {is: 'emby-tabs'});
-            } catch (err) {
-                // older browser not supporting options for createElement
-                tabsElement = document.createElement('div', 'emby-tabs');
-            }
-            if (selectedIndex != null) {
-                tabsElement.setAttribute('data-index', selectedIndex);
-            }
-            tabsElement.className = 'tabs-viewmenubar';
-            tabsElement.innerHTML = '<div class="emby-tabs-slider" style="white-space:nowrap;">' + getTabsFn().map(function (t) {*/
-            var html = '<div is="emby-tabs" ' + (selectedIndex != null ? 'data-index="' + selectedIndex + '" ' : '') + 'class="tabs-viewmenubar">' + '<div class="emby-tabs-slider" style="white-space:nowrap;">' + getTabsFn().map(function (t) {*/
+            var indexAttribute = selectedIndex == null ? '' : (' data-index="' + selectedIndex + '"');
+            var tabsHtml = '<div is="emby-tabs"' + indexAttribute + ' class="tabs-viewmenubar"><div class="emby-tabs-slider" style="white-space:nowrap;">' + getTabsFn().map(function (t) {
 
                 var tabClass = 'emby-tab-button';
 
@@ -176,11 +165,8 @@ define(['dom', 'browser', 'events', 'emby-tabs', 'emby-button'], function (dom, 
 
             }).join('') + '</div></div>';
 
-            /*while (tabsContainerElem.children.length != 0) {
-                tabsContainerElem.removeChild(tabsContainerElem.children[0]);
-            }
-            tabsContainerElem.appendChild(tabsElement);*/
-            tabsContainerElem.innerHTML = html;
+            tabsContainerElem.innerHTML = tabsHtml;
+            CustomElements.upgradeSubtree(tabsContainerElem);
 
             document.body.classList.add('withSectionTabs');
             tabOwnerView = view;

--- a/src/components/maintabsmanager.js
+++ b/src/components/maintabsmanager.js
@@ -166,7 +166,7 @@ define(['dom', 'browser', 'events', 'emby-tabs', 'emby-button'], function (dom, 
             }).join('') + '</div></div>';
 
             tabsContainerElem.innerHTML = tabsHtml;
-            CustomElements.upgradeSubtree(tabsContainerElem);
+            window.CustomElements.upgradeSubtree(tabsContainerElem);
 
             document.body.classList.add('withSectionTabs');
             tabOwnerView = view;

--- a/src/components/maintabsmanager.js
+++ b/src/components/maintabsmanager.js
@@ -139,7 +139,7 @@ define(['dom', 'browser', 'events', 'emby-tabs', 'emby-button'], function (dom, 
 
             var index = 0;
 
-            var tabsElement;
+            /*var tabsElement;
             try {
                 tabsElement = document.createElement('div', {is: 'emby-tabs'});
             } catch (err) {
@@ -150,7 +150,8 @@ define(['dom', 'browser', 'events', 'emby-tabs', 'emby-button'], function (dom, 
                 tabsElement.setAttribute('data-index', selectedIndex);
             }
             tabsElement.className = 'tabs-viewmenubar';
-            tabsElement.innerHTML = '<div class="emby-tabs-slider" style="white-space:nowrap;">' + getTabsFn().map(function (t) {
+            tabsElement.innerHTML = '<div class="emby-tabs-slider" style="white-space:nowrap;">' + getTabsFn().map(function (t) {*/
+            var html = '<div is="emby-tabs" ' + (selectedIndex != null ? 'data-index="' + selectedIndex + '" ' : '') + 'class="tabs-viewmenubar">' + '<div class="emby-tabs-slider" style="white-space:nowrap;">' + getTabsFn().map(function (t) {*/
 
                 var tabClass = 'emby-tab-button';
 
@@ -173,12 +174,13 @@ define(['dom', 'browser', 'events', 'emby-tabs', 'emby-button'], function (dom, 
                 index++;
                 return tabHtml;
 
-            }).join('') + '</div>';
+            }).join('') + '</div></div>';
 
-            while (tabsContainerElem.children.length != 0) {
+            /*while (tabsContainerElem.children.length != 0) {
                 tabsContainerElem.removeChild(tabsContainerElem.children[0]);
             }
-            tabsContainerElem.appendChild(tabsElement);
+            tabsContainerElem.appendChild(tabsElement);*/
+            tabsContainerElem.innerHTML = html;
 
             document.body.classList.add('withSectionTabs');
             tabOwnerView = view;

--- a/src/components/notifications/notifications.js
+++ b/src/components/notifications/notifications.js
@@ -5,7 +5,8 @@ define(['serverNotifications', 'playbackManager', 'events', 'globalize', 'requir
         document.removeEventListener('click', onOneDocumentClick);
         document.removeEventListener('keydown', onOneDocumentClick);
 
-        if (window.Notification) {
+        // don't request notification permissions if they're already granted or denied
+        if (window.Notification && window.Notification.permission === "default") {
             /* eslint-disable-next-line compat/compat */
             Notification.requestPermission();
         }

--- a/src/scripts/browser.js
+++ b/src/scripts/browser.js
@@ -22,7 +22,7 @@ define([], function () {
             return true;
         }
 
-        if (userAgent.indexOf('webos') !== -1) {
+        if (userAgent.indexOf('web0s') !== -1) {
             return true;
         }
 

--- a/src/scripts/browserdeviceprofile.js
+++ b/src/scripts/browserdeviceprofile.js
@@ -887,6 +887,16 @@ define(['browser'], function (browser) {
                 Method: 'External'
             });
         }
+        if (options.enableSsaRender) {
+            profile.SubtitleProfiles.push({
+                Format: 'ass',
+                Method: 'External'
+            });
+            profile.SubtitleProfiles.push({
+                Format: 'ssa',
+                Method: 'External'
+            });
+        }
 
         profile.ResponseProfiles = [];
         profile.ResponseProfiles.push({

--- a/src/scripts/settings/webSettings.js
+++ b/src/scripts/settings/webSettings.js
@@ -11,5 +11,8 @@ function getConfig() {
 export function enableMultiServer() {
     return getConfig().then(config => {
         return config.multiserver;
+    }).catch(error => {
+        console.log("cannot get web config:", error);
+        return false;
     });
 }

--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -709,6 +709,10 @@ var AppInfo = {};
             onError: onRequireJsError
         });
 
+        require(["fetch"], function (fetch) {
+            console.debug("fetch is here", fetch);
+        });
+
         require(["polyfill"]);
         require(["fast-text-encoding"]);
         require(["intersection-observer"]);

--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -709,10 +709,7 @@ var AppInfo = {};
             onError: onRequireJsError
         });
 
-        require(["fetch"], function (fetch) {
-            console.debug("fetch is here", fetch);
-        });
-
+        require(["fetch"]);
         require(["polyfill"]);
         require(["fast-text-encoding"]);
         require(["intersection-observer"]);

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -14,7 +14,7 @@ module.exports = merge(common, {
         rules: [
             {
                 test: /\.js$/,
-                exclude: /node_modules[\\/](?!query-string)/,
+                exclude: /node_modules[\\/](?!query-string|split-on-first|strict-uri-encode)/,
                 loader: "babel-loader"
             },
             {

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -7,7 +7,7 @@ module.exports = merge(common, {
         rules: [
             {
                 test: /\.js$/,
-                exclude: /node_modules[\\/](?!query-string)/,
+                exclude: /node_modules[\\/](?!query-string|split-on-first|strict-uri-encode)/,
                 loader: "babel-loader"
             },
             {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
* Fix silent app crash on WebOS 1.2 when app requested notification permission (this code is more correct anyway, and permission is granted on WebOS by default)
* Fix WebOS detection by user agent (typo - `big O` changed to `zero`).
* Create home tabs element properly using `document.createElement()` because instead the polyfill used would add custom class later (based on document mutation), and we need custom methods in this execution context. This is a more correct thing to do in any case, it's just in modern browsers element is _usually_ parsed into custom element immediately (but WWW standards do not require so).
* Require `fetch` explicitly and call Babel on some more modules within `node_modules` so WebOS doesn't choke on them.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
No ready-made issues, but this being applied to latest master allows me to open my test JF instance in our jf-webos app in WebOS 1.2 and WebOS 2.0 (in emulators). Still not completely functional, but it's a start.