### PR TITLE
Don't start time sync if not in SyncPlay mode

### DIFF
--- a/src/components/syncPlay/timeSyncManager.js
+++ b/src/components/syncPlay/timeSyncManager.js
@@ -65,8 +65,6 @@ class TimeSyncManager {
         this.pings = 0; // number of pings
         this.measurement = null; // current time sync
         this.measurements = [];
-
-        this.startPing();
     }
 
     /**


### PR DESCRIPTION
`timeSyncManager` starts syncing even on server select screen.
I believe that `startPing` will be called this way
https://github.com/jellyfin/jellyfin-web/blob/1b6a600496bab236583b5f81a413bb0bf0dda1b7/src/components/syncPlay/syncPlayManager.js#L484
https://github.com/jellyfin/jellyfin-web/blob/1b6a600496bab236583b5f81a413bb0bf0dda1b7/src/components/syncPlay/syncPlayManager.js#L497
https://github.com/jellyfin/jellyfin-web/blob/1b6a600496bab236583b5f81a413bb0bf0dda1b7/src/components/syncPlay/timeSyncManager.js#L182
i.e. when we join the group.

I have tested a bit, and sync is vary 0.1-0.4s (mostly 0.1s)
Better if @OancaAndrei confirms that this doesn't break SyncPlay.

**Changes**
Remove `startPing` call from the constructor.

**Issues**
```
Uncaught TypeError: Cannot read property 'getServerTime' of undefined
    at timeSyncManager.js?v=18:1
```
<details>
<summary>Stacktrace</summary>

```
(anonymous) @ timeSyncManager.js?v=18:1
setTimeout (async)
requestPing @ timeSyncManager.js?v=18:1
startPing @ timeSyncManager.js?v=18:1
TimeSyncManager @ timeSyncManager.js?v=18:1
(anonymous) @ timeSyncManager.js?v=18:1
execCb @ alameda.js:1233
defineModule @ alameda.js:493
depFinished @ alameda.js:526
(anonymous) @ alameda.js:589
Promise.then (async)
waitForDep @ alameda.js:588
(anonymous) @ alameda.js:1079
main @ alameda.js:1061
takeQueue @ alameda.js:296
(anonymous) @ alameda.js:690
load (async)
load @ alameda.js:688
callDep @ alameda.js:781
waitForDep @ alameda.js:588
(anonymous) @ alameda.js:1079
main @ alameda.js:1061
callDep @ alameda.js:746
waitForDep @ alameda.js:588
(anonymous) @ alameda.js:1079
main @ alameda.js:1061
takeQueue @ alameda.js:296
(anonymous) @ alameda.js:690
load (async)
load @ alameda.js:688
callDep @ alameda.js:781
waitForDep @ alameda.js:588
(anonymous) @ alameda.js:1079
main @ alameda.js:1061
callDep @ alameda.js:746
waitForDep @ alameda.js:588
(anonymous) @ alameda.js:1079
main @ alameda.js:1061
takeQueue @ alameda.js:296
(anonymous) @ alameda.js:690
load (async)
load @ alameda.js:688
callDep @ alameda.js:781
waitForDep @ alameda.js:588
(anonymous) @ alameda.js:1079
main @ alameda.js:1061
callDep @ alameda.js:746
waitForDep @ alameda.js:588
(anonymous) @ alameda.js:1079
main @ alameda.js:1061
takeQueue @ alameda.js:296
(anonymous) @ alameda.js:690
load (async)
load @ alameda.js:688
callDep @ alameda.js:781
waitForDep @ alameda.js:588
(anonymous) @ alameda.js:1079
main @ alameda.js:1061
(anonymous) @ alameda.js:363
Promise.then (async)
req @ alameda.js:359
(anonymous) @ pluginManager.js?v=18:1
PluginManager.loadPlugin @ pluginManager.js?v=18:1
(anonymous) @ site.js:1
execCb @ alameda.js:1233
defineModule @ alameda.js:493
depFinished @ alameda.js:526
(anonymous) @ alameda.js:589
Promise.then (async)
waitForDep @ alameda.js:588
(anonymous) @ alameda.js:1079
main @ alameda.js:1061
(anonymous) @ alameda.js:363
Promise.then (async)
req @ alameda.js:359
(anonymous) @ site.js:1
loadPlugin @ site.js:1
(anonymous) @ site.js:1
loadPlugins @ site.js:1
(anonymous) @ site.js:1
execCb @ alameda.js:1233
defineModule @ alameda.js:493
depFinished @ alameda.js:526
(anonymous) @ alameda.js:589
Promise.then (async)
waitForDep @ alameda.js:588
(anonymous) @ alameda.js:1079
main @ alameda.js:1061
(anonymous) @ alameda.js:363
Promise.then (async)
req @ alameda.js:359
onGlobalizeInit @ site.js:1
(anonymous) @ site.js:1
Promise.then (async)
(anonymous) @ site.js:1
execCb @ alameda.js:1233
defineModule @ alameda.js:493
depFinished @ alameda.js:526
(anonymous) @ alameda.js:589
Promise.then (async)
waitForDep @ alameda.js:588
(anonymous) @ alameda.js:1079
main @ alameda.js:1061
(anonymous) @ alameda.js:363
Promise.then (async)
req @ alameda.js:359
(anonymous) @ site.js:1
Promise.then (async)
(anonymous) @ site.js:1
Promise.then (async)
init @ site.js:1
onWebComponentsReady @ site.js:1
(anonymous) @ site.js:1
(anonymous) @ site.js:1
apphost.js?v=18:1 app is hidden
```
</details>