### PR TITLE
Fix "Drop image here, or click to browse" persistent Visual

### DIFF
--- a/src/components/imageUploader/imageUploader.js
+++ b/src/components/imageUploader/imageUploader.js
@@ -58,6 +58,7 @@ define(['dialogHelper', 'connectionManager', 'dom', 'loading', 'scrollHelper', '
                 var html = ['<img style="max-width:100%;max-height:100%;" src="', e.target.result, '" title="', escape(theFile.name), '"/>'].join('');
 
                 page.querySelector('#imageOutput').innerHTML = html;
+                page.querySelector('#dropImageText').classList.add('hide');
                 page.querySelector('#fldUpload').classList.remove('hide');
             };
         })(file);

--- a/src/components/imageUploader/imageUploader.template.html
+++ b/src/components/imageUploader/imageUploader.template.html
@@ -20,7 +20,7 @@
             </div>
             <div>
                 <div class="imageEditor-dropZone fieldDescription">
-                    <div>${LabelDropImageHere}</div>
+                    <div class="dropImageText">${LabelDropImageHere}</div>
                     <output id="imageOutput" class="flex align-items-center justify-content-center" style="position: absolute;top:0;left:0;right:0;bottom:0;width:100%;"></output>
                     <input type="file" accept="image/*" id="uploadImage" name="uploadImage" style="position: absolute;top:0;left:0;right:0;bottom:0;width:100%;opacity:0;" />
                 </div>


### PR DESCRIPTION
Fixes visible text when dragging a portrait picture into the upload Image UI.

**Changes**
Before:
![2020-06-15-presistant-text-fix-original](https://user-images.githubusercontent.com/18101008/84633534-76fa9200-aee8-11ea-8f0a-9c461d562291.gif)

After:
![2020-06-15-presistant-text-fix](https://user-images.githubusercontent.com/18101008/84633539-79f58280-aee8-11ea-909b-ed158fe4e627.gif)


**Issues**
Fixes #1388
