### PR TITLE
Convert XMLHttpRequest to Fetch API

### DIFF
--- a/src/components/require/requiretext.js
+++ b/src/components/require/requiretext.js
@@ -6,7 +6,7 @@ define(function () {
 
     return {
 
-        load: function (url, req, load, config) {
+        load: async function (url, req, load, config) {
 
             if (url.indexOf('://') === -1) {
                 url = config.baseUrl + url;
@@ -26,14 +26,10 @@ define(function () {
                 url += 'r=0';
             }
 
-            var xhr = new XMLHttpRequest();
-            xhr.open('GET', url, true);
+            const response = await fetch(url);
+            const textContent = await response.text();
 
-            xhr.onload = function (e) {
-                load(this.response);
-            };
-
-            xhr.send();
+            load(textContent);
         },
 
         normalize: function (name, normalize) {

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1028,7 +1028,7 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
             try {
                 const response = await fetch(url);
                 decrementFetchQueue();
-                return await response.json;
+                return await response.json();
             } catch (error) {
                 decrementFetchQueue();
                 throw new Error(error);

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1017,31 +1017,22 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
             });
         }
 
-        function fetchSubtitles(track, item) {
+        async function fetchSubtitles(track, item) {
             if (window.Windows && itemHelper.isLocalItem(item)) {
                 return fetchSubtitlesUwp(track, item);
             }
 
             incrementFetchQueue();
-            return new Promise(function (resolve, reject) {
-                var xhr = new XMLHttpRequest();
+            var url = getTextTrackUrl(track, item, '.js');
 
-                var url = getTextTrackUrl(track, item, '.js');
-
-                xhr.open('GET', url, true);
-
-                xhr.onload = function (e) {
-                    resolve(JSON.parse(this.response));
-                    decrementFetchQueue();
-                };
-
-                xhr.onerror = function (e) {
-                    reject(e);
-                    decrementFetchQueue();
-                };
-
-                xhr.send();
-            });
+            try {
+                const response = await fetch(url);
+                decrementFetchQueue();
+                return await response.json;
+            } catch (error) {
+                decrementFetchQueue();
+                throw new Error(error);
+            }
         }
 
         function setTrackForDisplay(videoElement, track) {

--- a/src/scripts/globalize.js
+++ b/src/scripts/globalize.js
@@ -153,9 +153,8 @@ define(['userSettings', 'events'], function (userSettings, events) {
             });
         }
 
-        return new Promise(function (resolve, reject) {
+        async function getTranslationFile(resolve, reject) {
             if (!filtered.length) {
-                resolve();
                 return;
             }
 
@@ -164,22 +163,17 @@ define(['userSettings', 'events'], function (userSettings, events) {
             url += url.indexOf('?') === -1 ? '?' : '&';
             url += 'v=' + cacheParam;
 
-            var xhr = new XMLHttpRequest();
-            xhr.open('GET', url, true);
+            const response = await fetch(url);
+            const jsonConntent = await response.json();
 
-            xhr.onload = function (e) {
-                if (this.status < 400) {
-                    resolve(JSON.parse(this.response));
-                } else {
-                    resolve({});
-                }
-            };
+            if (response.status < 400) {
+                return jsonConntent;
+            } else {
+                return {};
+            }
+        }
 
-            xhr.onerror = function () {
-                resolve({});
-            };
-            xhr.send();
-        });
+        return getTranslationFile();
     }
 
     function translateKey(key) {


### PR DESCRIPTION
**Changes**

This converts the instances of XMLHttpRequest in the code to tthe Fetch API.

The Fetch API is cleaner, faster and more readable than the old XMLHttpRequest.

Surface testing was done, but I might've missed stuff.

The various editors aren't covered in this since there are ES6 PRs for them currently opened.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
