### PR TITLE
Remove the small logo in OSD and details page

### DIFF
--- a/src/controllers/itemdetailpage.js
+++ b/src/controllers/itemdetailpage.js
@@ -554,7 +554,7 @@ define(["loading", "appRouter", "layoutManager", "connectionManager", "userSetti
         renderTimerEditor(page, item, apiClient, user);
         renderImage(page, item, apiClient, user);
         renderLogo(page, item, apiClient);
-        setTitle(item, apiClient);
+        Emby.Page.setTitle('');
         setInitialCollapsibleState(page, item, apiClient, context, user);
         renderDetails(page, item, apiClient, context);
         renderTrackSelections(page, instance, item);
@@ -664,19 +664,6 @@ define(["loading", "appRouter", "layoutManager", "connectionManager", "userSetti
         }
 
         return null;
-    }
-
-    function setTitle(item, apiClient) {
-        var url = logoImageUrl(item, apiClient, {});
-
-        if (url != null) {
-            var pageTitle = document.querySelector(".pageTitle");
-            pageTitle.style.backgroundImage = "url('" + url + "')";
-            pageTitle.classList.add("pageTitleWithLogo");
-            pageTitle.innerHTML = "";
-        } else {
-            Emby.Page.setTitle("");
-        }
     }
 
     function renderLogo(page, item, apiClient) {
@@ -2116,7 +2103,7 @@ define(["loading", "appRouter", "layoutManager", "connectionManager", "userSetti
 
             if (e.detail.isRestored) {
                 if (currentItem) {
-                    setTitle(currentItem, connectionManager.getApiClient(currentItem.ServerId));
+                    Emby.Page.setTitle('');
                     renderTrackSelections(page, self, currentItem, true);
                 }
             } else {

--- a/src/controllers/playback/videoosd.js
+++ b/src/controllers/playback/videoosd.js
@@ -45,23 +45,6 @@ define(["playbackManager", "dom", "inputManager", "datetime", "itemHelper", "med
         return null;
     }
 
-    function logoImageUrl(item, apiClient, options) {
-        options = options || {};
-        options.type = "Logo";
-
-        if (item.ImageTags && item.ImageTags.Logo) {
-            options.tag = item.ImageTags.Logo;
-            return apiClient.getScaledImageUrl(item.Id, options);
-        }
-
-        if (item.ParentLogoImageTag) {
-            options.tag = item.ParentLogoImageTag;
-            return apiClient.getScaledImageUrl(item.ParentLogoItemId, options);
-        }
-
-        return null;
-    }
-
     return function (view, params) {
         function onVerticalSwipe(e, elem, data) {
             var player = currentPlayer;

--- a/src/controllers/playback/videoosd.js
+++ b/src/controllers/playback/videoosd.js
@@ -309,18 +309,7 @@ define(["playbackManager", "dom", "inputManager", "datetime", "itemHelper", "med
         }
 
         function setTitle(item, parentName) {
-            var url = logoImageUrl(item, connectionManager.getApiClient(item.ServerId), {});
-
-            if (url) {
-                Emby.Page.setTitle("");
-                var pageTitle = document.querySelector(".pageTitle");
-                pageTitle.style.backgroundImage = "url('" + url + "')";
-                pageTitle.classList.add("pageTitleWithLogo");
-                pageTitle.classList.remove("pageTitleWithDefaultLogo");
-                pageTitle.innerHTML = "";
-            } else {
-                Emby.Page.setTitle(parentName || "");
-            }
+            Emby.Page.setTitle(parentName || '');
 
             var documentTitle = parentName || (item ? item.Name : null);
 


### PR DESCRIPTION
**Changes**

Removes the small useless logo on the OSD and details pages.

![Screenshot_2020-04-30 Jellyfin(1)](https://user-images.githubusercontent.com/19396809/80744780-7f0c9700-8b1f-11ea-93ab-5e3ecce30900.png)

![Screenshot_2020-04-30 Jellyfin](https://user-images.githubusercontent.com/19396809/80744791-816ef100-8b1f-11ea-8b1a-0ad6f22ef97d.png)

**Issues**

