### PR TITLE
Use builtins when injecting core-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,14 +85,14 @@
   },
   "babel": {
     "presets": [
-    [
-      "@babel/preset-env",
-      {
-        "useBuiltIns": "entry",
-        "corejs": "3"
-      }
-    ]
-  ],
+      [
+        "@babel/preset-env",
+        {
+            "useBuiltIns": "entry",
+            "corejs": "3"
+        }
+      ]
+    ],
     "overrides": [
       {
         "test": [

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "query-string": "^6.13.1",
     "resize-observer-polyfill": "^1.5.1",
     "screenfull": "^5.0.2",
-    "shaka-player": "^3.0.1",
+    "shaka-player": "^2.5.13",
     "sortablejs": "^1.10.2",
     "swiper": "^5.4.5",
     "webcomponents.js": "^0.7.24",

--- a/package.json
+++ b/package.json
@@ -85,8 +85,14 @@
   },
   "babel": {
     "presets": [
-      "@babel/preset-env"
-    ],
+    [
+      "@babel/preset-env",
+      {
+        "useBuiltIns": "entry",
+        "corejs": "3"
+      }
+    ]
+  ],
     "overrides": [
       {
         "test": [

--- a/src/bundle.js
+++ b/src/bundle.js
@@ -1,3 +1,6 @@
+import 'core-js/stable';
+import 'regenerator-runtime/runtime';
+
 /**
  * require.js module definitions bundled by webpack
  */
@@ -117,12 +120,6 @@ _define('epubjs', function () {
 var page = require('page');
 _define('page', function() {
     return page;
-});
-
-// core-js
-var polyfill = require('@babel/polyfill/dist/polyfill');
-_define('polyfill', function () {
-    return polyfill;
 });
 
 // domtokenlist-shim

--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -691,7 +691,6 @@ var AppInfo = {};
                     'jellyfin-noto',
                     'date-fns',
                     'page',
-                    'polyfill',
                     'fast-text-encoding',
                     'intersection-observer',
                     'classlist-polyfill',
@@ -710,7 +709,6 @@ var AppInfo = {};
         });
 
         require(['fetch']);
-        require(['polyfill']);
         require(['fast-text-encoding']);
         require(['intersection-observer']);
         require(['classlist-polyfill']);

--- a/yarn.lock
+++ b/yarn.lock
@@ -10074,10 +10074,10 @@ sha.js@^2.4.0, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-shaka-player@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/shaka-player/-/shaka-player-3.0.1.tgz#abb87b28e4060e82266211f9d406aa28e789a281"
-  integrity sha512-sd//nbjJUlEZKRnGk6IBu0YW+Iw0ia8m5Zm4MxoL19VtDaiv0YuHo7ydFYkE3TcNOn++SCMQ+YntWtbNvRuQHw==
+shaka-player@^2.5.13:
+  version "2.5.13"
+  resolved "https://registry.yarnpkg.com/shaka-player/-/shaka-player-2.5.13.tgz#f8c493b825c735fc86d619cba8b2eb2f2a382233"
+  integrity sha512-rEh7juGlTvvF10oD7+EukS12EysZXI2fiGvNLqO7GsBQ5R/sFwcTGEB8A6lWlHQXeGVbT+MxZWKMZwFE805G6A==
   dependencies:
     eme-encryption-scheme-polyfill "^2.0.1"
 


### PR DESCRIPTION
**Changes**

This should slightly reduce the amount of core-js polyfills inserted into bundle.js, by only inserting what we actually need.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
