### PR TITLE
Remove the 500 item limitation on photo playback

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -1907,11 +1907,8 @@ define(['events', 'datetime', 'appSettings', 'itemHelper', 'pluginManager', 'pla
                     // Setting this to true may cause some incorrect sorting
                     Recursive: false,
                     SortBy: options.shuffle ? 'Random' : 'SortName',
-                    MediaTypes: 'Photo,Video',
-                    Limit: 500
-
+                    MediaTypes: 'Photo,Video'
                 }).then(function (result) {
-
                     var items = result.Items;
 
                     var index = items.map(function (i) {


### PR DESCRIPTION
**Changes**

Seems we had a 500 photo limitation in place when playing them, most likely due to the old photo player loading every photo in DOM.

We're only ever rendering 3 now, so we may as well get everything now.

**Issues**

Fixes #590