### PR TITLE
Make DVR heading translatable.

### DIFF
--- a/src/livetvsettings.html
+++ b/src/livetvsettings.html
@@ -3,7 +3,7 @@
         <div class="content-primary">
             <div class="verticalSection">
                 <div class="sectionTitleContainer flex align-items-center">
-                    <h2 class="sectionTitle">DVR</h2>
+                    <h2 class="sectionTitle">${HeaderDVR}</h2>
                     <a is="emby-linkbutton" rel="noopener noreferrer" class="raised button-alt headerHelpButton" target="_blank" href="https://docs.jellyfin.org/general/server/live-tv/index.html">${Help}</a>
                 </div>
             </div>

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -989,7 +989,7 @@
     "MessageContactAdminToResetPassword": "Please contact your system administrator to reset your password.",
     "MessageCreateAccountAt": "Create an account at {0}",
     "MessageDeleteTaskTrigger": "Are you sure you wish to delete this task trigger?",
-    "MessageDirectoryPickerBSDInstruction": "For BSD, you may need to configure storage within your FreeNAS Jail in order to allow Jellyfin to access it.",
+    "MessageDirectoryPickerBSDInstruction": "For FreeBSD or FreeNAS, you may need to configure storage using a jail in order to allow Jellyfin to access it.",
     "MessageDirectoryPickerInstruction": "Network paths can be entered manually in the event the Network button fails to locate your devices. For example, {0} or {1}.",
     "MessageDirectoryPickerLinuxInstruction": "For Linux on Arch Linux, CentOS, Debian, Fedora, openSUSE, or Ubuntu, you must grant the service user at least read access to your storage locations.",
     "MessageDownloadQueued": "Download queued.",

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -989,7 +989,7 @@
     "MessageContactAdminToResetPassword": "Please contact your system administrator to reset your password.",
     "MessageCreateAccountAt": "Create an account at {0}",
     "MessageDeleteTaskTrigger": "Are you sure you wish to delete this task trigger?",
-    "MessageDirectoryPickerBSDInstruction": "For FreeBSD or FreeNAS, you may need to configure storage using a jail in order to allow Jellyfin to access it.",
+    "MessageDirectoryPickerBSDInstruction": "For BSD, you may need to configure storage within your FreeNAS Jail in order to allow Jellyfin to access it.",
     "MessageDirectoryPickerInstruction": "Network paths can be entered manually in the event the Network button fails to locate your devices. For example, {0} or {1}.",
     "MessageDirectoryPickerLinuxInstruction": "For Linux on Arch Linux, CentOS, Debian, Fedora, openSUSE, or Ubuntu, you must grant the service user at least read access to your storage locations.",
     "MessageDownloadQueued": "Download queued.",


### PR DESCRIPTION
The heading of the DVR section was hard-coded and couldn't be translated.

Fixes #1270. 
