### PR TITLE
Use root build config

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-env"]
-}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,10 +1,11 @@
+const packageConfig = require('./package.json');
 const postcssPresetEnv = require('postcss-preset-env');
 const autoprefixer = require('autoprefixer');
 const cssnano = require('cssnano');
 
 const config = () => ({
     plugins: [
-        postcssPresetEnv(),
+        postcssPresetEnv({browsers: packageConfig.browserslist}),
         autoprefixer(),
         cssnano()
     ]

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,6 +1,8 @@
 const path = require('path');
 const common = require('./webpack.common');
 const merge = require('webpack-merge');
+const packageConfig = require('./package.json');
+const postcssConfig = require('./postcss.config.js');
 
 module.exports = merge(common, {
     mode: 'development',
@@ -15,11 +17,23 @@ module.exports = merge(common, {
             {
                 test: /\.js$/,
                 exclude: /node_modules[\\/](?!query-string|split-on-first|strict-uri-encode)/,
-                loader: 'babel-loader'
+                use: {
+                    loader: 'babel-loader',
+                    options: {
+                        presets: packageConfig.babel.presets
+                    }
+                }
             },
             {
                 test: /\.css$/i,
-                use: ['style-loader', 'css-loader', 'postcss-loader']
+                use: [
+                    'style-loader',
+                    'css-loader',
+                    {
+                        loader: 'postcss-loader',
+                        options: postcssConfig()
+                    }
+                ]
             },
             {
                 test: /\.(png|jpg|gif)$/i,

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,5 +1,7 @@
 const common = require('./webpack.common');
 const merge = require('webpack-merge');
+const packageConfig = require('./package.json');
+const postcssConfig = require('./postcss.config.js');
 
 module.exports = merge(common, {
     mode: 'production',
@@ -8,11 +10,23 @@ module.exports = merge(common, {
             {
                 test: /\.js$/,
                 exclude: /node_modules[\\/](?!query-string|split-on-first|strict-uri-encode)/,
-                loader: 'babel-loader'
+                use: {
+                    loader: 'babel-loader',
+                    options: {
+                        presets: packageConfig.babel.presets
+                    }
+                }
             },
             {
                 test: /\.css$/i,
-                use: ['style-loader', 'css-loader', 'postcss-loader']
+                use: [
+                    'style-loader',
+                    'css-loader',
+                    {
+                        loader: 'postcss-loader',
+                        options: postcssConfig()
+                    }
+                ]
             },
             {
                 test: /\.(png|jpg|gif)$/i,


### PR DESCRIPTION
If node module has own config it overrides ours due to ... JS ecosystem :p

This PR forces webpack to use our configs.

I remove `babel.config.json` because it was created by me just to fix the same issue when `query-string` kept unbabeled.