### PR TITLE
Remove standalone mode

### DIFF
--- a/.ci/azure-pipelines-build.yml
+++ b/.ci/azure-pipelines-build.yml
@@ -8,6 +8,8 @@ jobs:
         BuildConfiguration: development
       Production:
         BuildConfiguration: production
+      Standalone:
+        BuildConfiguration: standalone
 
   pool:
     vmImage: 'ubuntu-latest'
@@ -36,6 +38,10 @@ jobs:
   - script: 'yarn build:production'
     displayName: 'Build Production'
     condition: eq(variables['BuildConfiguration'], 'production')
+
+  - script: 'yarn build:standalone'
+    displayName: 'Build Standalone'
+    condition: eq(variables['BuildConfiguration'], 'standalone')
 
   - script: 'test -d dist'
     displayName: 'Check Build'

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,6 +16,7 @@ const stream = require('webpack-stream');
 const inject = require('gulp-inject');
 const postcss = require('gulp-postcss');
 const sass = require('gulp-sass');
+const gulpif = require('gulp-if');
 const lazypipe = require('lazypipe');
 
 sass.compiler = require('node-sass');
@@ -67,7 +68,7 @@ function serve() {
         }
     });
 
-    watch(options.apploader.query, apploader());
+    watch(options.apploader.query, apploader(true));
 
     watch('src/bundle.js', webpack);
 
@@ -130,12 +131,18 @@ function javascript(query) {
         .pipe(browserSync.stream());
 }
 
-function apploader() {
-    return src(options.apploader.query, { base: './src/' })
-        .pipe(concat('scripts/apploader.js'))
-        .pipe(pipelineJavascript())
-        .pipe(dest('dist/'))
-        .pipe(browserSync.stream());
+function apploader(standalone) {
+    function task() {
+        return src(options.apploader.query, { base: './src/' })
+            .pipe(gulpif(standalone, concat('scripts/apploader.js')))
+            .pipe(pipelineJavascript())
+            .pipe(dest('dist/'))
+            .pipe(browserSync.stream());
+    }
+
+    task.displayName = 'apploader';
+
+    return task;
 }
 
 function webpack() {
@@ -183,5 +190,10 @@ function injectBundle() {
         .pipe(browserSync.stream());
 }
 
-exports.default = series(clean, parallel(javascript, apploader, webpack, css, html, images, copy), injectBundle);
-exports.serve = series(exports.default, serve);
+function build(standalone) {
+    return series(clean, parallel(javascript, apploader(standalone), webpack, css, html, images, copy));
+}
+
+exports.default = series(build(false), injectBundle);
+exports.standalone = series(build(true), injectBundle);
+exports.serve = series(exports.standalone, serve);

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "prepare": "gulp --production",
     "build:development": "gulp --development",
     "build:production": "gulp --production",
+    "build:standalone": "gulp standalone --development",
     "lint": "eslint \".\"",
     "stylelint": "stylelint \"src/**/*.css\""
   }


### PR DESCRIPTION
**Changes**

**Untested** Injects the Javascript in all cases but keeps standalone mode only when running a standalone build.

The goal is to inject JS so the app is self-starting while still keeping the old behavior elsewhere in the client when bundled with the server.

**Issues**

Fixes #1433