### PR TITLE
Babel apiclient and fix reference name

### DIFF
--- a/src/bundle.js
+++ b/src/bundle.js
@@ -158,7 +158,7 @@ _define('headroom', function () {
 var apiclient = require('jellyfin-apiclient');
 
 _define('apiclient', function () {
-    return apiclient.apiclient;
+    return apiclient.ApiClient;
 });
 
 _define('events', function () {

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -16,7 +16,7 @@ module.exports = merge(common, {
         rules: [
             {
                 test: /\.js$/,
-                exclude: /node_modules[\\/](?!query-string|split-on-first|strict-uri-encode)/,
+                exclude: /node_modules[\\/](?!jellyfin-apiclient|query-string|split-on-first|strict-uri-encode)/,
                 use: {
                     loader: 'babel-loader',
                     options: {

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -9,7 +9,7 @@ module.exports = merge(common, {
         rules: [
             {
                 test: /\.js$/,
-                exclude: /node_modules[\\/](?!query-string|split-on-first|strict-uri-encode)/,
+                exclude: /node_modules[\\/](?!jellyfin-apiclient|query-string|split-on-first|strict-uri-encode)/,
                 use: {
                     loader: 'babel-loader',
                     options: {


### PR DESCRIPTION
Web works from `yarn serve` but doesn't work from server.

**Changes**
* Enable babel for `jellyfin-apiclient`.
* Fix class name reference.
