### PR TITLE
Make the portable web archive and dir consistent

### DIFF
--- a/deployment/build.portable
+++ b/deployment/build.portable
@@ -15,8 +15,8 @@ fi
 
 # build archives
 npx yarn install
-mv dist jellyfin-web-${version}
-tar -czf jellyfin-web-${version}-portable.tar.gz jellyfin-web-${version}
+mv dist jellyfin-web_${version}
+tar -czf jellyfin-web_${version}_portable.tar.gz jellyfin-web_${version}
 rm -rf dist
 
 # move the artifacts


### PR DESCRIPTION
*Changes**
Make the portable web archive and directory names consistent with the server archives. They use `jellyfin-server_version`, not `jellyfin-server-version`, so this should too.

**Issues**
N/A