### PR TITLE
Babel epubjs (WebOS 1.2)

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -15,7 +15,7 @@ module.exports = merge(common, {
         rules: [
             {
                 test: /\.js$/,
-                exclude: /node_modules[\\/](?!date-fns|jellyfin-apiclient|query-string|split-on-first|strict-uri-encode)/,
+                exclude: /node_modules[\\/](?!date-fns|epubjs|jellyfin-apiclient|query-string|split-on-first|strict-uri-encode)/,
                 use: {
                     loader: 'babel-loader',
                     options: {

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -8,7 +8,7 @@ module.exports = merge(common, {
         rules: [
             {
                 test: /\.js$/,
-                exclude: /node_modules[\\/](?!date-fns|jellyfin-apiclient|query-string|split-on-first|strict-uri-encode)/,
+                exclude: /node_modules[\\/](?!date-fns|epubjs|jellyfin-apiclient|query-string|split-on-first|strict-uri-encode)/,
                 use: {
                     loader: 'babel-loader',
                     options: {


### PR DESCRIPTION
**Changes**
Enable babel for `epubjs`

**Issues**
WebOS 1.2 fails on `class` keyword.
