### PR TITLE
Adjust text selection rules and add provider name to identification results

### DIFF
--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -3,6 +3,10 @@ html {
     margin: 0;
     padding: 0;
     height: 100%;
+}
+
+.layout-mobile,
+.layout-tv {
     user-select: none;
 }
 

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -7,6 +7,7 @@ html {
 
 .layout-mobile,
 .layout-tv {
+    -webkit-touch-callout: none;
     user-select: none;
 }
 
@@ -37,12 +38,6 @@ html {
 
 html {
     line-height: 1.35;
-}
-
-.layout-mobile,
-.layout-tv {
-    -webkit-touch-callout: none;
-    user-select: none;
 }
 
 body {

--- a/src/components/itemidentifier/itemidentifier.js
+++ b/src/components/itemidentifier/itemidentifier.js
@@ -221,12 +221,14 @@ define(['dialogHelper', 'loading', 'connectionManager', 'require', 'globalize', 
         html += '</div>';
         html += '</div>';
 
-        var numLines = 2;
+        var numLines = 3;
         if (currentItemType === 'MusicAlbum') {
             numLines++;
         }
 
         var lines = [result.Name];
+
+        lines.push(result.SearchProviderName);
 
         if (result.AlbumArtist) {
             lines.push(result.AlbumArtist.Name);


### PR DESCRIPTION
**Changes**

Does what it says on the tin.

Text is can now be selected on desktop layouts, but no on mobile or TV.

Results in the Identify dialog now show the provider name.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
