### PR TITLE
Fix Page jumps when entering custom css

### DIFF
--- a/src/dashboardgeneral.html
+++ b/src/dashboardgeneral.html
@@ -62,7 +62,7 @@
                         <input is="emby-input" type="text" id="txtLoginDisclaimer" label="${LabelLoginDisclaimer}" />
                         <div class="fieldDescription">${LabelLoginDisclaimerHelp}</div>
                     </div>
-                    <div class="inputContainer">
+                    <div class="inputContainer customCSS">
                         <textarea is="emby-textarea" id="txtCustomCss" label="${LabelCustomCss}" class="textarea-mono"></textarea>
                         <div class="fieldDescription">${LabelCustomCssHelp}</div>
                     </div>

--- a/src/dashboardgeneral.html
+++ b/src/dashboardgeneral.html
@@ -62,7 +62,7 @@
                         <input is="emby-input" type="text" id="txtLoginDisclaimer" label="${LabelLoginDisclaimer}" />
                         <div class="fieldDescription">${LabelLoginDisclaimerHelp}</div>
                     </div>
-                    <div class="inputContainer customCSS">
+                    <div class="inputContainer customCssContainer">
                         <textarea is="emby-textarea" id="txtCustomCss" label="${LabelCustomCss}" class="textarea-mono"></textarea>
                         <div class="fieldDescription">${LabelCustomCssHelp}</div>
                     </div>

--- a/src/elements/emby-textarea/emby-textarea.js
+++ b/src/elements/emby-textarea/emby-textarea.js
@@ -55,6 +55,7 @@ define(['layoutManager', 'browser', 'css!./emby-textarea', 'registerElement', 'e
                 newHeight = textarea.scrollHeight/* - offset*/;
                 hasGrown = true;
             }
+            $('.customCSS1').css("height",newHeight + 'px');
             textarea.style.height = newHeight + 'px';
         }
 

--- a/src/elements/emby-textarea/emby-textarea.js
+++ b/src/elements/emby-textarea/emby-textarea.js
@@ -55,7 +55,7 @@ define(['layoutManager', 'browser', 'css!./emby-textarea', 'registerElement', 'e
                 newHeight = textarea.scrollHeight/* - offset*/;
                 hasGrown = true;
             }
-            $('.customCSS1').css("height",newHeight + 'px');
+            $('.customCSS').css("height",newHeight + 'px');
             textarea.style.height = newHeight + 'px';
         }
 

--- a/src/elements/emby-textarea/emby-textarea.js
+++ b/src/elements/emby-textarea/emby-textarea.js
@@ -55,7 +55,7 @@ define(['layoutManager', 'browser', 'css!./emby-textarea', 'registerElement', 'e
                 newHeight = textarea.scrollHeight/* - offset*/;
                 hasGrown = true;
             }
-            $('.customCssContainer').css("height",newHeight + 'px');
+            $('.customCssContainer').css("height", newHeight + 'px');
             textarea.style.height = newHeight + 'px';
         }
 

--- a/src/elements/emby-textarea/emby-textarea.js
+++ b/src/elements/emby-textarea/emby-textarea.js
@@ -55,7 +55,7 @@ define(['layoutManager', 'browser', 'css!./emby-textarea', 'registerElement', 'e
                 newHeight = textarea.scrollHeight/* - offset*/;
                 hasGrown = true;
             }
-            $('.customCSS').css("height",newHeight + 'px');
+            $('.customCssContainer').css("height",newHeight + 'px');
             textarea.style.height = newHeight + 'px';
         }
 


### PR DESCRIPTION
Fix Selecting the custom css field causes the page to jump to an earlier position of the page.

**Changes**

- Added class to div
- JS updates div height as well as text-area height 

**Issues**
Fixes Page jumps when entering custom css  jellyfin/jellyfin-web#1318
