### PR TITLE
Ensure collection step depends on build steps

### DIFF
--- a/.ci/azure-pipelines-package.yml
+++ b/.ci/azure-pipelines-package.yml
@@ -83,6 +83,7 @@ jobs:
   dependsOn:
   - BuildPackage
   - BuildDocker
+  condition: and(succeeded('BuildPackage'), succeeded('BuildDocker'))
 
   pool:
     vmImage: 'ubuntu-latest'

--- a/.ci/azure-pipelines-package.yml
+++ b/.ci/azure-pipelines-package.yml
@@ -80,6 +80,9 @@ jobs:
 
 - job: CollectArtifacts
   displayName: 'Collect Artifacts'
+  dependsOn:
+  - BuildPackage
+  - BuildDocker
 
   pool:
     vmImage: 'ubuntu-latest'


### PR DESCRIPTION
**Changes**
Dependency fail in the CI jobs. Fixes this so collection only happens after all the builds are done.

**Issues**
N/A
