### PR TITLE
Add defered appLoader and splash screen

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -184,7 +184,12 @@ function copy(query) {
 function injectBundle() {
     return src(options.injectBundle.query, { base: './src/' })
         .pipe(inject(
-            src(['src/scripts/apploader.js'], { read: false }, { base: './src/' }), { relative: true }
+            src(['src/scripts/apploader.js'], { read: false }, { base: './src/' }), {
+                relative: true,
+                transform: function (filepath) {
+                    return `<script src="${filepath}" defer></script>`;
+                }
+            }
         ))
         .pipe(dest('dist/'))
         .pipe(browserSync.stream());

--- a/src/index.html
+++ b/src/index.html
@@ -104,6 +104,16 @@
             width: 0.8em;
         }
 
+        @-webkit-keyframes fadein {
+            from {
+                opacity: 0;
+            }
+
+            to {
+                opacity: 1;
+            }
+        }
+
         @keyframes fadein {
             from {
                 opacity: 0;
@@ -115,6 +125,7 @@
         }
 
         .splashLogo {
+            -webkit-animation: fadein 0.5s;
             animation: fadein 0.5s;
             width: 30%;
             height: 30%;
@@ -125,6 +136,7 @@
             position: fixed;
             top: 50%;
             left: 50%;
+            -webkit-transform: translate(-50%, -50%);
             transform: translate(-50%, -50%);
         }
     </style>

--- a/src/index.html
+++ b/src/index.html
@@ -52,7 +52,7 @@
     <!-- iPad Pro 1 -->
     <link href="assets/splash/ipadpro1_splash.png" media="screen and (device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" rel="apple-touch-startup-image" />
     <link href="assets/splash/ipadpro1_splash_l.png" media="screen and (device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" rel="apple-touch-startup-image" />
-    
+
     <!-- iPad Pro 3 -->
     <link href="assets/splash/ipadpro3_splash.png" media="screen and (device-width: 834px) and (device-height: 1194px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" rel="apple-touch-startup-image" />
     <link href="assets/splash/ipadpro3_splash_l.png" media="screen and (device-width: 834px) and (device-height: 1194px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" rel="apple-touch-startup-image" />
@@ -69,12 +69,19 @@
     <title>Jellyfin</title>
 
     <style>
-        .transparentDocument, .backgroundContainer-transparent:not(.withBackdrop) {
+        .transparentDocument,
+        .backgroundContainer-transparent:not(.withBackdrop) {
             background: none !important;
             background-color: transparent !important;
         }
 
-        .mouseIdle, .mouseIdle button, .mouseIdle select, .mouseIdle input, .mouseIdle textarea, .mouseIdle a, .mouseIdle label {
+        .mouseIdle,
+        .mouseIdle button,
+        .mouseIdle select,
+        .mouseIdle input,
+        .mouseIdle textarea,
+        .mouseIdle a,
+        .mouseIdle label {
             cursor: none !important;
         }
 
@@ -82,7 +89,9 @@
             background-color: #101010;
         }
 
-        .hide, .mouseIdle .hide-mouse-idle, .mouseIdle-tv .hide-mouse-idle-tv {
+        .hide,
+        .mouseIdle .hide-mouse-idle,
+        .mouseIdle-tv .hide-mouse-idle-tv {
             display: none !important;
         }
 
@@ -94,6 +103,30 @@
             z-index: 1;
             width: 0.8em;
         }
+
+        @keyframes fadein {
+            from {
+                opacity: 0;
+            }
+
+            to {
+                opacity: 1;
+            }
+        }
+
+        .splashLogo {
+            animation: fadein 0.5s;
+            width: 30%;
+            height: 30%;
+            background-image: url(assets/img/banner-light.png);
+            background-position: center center;
+            background-repeat: no-repeat;
+            background-size: contain;
+            position: fixed;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+        }
     </style>
 </head>
 <body>
@@ -103,7 +136,9 @@
         <div class="mainDrawer-scrollContainer scrollContainer focuscontainer-y"></div>
     </div>
     <div class="skinHeader focuscontainer-x"></div>
-    <div class="mainAnimatedPages skinBody"></div>
+    <div class="mainAnimatedPages skinBody">
+        <div class="splashLogo"></div>
+    </div>
     <div class="mainDrawerHandle"></div>
 
     <!-- inject:js -->

--- a/src/scripts/apploader.js
+++ b/src/scripts/apploader.js
@@ -11,6 +11,7 @@
             src += `?v=${self.dashboardVersion}`;
         }
         script.src = src;
+        script.setAttribute('async', '');
 
         if (onload) {
             script.onload = onload;


### PR DESCRIPTION
**Changes**

Adds a `defer` tag to the injected appLoader script in order to load and parse `appLoader.js` before signaling `DOMContentLoaded`.

Adds an `async` tag to all the scripts inserted by appLoader. This allows the browser to fetch and parse the scripts at the same time, making them load fast.

Adds a nice splash screen with the Jellyfin logo during the bootstrap of the app.

*I get around 2s better loading with this PR than on current master (12s -> 10s before fully loaded)*

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
