### PR TITLE
Do not translate the "General" external id type

### DIFF
--- a/src/components/itemidentifier/itemidentifier.js
+++ b/src/components/itemidentifier/itemidentifier.js
@@ -304,12 +304,12 @@ define(['dialogHelper', 'loading', 'connectionManager', 'require', 'globalize', 
 
                 html += '<div class="inputContainer">';
 
-                var fullName = idInfo.Name;
-                if (idInfo.Type) {
-                    fullName = idInfo.Name + ' ' + globalize.translate(idInfo.Type);
-                }
-
-                var idLabel = globalize.translate('LabelDynamicExternalId', fullName);
+                // Get external Id label text
+                const hasSpecificType = idInfo.Type && idInfo.Type !== 'General';
+                const fullName = hasSpecificType
+                    ? idInfo.Name + ' ' + globalize.translate(idInfo.Type)
+                    : idInfo.Name;
+                const idLabel = globalize.translate('LabelDynamicExternalId', fullName);
 
                 html += '<input is="emby-input" class="txtLookupId" data-providerkey="' + idInfo.Key + '" id="' + id + '" label="' + idLabel + '"/>';
 

--- a/src/components/metadataeditor/metadataeditor.js
+++ b/src/components/metadataeditor/metadataeditor.js
@@ -465,12 +465,12 @@ define(['itemHelper', 'dom', 'layoutManager', 'dialogHelper', 'datetime', 'loadi
             var id = 'txt1' + idInfo.Key;
             var formatString = idInfo.UrlFormatString || '';
 
-            var fullName = idInfo.Name;
-            if (idInfo.Type) {
-                fullName = idInfo.Name + ' ' + globalize.translate(idInfo.Type);
-            }
-
-            var labelText = globalize.translate('LabelDynamicExternalId', fullName);
+            // Get external Id label text
+            const hasSpecificType = idInfo.Type && idInfo.Type !== 'General';
+            const fullName = hasSpecificType
+                ? idInfo.Name + ' ' + globalize.translate(idInfo.Type)
+                : idInfo.Name;
+            const labelText = globalize.translate('LabelDynamicExternalId', fullName);
 
             html += '<div class="inputContainer">';
             html += '<div class="flex align-items-center">';


### PR DESCRIPTION
**Changes**
This accompanies the associated server-side change in https://github.com/jellyfin/jellyfin/pull/3137 that adds a "General" external id type.

The new "General" value is returned instead of null. It does not need to be translated so the translation logic is changed here to ignore that value.