### PR TITLE
Fix broken image uploader due to missing '#dropImageText' element

### DIFF
--- a/src/components/imageUploader/imageUploader.template.html
+++ b/src/components/imageUploader/imageUploader.template.html
@@ -20,7 +20,7 @@
             </div>
             <div>
                 <div class="imageEditor-dropZone fieldDescription">
-                    <div class="dropImageText">${LabelDropImageHere}</div>
+                    <div id="dropImageText">${LabelDropImageHere}</div>
                     <output id="imageOutput" class="flex align-items-center justify-content-center" style="position: absolute;top:0;left:0;right:0;bottom:0;width:100%;"></output>
                     <input type="file" accept="image/*" id="uploadImage" name="uploadImage" style="position: absolute;top:0;left:0;right:0;bottom:0;width:100%;opacity:0;" />
                 </div>


### PR DESCRIPTION

**Changes**
Currently, trying to upload an image using `master` generate a `TypeError: page.querySelector(...) is null` in the console.

@Influence365 The PR #1409 added a new `dropImageText` **class** in the template but the JS function search for an **id**. Is it a typo?

**Issues**
None