### PR TITLE
Smaller library tiles

### DIFF
--- a/src/components/homesections/homesections.js
+++ b/src/components/homesections/homesections.js
@@ -342,16 +342,11 @@ define(['connectionManager', 'cardBuilder', 'appSettings', 'dom', 'apphost', 'la
         var html = '';
         if (userViews.length) {
             html += '<h2 class="sectionTitle sectionTitle-cards padded-left">' + globalize.translate('HeaderMyMedia') + '</h2>';
-            if (enableScrollX()) {
-                html += '<div is="emby-scroller" class="padded-top-focusscale padded-bottom-focusscale" data-centerfocus="true">';
-                html += '<div is="emby-itemscontainer" class="itemsContainer scrollSlider focuscontainer-x">';
-            } else {
-                html += '<div is="emby-itemscontainer" class="itemsContainer padded-left padded-right focuscontainer-x vertical-wrap">';
-            }
+            html += '<div is="emby-itemscontainer" class="itemsContainer padded-left padded-right focuscontainer-x vertical-wrap">';
 
             html += cardBuilder.getCardsHtml({
                 items: userViews,
-                shape: getThumbShape(),
+                shape: shape,
                 showTitle: true,
                 centerText: true,
                 overlayText: false,
@@ -360,9 +355,6 @@ define(['connectionManager', 'cardBuilder', 'appSettings', 'dom', 'apphost', 'la
                 allowBottomPadding: !enableScrollX()
             });
 
-            if (enableScrollX()) {
-                html += '</div>';
-            }
             html += '</div>';
         }
 


### PR DESCRIPTION
If you have a lot of libraries you have to scroll through all cards via the small arrows to get to the one in the back.
All libraries should be accessible with one click

**Changes**
Switch the library tiles to small cards to see all of them on the homescreen:

Old:
![image](https://user-images.githubusercontent.com/14938497/86777627-af117280-c059-11ea-9f3d-db5d05d3c899.png)

New:
![image](https://user-images.githubusercontent.com/14938497/86777621-acaf1880-c059-11ea-8269-b939345127fc.png)
