### PR TITLE
Rearrange keydown event handling

### DIFF
--- a/src/components/subtitlesync/subtitlesync.js
+++ b/src/components/subtitlesync/subtitlesync.js
@@ -65,6 +65,9 @@ define(['playbackManager', 'layoutManager', 'text!./subtitlesync.template.html',
                     event.preventDefault();
                 }
             }
+
+            // FIXME: TV layout will require special handling for navigation keys. But now field is not focusable
+            event.stopPropagation();
         });
 
         subtitleSyncTextField.blur = function() {

--- a/src/controllers/playback/videoosd.js
+++ b/src/controllers/playback/videoosd.js
@@ -1080,7 +1080,7 @@ define(['playbackManager', 'dom', 'inputManager', 'datetime', 'itemHelper', 'med
          */
         var clickedElement;
 
-        function onWindowKeyDown(e) {
+        function onKeyDown(e) {
             clickedElement = e.srcElement;
 
             var key = keyboardnavigation.getKeyName(e);
@@ -1191,6 +1191,13 @@ define(['playbackManager', 'dom', 'inputManager', 'datetime', 'itemHelper', 'med
                     var percent = parseInt(key, 10) * 10;
                     playbackManager.seekPercent(percent, currentPlayer);
                     break;
+            }
+        }
+
+        function onKeyDownCapture() {
+            // Restart hide timer if OSD is currently visible
+            if (currentVisibleMenu) {
+                showOsd();
             }
         }
 
@@ -1330,7 +1337,8 @@ define(['playbackManager', 'dom', 'inputManager', 'datetime', 'itemHelper', 'med
                 });
                 showOsd();
                 inputManager.on(window, onInputCommand);
-                dom.addEventListener(window, 'keydown', onWindowKeyDown, {
+                document.addEventListener('keydown', onKeyDown);
+                dom.addEventListener(document, 'keydown', onKeyDownCapture, {
                     capture: true
                 });
                 dom.addEventListener(window, window.PointerEvent ? 'pointerdown' : 'mousedown', onWindowMouseDown, {
@@ -1350,7 +1358,8 @@ define(['playbackManager', 'dom', 'inputManager', 'datetime', 'itemHelper', 'med
                 statsOverlay.enabled(false);
             }
 
-            dom.removeEventListener(window, 'keydown', onWindowKeyDown, {
+            document.removeEventListener('keydown', onKeyDown);
+            dom.removeEventListener(document, 'keydown', onKeyDownCapture, {
                 capture: true
             });
             dom.removeEventListener(window, window.PointerEvent ? 'pointerdown' : 'mousedown', onWindowMouseDown, {

--- a/src/controllers/playback/videoosd.js
+++ b/src/controllers/playback/videoosd.js
@@ -1319,9 +1319,11 @@ define(['playbackManager', 'dom', 'inputManager', 'datetime', 'itemHelper', 'med
         var headerElement = document.querySelector('.skinHeader');
         var osdBottomElement = document.querySelector('.videoOsdBottom-maincontrols');
 
+        nowPlayingPositionSlider.enableKeyboardDragging();
+        nowPlayingVolumeSlider.enableKeyboardDragging();
+
         if (layoutManager.tv) {
             nowPlayingPositionSlider.classList.add('focusable');
-            nowPlayingPositionSlider.enableKeyboardDragging();
         }
 
         view.addEventListener('viewbeforeshow', function (e) {
@@ -1456,16 +1458,13 @@ define(['playbackManager', 'dom', 'inputManager', 'datetime', 'itemHelper', 'med
             }, options);
         }
 
-        function setVolume() {
-            playbackManager.setVolume(this.value, currentPlayer);
-        }
-
         view.querySelector('.buttonMute').addEventListener('click', function () {
             playbackManager.toggleMute(currentPlayer);
         });
-        nowPlayingVolumeSlider.addEventListener('change', setVolume);
-        nowPlayingVolumeSlider.addEventListener('mousemove', setVolume);
-        nowPlayingVolumeSlider.addEventListener('touchmove', setVolume);
+
+        nowPlayingVolumeSlider.addEventListener('input', (e) => {
+            playbackManager.setVolume(e.target.value, currentPlayer);
+        });
 
         nowPlayingPositionSlider.addEventListener('change', function () {
             var player = currentPlayer;

--- a/src/scripts/keyboardNavigation.js
+++ b/src/scripts/keyboardNavigation.js
@@ -78,7 +78,7 @@ export function isNavigationKey(key) {
 }
 
 export function enable() {
-    document.addEventListener('keydown', function (e) {
+    window.addEventListener('keydown', function (e) {
         const key = getKeyName(e);
 
         // Ignore navigation keys for non-TV


### PR DESCRIPTION
~Attempt to remove captures.~ _We still have to "capture" because of `stopPropagation`s._

Let event to bubble.
* element
* document ~ view/page
* window ~ unhandled

**Changes**
- Rearrange `keydown` event handling.
- Add keyboard dragging to volume slider. _Now volume and position sliders work as on TV, but still no focus indication._

**Issues**
Buggy handling of numeric keys at subtitle sync dialog. They are not only set subtitle offset, but also move playback position (after we added those key bindings).
Fixes #957

**Notes**
Since this affects globally, additional testing is welcome.