### PR TITLE
Support for faster playback rates.

### DIFF
--- a/src/components/htmlVideoPlayer/plugin.js
+++ b/src/components/htmlVideoPlayer/plugin.js
@@ -996,6 +996,7 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
             customTrackIndex = -1;
             currentClock = null;
             self._currentAspectRatio = null;
+            self._currentPlaybackRate = null;
 
             var octopus = currentSubtitlesOctopus;
             if (octopus) {
@@ -1438,6 +1439,7 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
 
         list.push('SetBrightness');
         list.push('SetAspectRatio');
+        list.push('SetPlaybackRate');
 
         return list;
     }
@@ -1719,6 +1721,43 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
         }, {
             name: 'Fill',
             id: 'fill'
+        }];
+    };
+
+    HtmlVideoPlayer.prototype.setPlaybackRate = function (val) {
+        var mediaElement = this._mediaElement;
+        if (mediaElement) {
+            mediaElement.playbackRate = val;
+        }
+        this._currentPlaybackRate = val;
+    };
+
+    HtmlVideoPlayer.prototype.getPlaybackRate = function () {
+        return this._currentPlaybackRate || 1.0;
+    };
+
+    HtmlVideoPlayer.prototype.getSupportedPlaybackRates = function () {
+        return [{
+            name: '0.5x',
+            id: 0.5
+        }, {
+            name: '0.75x',
+            id: 0.75
+        }, {
+            name: '1x',
+            id: 1.0
+        }, {
+            name: '1.25x',
+            id: 1.25
+        }, {
+            name: '1.5x',
+            id: 1.5
+        }, {
+            name: '1.75x',
+            id: 1.75
+        }, {
+            name: '2x',
+            id: 2.0
         }];
     };
 

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -1208,6 +1208,66 @@ define(['events', 'datetime', 'appSettings', 'itemHelper', 'pluginManager', 'pla
             }
         };
 
+        self.increasePlaybackRate = function (player) {
+            player = player || self._currentPlayer;
+            if (player) {
+                var current = self.getPlaybackRate(player);
+                var supported = self.getSupportedPlaybackRates(player);
+
+                var index = -1;
+                for (var i = 0, length = supported.length; i < length; i++) {
+                    if (supported[i].id === current) {
+                        index = i;
+                        break;
+                    }
+                }
+
+                index = Math.min(index + 1, supported.length - 1);
+                self.setPlaybackRate(supported[index].id, player);
+            }
+        };
+
+        self.decreasePlaybackRate = function (player) {
+            player = player || self._currentPlayer;
+            if (player) {
+                var current = self.getPlaybackRate(player);
+                var supported = self.getSupportedPlaybackRates(player);
+
+                var index = -1;
+                for (var i = 0, length = supported.length; i < length; i++) {
+                    if (supported[i].id === current) {
+                        index = i;
+                        break;
+                    }
+                }
+
+                index = Math.max(index - 1, 0);
+                self.setPlaybackRate(supported[index].id, player);
+            }
+        };
+
+        self.setPlaybackRate = function (val, player) {
+            player = player || self._currentPlayer;
+            if (player && player.setPlaybackRate) {
+                player.setPlaybackRate(val);
+            }
+        };
+
+        self.getSupportedPlaybackRates = function (player) {
+            player = player || self._currentPlayer;
+            if (player && player.getSupportedPlaybackRates) {
+                return player.getSupportedPlaybackRates();
+            }
+            return [];
+        };
+
+        self.getPlaybackRate = function (player) {
+            player = player || self._currentPlayer;
+            if (player && player.getPlaybackRate) {
+                return player.getPlaybackRate();
+            }
+        };
+
         var brightnessOsdLoaded;
         self.setBrightness = function (val, player) {
 
@@ -3885,6 +3945,9 @@ define(['events', 'datetime', 'appSettings', 'itemHelper', 'pluginManager', 'pla
                 if (player.supports('SetAspectRatio')) {
                     list.push('SetAspectRatio');
                 }
+                if (player.supports('SetPlaybackRate')) {
+                    list.push('SetPlaybackRate');
+                }
             }
 
             return list;
@@ -4003,6 +4066,9 @@ define(['events', 'datetime', 'appSettings', 'itemHelper', 'pluginManager', 'pla
                 break;
             case 'SetAspectRatio':
                 this.setAspectRatio(cmd.Arguments.AspectRatio, player);
+                break;
+            case 'SetPlaybackRate':
+                this.setPlaybackRate(cmd.Arguments.PlaybackRate, player);
                 break;
             case 'SetBrightness':
                 this.setBrightness(cmd.Arguments.Brightness, player);

--- a/src/components/playback/playersettingsmenu.js
+++ b/src/components/playback/playersettingsmenu.js
@@ -163,6 +163,30 @@ define(['connectionManager', 'actionsheet', 'datetime', 'playbackManager', 'glob
         });
     }
 
+    function showPlaybackRateMenu(player, btn) {
+        // each has a name and id
+        var currentId = playbackManager.getPlaybackRate(player);
+        var menuItems = playbackManager.getSupportedPlaybackRates(player).map(function (i) {
+            return {
+                id: i.id,
+                name: i.name,
+                selected: i.id === currentId
+            };
+        });
+
+        return actionsheet.show({
+            items: menuItems,
+            positionTo: btn
+        }).then(function (id) {
+            if (id) {
+                playbackManager.setPlaybackRate(id, player);
+                return Promise.resolve();
+            }
+
+            return Promise.reject();
+        });
+    }
+
     function showWithUser(options, player, user) {
         var supportedCommands = playbackManager.getSupportedCommands(player);
         var mediaType = options.mediaType;
@@ -178,6 +202,19 @@ define(['connectionManager', 'actionsheet', 'datetime', 'playbackManager', 'glob
                 name: globalize.translate('AspectRatio'),
                 id: 'aspectratio',
                 asideText: currentAspectRatio ? currentAspectRatio.name : null
+            });
+        }
+
+        if (supportedCommands.indexOf('SetPlaybackRate') !== -1) {
+            var currentPlaybackRateId = playbackManager.getPlaybackRate(player);
+            var currentPlaybackRate = playbackManager.getSupportedPlaybackRates(player).filter(function (i) {
+                return i.id === currentPlaybackRateId;
+            })[0];
+
+            menuItems.push({
+                name: globalize.translate('PlaybackRate'),
+                id: 'playbackrate',
+                asideText: currentPlaybackRate ? currentPlaybackRate.name : null
             });
         }
 
@@ -245,6 +282,8 @@ define(['connectionManager', 'actionsheet', 'datetime', 'playbackManager', 'glob
                 return showQualityMenu(player, options.positionTo);
             case 'aspectratio':
                 return showAspectRatioMenu(player, options.positionTo);
+            case 'playbackrate':
+                return showPlaybackRateMenu(player, options.positionTo);
             case 'repeatmode':
                 return showRepeatModeMenu(player, options.positionTo);
             case 'stats':

--- a/src/controllers/playback/videoosd.js
+++ b/src/controllers/playback/videoosd.js
@@ -1191,6 +1191,12 @@ define(['playbackManager', 'dom', 'inputManager', 'datetime', 'itemHelper', 'med
                     var percent = parseInt(key, 10) * 10;
                     playbackManager.seekPercent(percent, currentPlayer);
                     break;
+                case '>':
+                    playbackManager.increasePlaybackRate(currentPlayer);
+                    break;
+                case '<':
+                    playbackManager.decreasePlaybackRate(currentPlayer);
+                    break;
             }
         }
 

--- a/src/scripts/inputManager.js
+++ b/src/scripts/inputManager.js
@@ -183,6 +183,12 @@ import appHost from 'apphost';
             'changezoom': () => {
                 playbackManager.toggleAspectRatio();
             },
+            'increaseplaybackrate': () => {
+                playbackManager.increasePlaybackRate();
+            },
+            'decreaseplaybackrate': () => {
+                playbackManager.decreasePlaybackRate();
+            },
             'changeaudiotrack': () => {
                 playbackManager.changeAudioStream();
             },

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1248,6 +1248,7 @@
     "Play": "Play",
     "PlayAllFromHere": "Play all from here",
     "PlaybackData": "Playback Data",
+    "PlaybackRate": "Playback Rate",
     "PlayCount": "Play count",
     "PlayFromBeginning": "Play from beginning",
     "PlayNext": "Play next",


### PR DESCRIPTION
The HTML5 video element already has a well-supported "playbackRate" attribute
which can be used to increase playback rate.  This change wires up that control
to be displayed in the Jellyfish web player.

The playback rates offered are between 1x and 2x in 0.25x increments, which
matches the YouTube player.  This change also wires up the ">" and "<" key
events to increase and decrease the playback rate, which mirrors the keyboard
shortcuts supported by YouTube.