### PR TITLE
Restore menu options in mobile view

### DIFF
--- a/src/controllers/user/menu.js
+++ b/src/controllers/user/menu.js
@@ -43,12 +43,6 @@ define(['apphost', 'connectionManager', 'layoutManager', 'listViewStyle', 'emby-
                 page.querySelector('.adminSection').classList.add('hide');
             }
 
-            if (layoutManager.mobile) {
-                page.querySelector('.headerUsername').classList.add('hide');
-                page.querySelector('.adminSection').classList.add('hide');
-                page.querySelector('.userSection').classList.add('hide');
-            }
-
             ApiClient.getUser(userId).then(function(user) {
                 page.querySelector('.headerUsername').innerHTML = user.Name;
                 if (!user.Policy.IsAdministrator) {


### PR DESCRIPTION
**Changes**
Restores user menu options that were hidden in mobile display mode only. I was opposed to these being removed, but it makes no sense to me to _only_ remove them for the mobile layout and keep them for desktop. Arbitrarily removing features from mobile that are present on desktop seems like a poor practice.

**Issues**
N/A
