### PR TITLE
Download button fix on photos slideshow

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -34,6 +34,7 @@
  - [Ryan Hartzell](https://github.com/ryan-hartzell)
  - [Thibault Nocchi](https://github.com/ThibaultNocchi)
  - [MrTimscampi](https://github.com/MrTimscampi)
+ - [Sarab Singh](https://github.com/sarab97)
 
 # Emby Contributors
 

--- a/src/components/photoplayer/plugin.js
+++ b/src/components/photoplayer/plugin.js
@@ -22,24 +22,24 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
                 var index = options.startIndex || 0;
 
                 var apiClient = connectionManager.currentApiClient();
-                    
-                    apiClient.getCurrentUser().then(function(result){ 
-                        
-                        var newSlideShow = new slideshow({
-                            showTitle: false,
-                            cover: false,
-                            items: options.items,
-                            startIndex: index,
-                            interval: 11000,
-                            interactive: true,
-                            user: result
-                        });
-                        
-                        newSlideShow.show();
-                        
-                        resolve();
+
+                apiClient.getCurrentUser().then(function(result){
+
+                    var newSlideShow = new slideshow({
+                        showTitle: false,
+                        cover: false,
+                        items: options.items,
+                        startIndex: index,
+                        interval: 11000,
+                        interactive: true,
+                        user: result
                     });
+
+                    newSlideShow.show();
+
+                    resolve();
                 });
+            });
         });
     };
 

--- a/src/components/photoplayer/plugin.js
+++ b/src/components/photoplayer/plugin.js
@@ -21,19 +21,25 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
 
                 var index = options.startIndex || 0;
 
-                var newSlideShow = new slideshow({
-                    showTitle: false,
-                    cover: false,
-                    items: options.items,
-                    startIndex: index,
-                    interval: 11000,
-                    interactive: true
+                var apiClient = connectionManager.currentApiClient();
+                    
+                    apiClient.getCurrentUser().then(function(result){ 
+                        
+                        var newSlideShow = new slideshow({
+                            showTitle: false,
+                            cover: false,
+                            items: options.items,
+                            startIndex: index,
+                            interval: 11000,
+                            interactive: true,
+                            user: result
+                        });
+                        
+                        newSlideShow.show();
+                        
+                        resolve();
+                    });
                 });
-
-                newSlideShow.show();
-
-                resolve();
-            });
         });
     };
 

--- a/src/components/photoplayer/plugin.js
+++ b/src/components/photoplayer/plugin.js
@@ -23,7 +23,7 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
 
                 var apiClient = connectionManager.currentApiClient();
 
