### PR TITLE
 Fix media info dialog visually refreshing library page in background 

### DIFF
--- a/src/components/itemContextMenu.js
+++ b/src/components/itemContextMenu.js
@@ -403,7 +403,7 @@ define(['apphost', 'globalize', 'connectionManager', 'itemHelper', 'appRouter', 
                     break;
                 case 'moremediainfo':
                     require(['itemMediaInfo'], function (itemMediaInfo) {
-                        itemMediaInfo.show(itemId, serverId).then(getResolveFunction(resolve, id, true), getResolveFunction(resolve, id));
+                        itemMediaInfo.show(itemId, serverId).then(getResolveFunction(resolve, id), getResolveFunction(resolve, id));
                     });
                     break;
                 case 'refresh':


### PR DESCRIPTION

**Changes**
Does anyone know why `getResolveFunction()` is called with argument `changed=true` for the _Media Info_ menu entry?

Pinging @grafixeyehero as you developed #386. :p

Before:
![Peek 2020-06-19 14-33](https://user-images.githubusercontent.com/4193924/85134001-10ed7200-b23c-11ea-945e-91b6fa6c222a.gif)


After:
![Peek 2020-06-19 14-34](https://user-images.githubusercontent.com/4193924/85134010-13e86280-b23c-11ea-849f-86c536404c93.gif)
