### PR TITLE
Expand interface effects

### DIFF
--- a/src/components/cardbuilder/card.css
+++ b/src/components/cardbuilder/card.css
@@ -53,6 +53,7 @@ button::-moz-focus-inner {
 .cardScalable {
     position: relative;
     contain: layout style;
+    overflow: hidden;
 }
 
 .cardPadder-backdrop,
@@ -78,6 +79,7 @@ button::-moz-focus-inner {
 .overflowPortraitCard-textCardPadder {
     padding-bottom: 150%;
     contain: strict;
+    overflow: hidden;
 }
 
 .cardPadder-banner {
@@ -167,6 +169,10 @@ button::-moz-focus-inner {
     position: relative;
     background-clip: content-box !important;
     color: inherit;
+    /* This makes animations at mouse leave smoother (when zoomIn enabled) */
+    transform: scale(1);
+    transition: transform .2s;
+    overflow: hidden;
 
     /* This is only needed for scalable cards */
     height: 100%;
@@ -774,8 +780,11 @@ button::-moz-focus-inner {
     width: 18.8vw;
 }
 
+.cardOverlayContainerDark {
+    background: rgba(0, 0, 0, 0.5) !important;
+}
+
 .cardOverlayContainer {
-    background: rgba(0, 0, 0, 0.5);
     opacity: 0;
     transition: opacity 0.2s;
     position: absolute;
@@ -788,6 +797,15 @@ button::-moz-focus-inner {
 
 .card-hoverable:hover .cardOverlayContainer {
     opacity: 1;
+}
+
+.card-hoverable:hover .lazy.cardImageContainer.hoverZoom {
+    transform: scale(1.1);
+    transition: transform 0.2s;
+}
+
+.card-hoverable:hover .lazy.cardImageContainer.hoverBlur {
+    filter: blur(.09em);
 }
 
 .cardOverlayButton-hover {

--- a/src/components/cardbuilder/card.css
+++ b/src/components/cardbuilder/card.css
@@ -169,9 +169,10 @@ button::-moz-focus-inner {
     position: relative;
     background-clip: content-box !important;
     color: inherit;
+
     /* This makes animations at mouse leave smoother (when zoomIn enabled) */
     transform: scale(1);
-    transition: transform .2s;
+    transition: transform 0.2s;
     overflow: hidden;
 
     /* This is only needed for scalable cards */
@@ -805,7 +806,7 @@ button::-moz-focus-inner {
 }
 
 .card-hoverable:hover .lazy.cardImageContainer.hoverBlur {
-    filter: blur(.09em);
+    filter: blur(0.09em);
 }
 
 .cardOverlayButton-hover {

--- a/src/components/cardbuilder/card.css
+++ b/src/components/cardbuilder/card.css
@@ -805,6 +805,11 @@ button::-moz-focus-inner {
     transition: transform 0.2s;
 }
 
+.card-hoverable .lazy.cardImageContainer.hoverBlur {
+    filter: none;
+    transition: filter 0.5s;
+}
+
 .card-hoverable:hover .lazy.cardImageContainer.hoverBlur {
     filter: blur(0.09em);
 }

--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -21,6 +21,7 @@ import imageHelper from 'scripts/imagehelper';
 import 'css!./card';
 import 'paper-icon-button-light';
 import 'programStyles';
+import * as userSettings from 'userSettings';
 
         const enableFocusTransform = !browser.slow && !browser.edge;
 
@@ -1257,6 +1258,13 @@ import 'programStyles';
             const overlayText = options.overlayText;
 
             let cardImageContainerClass = 'cardImageContainer';
+            if (userSettings.enableHoverBlur()) {
+                cardImageContainerClass += ' hoverBlur';
+            }
+            if (userSettings.enableHoverZoom()) {
+                cardImageContainerClass += ' hoverZoom';
+            }
+
             const coveredImage = options.coverImage || imgInfo.coverImage;
 
             if (coveredImage) {
@@ -1368,6 +1376,7 @@ import 'programStyles';
             let cardImageContainerClose = '';
             let cardBoxClose = '';
             let cardScalableClose = '';
+            let forceDarkHover = false;
 
             let cardContentClass = 'cardContent';
             if (!options.cardLayout) {
@@ -1377,6 +1386,8 @@ import 'programStyles';
             let blurhashAttrib = '';
             if (blurhash && blurhash.length > 0) {
                 blurhashAttrib = 'data-blurhash="' + blurhash + '"';
+            } else {
+                forceDarkHover = true;
             }
 
             if (layoutManager.tv) {
@@ -1430,6 +1441,7 @@ import 'programStyles';
 
             if (!imgUrl) {
                 cardImageContainerOpen += getDefaultText(item, options);
+                forceDarkHover = true;
             }
 
             const tagName = (layoutManager.tv) && !overlayButtons ? 'button' : 'div';
@@ -1474,7 +1486,7 @@ import 'programStyles';
             let additionalCardContent = '';
 
             if (layoutManager.desktop) {
-                additionalCardContent += getHoverMenuHtml(item, action);
+                additionalCardContent += getHoverMenuHtml(item, action, forceDarkHover);
             }
 
             return '<' + tagName + ' data-index="' + index + '"' + timerAttributes + actionAttribute + ' data-isfolder="' + (item.IsFolder || false) + '" data-serverid="' + (item.ServerId || options.serverId) + '" data-id="' + (item.Id || item.ItemId) + '" data-type="' + item.Type + '"' + mediaTypeData + collectionTypeData + channelIdData + positionTicksData + collectionIdData + playlistIdData + contextData + parentIdData + ' data-prefix="' + prefix + '" class="' + className + '">' + cardImageContainerOpen + innerCardFooter + cardImageContainerClose + overlayButtons + additionalCardContent + cardScalableClose + outerCardFooter + cardBoxClose + '</' + tagName + '>';
@@ -1484,12 +1496,19 @@ import 'programStyles';
          * Generates HTML markup for the card overlay.
          * @param {object} item - Item used to generate the card overlay.
          * @param {string} action - Action assigned to the overlay.
+         * @param {bool} dark - Forces darkened overlay on hover, overriding user settings
          * @returns {string} HTML markup of the card overlay.
          */
-        function getHoverMenuHtml(item, action) {
+        function getHoverMenuHtml(item, action, dark) {
             let html = '';
 
-            html += '<div class="cardOverlayContainer itemAction" data-action="' + action + '">';
+            let cssClass = "cardOverlayContainer itemAction"
+
+            if (userSettings.enableHoverDarkening() || dark) {
+                cssClass += " cardOverlayContainerDark"
+            }
+
+            html += '<div class="' + cssClass + '" data-action="' + action + '">';
 
             const btnCssClass = 'cardOverlayButton cardOverlayButton-hover itemAction paper-icon-button-light';
 

--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -1502,10 +1502,10 @@ import * as userSettings from 'userSettings';
         function getHoverMenuHtml(item, action, dark) {
             let html = '';
 
-            let cssClass = "cardOverlayContainer itemAction"
+            let cssClass = 'cardOverlayContainer itemAction';
 
             if (userSettings.enableHoverDarkening() || dark) {
-                cssClass += " cardOverlayContainerDark"
+                cssClass += ' cardOverlayContainerDark';
             }
 
             html += '<div class="' + cssClass + '" data-action="' + action + '">';

--- a/src/components/displaySettings/displaySettings.js
+++ b/src/components/displaySettings/displaySettings.js
@@ -182,6 +182,9 @@ define(['require', 'browser', 'layoutManager', 'appSettings', 'pluginManager', '
         context.querySelector('#chkThemeVideo').checked = userSettings.enableThemeVideos();
         context.querySelector('#chkFadein').checked = userSettings.enableFastFadein();
         context.querySelector('#chkBlurhash').checked = userSettings.enableBlurhash();
+        context.querySelector('#chkHoverZoom').checked = userSettings.enableHoverZoom();
+        context.querySelector('#chkHoverBlur').checked = userSettings.enableHoverBlur();
+        context.querySelector('#chkHoverDarkening').checked = userSettings.enableHoverDarkening();
         context.querySelector('#chkBackdrops').checked = userSettings.enableBackdrops();
         context.querySelector('#chkDetailsBanner').checked = userSettings.detailsBanner();
 
@@ -225,6 +228,9 @@ define(['require', 'browser', 'layoutManager', 'appSettings', 'pluginManager', '
 
         userSettingsInstance.enableFastFadein(context.querySelector('#chkFadein').checked);
         userSettingsInstance.enableBlurhash(context.querySelector('#chkBlurhash').checked);
+        userSettingsInstance.enableHoverZoom(context.querySelector('#chkHoverZoom').checked);
+        userSettingsInstance.enableHoverBlur(context.querySelector('#chkHoverBlur').checked);
+        userSettingsInstance.enableHoverDarkening(context.querySelector('#chkHoverDarkening').checked);
         userSettingsInstance.enableBackdrops(context.querySelector('#chkBackdrops').checked);
         userSettingsInstance.detailsBanner(context.querySelector('#chkDetailsBanner').checked);
 

--- a/src/components/displaySettings/displaySettings.template.html
+++ b/src/components/displaySettings/displaySettings.template.html
@@ -144,7 +144,7 @@
     </div>
 
     <h2 class="sectionTitle">
-        ${TabLibrary}
+        ${HeaderLibraries}
     </h2>
 
     <div class="inputContainer inputContainer-withDescription">

--- a/src/components/displaySettings/displaySettings.template.html
+++ b/src/components/displaySettings/displaySettings.template.html
@@ -143,6 +143,10 @@
         <select is="emby-select" class="selectSoundEffects" label="${LabelSoundEffects}"></select>
     </div>
 
+    <h2 class="sectionTitle">
+        ${TabLibrary}
+    </h2>
+
     <div class="inputContainer inputContainer-withDescription">
         <input is="emby-input" type="number" id="txtLibraryPageSize" pattern="[0-9]*" required="required" min="0" max="1000" step="1" label="${LabelLibraryPageSize}" />
         <div class="fieldDescription">${LabelLibraryPageSizeHelp}</div>
@@ -162,6 +166,27 @@
             <span>${EnableBlurhash}</span>
         </label>
         <div class="fieldDescription checkboxFieldDescription">${EnableBlurhashHelp}</div>
+    </div>
+
+    <div class="checkboxContainer checkboxContainer-withDescription">
+        <label>
+            <input type="checkbox" is="emby-checkbox" id="chkHoverZoom" />
+            <span>${EnableHoverZoomIn}</span>
+        </label>
+    </div>
+
+    <div class="checkboxContainer checkboxContainer-withDescription">
+        <label>
+            <input type="checkbox" is="emby-checkbox" id="chkHoverBlur" />
+            <span>${EnableHoverBlur}</span>
+        </label>
+    </div>
+
+    <div class="checkboxContainer checkboxContainer-withDescription">
+        <label>
+            <input type="checkbox" is="emby-checkbox" id="chkHoverDarkening" />
+            <span>${EnableHoverDarkening}</span>
+        </label>
     </div>
 
     <div class="checkboxContainer checkboxContainer-withDescription">

--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -195,6 +195,48 @@ export class UserSettings {
     }
 
     /**
+     * Get or set 'hoverZoom' state.
+     * @param {boolean|undefined} val - Flag to enable 'hoverZoom' or undefined.
+     * @return {boolean} 'hoverZoom' state.
+     */
+    enableHoverZoom(val) {
+        if (val !== undefined) {
+            return this.set('hoverZoom', val.toString(), false);
+        }
+
+        val = this.get('hoverZoom', false);
+        return val !== 'false';
+    }
+
+    /**
+     * Get or set 'hoverBlur' state.
+     * @param {boolean|undefined} val - Flag to enable 'hoverBlur' or undefined.
+     * @return {boolean} 'hoverBlur' state.
+     */
+    enableHoverBlur(val) {
+        if (val !== undefined) {
+            return this.set('hoverBlur', val.toString(), false);
+        }
+
+        val = this.get('hoverBlur', false);
+        return val !== 'false';
+    }
+
+    /**
+     * Get or set 'hoverDarkening' state.
+     * @param {boolean|undefined} val - Flag to enable 'hoverDarkening' or undefined.
+     * @return {boolean} 'hoverDarkening' state.
+     */
+    enableHoverDarkening(val) {
+        if (val !== undefined) {
+            return this.set('hoverDarkening', val.toString(), false);
+        }
+
+        val = this.get('hoverDarkening', false);
+        return val !== 'false';
+    }
+
+    /**
      * Get or set 'Backdrops' state.
      * @param {boolean|undefined} val - Flag to enable 'Backdrops' or undefined.
      * @return {boolean} 'Backdrops' state.
@@ -459,6 +501,9 @@ export const enableThemeSongs = currentSettings.enableThemeSongs.bind(currentSet
 export const enableThemeVideos = currentSettings.enableThemeVideos.bind(currentSettings);
 export const enableFastFadein = currentSettings.enableFastFadein.bind(currentSettings);
 export const enableBlurhash = currentSettings.enableBlurhash.bind(currentSettings);
+export const enableHoverZoom = currentSettings.enableHoverZoom.bind(currentSettings);
+export const enableHoverBlur = currentSettings.enableHoverBlur.bind(currentSettings);
+export const enableHoverDarkening = currentSettings.enableHoverDarkening.bind(currentSettings);
 export const enableBackdrops = currentSettings.enableBackdrops.bind(currentSettings);
 export const detailsBanner = currentSettings.detailsBanner.bind(currentSettings);
 export const language = currentSettings.language.bind(currentSettings);

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1551,5 +1551,8 @@
     "OnApplicationStartup": "On application startup",
     "UnsupportedPlayback": "Jellyfin cannot decrypt content protected by DRM but all content will be attempted regardless, including protected titles. Some files may appear completely black due to encryption or other unsupported features, such as interactive titles.",
     "EnableBlurhash": "Enable blurred placeholders for images",
-    "EnableBlurhashHelp": "Images that are still being loaded will be displayed with a blurred placeholder"
+    "EnableBlurhashHelp": "Images that are still being loaded will be displayed with a blurred placeholder",
+    "EnableHoverZoomIn": "Zoom images when the cursor is hovering them",
+    "EnableHoverBlur": "Blur images when the cursor is hovering them",
+    "EnableHoverDarkening": "Darken the images when the cursor is hovering them"
 }

--- a/src/strings/es.json
+++ b/src/strings/es.json
@@ -1560,5 +1560,8 @@
     "EnableDetailsBannerHelp": "Mostrar imagen de banner en el tope de la página de detalles del elemento.",
     "EnableDetailsBanner": "Barra de Detalles",
     "ShowMore": "Mostrar más",
-    "ShowLess": "Mostrar menos"
+    "ShowLess": "Mostrar menos",
+    "EnableHoverZoomIn": "Ampliar las imágenes al pasar el cursor por encima",
+    "EnableHoverBlur": "Difuminar las imágenes al pasar el cursor por encima",
+    "EnableHoverDarkening": "Oscurecer las imágenes al pasar el cursor por encima"
 }


### PR DESCRIPTION
This is a quick PR made after a Matrix discussion. This 
adds more effects when hovering images (+ proper customization), based on the blur effects we're adding with blurhash.

I also took the freedom to reorganize the display settings page, **moving all content related settings to a new "Library" section**:
![image](https://user-images.githubusercontent.com/10274099/84154624-a08a6800-aa67-11ea-8c1c-a4cc1db9c525.png)

## Effect showcase

**Darkening + blur + zoomIn** *(Default one)*
![all](https://user-images.githubusercontent.com/10274099/84154904-f6f7a680-aa67-11ea-91bd-9ac04d863550.gif)

**Darkening + blur**
![blur+dark](https://user-images.githubusercontent.com/10274099/84155152-49d15e00-aa68-11ea-9199-93046056c5b3.gif)

**Darkening + ZoomIn**
![dark+zoom](https://user-images.githubusercontent.com/10274099/84155407-94eb7100-aa68-11ea-9215-a07e46fbf5c2.gif)

**ZoomIn + Blur**
![zoom+blur](https://user-images.githubusercontent.com/10274099/84155653-dda32a00-aa68-11ea-8803-a3d59a61a8fb.gif)

**Blur**
![blur](https://user-images.githubusercontent.com/10274099/84155859-1fcc6b80-aa69-11ea-900b-61f2d7866d81.gif)

**ZoomIn**
![zoom](https://user-images.githubusercontent.com/10274099/84156215-881b4d00-aa69-11ea-8c81-1e8c9da7f23a.gif)

**Darkening**
*This is what we have right now*

**Nothing**
![nothing](https://user-images.githubusercontent.com/10274099/84156353-af721a00-aa69-11ea-9bf2-6bfcbf2a1df5.gif)

## To do
**ZoomIn effect needs to be fixed for Purple Haze and themes that have rounded corners**

**This only affects card elements, other images are unaffected**

## Details

TV layout zoom affect is handled by mouseManager so, in TV layout, the zoom effect doesn't change anything.