### PR TITLE
Fix browserslist for autoprefixer

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -5,8 +5,10 @@ const cssnano = require('cssnano');
 
 const config = () => ({
     plugins: [
+        // Explicitly specify browserslist to override ones from node_modules
+        // For example, Swiper has it in its package.json
         postcssPresetEnv({browsers: packageConfig.browserslist}),
-        autoprefixer(),
+        autoprefixer({overrideBrowserslist: packageConfig.browserslist}),
         cssnano()
     ]
 });

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -2,7 +2,6 @@ const path = require('path');
 const common = require('./webpack.common');
 const merge = require('webpack-merge');
 const packageConfig = require('./package.json');
-const postcssConfig = require('./postcss.config.js');
 
 module.exports = merge(common, {
     mode: 'development',
@@ -31,7 +30,11 @@ module.exports = merge(common, {
                     'css-loader',
                     {
                         loader: 'postcss-loader',
-                        options: postcssConfig()
+                        options: {
+                            config: {
+                                path: __dirname
+                            }
+                        }
                     }
                 ]
             },

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,7 +1,6 @@
 const common = require('./webpack.common');
 const merge = require('webpack-merge');
 const packageConfig = require('./package.json');
-const postcssConfig = require('./postcss.config.js');
 
 module.exports = merge(common, {
     mode: 'production',
@@ -24,7 +23,11 @@ module.exports = merge(common, {
                     'css-loader',
                     {
                         loader: 'postcss-loader',
-                        options: postcssConfig()
+                        options: {
+                            config: {
+                                path: __dirname
+                            }
+                        }
                     }
                 ]
             },


### PR DESCRIPTION
`autoprefixer` retrieves browserslist from somewhere. So we need to override browserslist using ours.

Also, I changed passing of `postcss` config. This will make it possible to adapt to each processed file.
