### PR TITLE
Enable babel for date-fns

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -15,7 +15,7 @@ module.exports = merge(common, {
         rules: [
             {
                 test: /\.js$/,
-                exclude: /node_modules[\\/](?!jellyfin-apiclient|query-string|split-on-first|strict-uri-encode)/,
+                exclude: /node_modules[\\/](?!date-fns|jellyfin-apiclient|query-string|split-on-first|strict-uri-encode)/,
                 use: {
                     loader: 'babel-loader',
                     options: {

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -8,7 +8,7 @@ module.exports = merge(common, {
         rules: [
             {
                 test: /\.js$/,
-                exclude: /node_modules[\\/](?!jellyfin-apiclient|query-string|split-on-first|strict-uri-encode)/,
+                exclude: /node_modules[\\/](?!date-fns|jellyfin-apiclient|query-string|split-on-first|strict-uri-encode)/,
                 use: {
                     loader: 'babel-loader',
                     options: {


### PR DESCRIPTION
WebOS 1.2 and 2.0 fail on `[-1]: ...` after upgrading `date-fns` #1299
https://github.com/date-fns/date-fns/blob/81ab18785146405ca2ae28710cdfbb13a294ec50/src/locale/hu/_lib/formatDistance/index.js#L21

**Changes**
Enable babel for `date-fns`.
