### PR TITLE
Fix latest section portrait cards not being portrait in all cases

### DIFF
--- a/src/components/homesections/homesections.js
+++ b/src/components/homesections/homesections.js
@@ -168,7 +168,7 @@ define(['connectionManager', 'cardBuilder', 'appSettings', 'dom', 'apphost', 'la
     }
 
     function getPortraitShape() {
-        return enableScrollX() ? 'autooverflow' : 'auto';
+        return enableScrollX() ? 'overflowPortrait' : 'portrait';
     }
 
     function getLibraryButtonsHtml(items) {


### PR DESCRIPTION
**Changes**

Fixes the card shapes for home sections where the library type should use a Portrait-shaped card but no item has an image.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
