### PR TITLE
Remove leftover from #1046

### DIFF
--- a/src/controllers/dashboard/dashboard.js
+++ b/src/controllers/dashboard/dashboard.js
@@ -567,7 +567,6 @@ define(['datetime', 'events', 'itemHelper', 'serverNotifications', 'dom', 'globa
             row.querySelector('.sessionNowPlayingTime').innerHTML = DashboardPage.getSessionNowPlayingTime(session);
             row.querySelector('.sessionUserName').innerHTML = DashboardPage.getUsersHtml(session);
             row.querySelector('.sessionAppSecondaryText').innerHTML = DashboardPage.getAppSecondaryText(session);
-            row.querySelector('.sessionTranscodingFramerate').innerHTML = session.TranscodingInfo && session.TranscodingInfo.Framerate ? session.TranscodingInfo.Framerate + ' fps' : '';
             var nowPlayingName = DashboardPage.getNowPlayingName(session);
             var nowPlayingInfoElem = row.querySelector('.sessionNowPlayingInfo');
 


### PR DESCRIPTION
Media that isn't transcoding is spamming the console with ``undefined`` errors.

I checked and transcode FPS updates with @nyanmisaka changes, so I think this is safe to remove.

FPS updating is already handled [here](https://github.com/jellyfin/jellyfin-web/commit/02baff1fe0c5a22d9b1563f7101d0a01824e34cd#diff-56bba5895ccb79a89cbb7136a9c211cdL261)
