### PR TITLE
Prevent removal of system plugins

### DIFF
--- a/src/controllers/dashboard/plugins/installed.js
+++ b/src/controllers/dashboard/plugins/installed.js
@@ -120,7 +120,7 @@ define(['loading', 'libraryMenu', 'dom', 'globalize', 'cardStyle', 'emby-button'
             });
         }
 
-        if (removable == 'true') {
+        if (removable === 'true') {
             menuItems.push({
                 name: globalize.translate('ButtonUninstall'),
                 id: 'delete',

--- a/src/controllers/dashboard/plugins/installed.js
+++ b/src/controllers/dashboard/plugins/installed.js
@@ -37,7 +37,7 @@ define(['loading', 'libraryMenu', 'dom', 'globalize', 'cardStyle', 'emby-button'
         })[0];
         var configPageUrl = configPage ? Dashboard.getConfigurationPageUrl(configPage.Name) : null;
         var html = '';
-        html += "<div data-id='" + plugin.Id + "' data-name='" + plugin.Name + "' class='card backdropCard'>";
+        html += "<div data-id='" + plugin.Id + "' data-name='" + plugin.Name + "' data-removable='" + plugin.CanUninstall  + "' class='card backdropCard'>";
         html += '<div class="cardBox visualCardBox">';
         html += '<div class="cardScalable">';
         html += '<div class="cardPadder cardPadder-backdrop"></div>';
@@ -46,9 +46,13 @@ define(['loading', 'libraryMenu', 'dom', 'globalize', 'cardStyle', 'emby-button'
         html += configPageUrl ? '</a>' : '</div>';
         html += '</div>';
         html += '<div class="cardFooter">';
-        html += '<div style="text-align:right; float:right;padding-top:5px;">';
-        html += '<button type="button" is="paper-icon-button-light" class="btnCardMenu autoSize"><span class="material-icons more_vert"></span></button>';
-        html += '</div>';
+
+        if (configPage || plugin.CanUninstall) {
+            html += '<div style="text-align:right; float:right;padding-top:5px;">';
+            html += '<button type="button" is="paper-icon-button-light" class="btnCardMenu autoSize"><span class="material-icons more_vert"></span></button>';
+            html += '</div>';
+        }
+
         html += "<div class='cardText'>";
         html += configPage && configPage.DisplayName ? configPage.DisplayName : plugin.Name;
         html += '</div>';
@@ -104,6 +108,7 @@ define(['loading', 'libraryMenu', 'dom', 'globalize', 'cardStyle', 'emby-button'
         var card = dom.parentWithClass(elem, 'card');
         var id = card.getAttribute('data-id');
         var name = card.getAttribute('data-name');
+        var removable = card.getAttribute('data-removable');
         var configHref = card.querySelector('.cardContent').getAttribute('href');
         var menuItems = [];
 
@@ -115,11 +120,13 @@ define(['loading', 'libraryMenu', 'dom', 'globalize', 'cardStyle', 'emby-button'
             });
         }
 
-        menuItems.push({
-            name: globalize.translate('ButtonUninstall'),
-            id: 'delete',
-            icon: 'delete'
-        });
+        if (removable == 'true') {
+            menuItems.push({
+                name: globalize.translate('ButtonUninstall'),
+                id: 'delete',
+                icon: 'delete'
+            });
+        }
 
         require(['actionsheet'], function (actionsheet) {
             actionsheet.show({

--- a/src/controllers/dashboard/plugins/installed.js
+++ b/src/controllers/dashboard/plugins/installed.js
@@ -37,7 +37,7 @@ define(['loading', 'libraryMenu', 'dom', 'globalize', 'cardStyle', 'emby-button'
         })[0];
         var configPageUrl = configPage ? Dashboard.getConfigurationPageUrl(configPage.Name) : null;
         var html = '';
-        html += "<div data-id='" + plugin.Id + "' data-name='" + plugin.Name + "' data-removable='" + plugin.CanUninstall  + "' class='card backdropCard'>";
+        html += "<div data-id='" + plugin.Id + "' data-name='" + plugin.Name + "' data-removable='" + plugin.CanUninstall + "' class='card backdropCard'>";
         html += '<div class="cardBox visualCardBox">';
         html += '<div class="cardScalable">';
         html += '<div class="cardPadder cardPadder-backdrop"></div>';


### PR DESCRIPTION
**Changes**
Plugins now have a `CanUninstall` property (see jellyfin/jellyfin#3411).  When set to false the "Uninstall" option is not displayed on the Plugin Menu.

If the property is set to false, and the Plugin has no Configuration Page, then the Plugin Menu button is not displayed on the card.

Server PR:  jellyfin/jellyfin#3411

**Issues**
Refs jellyfin/jellyfin#2555