### PR TITLE
Fix Quality Settings for Aspect Ratios less than 16:9 (1.77)

### DIFF
--- a/src/components/playback/playersettingsmenu.js
+++ b/src/components/playback/playersettingsmenu.js
@@ -7,11 +7,13 @@ define(['connectionManager', 'actionsheet', 'datetime', 'playbackManager', 'glob
             return stream.Type === 'Video';
         })[0];
         var videoWidth = videoStream ? videoStream.Width : null;
+        var videoHeight = videoStream ? videoStream.Height : null;
 
         var options = qualityoptions.getVideoQualityOptions({
             currentMaxBitrate: playbackManager.getMaxStreamingBitrate(player),
             isAutomaticBitrateEnabled: playbackManager.enableAutomaticBitrateDetection(player),
             videoWidth: videoWidth,
+            videoHeight: videoHeight,
             enableAuto: true
         });
 
@@ -91,11 +93,13 @@ define(['connectionManager', 'actionsheet', 'datetime', 'playbackManager', 'glob
         })[0];
 
         var videoWidth = videoStream ? videoStream.Width : null;
+        var videoHeight = videoStream ? videoStream.Height : null;
 
         var options = qualityoptions.getVideoQualityOptions({
             currentMaxBitrate: playbackManager.getMaxStreamingBitrate(player),
             isAutomaticBitrateEnabled: playbackManager.enableAutomaticBitrateDetection(player),
             videoWidth: videoWidth,
+            videoHeight: videoHeight,
             enableAuto: true
         });
 

--- a/src/components/qualityOptions.js
+++ b/src/components/qualityOptions.js
@@ -9,8 +9,8 @@ define(['globalize'], function (globalize) {
 
         //If the aspect ratio is less than 16/9 (1.77), set the height as if it were pillerboxed.
         // 4:3 1440x1080 -> 1920x1080
-        if (videoWidth/videoHeight < 16/9) {
-            videoWidth=videoHeight*(16/9);
+        if (videoWidth / videoHeight < 16 / 9) {
+            videoWidth = videoHeight * (16 / 9);
         }
 
         var maxAllowedWidth = videoWidth || 4096;

--- a/src/components/qualityOptions.js
+++ b/src/components/qualityOptions.js
@@ -5,6 +5,13 @@ define(['globalize'], function (globalize) {
 
         var maxStreamingBitrate = options.currentMaxBitrate;
         var videoWidth = options.videoWidth;
+        var videoHeight = options.videoHeight;
+
+        //If the aspect ratio is less than 16/9 (1.77), set the height as if it were pillerboxed.
+        // 4:3 1440x1080 -> 1920x1080
+        if (videoWidth/videoHeight < 16/9) {
+            videoWidth=videoHeight*(16/9);
+        }
 
         var maxAllowedWidth = videoWidth || 4096;
         //var maxAllowedHeight = videoHeight || 2304;

--- a/src/components/qualityOptions.js
+++ b/src/components/qualityOptions.js
@@ -7,7 +7,7 @@ define(['globalize'], function (globalize) {
         var videoWidth = options.videoWidth;
         var videoHeight = options.videoHeight;
 
-        //If the aspect ratio is less than 16/9 (1.77), set the height as if it were pillerboxed.
+        // If the aspect ratio is less than 16/9 (1.77), set the width as if it were pillarboxed.
         // 4:3 1440x1080 -> 1920x1080
         if (videoWidth / videoHeight < 16 / 9) {
             videoWidth = videoHeight * (16 / 9);


### PR DESCRIPTION
**Changes**
qualityoptions.js now checks if the aspect ratio is less than 16:9 (1.77), and if so pads the width to 16:9, in order to show correct options for content narrower than 16:9 (1.77) such as 4:3 (1.33).

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #1250 