### PR TITLE
Avoid async rendering of MediaSources tracks to prevent content jump

### DIFF
--- a/src/controllers/itemDetails.js
+++ b/src/controllers/itemDetails.js
@@ -141,29 +141,29 @@ define(['loading', 'appRouter', 'layoutManager', 'connectionManager', 'userSetti
             return;
         }
 
-        playbackManager.getPlaybackMediaSources(item).then(function (mediaSources) {
-            instance._currentPlaybackMediaSources = mediaSources;
-            page.querySelector('.trackSelections').classList.remove('hide');
-            select.setLabel(globalize.translate('LabelVersion'));
-            var currentValue = select.value;
-            var selectedId = mediaSources[0].Id;
-            select.innerHTML = mediaSources.map(function (v) {
-                var selected = v.Id === selectedId ? ' selected' : '';
-                return '<option value="' + v.Id + '"' + selected + '>' + v.Name + '</option>';
-            }).join('');
+        var mediaSources = item.MediaSources;
+        instance._currentPlaybackMediaSources = mediaSources;
+        page.querySelector('.trackSelections').classList.remove('hide');
+        select.setLabel(globalize.translate('LabelVersion'));
+        var currentValue = select.value;
+        var selectedId = mediaSources[0].Id;
+        select.innerHTML = mediaSources.map(function (v) {
+            var selected = v.Id === selectedId ? ' selected' : '';
+            return '<option value="' + v.Id + '"' + selected + '>' + v.Name + '</option>';
+        }).join('');
 
-            if (mediaSources.length > 1) {
-                page.querySelector('.selectSourceContainer').classList.remove('hide');
-            } else {
-                page.querySelector('.selectSourceContainer').classList.add('hide');
-            }
+        if (mediaSources.length > 1) {
+            page.querySelector('.selectSourceContainer').classList.remove('hide');
+        } else {
+            page.querySelector('.selectSourceContainer').classList.add('hide');
+        }
 
-            if (select.value !== currentValue || forceReload) {
-                renderVideoSelections(page, mediaSources);
-                renderAudioSelections(page, mediaSources);
-                renderSubtitleSelections(page, mediaSources);
-            }
-        });
+        if (select.value !== currentValue || forceReload) {
+            renderVideoSelections(page, mediaSources);
+            renderAudioSelections(page, mediaSources);
+            renderSubtitleSelections(page, mediaSources);
+        }
+
     }
 
     function renderVideoSelections(page, mediaSources) {


### PR DESCRIPTION
**Changes**

The `MediaSources` returned by `.getPlaybackMediaSources()` seems already available in the `item`, can we use it directly an avoid sending a request to the server?

Certainly `getPlaybackMediaSources()` is called for a good reason, but I tried to go down the rabbit hole on the server side and, well... I don't understand anything. That's quite frustrating.

`MediaSources` are retrieved here: [jellyfin/MediaInfoService.cs#L30](https://github.com/jellyfin/jellyfin/blob/403cd3205ffb970cfda88b6c49dc69127fada798/MediaBrowser.Api/Playback/MediaInfoService.cs#L30). There are many similarities between `item` and `playbackInfoResult`, I don't know why both are needed.

I'm opening this PR in the hope that there's someone who understands the topic. Certainly, it is possible to avoid making two calls to the api in one way or another, and the rendering would be greatly improved.

Before:
![Peek 2020-06-14 21-30](https://user-images.githubusercontent.com/4193924/84603428-b6949000-ae8e-11ea-9d29-b422d1b7ed60.gif)

After:
![Peek 2020-06-14 21-28](https://user-images.githubusercontent.com/4193924/84603429-b72d2680-ae8e-11ea-84a0-fcaf45c2c5b2.gif)

**Issues**
Related to #1233
