### PR TITLE
Friendly SubtitleSync

### DIFF
--- a/src/components/subtitlesync/subtitlesync.css
+++ b/src/components/subtitlesync/subtitlesync.css
@@ -1,12 +1,18 @@
+.subtitleSync {
+    position: absolute;
+    width: 100%;
+}
+
 .subtitleSyncContainer {
     width: 40%;
-    margin-left: 30%;
-    margin-right: 30%;
+    min-width: 18em;
+    margin-left: auto;
+    margin-right: auto;
     height: 4.2em;
     background: rgba(28, 28, 28, 0.8);
     border-radius: 0.3em;
     color: #fff;
-    position: absolute;
+    position: relative;
 }
 
 .subtitleSync-closeButton {

--- a/src/components/subtitlesync/subtitlesync.js
+++ b/src/components/subtitlesync/subtitlesync.js
@@ -87,14 +87,6 @@ define(['playbackManager', 'layoutManager', 'text!./subtitlesync.template.html',
                 getOffsetFromPercentage(this.value));
         });
 
-        subtitleSyncSlider.addEventListener('touchmove', function () {
-            // set new offset
-            playbackManager.setSubtitleOffset(getOffsetFromPercentage(this.value), player);
-            // synchronize with textField value
-            subtitleSyncTextField.updateOffset(
-                getOffsetFromPercentage(this.value));
-        });
-
         subtitleSyncSlider.getBubbleHtml = function (value) {
             var newOffset = getOffsetFromPercentage(value);
             return '<h1 class="sliderBubbleText">' +

--- a/src/components/subtitlesync/subtitlesync.template.html
+++ b/src/components/subtitlesync/subtitlesync.template.html
@@ -3,7 +3,7 @@
         <button type="button" is="paper-icon-button-light" class="subtitleSync-closeButton"><span class="material-icons close"></span></button>
         <div class="subtitleSyncTextField" contenteditable="true" spellcheck="false">0s</div>
         <div class="sliderContainer subtitleSyncSliderContainer">
-            <input is="emby-slider" type="range" step="1" min="0" max="100" value="50" class="subtitleSyncSlider" />
+            <input is="emby-slider" type="range" step="1" min="0" max="100" value="50" class="subtitleSyncSlider" data-slider-keep-progress="true" />
         </div>
     </div>
 </div>

--- a/src/components/subtitlesync/subtitlesync.template.html
+++ b/src/components/subtitlesync/subtitlesync.template.html
@@ -1,7 +1,9 @@
-<div class="subtitleSyncContainer">
-    <button type="button" is="paper-icon-button-light" class="subtitleSync-closeButton"><span class="material-icons close"></span></button>
-    <div class="subtitleSyncTextField" contenteditable="true" spellcheck="false">0s</div>
-    <div class="sliderContainer subtitleSyncSliderContainer">
-        <input is="emby-slider" type="range" step="1" min="0" max="100" value="50" class="subtitleSyncSlider" />
+<div class="subtitleSync">
+    <div class="subtitleSyncContainer">
+        <button type="button" is="paper-icon-button-light" class="subtitleSync-closeButton"><span class="material-icons close"></span></button>
+        <div class="subtitleSyncTextField" contenteditable="true" spellcheck="false">0s</div>
+        <div class="sliderContainer subtitleSyncSliderContainer">
+            <input is="emby-slider" type="range" step="1" min="0" max="100" value="50" class="subtitleSyncSlider" />
+        </div>
     </div>
 </div>


### PR DESCRIPTION
Subtitle offset slider lags due to the fact that cue offset is updated with each `touchmove`. More lines of text - more lag.
With this PR, we listen `change` only: lack of continuous tuning, but it is more operable.

**Changes**
* Listen only slider `change`
* Add minimum width for SubtitleSync dialog. _On iPhone 5, slider was too small that I couldn't set 0_
* Prevent OSD from being hidden when user works with UI

**Issues**
Fixes #1478
