### PR TITLE
Update emby-select.css

### DIFF
--- a/src/elements/emby-select/emby-select.css
+++ b/src/elements/emby-select/emby-select.css
@@ -81,7 +81,7 @@
 }
 
 .trackSelections > .selectContainer {
-    margin: 0.4em 0;
+    margin: 0.4em 0.4em;
 }
 
 .emby-select-withcolor {


### PR DESCRIPTION
**Changes**
Introduce more space on selectionFields.

Before:
![image](https://user-images.githubusercontent.com/135993/82240715-2e78a480-993b-11ea-9e2d-5cffdf08b9db.png)

After:
![image](https://user-images.githubusercontent.com/135993/82240782-47815580-993b-11ea-8ece-80ad0e664ad4.png)

Additionally, I like the left margin because the settings stands out a bit to give them more attention.
What do you think?

**Issues**
The fields should not be sticked together.
