### PR TITLE
Hide the previous page when loading videoOsd

### DIFF
--- a/src/components/htmlvideoplayer/plugin.js
+++ b/src/components/htmlvideoplayer/plugin.js
@@ -106,10 +106,16 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
         });
     }
 
+    function hidePrePlaybackPage() {
+        let animatedPage = document.querySelector('.page:not(.hide)');
+        animatedPage.classList.add('hide');
+    }
+
     function zoomIn(elem) {
         return new Promise(function (resolve, reject) {
             var duration = 240;
             elem.style.animation = 'htmlvideoplayer-zoomin ' + duration + 'ms ease-in normal';
+            hidePrePlaybackPage();
             dom.addEventListener(elem, dom.whichAnimationEvent(), resolve, {
                 once: true
             });
@@ -1367,6 +1373,7 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
                                 resolve(videoElement);
                             });
                         } else {
+                            hidePrePlaybackPage();
                             resolve(videoElement);
                         }
                     });


### PR DESCRIPTION
**Changes**

Hides the previous page when starting to navigate to the video player, to hide the scrollbar that is still shown for a split second.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
