### PR TITLE
Transfer whole playlist when transferring playback

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
           "src/components/images/imageLoader.js",
           "src/components/lazyLoader/lazyLoaderIntersectionObserver.js",
           "src/components/playback/mediasession.js",
+          "src/components/playback/remotecontrolautoplay.js",
           "src/components/sanatizefilename.js",
           "src/components/scrollManager.js",
           "src/scripts/dfnshelper.js",

--- a/src/components/playback/remotecontrolautoplay.js
+++ b/src/components/playback/remotecontrolautoplay.js
@@ -1,47 +1,45 @@
-define(['events', 'playbackManager'], function (events, playbackManager) {
-    'use strict';
+import events from 'events';
+import playbackManager from 'playbackManager';
 
-    function transferPlayback(oldPlayer, newPlayer) {
+function transferPlayback(oldPlayer, newPlayer) {
+    const state = playbackManager.getPlayerState(oldPlayer);
+    const item = state.NowPlayingItem;
 
-        var state = playbackManager.getPlayerState(oldPlayer);
-
-        var item = state.NowPlayingItem;
-
-        if (!item) {
-            return;
-        }
-
-        var playState = state.PlayState || {};
-        var resumePositionTicks = playState.PositionTicks || 0;
-
-        playbackManager.stop(oldPlayer).then(function () {
-
-            playbackManager.play({
-                ids: [item.Id],
-                serverId: item.ServerId,
-                startPositionTicks: resumePositionTicks
-
-            }, newPlayer);
-        });
+    if (!item) {
+        return;
     }
 
-    events.on(playbackManager, 'playerchange', function (e, newPlayer, newTarget, oldPlayer) {
+    const playlist = playbackManager.getPlaylist(oldPlayer).then(playlist => {
+        const playlistIds = playlist.map(x => x.Id);
+        const playState = state.PlayState || {};
+        const resumePositionTicks = playState.PositionTicks || 0;
+        const playlistIndex = playlistIds.indexOf(item.Id) || 0;
 
-        if (!oldPlayer || !newPlayer) {
-            return;
-        }
-
-        if (!oldPlayer.isLocalPlayer) {
-            console.debug('Skipping remote control autoplay because oldPlayer is not a local player');
-            return;
-        }
-
-        if (newPlayer.isLocalPlayer) {
-            console.debug('Skipping remote control autoplay because newPlayer is a local player');
-            return;
-        }
-
-        transferPlayback(oldPlayer, newPlayer);
+        playbackManager.stop(oldPlayer).then(() => {
+            playbackManager.play({
+                ids: playlistIds,
+                serverId: item.ServerId,
+                startPositionTicks: resumePositionTicks,
+                startIndex: playlistIndex
+            }, newPlayer);
+        });
     });
+}
 
+events.on(playbackManager, 'playerchange', (e, newPlayer, newTarget, oldPlayer) => {
+    if (!oldPlayer || !newPlayer) {
+        return;
+    }
+
+    if (!oldPlayer.isLocalPlayer) {
+        console.debug('Skipping remote control autoplay because oldPlayer is not a local player');
+        return;
+    }
+
+    if (newPlayer.isLocalPlayer) {
+        console.debug('Skipping remote control autoplay because newPlayer is a local player');
+        return;
+    }
+
+    transferPlayback(oldPlayer, newPlayer);
 });

--- a/src/components/playback/remotecontrolautoplay.js
+++ b/src/components/playback/remotecontrolautoplay.js
@@ -9,7 +9,7 @@ function transferPlayback(oldPlayer, newPlayer) {
         return;
     }
 
-    const playlist = playbackManager.getPlaylist(oldPlayer).then(playlist => {
+    playbackManager.getPlaylist(oldPlayer).then(playlist => {
         const playlistIds = playlist.map(x => x.Id);
         const playState = state.PlayState || {};
         const resumePositionTicks = playState.PositionTicks || 0;


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

Rebased changes on a separate branch, hence the new PR.

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

When casting to another player, I feel like it makes sense to transfer the entire playlist and not just the currently played item. This particularly makes sense for music playback.

I took the opportunity to port the modified file to ES6.
**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
#1290 