### PR TITLE
Enable a simple color placeholder for loading cards

### DIFF
--- a/src/components/cardbuilder/card.css
+++ b/src/components/cardbuilder/card.css
@@ -212,13 +212,13 @@ button::-moz-focus-inner {
     background-color: #242424;
 }
 
-.backdropCard .cardContent:not(.defaultCardBackground) {
-    background-color: transparent;
-}
-
 .visualCardBox .cardContent {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
+}
+
+.backdropCard .cardContent:not(.defaultCardBackground) {
+    background-color: transparent;
 }
 
 .cardContent-shadow {

--- a/src/components/cardbuilder/card.css
+++ b/src/components/cardbuilder/card.css
@@ -209,6 +209,10 @@ button::-moz-focus-inner {
 }
 
 .cardContent:not(.defaultCardBackground) {
+    background-color: transparent;
+}
+
+.cardBox:not(.visualCardBox) .cardPadder {
     background-color: #242424;
 }
 
@@ -217,7 +221,8 @@ button::-moz-focus-inner {
     border-bottom-right-radius: 0;
 }
 
-.cardContent-shadow {
+.cardContent-shadow,
+.cardBox:not(.visualCardBox) .cardPadder {
     box-shadow: 0 0.0725em 0.29em 0 rgba(0, 0, 0, 0.37);
 }
 

--- a/src/components/cardbuilder/card.css
+++ b/src/components/cardbuilder/card.css
@@ -192,9 +192,14 @@ button::-moz-focus-inner {
 
     /* Needed in case this is a button */
     display: block;
-
-    /* Needed in case this is a button */
     margin: 0 !important;
+    border: 0 !important;
+    padding: 0 !important;
+    cursor: pointer;
+    color: inherit;
+    width: 100%;
+    font-family: inherit;
+    font-size: inherit;
 
     /* Needed in safari */
     height: 100%;
@@ -203,18 +208,7 @@ button::-moz-focus-inner {
     contain: strict;
 }
 
-.cardContent-button {
-    border: 0 !important;
-    padding: 0 !important;
-    cursor: pointer;
-    color: inherit;
-    width: 100%;
-    vertical-align: middle;
-    font-family: inherit;
-    font-size: inherit;
-}
-
-.cardContent-button:not(.defaultCardBackground) {
+.cardContent:not(.defaultCardBackground) {
     background-color: #202020;
 }
 

--- a/src/components/cardbuilder/card.css
+++ b/src/components/cardbuilder/card.css
@@ -209,7 +209,7 @@ button::-moz-focus-inner {
 }
 
 .cardContent:not(.defaultCardBackground) {
-    background-color: #202020;
+    background-color: #242424;
 }
 
 .visualCardBox .cardContent {

--- a/src/components/cardbuilder/card.css
+++ b/src/components/cardbuilder/card.css
@@ -215,7 +215,7 @@ button::-moz-focus-inner {
 }
 
 .cardContent-button:not(.defaultCardBackground) {
-    background-color: transparent;
+    background-color: #202020;
 }
 
 .visualCardBox .cardContent {

--- a/src/components/cardbuilder/card.css
+++ b/src/components/cardbuilder/card.css
@@ -217,10 +217,6 @@ button::-moz-focus-inner {
     border-bottom-right-radius: 0;
 }
 
-.backdropCard .cardContent:not(.defaultCardBackground) {
-    background-color: transparent;
-}
-
 .cardContent-shadow {
     box-shadow: 0 0.0725em 0.29em 0 rgba(0, 0, 0, 0.37);
 }

--- a/src/components/cardbuilder/card.css
+++ b/src/components/cardbuilder/card.css
@@ -212,6 +212,10 @@ button::-moz-focus-inner {
     background-color: #242424;
 }
 
+.backdropCard .cardContent:not(.defaultCardBackground) {
+    background-color: transparent;
+}
+
 .visualCardBox .cardContent {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;

--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -1380,7 +1380,7 @@ import 'programStyles';
                 cardImageContainerClose = '</div>';
             } else {
                 // Don't use the IMG tag with safari because it puts a white border around it
-                cardImageContainerOpen = imgUrl ? ('<button data-action="' + action + '" class="cardContent-button ' + cardImageContainerClass + ' ' + cardContentClass + ' itemAction lazy" data-src="' + imgUrl + '" ' + blurhashAttrib + '>') : ('<button data-action="' + action + '" class="cardContent-button ' + cardImageContainerClass + ' ' + cardContentClass + ' itemAction">');
+                cardImageContainerOpen = imgUrl ? ('<button data-action="' + action + '" class="' + cardImageContainerClass + ' ' + cardContentClass + ' itemAction lazy" data-src="' + imgUrl + '" ' + blurhashAttrib + '>') : ('<button data-action="' + action + '" class="' + cardImageContainerClass + ' ' + cardContentClass + ' itemAction">');
 
                 cardImageContainerClose = '</button>';
             }

--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -1377,7 +1377,6 @@ import 'programStyles';
             }
 
             if (layoutManager.tv) {
-
                 // Don't use the IMG tag with safari because it puts a white border around it
                 cardImageContainerOpen = imgUrl ? ('<div class="' + cardImageContainerClass + ' ' + cardContentClass + ' lazy" data-src="' + imgUrl + '" ' + blurhashAttrib + '>') : ('<div class="' + cardImageContainerClass + ' ' + cardContentClass + '">');
 

--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -1367,9 +1367,6 @@ import 'programStyles';
             let cardScalableClose = '';
 
             let cardContentClass = 'cardContent';
-            if (!options.cardLayout) {
-                cardContentClass += ' cardContent-shadow';
-            }
 
             let blurhashAttrib = '';
             if (blurhash && blurhash.length > 0) {
@@ -1390,7 +1387,7 @@ import 'programStyles';
 
             let cardScalableClass = 'cardScalable';
 
-            cardImageContainerOpen = '<div class="' + cardBoxClass + '"><div class="' + cardScalableClass + '"><div class="cardPadder-' + shape + '"></div>' + cardImageContainerOpen;
+            cardImageContainerOpen = '<div class="' + cardBoxClass + '"><div class="' + cardScalableClass + '"><div class="cardPadder cardPadder-' + shape + '"></div>' + cardImageContainerOpen;
             cardBoxClose = '</div>';
             cardScalableClose = '</div>';
 

--- a/src/components/images/style.css
+++ b/src/components/images/style.css
@@ -1,11 +1,11 @@
 .lazy-image-fadein {
     opacity: 1;
-    transition: opacity 0.7s;
+    transition: opacity 0.5s;
 }
 
 .lazy-image-fadein-fast {
     opacity: 1;
-    transition: opacity 0.2s;
+    transition: opacity 0.1s;
 }
 
 .lazy-hidden {

--- a/src/components/remotecontrol/remotecontrol.js
+++ b/src/components/remotecontrol/remotecontrol.js
@@ -196,7 +196,7 @@ define(['browser', 'datetime', 'backdrop', 'libraryBrowser', 'listView', 'imageL
                 context.querySelector('.nowPlayingPageImage').classList.remove('nowPlayingPageImageAudio');
             }
         } else {
-            imgContainer.innerHTML = '<div class="nowPlayingPageImageContainerNoAlbum"><button data-action="link" class="cardContent-button cardImageContainer coveredImage ' + cardBuilder.getDefaultBackgroundClass(item.Name) + ' cardContent cardContent-shadow itemAction"><span class="cardImageIcon material-icons album"></span></button></div>';
+            imgContainer.innerHTML = '<div class="nowPlayingPageImageContainerNoAlbum"><button data-action="link" class="cardImageContainer coveredImage ' + cardBuilder.getDefaultBackgroundClass(item.Name) + ' cardContent cardContent-shadow itemAction"><span class="cardImageIcon material-icons album"></span></button></div>';
         }
     }
 

--- a/src/themes/appletv/theme.css
+++ b/src/themes/appletv/theme.css
@@ -464,3 +464,18 @@ html {
 .metadataSidebarIcon {
     color: #00a4dc;
 }
+
+.cardPadder-square,
+.cardPadder-mixedSquare,
+.cardPadder-overflowSquare,
+.cardPadder-portrait,
+.cardPadder-mixedPortrait,
+.cardPadder-overflowPortrait,
+.cardPadder-banner,
+.cardPadder-backdrop,
+.cardPadder-mixedBackdrop,
+.cardPadder-smallBackdrop,
+.cardPadder-overflowBackdrop,
+.cardPadder-overflowSmallBackdrop {
+    background-color: #d2d2d2;
+}

--- a/src/themes/appletv/theme.css
+++ b/src/themes/appletv/theme.css
@@ -123,7 +123,7 @@ html {
 
 .paperList,
 .visualCardBox,
-.cardContent:not(.defaultCardBackground) {
+.cardBox:not(.visualCardBox) .cardPadder {
     background-color: rgba(0, 0, 0, 0.1);
 }
 
@@ -463,19 +463,4 @@ html {
 
 .metadataSidebarIcon {
     color: #00a4dc;
-}
-
-.cardPadder-square,
-.cardPadder-mixedSquare,
-.cardPadder-overflowSquare,
-.cardPadder-portrait,
-.cardPadder-mixedPortrait,
-.cardPadder-overflowPortrait,
-.cardPadder-banner,
-.cardPadder-backdrop,
-.cardPadder-mixedBackdrop,
-.cardPadder-smallBackdrop,
-.cardPadder-overflowBackdrop,
-.cardPadder-overflowSmallBackdrop {
-    background-color: #d2d2d2;
 }

--- a/src/themes/appletv/theme.css
+++ b/src/themes/appletv/theme.css
@@ -455,7 +455,6 @@ html {
     border-color: #00a4dc !important;
 }
 
-.cardContent-button,
 .itemDetailImage,
 .cardOverlayContainer {
     border-radius: 0.5rem;

--- a/src/themes/appletv/theme.css
+++ b/src/themes/appletv/theme.css
@@ -122,8 +122,8 @@ html {
 }
 
 .paperList,
-.visualCardBox {
-    background-color: #fff;
+.visualCardBox,
+.cardContent:not(.defaultCardBackground) {
     background-color: rgba(0, 0, 0, 0.1);
 }
 

--- a/src/themes/blueradiance/theme.css
+++ b/src/themes/blueradiance/theme.css
@@ -450,6 +450,10 @@ html {
     color: #4285f4;
 }
 
+.cardContent:not(.defaultCardBackground) {
+    background-color: rgba(0, 0, 0, 0.5);
+}
+
 .card:focus .cardBox.visualCardBox,
 .card:focus .cardBox:not(.visualCardBox) .cardScalable {
     border-color: #00a4dc !important;

--- a/src/themes/blueradiance/theme.css
+++ b/src/themes/blueradiance/theme.css
@@ -487,3 +487,18 @@ html {
 .metadataSidebarIcon {
     color: #00a4dc;
 }
+
+.cardPadder-square,
+.cardPadder-mixedSquare,
+.cardPadder-overflowSquare,
+.cardPadder-portrait,
+.cardPadder-mixedPortrait,
+.cardPadder-overflowPortrait,
+.cardPadder-banner,
+.cardPadder-backdrop,
+.cardPadder-mixedBackdrop,
+.cardPadder-smallBackdrop,
+.cardPadder-overflowBackdrop,
+.cardPadder-overflowSmallBackdrop {
+    background-color: #022950;
+}

--- a/src/themes/blueradiance/theme.css
+++ b/src/themes/blueradiance/theme.css
@@ -450,7 +450,7 @@ html {
     color: #4285f4;
 }
 
-.cardContent:not(.defaultCardBackground) {
+.cardBox:not(.visualCardBox) .cardPadder {
     background-color: rgba(0, 0, 0, 0.5);
 }
 
@@ -486,19 +486,4 @@ html {
 
 .metadataSidebarIcon {
     color: #00a4dc;
-}
-
-.cardPadder-square,
-.cardPadder-mixedSquare,
-.cardPadder-overflowSquare,
-.cardPadder-portrait,
-.cardPadder-mixedPortrait,
-.cardPadder-overflowPortrait,
-.cardPadder-banner,
-.cardPadder-backdrop,
-.cardPadder-mixedBackdrop,
-.cardPadder-smallBackdrop,
-.cardPadder-overflowBackdrop,
-.cardPadder-overflowSmallBackdrop {
-    background-color: #022950;
 }

--- a/src/themes/dark/theme.css
+++ b/src/themes/dark/theme.css
@@ -453,18 +453,3 @@ html {
 .metadataSidebarIcon {
     color: #00a4dc;
 }
-
-.cardPadder-square,
-.cardPadder-mixedSquare,
-.cardPadder-overflowSquare,
-.cardPadder-portrait,
-.cardPadder-mixedPortrait,
-.cardPadder-overflowPortrait,
-.cardPadder-banner,
-.cardPadder-backdrop,
-.cardPadder-mixedBackdrop,
-.cardPadder-smallBackdrop,
-.cardPadder-overflowBackdrop,
-.cardPadder-overflowSmallBackdrop {
-    background-color: #202020;
-}

--- a/src/themes/dark/theme.css
+++ b/src/themes/dark/theme.css
@@ -421,7 +421,8 @@ html {
     color: #4285f4;
 }
 
-.card:focus .cardBox.visualCardBox {
+.card:focus .cardBox.visualCardBox,
+.card:focus .cardBox:not(.visualCardBox) .cardScalable {
     border-color: #00a4dc !important;
 }
 

--- a/src/themes/dark/theme.css
+++ b/src/themes/dark/theme.css
@@ -421,8 +421,7 @@ html {
     color: #4285f4;
 }
 
-.card:focus .cardBox.visualCardBox,
-.card:focus .cardBox:not(.visualCardBox) .cardScalable {
+.card:focus .cardBox.visualCardBox {
     border-color: #00a4dc !important;
 }
 

--- a/src/themes/dark/theme.css
+++ b/src/themes/dark/theme.css
@@ -453,3 +453,18 @@ html {
 .metadataSidebarIcon {
     color: #00a4dc;
 }
+
+.cardPadder-square,
+.cardPadder-mixedSquare,
+.cardPadder-overflowSquare,
+.cardPadder-portrait,
+.cardPadder-mixedPortrait,
+.cardPadder-overflowPortrait,
+.cardPadder-banner,
+.cardPadder-backdrop,
+.cardPadder-mixedBackdrop,
+.cardPadder-smallBackdrop,
+.cardPadder-overflowBackdrop,
+.cardPadder-overflowSmallBackdrop {
+    background-color: #202020;
+}

--- a/src/themes/light/theme.css
+++ b/src/themes/light/theme.css
@@ -432,7 +432,7 @@ html {
     color: #4285f4;
 }
 
-.cardContent:not(.defaultCardBackground) {
+.cardBox:not(.visualCardBox) .cardPadder {
     background-color: #fff;
 }
 
@@ -443,19 +443,4 @@ html {
 
 .metadataSidebarIcon {
     color: #00a4dc;
-}
-
-.cardPadder-square,
-.cardPadder-mixedSquare,
-.cardPadder-overflowSquare,
-.cardPadder-portrait,
-.cardPadder-mixedPortrait,
-.cardPadder-overflowPortrait,
-.cardPadder-banner,
-.cardPadder-backdrop,
-.cardPadder-mixedBackdrop,
-.cardPadder-smallBackdrop,
-.cardPadder-overflowBackdrop,
-.cardPadder-overflowSmallBackdrop {
-    background-color: #fff;
 }

--- a/src/themes/light/theme.css
+++ b/src/themes/light/theme.css
@@ -444,3 +444,18 @@ html {
 .metadataSidebarIcon {
     color: #00a4dc;
 }
+
+.cardPadder-square,
+.cardPadder-mixedSquare,
+.cardPadder-overflowSquare,
+.cardPadder-portrait,
+.cardPadder-mixedPortrait,
+.cardPadder-overflowPortrait,
+.cardPadder-banner,
+.cardPadder-backdrop,
+.cardPadder-mixedBackdrop,
+.cardPadder-smallBackdrop,
+.cardPadder-overflowBackdrop,
+.cardPadder-overflowSmallBackdrop {
+    background-color: #fff;
+}

--- a/src/themes/light/theme.css
+++ b/src/themes/light/theme.css
@@ -432,6 +432,10 @@ html {
     color: #4285f4;
 }
 
+.cardContent:not(.defaultCardBackground) {
+    background-color: #fff;
+}
+
 .card:focus .cardBox.visualCardBox,
 .card:focus .cardBox:not(.visualCardBox) .cardScalable {
     border-color: #00a4dc !important;

--- a/src/themes/purplehaze/theme.css
+++ b/src/themes/purplehaze/theme.css
@@ -623,3 +623,18 @@ a[data-role=button] {
 .personCard .cardOverlayButton-br {
     right: 20%;
 }
+
+.cardPadder-square,
+.cardPadder-mixedSquare,
+.cardPadder-overflowSquare,
+.cardPadder-portrait,
+.cardPadder-mixedPortrait,
+.cardPadder-overflowPortrait,
+.cardPadder-banner,
+.cardPadder-backdrop,
+.cardPadder-mixedBackdrop,
+.cardPadder-smallBackdrop,
+.cardPadder-overflowBackdrop,
+.cardPadder-overflowSmallBackdrop {
+    background-color: #200c3d;
+}

--- a/src/themes/purplehaze/theme.css
+++ b/src/themes/purplehaze/theme.css
@@ -548,17 +548,23 @@ a[data-role=button] {
 }
 
 .personCard .cardScalable {
-    border-radius: 50%;
+    border-radius: 50% !important;
     border: 1px solid rgb(255, 255, 255);
 }
 
-.cardContent:not(.defaultCardBackground) {
+.cardBox:not(.visualCardBox) .cardPadder {
     background-color: rgba(0, 0, 0, 0.5);
+    border-radius: 1em;
 }
 
 .card:focus .cardBox.visualCardBox,
 .card:focus .cardBox:not(.visualCardBox) .cardScalable {
     border-color: #ff77f1 !important;
+}
+
+.card.show-focus:not(.show-animation) .cardBox.visualCardBox,
+.card.show-focus:not(.show-animation) .cardBox:not(.visualCardBox) .cardScalable {
+    border-radius: 1.5em;
 }
 
 .layout-desktop,
@@ -618,23 +624,9 @@ a[data-role=button] {
     right: 20%;
 }
 
-.cardPadder-square,
-.cardPadder-mixedSquare,
-.cardPadder-overflowSquare,
-.cardPadder-portrait,
-.cardPadder-mixedPortrait,
-.cardPadder-overflowPortrait,
-.cardPadder-banner,
-.cardPadder-backdrop,
-.cardPadder-mixedBackdrop,
-.cardPadder-smallBackdrop,
-.cardPadder-overflowBackdrop,
-.cardPadder-overflowSmallBackdrop {
-    background-color: #200c3d;
-}
-
 .personCard .cardPadder-overflowPortrait,
 .personCard .cardPadder-portrait {
     padding-bottom: 100%;
     contain: strict;
+    border-radius: 50% !important;
 }

--- a/src/themes/purplehaze/theme.css
+++ b/src/themes/purplehaze/theme.css
@@ -606,12 +606,6 @@ a[data-role=button] {
     width: 40vw;
 }
 
-.personCard .cardPadder-overflowPortrait,
-.personCard .cardPadder-portrait {
-    padding-bottom: 100%;
-    contain: strict;
-}
-
 .personCard .coveredImage {
     clip-path: circle(50% at 50% 50%);
 }
@@ -637,4 +631,10 @@ a[data-role=button] {
 .cardPadder-overflowBackdrop,
 .cardPadder-overflowSmallBackdrop {
     background-color: #200c3d;
+}
+
+.personCard .cardPadder-overflowPortrait,
+.personCard .cardPadder-portrait {
+    padding-bottom: 100%;
+    contain: strict;
 }

--- a/src/themes/purplehaze/theme.css
+++ b/src/themes/purplehaze/theme.css
@@ -552,6 +552,10 @@ a[data-role=button] {
     border: 1px solid rgb(255, 255, 255);
 }
 
+.cardContent:not(.defaultCardBackground) {
+    background-color: rgba(0, 0, 0, 0.5);
+}
+
 .card:focus .cardBox.visualCardBox,
 .card:focus .cardBox:not(.visualCardBox) .cardScalable {
     border-color: #ff77f1 !important;

--- a/src/themes/wmc/theme.css
+++ b/src/themes/wmc/theme.css
@@ -430,7 +430,7 @@ html {
     color: #4285f4;
 }
 
-.cardContent:not(.defaultCardBackground) {
+.cardBox:not(.visualCardBox) .cardPadder {
     background-color: #0f3562;
 }
 
@@ -462,19 +462,4 @@ html {
 
 .metadataSidebarIcon {
     color: #00a4dc;
-}
-
-.cardPadder-square,
-.cardPadder-mixedSquare,
-.cardPadder-overflowSquare,
-.cardPadder-portrait,
-.cardPadder-mixedPortrait,
-.cardPadder-overflowPortrait,
-.cardPadder-banner,
-.cardPadder-backdrop,
-.cardPadder-mixedBackdrop,
-.cardPadder-smallBackdrop,
-.cardPadder-overflowBackdrop,
-.cardPadder-overflowSmallBackdrop {
-    background-color: #0f3562;
 }

--- a/src/themes/wmc/theme.css
+++ b/src/themes/wmc/theme.css
@@ -463,3 +463,18 @@ html {
 .metadataSidebarIcon {
     color: #00a4dc;
 }
+
+.cardPadder-square,
+.cardPadder-mixedSquare,
+.cardPadder-overflowSquare,
+.cardPadder-portrait,
+.cardPadder-mixedPortrait,
+.cardPadder-overflowPortrait,
+.cardPadder-banner,
+.cardPadder-backdrop,
+.cardPadder-mixedBackdrop,
+.cardPadder-smallBackdrop,
+.cardPadder-overflowBackdrop,
+.cardPadder-overflowSmallBackdrop {
+    background-color: #0f3562;
+}

--- a/src/themes/wmc/theme.css
+++ b/src/themes/wmc/theme.css
@@ -430,6 +430,10 @@ html {
     color: #4285f4;
 }
 
+.cardContent:not(.defaultCardBackground) {
+    background-color: #0f3562;
+}
+
 .card:focus .cardBox.visualCardBox,
 .card:focus .cardBox:not(.visualCardBox) .cardScalable {
     border-color: #fff !important;


### PR DESCRIPTION
**Changes**

As a first step towards getting something more polished down the line, this replaces the transparent colors of cards with our main dark grey.

Note: Using the default colors was tried, but it looked a bit too jarring IMO.

Here is how it looks without images:
![image](https://user-images.githubusercontent.com/19396809/80867334-febb7280-8c93-11ea-9b12-4326076d06bc.png)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
