### PR TITLE
Revert 9a47428 changes

### DIFF
--- a/src/addserver.html
+++ b/src/addserver.html
@@ -3,7 +3,7 @@
         <form class="addServerForm" style="margin: 0 auto;">
             <h1>${HeaderConnectToServer}</h1>
             <div class="inputContainer">
-                <input is="emby-input" type="url" id="txtServerHost" required="required" label="${LabelServerHost}"/>
+                <input is="emby-input" type="text" id="txtServerHost" required="required" label="${LabelServerHost}"/>
                 <div class="fieldDescription">${LabelServerHostHelp}</div>
             </div>
             <br />


### PR DESCRIPTION
With the changes made to that field, it's impossible to give an IP address at the server page: You're forced to add the HTTP or HTTPS protocol.

![firefox](https://user-images.githubusercontent.com/10274099/82120827-1eb95e80-9789-11ea-8950-6d09065bdddc.png)

