### PR TITLE
Fix details position while poster is loading

### DIFF
--- a/src/assets/css/librarybrowser.css
+++ b/src/assets/css/librarybrowser.css
@@ -598,6 +598,7 @@
     position: relative;
     margin-top: -25vh;
     float: left;
+    min-height: 35vh;
     width: 25vw;
     z-index: 3;
 }


### PR DESCRIPTION
**Changes**

Pushes the content of the details page to their proper position while the poster loads, to prevent having them slide over.

**Issues**

I'm pretty sure there was an issue for this, but I'm not able to find it.
