### PR TITLE
Switch player backdrops to poster attribute of the video element

### DIFF
--- a/src/components/htmlvideoplayer/plugin.js
+++ b/src/components/htmlvideoplayer/plugin.js
@@ -836,7 +836,6 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
         function onNavigatedToOsd() {
             var dlg = videoDialog;
             if (dlg) {
-                dlg.classList.remove('videoPlayerContainer-withBackdrop');
                 dlg.classList.remove('videoPlayerContainer-onTop');
 
                 onStartedAndNavigatedToOsd();
@@ -869,7 +868,6 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
 
                 } else {
                     appRouter.setTransparency('backdrop');
-                    videoDialog.classList.remove('videoPlayerContainer-withBackdrop');
                     videoDialog.classList.remove('videoPlayerContainer-onTop');
 
                     onStartedAndNavigatedToOsd();
@@ -1299,11 +1297,6 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
 
                         dlg.classList.add('videoPlayerContainer');
 
-                        if (options.backdropUrl) {
-                            dlg.classList.add('videoPlayerContainer-withBackdrop');
-                            dlg.style.backgroundImage = "url('" + options.backdropUrl + "')";
-                        }
-
                         if (options.fullscreen) {
                             dlg.classList.add('videoPlayerContainer-onTop');
                         }
@@ -1337,6 +1330,9 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
                         videoElement.addEventListener('play', onPlay);
                         videoElement.addEventListener('click', onClick);
                         videoElement.addEventListener('dblclick', onDblClick);
+                        if (options.backdropUrl) {
+                            videoElement.poster = options.backdropUrl;
+                        }
 
                         document.body.insertBefore(dlg, document.body.firstChild);
                         videoDialog = dlg;
@@ -1360,11 +1356,6 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
                         }
                     });
                 } else {
-                    if (options.backdropUrl) {
-                        dlg.classList.add('videoPlayerContainer-withBackdrop');
-                        dlg.style.backgroundImage = "url('" + options.backdropUrl + "')";
-                    }
-
                     resolve(dlg.querySelector('video'));
                 }
             });

--- a/src/components/htmlvideoplayer/plugin.js
+++ b/src/components/htmlvideoplayer/plugin.js
@@ -1285,12 +1285,6 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
 
         function createMediaElement(options) {
 
-            if (browser.tv || browser.iOS || browser.mobile) {
-                // too slow
-                // also on iOS, the backdrop image doesn't look right
-                // on android mobile, it works, but can be slow to have the video surface fully cover the backdrop
-                options.backdropUrl = null;
-            }
             return new Promise(function (resolve, reject) {
 
                 var dlg = document.querySelector('.videoPlayerContainer');

--- a/src/components/htmlvideoplayer/style.css
+++ b/src/components/htmlvideoplayer/style.css
@@ -6,18 +6,7 @@
     right: 0;
     display: flex;
     align-items: center;
-}
-
-.videoPlayerContainer:not(.videoPlayerContainer-withBackdrop) {
     background: #000 !important;
-}
-
-.videoPlayerContainer-withBackdrop {
-    background-repeat: no-repeat;
-    background-position: center center;
-    background-size: cover;
-    background-attachment: fixed;
-    background-color: #000;
 }
 
 .videoPlayerContainer-onTop {
@@ -74,7 +63,6 @@ video::-webkit-media-controls {
         transform: scale3d(0.2, 0.2, 0.2);
         opacity: 0.6;
     }
-
     to {
         transform: none;
         opacity: initial;

--- a/src/components/htmlvideoplayer/style.css
+++ b/src/components/htmlvideoplayer/style.css
@@ -63,6 +63,7 @@ video::-webkit-media-controls {
         transform: scale3d(0.2, 0.2, 0.2);
         opacity: 0.6;
     }
+
     to {
         transform: none;
         opacity: initial;


### PR DESCRIPTION
We've been using a custom implementation for displaying a video backdrop while the video that is going to be played was loading. However, this implementation was disabled in TVs and mobile devices because it looked weird and even in desktop it did weird things sometimes.

**Changes**
* Use the **poster** attribute of the video element for backdrops
* Show backdrops in all devices
* Backdrops now take the full size of the video element, instead of taking all the available space (so it should remove the seams that appeared once the video was loaded and it started playing)

**Before**
![before](https://user-images.githubusercontent.com/10274099/81350288-e39c9880-90c1-11ea-9b82-59035e86cdfb.png)

**After**
![after](https://user-images.githubusercontent.com/10274099/81350383-12b30a00-90c2-11ea-854c-9cc4d2bf1801.png)

