### PR TITLE
Remove repeated fav icon in remotecontrol in desktop layout

### DIFF
--- a/src/components/remotecontrol/remotecontrol.css
+++ b/src/components/remotecontrol/remotecontrol.css
@@ -278,6 +278,10 @@
         flex-direction: column;
     }
 
+    .layout-desktop .nowPlayingPageUserDataButtons {
+        display: none;
+    }
+
     .nowPlayingInfoContainer {
         -webkit-box-orient: vertical !important;
         -webkit-box-direction: normal !important;


### PR DESCRIPTION
In desktop layout, when resizing the player width, a duplicated favorite button appears.

This PR fixes that.
