### PR TITLE
Fix dependency loop

### DIFF
--- a/src/components/appRouter.js
+++ b/src/components/appRouter.js
@@ -1,4 +1,4 @@
-define(['loading', 'globalize', 'events', 'viewManager', 'layoutManager', 'skinManager', 'pluginManager', 'backdrop', 'browser', 'page', 'appSettings', 'apphost', 'connectionManager'], function (loading, globalize, events, viewManager, layoutManager, skinManager, pluginManager, backdrop, browser, page, appSettings, appHost, connectionManager) {
+define(['loading', 'globalize', 'events', 'viewManager', 'skinManager', 'backdrop', 'browser', 'page', 'appSettings', 'apphost', 'connectionManager'], function (loading, globalize, events, viewManager, skinManager, backdrop, browser, page, appSettings, appHost, connectionManager) {
     'use strict';
 
     var appRouter = {

--- a/src/components/pluginManager.js
+++ b/src/components/pluginManager.js
@@ -1,4 +1,4 @@
-define(['events', 'globalize', 'appRouter'], function (events, globalize, appRouter) {
+define(['events', 'globalize'], function (events, globalize) {
     'use strict';
 
     // TODO: replace with each plugin version
@@ -70,14 +70,6 @@ define(['events', 'globalize', 'appRouter'], function (events, globalize, appRou
                     }
 
                     plugin.installUrl = pluginSpec;
-
-                    var urlLower = pluginSpec.toLowerCase();
-                    if (urlLower.indexOf('http:') === -1 && urlLower.indexOf('https:') === -1 && urlLower.indexOf('file:') === -1) {
-                        if (pluginSpec.indexOf(appRouter.baseUrl()) !== 0) {
-
-                            pluginSpec = appRouter.baseUrl() + '/' + pluginSpec;
-                        }
-                    }
 
                     var separatorIndex = Math.max(pluginSpec.lastIndexOf('/'), pluginSpec.lastIndexOf('\\'));
                     plugin.baseUrl = pluginSpec.substring(0, separatorIndex);

--- a/src/components/skinManager.js
+++ b/src/components/skinManager.js
@@ -1,4 +1,4 @@
-define(['apphost', 'userSettings', 'browser', 'events', 'pluginManager', 'backdrop', 'globalize', 'require', 'appSettings'], function (appHost, userSettings, browser, events, pluginManager, backdrop, globalize, require, appSettings) {
+define(['apphost', 'userSettings', 'browser', 'events', 'backdrop', 'globalize', 'require', 'appSettings'], function (appHost, userSettings, browser, events, backdrop, globalize, require, appSettings) {
     'use strict';
 
     var themeStyleElement;


### PR DESCRIPTION
We have dependency loop: `appRouter` ... - `pluginManager` - `appRouter`.
It seems that `requirejs` somehow handles `baseUrl`, because on Network tab I see valid URLs even with server baseurl (my testserver has such). Perhaps this is the merit of browser.
**Maybe I missed something**

**Changes**
- Remove `appRouter` from `pluginManager` dependencies.
- Remove prepending of `baseUrl` - in fact, web base URL: `http://server/baseurl/web`
- Remove some unused dependency.

**Issues**
```
Uncaught (in promise) TypeError: Cannot read property 'isPlayingLocally' of undefined
    at onRotationInterval (backdrop.js:278)
    at startRotation (backdrop.js:274)
    at Object.setBackdrops (backdrop.js:253)
    at autoBackdrops.js:48
```

Unfortunately, CORS errors still exist when `yarn serve`.