### PR TITLE
Fix lighter header/footer background color

### DIFF
--- a/src/themes/dark/theme.css
+++ b/src/themes/dark/theme.css
@@ -109,7 +109,7 @@ html {
 .formDialogHeader:not(.formDialogHeader-clear),
 .paperList,
 .visualCardBox {
-    background-color: #242424;
+    background-color: #202020;
 }
 
 .defaultCardBackground1 {


### PR DESCRIPTION
**Changes**
Fixes inconsistent header/footer colors. Some screens are using a slightly lighter shade of grey. It's noticeable in the iOS app where the status bar and tab bar use the same background color as the header.

![IMG_4165](https://user-images.githubusercontent.com/3450688/87686536-95a3b100-c752-11ea-810c-66137ad79813.PNG)

**Issues**
N/A
