### PR TITLE
Prevent viewcontainer from storing multiple pages

### DIFF
--- a/src/components/viewContainer.js
+++ b/src/components/viewContainer.js
@@ -247,7 +247,7 @@ define(['browser', 'dom', 'layoutManager', 'css!components/viewManager/viewConta
     var mainAnimatedPages = document.querySelector('.mainAnimatedPages');
     var allPages = [];
     var currentUrls = [];
-    var pageContainerCount = 3;
+    var pageContainerCount = 1;
     var selectedPageIndex = -1;
     reset();
     mainAnimatedPages.classList.remove('hide');


### PR DESCRIPTION
**Changes**

For some reason, viewContainer is set to store 3 pages at a time and doesn't delete them when it doesn't need them anymore.
This sets the `pageContainerCount` to 1, in order to force it to remove old pages from DOM.

Obviously this is a temporary fix for a bigger issue (The issue being that viewContainer is stupid).

**Issues**

Fixes #1450 
