### PR TITLE
Make the share url link to the actual item instead of github

### DIFF
--- a/src/components/itemContextMenu.js
+++ b/src/components/itemContextMenu.js
@@ -450,7 +450,7 @@ define(['apphost', 'globalize', 'connectionManager', 'itemHelper', 'appRouter', 
                     navigator.share({
                         title: item.Name,
                         text: item.Overview,
-                        url: 'https://github.com/jellyfin/jellyfin'
+                        url: `${apiClient.serverAddress()}/web/index.html#!/${appRouter.getRouteUrl(item)}`
                     });
                     break;
                 case 'album':


### PR DESCRIPTION
**Changes**
Sharing a link to Jellyfin's GitHub when sharing an item makes absolutely no sense. This changes it to link to the webpage for the item being shared. This assumes the web interface is available on the api server, which is probably safe for now. I didn't see a good way of handling it otherwise.

**Issues**
N/A
