### PR TITLE
CSS fixes when resizing library browser

### DIFF
--- a/src/assets/css/librarybrowser.css
+++ b/src/assets/css/librarybrowser.css
@@ -178,6 +178,10 @@
     width: 100%;
 }
 
+.layout-tv .sectionTabs {
+    width: 55%;
+}
+
 .selectedMediaFolder {
     background-color: #f2f2f2 !important;
 }
@@ -279,6 +283,10 @@
 
     .sectionTabs {
         font-size: 83.5%;
+    }
+
+    .layout-tv .sectionTabs {
+        width: 100%;
     }
 }
 

--- a/src/assets/css/librarybrowser.css
+++ b/src/assets/css/librarybrowser.css
@@ -821,20 +821,6 @@ div.itemDetailGalleryLink.defaultCardBackground {
 }
 
 @media all and (min-width: 100em) {
-    .headerTop {
-        padding-left: 0.8em;
-        padding-right: 0.8em;
-    }
-
-    .headerTabs {
-        align-self: center;
-        width: auto;
-        align-items: center;
-        justify-content: center;
-        margin-top: -4.2em;
-        position: relative;
-    }
-
     .detailFloatingButton {
         display: none !important;
     }

--- a/src/assets/css/librarybrowser.css
+++ b/src/assets/css/librarybrowser.css
@@ -272,7 +272,7 @@
     }
 }
 
-@media all and (max-width: 84em) {
+@media all and (max-width: 100em) {
     .withSectionTabs .headerTop {
         padding-bottom: 0.55em;
     }
@@ -282,7 +282,7 @@
     }
 }
 
-@media all and (min-width: 84em) {
+@media all and (min-width: 100em) {
     .headerTop {
         padding: 0.8em 0.8em;
     }
@@ -820,7 +820,7 @@ div.itemDetailGalleryLink.defaultCardBackground {
     }
 }
 
-@media all and (min-width: 62.5em) {
+@media all and (min-width: 100em) {
     .headerTop {
         padding-left: 0.8em;
         padding-right: 0.8em;

--- a/src/assets/css/scrollstyles.css
+++ b/src/assets/css/scrollstyles.css
@@ -12,6 +12,7 @@
 .hiddenScrollX,
 .layout-tv .scrollX {
     -ms-overflow-style: none;
+    scrollbar-width: none;
 }
 
 .hiddenScrollX-forced {
@@ -40,6 +41,7 @@
 .hiddenScrollY,
 .layout-tv .smoothScrollY {
     -ms-overflow-style: none;
+    scrollbar-width: none;
 
     /* Can't do this because it not only hides the scrollbar, but also prevents scrolling */
 

--- a/src/components/maintabsmanager.js
+++ b/src/components/maintabsmanager.js
@@ -140,7 +140,7 @@ define(['dom', 'browser', 'events', 'emby-tabs', 'emby-button'], function (dom, 
             var index = 0;
 
             var indexAttribute = selectedIndex == null ? '' : (' data-index="' + selectedIndex + '"');
-            var tabsHtml = '<div is="emby-tabs"' + indexAttribute + ' class="tabs-viewmenubar"><div class="emby-tabs-slider scrollX" style="white-space:nowrap;">' + getTabsFn().map(function (t) {
+            var tabsHtml = '<div is="emby-tabs"' + indexAttribute + ' class="tabs-viewmenubar"><div class="emby-tabs-slider" style="white-space:nowrap;">' + getTabsFn().map(function (t) {
 
                 var tabClass = 'emby-tab-button';
 

--- a/src/components/maintabsmanager.js
+++ b/src/components/maintabsmanager.js
@@ -140,7 +140,7 @@ define(['dom', 'browser', 'events', 'emby-tabs', 'emby-button'], function (dom, 
             var index = 0;
 
             var indexAttribute = selectedIndex == null ? '' : (' data-index="' + selectedIndex + '"');
-            var tabsHtml = '<div is="emby-tabs"' + indexAttribute + ' class="tabs-viewmenubar"><div class="emby-tabs-slider" style="white-space:nowrap;">' + getTabsFn().map(function (t) {
+            var tabsHtml = '<div is="emby-tabs"' + indexAttribute + ' class="tabs-viewmenubar"><div class="emby-tabs-slider scrollX" style="white-space:nowrap;">' + getTabsFn().map(function (t) {
 
                 var tabClass = 'emby-tab-button';
 

--- a/src/elements/emby-tabs/emby-tabs.css
+++ b/src/elements/emby-tabs/emby-tabs.css
@@ -31,11 +31,8 @@
 
 .emby-tabs-slider {
     position: relative;
-    overflow: hidden;
-}
-
-.layout-mobile .emby-tabs-slider {
     overflow: auto;
+    overflow-y: hidden;
 }
 
 .tabContent:not(.is-active) {

--- a/src/elements/emby-tabs/emby-tabs.css
+++ b/src/elements/emby-tabs/emby-tabs.css
@@ -31,8 +31,6 @@
 
 .emby-tabs-slider {
     position: relative;
-    overflow: auto;
-    overflow-y: hidden;
 }
 
 .tabContent:not(.is-active) {

--- a/src/themes/dark/theme.css
+++ b/src/themes/dark/theme.css
@@ -437,6 +437,7 @@ html {
 
 .layout-desktop ::-webkit-scrollbar {
     width: 0.4em;
+    height: 0.4em;
 }
 
 ::-webkit-scrollbar-thumb:horizontal,


### PR DESCRIPTION
These fixes work much better for pages with a lot of tabs, such as Music and TV Shows, **removing all the text overlapping**. Also, now the scaling of the cards is "synchronised" with the scaling of the header, being more seamless.

**Before**
![before](https://user-images.githubusercontent.com/10274099/85058412-62e1b980-b1a2-11ea-9cda-39ad35657482.gif)


**After**
![after](https://user-images.githubusercontent.com/10274099/85057690-5e68d100-b1a1-11ea-84d9-871884a703b0.gif)

Fixes #946 

