### PR TITLE
Add Server -> Libraries -> Display -> Apply ignore patterns checkbox

### DIFF
--- a/src/controllers/dashboard/librarydisplay.js
+++ b/src/controllers/dashboard/librarydisplay.js
@@ -24,6 +24,7 @@ define(['globalize', 'loading', 'libraryMenu', 'emby-checkbox', 'emby-button', '
                 view.querySelector('.chkGroupMoviesIntoCollections').checked = config.EnableGroupingIntoCollections;
                 view.querySelector('.chkDisplaySpecialsWithinSeasons').checked = config.DisplaySpecialsWithinSeasons;
                 view.querySelector('.chkExternalContentInSuggestions').checked = config.EnableExternalContentInSuggestions;
+                view.querySelector('.chkApplyIgnorePatterns').checked = config.ApplyIgnorePatterns;
                 view.querySelector('#chkSaveMetadataHidden').checked = config.SaveMetadataHidden;
             });
             ApiClient.getNamedConfiguration('metadata').then(function(metadata) {
@@ -39,6 +40,7 @@ define(['globalize', 'loading', 'libraryMenu', 'emby-checkbox', 'emby-button', '
                 config.EnableGroupingIntoCollections = form.querySelector('.chkGroupMoviesIntoCollections').checked;
                 config.DisplaySpecialsWithinSeasons = form.querySelector('.chkDisplaySpecialsWithinSeasons').checked;
                 config.EnableExternalContentInSuggestions = form.querySelector('.chkExternalContentInSuggestions').checked;
+                config.ApplyIgnorePatterns = form.querySelector('.chkApplyIgnorePatterns').checked;
                 config.SaveMetadataHidden = form.querySelector('#chkSaveMetadataHidden').checked;
                 ApiClient.updateServerConfiguration(config).then(Dashboard.processServerConfigurationUpdateResult);
             });

--- a/src/librarydisplay.html
+++ b/src/librarydisplay.html
@@ -39,6 +39,11 @@
                     <div class="fieldDescription checkboxFieldDescription">${OptionEnableExternalContentInSuggestionsHelp}</div>
                 </div>
 
+                <label class="checkboxContainer">
+                    <input type="checkbox" is="emby-checkbox" class="chkApplyIgnorePatterns"/>
+                    <span>${LabelApplyIgnorePatterns}</span>
+                </label>
+
                 <div class="checkboxContainer checkboxContainer-withDescription fldSaveMetadataHidden hide">
                     <label>
                         <input type="checkbox" is="emby-checkbox" class="chkAirDays" id="chkSaveMetadataHidden" data-filter="Sunday" />

--- a/src/strings/en-gb.json
+++ b/src/strings/en-gb.json
@@ -859,6 +859,7 @@
     "LabelDay": "Day:",
     "LabelDateTimeLocale": "Date time locale:",
     "LabelCustomDeviceDisplayNameHelp": "Supply a custom display name or leave empty to use the name reported by the device.",
+    "LabelApplyIgnorePatterns": "Apply ignore patterns",
     "HeaderYears": "Years",
     "HeaderVideos": "Videos",
     "HeaderVideoTypes": "Video Types",

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -563,6 +563,7 @@
     "LabelAllowServerAutoRestartHelp": "The server will only restart during idle periods when no users are active.",
     "LabelAllowedRemoteAddresses": "Remote IP address filter:",
     "LabelAllowedRemoteAddressesMode": "Remote IP address filter mode:",
+    "LabelApplyIgnorePatterns": "Apply ignore patterns",
     "LabelAppName": "App name",
     "LabelAppNameExample": "Example: Sickbeard, Sonarr",
     "LabelArtists": "Artists:",


### PR DESCRIPTION
**Changes**
Depends on jellyfin/jellyfin#3483

Adds "Server -> Libraries -> Display -> Apply ignore patterns" checkbox to control the system.xml `ApplyIgnorePatterns` setting as suggested in jellyfin/jellyfin#3483

**Issues**
Fixes jellyfin/jellyfin#3375

This is a draft. In case jellyfin/jellyfin#3483 does not get merged this option makes no sense and this PR should be closed.
