### PR TITLE
Fix slider thumb on WebOS 2

### DIFF
--- a/src/elements/emby-slider/emby-slider.css
+++ b/src/elements/emby-slider/emby-slider.css
@@ -87,10 +87,6 @@
     transform: scale(1.3);
 }
 
-.slider-no-webkit-thumb::-webkit-slider-thumb {
-    opacity: 0 !important;
-}
-
 .mdl-slider::-moz-range-thumb {
     -moz-appearance: none;
     width: 1.08em;

--- a/src/elements/emby-slider/emby-slider.js
+++ b/src/elements/emby-slider/emby-slider.js
@@ -148,9 +148,6 @@ define(['browser', 'dom', 'layoutManager', 'keyboardnavigation', 'css!./emby-sli
         this.classList.add('mdl-slider');
         this.classList.add('mdl-js-slider');
 
-        if (browser.noFlex) {
-            this.classList.add('slider-no-webkit-thumb');
-        }
         if (browser.edge || browser.msie) {
             this.classList.add('slider-browser-edge');
         }

--- a/src/scripts/browser.js
+++ b/src/scripts/browser.js
@@ -53,45 +53,6 @@ define([], function () {
         return false;
     }
 
-    function isStyleSupported(prop, value) {
-
-        if (typeof window === 'undefined') {
-            return false;
-        }
-
-        // If no value is supplied, use "inherit"
-        value = arguments.length === 2 ? value : 'inherit';
-        // Try the native standard method first
-        if ('CSS' in window && 'supports' in window.CSS) {
-            return window.CSS.supports(prop, value);
-        }
-        // Check Opera's native method
-        if ('supportsCSS' in window) {
-            return window.supportsCSS(prop, value);
-        }
-
-        // need try/catch because it's failing on tizen
-
-        try {
-            // Convert to camel-case for DOM interactions
-            var camel = prop.replace(/-([a-z]|[0-9])/ig, function (all, letter) {
-                return (letter + '').toUpperCase();
-            });
-            // Create test element
-            var el = document.createElement('div');
-            // Check if the property is supported
-            var support = (camel in el.style);
-            // Assign the property and value to invoke
-            // the CSS interpreter
-            el.style.cssText = prop + ':' + value;
-            // Ensure both the property and value are
-            // supported and return
-            return support && (el.style[camel] !== '');
-        } catch (err) {
-            return false;
-        }
-    }
-
     function hasKeyboard(browser) {
 
         if (browser.touch) {
@@ -282,10 +243,6 @@ define([], function () {
 
     browser.tv = isTv();
     browser.operaTv = browser.tv && userAgent.toLowerCase().indexOf('opr/') !== -1;
-
-    if (!isStyleSupported('display', 'flex')) {
-        browser.noFlex = true;
-    }
 
     if (browser.mobile || browser.tv) {
         browser.slow = true;


### PR DESCRIPTION
`browser.noFlex` disables slider thumb in WebOS 2.
`flex` checking is wrong - doesn't support prefixes. We use `flex` extensively (should be supported anyway). So `browser.noFlex` has become redundant.

**Changes**
* Remove flex support checking

_I recently fixed `isStyleSupported` and now completely remove it._ :smile:
