### PR TITLE
Support restarting the server on all platforms

### DIFF
--- a/src/controllers/dashboard/dashboard.js
+++ b/src/controllers/dashboard/dashboard.js
@@ -179,12 +179,6 @@ define(['datetime', 'events', 'itemHelper', 'serverNotifications', 'dom', 'globa
             view.querySelector('#operatingSystem').innerHTML = globalize.translate('DashboardOperatingSystem', systemInfo.OperatingSystem);
             view.querySelector('#architecture').innerHTML = globalize.translate('DashboardArchitecture', systemInfo.SystemArchitecture);
 
-            if (systemInfo.CanSelfRestart) {
-                view.querySelector('#btnRestartServer').classList.remove('hide');
-            } else {
-                view.querySelector('#btnRestartServer').classList.add('hide');
-            }
-
             view.querySelector('#cachePath').innerHTML = systemInfo.CachePath;
             view.querySelector('#logPath').innerHTML = systemInfo.LogPath;
             view.querySelector('#transcodePath').innerHTML = systemInfo.TranscodingTempPath;

--- a/src/controllers/dashboard/general.js
+++ b/src/controllers/dashboard/general.js
@@ -18,11 +18,6 @@ define(['jQuery', 'loading', 'globalize', 'fnchecked', 'emby-checkbox', 'emby-te
             return '<option value="' + language.Value + '">' + language.Name + '</option>';
         })).val(config.UICulture);
         currentLanguage = config.UICulture;
-        if (systemInfo.CanSelfRestart || systemInfo.CanSelfUpdate) {
-            $('.autoUpdatesContainer', page).removeClass('hide');
-        } else {
-            $('.autoUpdatesContainer', page).addClass('hide');
-        }
 
         loading.hide();
     }

--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -16,7 +16,7 @@
                     </div>
 
                     <div style="margin-top:1em;">
-                        <button is="emby-button" type="button" id="btnRestartServer" class="raised hide" onclick="DashboardPage.restart(this);" style="margin-left:0;">
+                        <button is="emby-button" type="button" id="btnRestartServer" class="raised" onclick="DashboardPage.restart(this);" style="margin-left:0;">
                             <span>${ButtonRestart}</span>
                         </button>
                         <button is="emby-button" type="button" id="btnShutdown" class="raised" onclick="DashboardPage.shutdown(this);">


### PR DESCRIPTION
**Changes**
Remove logic to check if server restart is supported and always display the restart button in the dashboard.

This change goes along with the server PR https://github.com/jellyfin/jellyfin/pull/3171, that changes the restart functionality to be cross-platform and removes `CanSelfRestart` property
