### PR TITLE
Fix Firefox subtitle offset

### DIFF
--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -649,7 +649,7 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
         function setTrackEventsSubtitleOffset(trackEvents, offsetValue) {
 
             if (Array.isArray(trackEvents)) {
-                offsetValue = updateCurrentTrackOffset(offsetValue);
+                offsetValue = updateCurrentTrackOffset(offsetValue) * 1e7; // ticks
                 trackEvents.forEach(function(trackEvent) {
                     trackEvent.StartPositionTicks -= offsetValue;
                     trackEvent.EndPositionTicks -= offsetValue;


### PR DESCRIPTION
**Changes**
Convert seconds to ticks.

**Issues**
Fixes #1493

**Notes**
There is another issue with handling of numeric keys. They are not only set subtitle offset, but also move playback position (after we added those key bindings).
I am going to fix it in separate PR because it may require more testing.
