### PR TITLE
Change Default for OptionAutomaticallyGroupSeries

### DIFF
--- a/src/components/libraryoptionseditor/libraryoptionseditor.template.html
+++ b/src/components/libraryoptionseditor/libraryoptionseditor.template.html
@@ -79,7 +79,7 @@
 
 <div class="checkboxContainer checkboxContainer-withDescription chkAutomaticallyGroupSeriesContainer hide advanced">
     <label>
-        <input type="checkbox" is="emby-checkbox" class="chkAutomaticallyGroupSeries" checked />
+        <input type="checkbox" is="emby-checkbox" class="chkAutomaticallyGroupSeries" />
         <span>${OptionAutomaticallyGroupSeries}</span>
     </label>
     <div class="fieldDescription checkboxFieldDescription">${OptionAutomaticallyGroupSeriesHelp}</div>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Currently Jellyfin cannot break apart two TV series once they are merged. 
https://github.com/jellyfin/jellyfin/issues/2441#issuecomment-637750030
Turning off the default for this, it's hidden by the advanced settings tab.
**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
