### PR TITLE
Hide hamburger button on TV

### DIFF
--- a/src/scripts/libraryMenu.js
+++ b/src/scripts/libraryMenu.js
@@ -834,6 +834,7 @@ define(['dom', 'layoutManager', 'inputManager', 'connectionManager', 'events', '
     var headerAudioPlayerButton;
     var headerSyncButton;
     var enableLibraryNavDrawer = layoutManager.desktop;
+    var enableLibraryNavDrawerHome = !layoutManager.tv;
     var skinHeader = document.querySelector('.skinHeader');
     var requiresUserRefresh = true;
     var lastOpenTime = new Date().getTime();
@@ -920,7 +921,7 @@ define(['dom', 'layoutManager', 'inputManager', 'connectionManager', 'events', '
             refreshDashboardInfoInDrawer(apiClient);
         } else {
             if (mainDrawerButton) {
-                if (enableLibraryNavDrawer || isHomePage) {
+                if (enableLibraryNavDrawer || (isHomePage && enableLibraryNavDrawerHome)) {
                     mainDrawerButton.classList.remove('hide');
                 } else {
                     mainDrawerButton.classList.add('hide');


### PR DESCRIPTION
Menu on TV is not implemented.
I suppose we should hide menu button for a while so that people don’t get scared by clicking on it.

**Changes**
Hide menu button on TV.

**Issues**
People get scared by clicking on menu button.
#1082
jellyfin/jellyfin-tizen#37
Can't say that this PR fixes them - just hides the problem.
