### PR TITLE
Toggle off uPnP Port Forwarding as Default for Startup Wizard

### DIFF
--- a/src/wizardremoteaccess.html
+++ b/src/wizardremoteaccess.html
@@ -13,7 +13,7 @@
                 </div>
                 <div class="checkboxContainer checkboxContainer-withDescription">
                     <label>
-                        <input type="checkbox" is="emby-checkbox" id="chkEnableUpnp" checked />
+                        <input type="checkbox" is="emby-checkbox" id="chkEnableUpnp" />
                         <span>${LabelEnableAutomaticPortMap}</span>
                     </label>
                     <div class="fieldDescription checkboxFieldDescription">${LabelEnableAutomaticPortMapHelp}</div>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
uPnP port forwarding is a security nightmare. If you're exposing your server to the internet, you should be using a reverse proxy, not upnp.
**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
