### PR TITLE
Include explicit yarn version

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Jellyfin Web is the frontend used for most of the clients available for end user
 
 ### Dependencies
 
-- Yarn
+- [Yarn 1.22.4](https://classic.yarnpkg.com/en/docs/install)
 - Gulp-cli
 
 ### Getting Started


### PR DESCRIPTION
**Changes**
To avoid confusion for new contributors, specify an explicit version of Yarn and link to classic install docs.