### PR TITLE
Fixing Chrome's Unnecessary AV1 Transcode and Combined WebM Profiles

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -176,6 +176,16 @@ define(['browser'], function (browser) {
         return false;
     }
 
+    function testCanPlayAv1(videoTestElement) {
+        if (browser.tizenVersion >= 5.5) {
+            return true;
+        } else if (browser.web0sVersion >= 5 && window.outerHeight >= 2160) {
+            return true;
+        }
+
+        return videoTestElement.canPlayType('video/webm; codecs="av01.0.15M.10"').replace(/no/, '');
+    }
+
     function testCanPlayTs() {
         return browser.tizen || browser.orsay || browser.web0s || browser.edgeUwp;
     }
@@ -317,7 +327,6 @@ define(['browser'], function (browser) {
 
         var canPlayVp8 = videoTestElement.canPlayType('video/webm; codecs="vp8"').replace(/no/, '');
         var canPlayVp9 = videoTestElement.canPlayType('video/webm; codecs="vp9"').replace(/no/, '');
-        var canPlayAv1 = videoTestElement.canPlayType('video/webm; codecs="av1"').replace(/no/, '');
         var webmAudioCodecs = ['vorbis'];
 
         var canPlayMkv = testCanPlayMkv(videoTestElement);
@@ -459,6 +468,7 @@ define(['browser'], function (browser) {
         });
 
         var mp4VideoCodecs = [];
+        var webmVideoCodecs = [];
         var hlsVideoCodecs = [];
 
         if (canPlayH264(videoTestElement)) {
@@ -490,14 +500,30 @@ define(['browser'], function (browser) {
 
         if (canPlayVp8) {
             mp4VideoCodecs.push('vp8');
+            webmVideoCodecs.push('vp8');
         }
 
         if (canPlayVp9) {
             mp4VideoCodecs.push('vp9');
+            webmVideoCodecs.push('vp9');
+        }
+
+        if (testCanPlayAv1(videoTestElement)) {
+            mp4VideoCodecs.push('av1');
+            webmVideoCodecs.push('av1');
         }
 
         if (canPlayVp8 || browser.tizen || browser.orsay) {
             videoAudioCodecs.push('vorbis');
+        }
+
+        if (webmVideoCodecs.length) {
+            profile.DirectPlayProfiles.push({
+                Container: 'webm',
+                Type: 'Video',
+                VideoCodec: webmVideoCodecs.join(','),
+                AudioCodec: webmAudioCodecs.join(',')
+            });
         }
 
         if (mp4VideoCodecs.length) {
@@ -557,33 +583,6 @@ define(['browser'], function (browser) {
                 });
             }
         });
-
-        if (canPlayVp8) {
-            profile.DirectPlayProfiles.push({
-                Container: 'webm',
-                Type: 'Video',
-                AudioCodec: webmAudioCodecs.join(','),
-                VideoCodec: 'VP8'
-            });
-        }
-
-        if (canPlayVp9) {
-            profile.DirectPlayProfiles.push({
-                Container: 'webm',
-                Type: 'Video',
-                AudioCodec: webmAudioCodecs.join(','),
-                VideoCodec: 'VP9'
-            });
-        }
-
-        if (canPlayAv1) {
-            profile.DirectPlayProfiles.push({
-                Container: 'webm',
-                Type: 'Video',
-                AudioCodec: webmAudioCodecs.join(','),
-                VideoCodec: 'AV1'
-            });
-        }
 
         profile.TranscodingProfiles = [];
 


### PR DESCRIPTION
Problems:
1) Chrome fails to DirectPlay AV1 Video
2) WebM profiles are coded redundantly

Solutions:
1) The canPlayType() function is currently inaccurate for AV1 on Chrome. Added temporary code to sidestep the issue. Also fixed AV1 with mkv.
Special thanks to @cconcolato and his [website](https://cconcolato.github.io/media-mime-support/) for stopping the pain and frustration of finding the issue.
2) Made a new array, webmVideoCodecs[] to handle webm video and combined the VP8, VP9 and AV1 device profiles together into one webm device profile.