-                apiClient.getCurrentUser().then(function(result){
+                apiClient.getCurrentUser().then(function(result) {
 
                     var newSlideShow = new slideshow({
                         showTitle: false,

--- a/src/components/slideshow/slideshow.js
+++ b/src/components/slideshow/slideshow.js
@@ -167,9 +167,9 @@ define(['dialogHelper', 'inputManager', 'connectionManager', 'layoutManager', 'f
 
                 if (!actionButtonsOnTop) {
                     html += '<div class="slideshowBottomBar hide">';
-
+                    
                     html += getIcon('play_arrow', 'btnSlideshowPause slideshowButton', true, true);
-                    if (appHost.supports('filedownload')) {
+                    if (appHost.supports('filedownload') && options.user.Policy.EnableContentDownloading) {
                         html += getIcon('file_download', 'btnDownload slideshowButton', true);
                     }
                     if (appHost.supports('sharing')) {

--- a/src/components/slideshow/slideshow.js
+++ b/src/components/slideshow/slideshow.js
@@ -155,7 +155,7 @@ define(['dialogHelper', 'inputManager', 'connectionManager', 'layoutManager', 'f
 
                 html += '<div class="topActionButtons">';
                 if (actionButtonsOnTop) {
-                    if (appHost.supports('filedownload')) {
+                    if (appHost.supports('filedownload') && options.user.Policy.EnableContentDownloading) {
                         html += getIcon('file_download', 'btnDownload slideshowButton', true);
                     }
                     if (appHost.supports('sharing')) {

--- a/src/components/slideshow/slideshow.js
+++ b/src/components/slideshow/slideshow.js
@@ -66,14 +66,14 @@ define(['dialogHelper', 'inputManager', 'connectionManager', 'layoutManager', 'f
      * @param {object} item - Item used to generate the image URL.
      * @returns {string} URL of the item's image.
      */
-    function getImgUrl(item) {
+    function getImgUrl(item, user) {
         var apiClient = connectionManager.getApiClient(item.ServerId);
         var imageOptions = {};
 
         if (item.BackdropImageTags && item.BackdropImageTags.length) {
             return getBackdropImageUrl(item, imageOptions, apiClient);
         } else {
-            if (item.MediaType === 'Photo') {
+            if (item.MediaType === 'Photo' && user.Policy.EnableContentDownloading) {
                 return apiClient.getItemDownloadUrl(item.Id);
             }
             imageOptions.type = "Primary";
@@ -167,7 +167,7 @@ define(['dialogHelper', 'inputManager', 'connectionManager', 'layoutManager', 'f
 
                 if (!actionButtonsOnTop) {
                     html += '<div class="slideshowBottomBar hide">';
-                    
+
                     html += getIcon('play_arrow', 'btnSlideshowPause slideshowButton', true, true);
                     if (appHost.supports('filedownload') && options.user.Policy.EnableContentDownloading) {
                         html += getIcon('file_download', 'btnDownload slideshowButton', true);
@@ -312,7 +312,7 @@ define(['dialogHelper', 'inputManager', 'connectionManager', 'layoutManager', 'f
          */
         function getSwiperSlideHtmlFromItem(item) {
             return getSwiperSlideHtmlFromSlide({
-                originalImage: getImgUrl(item),
+                originalImage: getImgUrl(item, currentOptions.user),
                 //title: item.Name,
                 //description: item.Overview
                 Id: item.Id,

--- a/src/components/slideshow/slideshow.js
+++ b/src/components/slideshow/slideshow.js
@@ -73,7 +73,7 @@ define(['dialogHelper', 'inputManager', 'connectionManager', 'layoutManager', 'f
         if (item.BackdropImageTags && item.BackdropImageTags.length) {
             return getBackdropImageUrl(item, imageOptions, apiClient);
         } else {
-            if (item.MediaType === 'Photo' && user.Policy.EnableContentDownloading) {
+            if (item.MediaType === 'Photo' && user && user.Policy.EnableContentDownloading) {
                 return apiClient.getItemDownloadUrl(item.Id);
             }
             imageOptions.type = "Primary";
@@ -155,7 +155,7 @@ define(['dialogHelper', 'inputManager', 'connectionManager', 'layoutManager', 'f
 
                 html += '<div class="topActionButtons">';
                 if (actionButtonsOnTop) {
-                    if (appHost.supports('filedownload') && options.user.Policy.EnableContentDownloading) {
+                    if (appHost.supports('filedownload') && options.user && options.user.Policy.EnableContentDownloading) {
                         html += getIcon('file_download', 'btnDownload slideshowButton', true);
                     }
                     if (appHost.supports('sharing')) {
@@ -169,7 +169,7 @@ define(['dialogHelper', 'inputManager', 'connectionManager', 'layoutManager', 'f
                     html += '<div class="slideshowBottomBar hide">';
 
                     html += getIcon('play_arrow', 'btnSlideshowPause slideshowButton', true, true);
-                    if (appHost.supports('filedownload') && options.user.Policy.EnableContentDownloading) {
+                    if (appHost.supports('filedownload') && options.user && options.user.Policy.EnableContentDownloading) {
                         html += getIcon('file_download', 'btnDownload slideshowButton', true);
                     }
                     if (appHost.supports('sharing')) {


### PR DESCRIPTION
Fix download button to hide in photos slideshow and getting file url in remote client if download permission is not granted to the user

**Changes**
Change in photoplayer/plugin.js to pass the user object to slideshow.js
Change in slideshow.js to check for download permission before showing the button
Change in slideshow.js to check for download permission before returning the download url for full sized image

**Issues**
Fixes #1059 