### PR TITLE
Fixing Border radius and light theme improvements

### DIFF
--- a/src/themes/appletv/theme.css
+++ b/src/themes/appletv/theme.css
@@ -125,6 +125,7 @@ html {
 .visualCardBox,
 .cardBox:not(.visualCardBox) .cardPadder {
     background-color: rgba(0, 0, 0, 0.1);
+    border-radius: 0.5rem;
 }
 
 .defaultCardBackground1 {
@@ -171,6 +172,10 @@ html {
 .cardFooter-vibrant .cardText-secondary {
     color: inherit;
     opacity: 0.5;
+}
+
+.cardImageContainer {
+    border-radius: 0.5rem;
 }
 
 .formDialogHeader a,
@@ -286,7 +291,10 @@ html {
     border-color: #fff;
 }
 
-.emby-checkbox:checked + span + .checkboxOutline,
+.emby-checkbox:checked + span + .checkboxOutline {
+    background-color: #00a4dc;
+}
+
 .itemProgressBarForeground {
     background: linear-gradient(90deg, rgba(0, 210, 201, 1) 0%, rgba(13, 194, 98, 1) 28%, rgba(0, 75, 185, 1) 100%);
 }
@@ -451,7 +459,12 @@ html {
 
 .card:focus .cardBox.visualCardBox,
 .card:focus .cardBox:not(.visualCardBox) .cardScalable {
+    border-radius: 0.5rem;
     border-color: #00a4dc !important;
+}
+
+.blurhash-canvas {
+    border-radius: 0.5rem;
 }
 
 .itemDetailImage,

--- a/src/themes/light/theme.css
+++ b/src/themes/light/theme.css
@@ -66,6 +66,10 @@ html {
     color: #00a4dc;
 }
 
+.emby-scrollbuttons .paper-icon-button-light {
+    color: #000000;
+}
+
 .fab,
 .raised {
     background: #d8d8d8;
@@ -234,7 +238,7 @@ html {
 }
 
 .listItem-border {
-    border-color: #f0f0f0 !important;
+    border-color: #a7a7a7 !important;
 }
 
 .listItem:focus {

--- a/src/themes/light/theme.css
+++ b/src/themes/light/theme.css
@@ -57,6 +57,10 @@ html {
     background-color: #f0f0f0;
 }
 
+.emby-scrollbuttons .paper-icon-button-light {
+    color: #000;
+}
+
 .paper-icon-button-light:hover:not(:disabled) {
     color: #00a4dc;
     background-color: rgba(0, 164, 220, 0.2);
@@ -64,10 +68,6 @@ html {
 
 .paper-icon-button-light.show-focus:focus {
     color: #00a4dc;
-}
-
-.emby-scrollbuttons .paper-icon-button-light {
-    color: #000000;
 }
 
 .fab,

--- a/src/themes/purplehaze/theme.css
+++ b/src/themes/purplehaze/theme.css
@@ -199,7 +199,7 @@ a[data-role=button] {
 }
 
 .cardContent {
-    border-radius: 1em;
+    border-radius: 0.8em;
 }
 
 .collapseContent,
@@ -208,10 +208,14 @@ a[data-role=button] {
 .paperList,
 .visualCardBox {
     background-color: rgba(0, 0, 0, 0.5);
-    border-radius: 1em;
+    border-radius: 0.8em;
 }
 
 .cardOverlayContainer {
+    border-radius: 0.8em;
+}
+
+.blurhash-canvas {
     border-radius: 0.8em;
 }
 
@@ -553,7 +557,7 @@ a[data-role=button] {
 
 .cardBox:not(.visualCardBox) .cardPadder {
     background-color: rgba(0, 0, 0, 0.5);
-    border-radius: 1em;
+    border-radius: 0.8em;
 }
 
 .card:focus .cardBox.visualCardBox,


### PR DESCRIPTION
A range of theme based fixes, including:


- fixing border radius with the addition of blur hash


- light theme changes to improve readability


**Changes**
See Below Screenshots

Scroll Arrows (light theme)
![2020-07-06-fix-light-mode-scroll-arrows](https://user-images.githubusercontent.com/18101008/86583766-b6624e80-bf7b-11ea-8e93-e4304f7bf6c4.png)
List Seperation (light theme)
![2020-07-06-fix-light-mode-list-seperation](https://user-images.githubusercontent.com/18101008/86583775-b8c4a880-bf7b-11ea-8fb1-5f3724fd5ed5.png)
Border Radius (Purple Haze)
![2020-07-06-fix-border-radius-1](https://user-images.githubusercontent.com/18101008/86584077-456f6680-bf7c-11ea-8a48-d63853071657.png)
Border Radius (Apple TV)
![2020-07-06-fix-border-radius-2](https://user-images.githubusercontent.com/18101008/86584081-47392a00-bf7c-11ea-8778-4157bf269aa7.png)



