### PR TITLE
Change FreeBSD-related wording.

### DIFF
--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -989,7 +989,7 @@
     "MessageContactAdminToResetPassword": "Please contact your system administrator to reset your password.",
     "MessageCreateAccountAt": "Create an account at {0}",
     "MessageDeleteTaskTrigger": "Are you sure you wish to delete this task trigger?",
-    "MessageDirectoryPickerBSDInstruction": "For BSD, you may need to configure storage within your FreeNAS Jail in order to allow Jellyfin to access it.",
+    "MessageDirectoryPickerBSDInstruction": "For FreeBSD or FreeNAS, you may need to configure storage using a jail in order to allow Jellyfin to access it.",
     "MessageDirectoryPickerInstruction": "Network paths can be entered manually in the event the Network button fails to locate your devices. For example, {0} or {1}.",
     "MessageDirectoryPickerLinuxInstruction": "For Linux on Arch Linux, CentOS, Debian, Fedora, openSUSE, or Ubuntu, you must grant the service user at least read access to your storage locations.",
     "MessageDownloadQueued": "Download queued.",


### PR DESCRIPTION
Changed wording related to FreeBSD-based systems describing one way of troubleshooting Jellyfin access.

Fixes #1268. 
