### PR TITLE
Remove non-standalone mode

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -21,8 +21,6 @@ jobs:
         BuildConfiguration: development
       Production:
         BuildConfiguration: production
-      Standalone:
-        BuildConfiguration: standalone
 
   pool:
     vmImage: 'ubuntu-latest'
@@ -51,10 +49,6 @@ jobs:
   - script: 'yarn build:production'
     displayName: 'Build Bundle'
     condition: eq(variables['BuildConfiguration'], 'production')
-
-  - script: 'yarn build:standalone'
-    displayName: 'Build Standalone'
-    condition: eq(variables['BuildConfiguration'], 'standalone')
 
   - script: 'test -d dist'
     displayName: 'Check Build'

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -47,7 +47,7 @@ jobs:
     condition: eq(variables['BuildConfiguration'], 'development')
 
   - script: 'yarn build:production'
-    displayName: 'Build Bundle'
+    displayName: 'Build Production'
     condition: eq(variables['BuildConfiguration'], 'production')
 
   - script: 'test -d dist'

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,30 +27,30 @@ module.exports = {
         'plugin:compat/recommended'
     ],
     rules: {
-        'block-spacing': ["error"],
-        'brace-style': ["error"],
-        'comma-dangle': ["error", "never"],
-        'comma-spacing': ["error"],
-        'eol-last': ["error"],
-        'indent': ["error", 4, { "SwitchCase": 1 }],
-        'keyword-spacing': ["error"],
-        'max-statements-per-line': ["error"],
-        'no-floating-decimal': ["error"],
-        'no-multi-spaces': ["error"],
-        'no-multiple-empty-lines': ["error", { "max": 1 }],
-        'no-trailing-spaces': ["error"],
-        'one-var': ["error", "never"],
-        'quotes': ["error", "single", { "avoidEscape": true, "allowTemplateLiterals": false }],
-        'semi': ["error"],
-        'space-before-blocks': ["error"],
-        "space-infix-ops": "error"
+        'block-spacing': ['error'],
+        'brace-style': ['error'],
+        'comma-dangle': ['error', 'never'],
+        'comma-spacing': ['error'],
+        'eol-last': ['error'],
+        'indent': ['error', 4, { 'SwitchCase': 1 }],
+        'keyword-spacing': ['error'],
+        'max-statements-per-line': ['error'],
+        'no-floating-decimal': ['error'],
+        'no-multi-spaces': ['error'],
+        'no-multiple-empty-lines': ['error', { 'max': 1 }],
+        'no-trailing-spaces': ['error'],
+        'one-var': ['error', 'never'],
+        'quotes': ['error', 'single', { 'avoidEscape': true, 'allowTemplateLiterals': false }],
+        'semi': ['error'],
+        'space-before-blocks': ['error'],
+        'space-infix-ops': 'error'
     },
     overrides: [
         {
             files: [
                 './src/**/*.js'
             ],
-            parser: "babel-eslint",
+            parser: 'babel-eslint',
             env: {
                 node: false,
                 amd: true,
@@ -98,11 +98,11 @@ module.exports = {
             },
             rules: {
                 // TODO: Fix warnings and remove these rules
-                'no-redeclare': ["warn"],
-                'no-unused-vars': ["warn"],
-                'no-useless-escape': ["warn"],
+                'no-redeclare': ['warn'],
+                'no-unused-vars': ['warn'],
+                'no-useless-escape': ['warn'],
                 // TODO: Remove after ES6 migration is complete
-                'import/no-unresolved': ["off"]
+                'import/no-unresolved': ['off']
             },
             settings: {
                 polyfills: [

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -67,7 +67,7 @@ function serve() {
         }
     });
 
-    watch(options.apploader.query, apploader(true));
+    watch(options.apploader.query, apploader());
 
     watch('src/bundle.js', webpack);
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,7 +16,6 @@ const stream = require('webpack-stream');
 const inject = require('gulp-inject');
 const postcss = require('gulp-postcss');
 const sass = require('gulp-sass');
-const gulpif = require('gulp-if');
 const lazypipe = require('lazypipe');
 
 sass.compiler = require('node-sass');
@@ -131,18 +130,12 @@ function javascript(query) {
         .pipe(browserSync.stream());
 }
 
-function apploader(standalone) {
-    function task() {
-        return src(options.apploader.query, { base: './src/' })
-            .pipe(gulpif(standalone, concat('scripts/apploader.js')))
-            .pipe(pipelineJavascript())
-            .pipe(dest('dist/'))
-            .pipe(browserSync.stream());
-    }
-
-    task.displayName = 'apploader';
-
-    return task;
+function apploader() {
+    return src(options.apploader.query, { base: './src/' })
+        .pipe(concat('scripts/apploader.js'))
+        .pipe(pipelineJavascript())
+        .pipe(dest('dist/'))
+        .pipe(browserSync.stream());
 }
 
 function webpack() {
@@ -181,12 +174,6 @@ function copy(query) {
         .pipe(browserSync.stream());
 }
 
-function copyIndex() {
-    return src(options.injectBundle.query, { base: './src/' })
-        .pipe(dest('dist/'))
-        .pipe(browserSync.stream());
-}
-
 function injectBundle() {
     return src(options.injectBundle.query, { base: './src/' })
         .pipe(inject(
@@ -196,10 +183,5 @@ function injectBundle() {
         .pipe(browserSync.stream());
 }
 
-function build(standalone) {
-    return series(clean, parallel(javascript, apploader(standalone), webpack, css, html, images, copy));
-}
-
-exports.default = series(build(false), copyIndex);
-exports.standalone = series(build(true), injectBundle);
-exports.serve = series(exports.standalone, serve);
+exports.default = series(clean, parallel(javascript, apploader, webpack, css, html, images, copy), injectBundle);
+exports.serve = series(exports.default, serve);

--- a/package.json
+++ b/package.json
@@ -146,7 +146,6 @@
     "prepare": "gulp --production",
     "build:development": "gulp --development",
     "build:production": "gulp --production",
-    "build:standalone": "gulp standalone --development",
     "lint": "eslint \".\"",
     "stylelint": "stylelint \"src/**/*.css\""
   }

--- a/src/elements/emby-textarea/emby-textarea.js
+++ b/src/elements/emby-textarea/emby-textarea.js
@@ -55,7 +55,7 @@ define(['layoutManager', 'browser', 'css!./emby-textarea', 'registerElement', 'e
                 newHeight = textarea.scrollHeight/* - offset*/;
                 hasGrown = true;
             }
-            $('.customCssContainer').css("height", newHeight + 'px');
+            $('.customCssContainer').css('height', newHeight + 'px');
             textarea.style.height = newHeight + 'px';
         }
 


### PR DESCRIPTION
**Changes**

Following the changes to https://github.com/jellyfin/jellyfin/pull/2966, this removes the bundled mode and sets standalone as the only build target.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
