### PR TITLE
Remove iOS footer hack

### DIFF
--- a/src/assets/css/ios.css
+++ b/src/assets/css/ios.css
@@ -1,8 +1,3 @@
 html {
     font-size: 82% !important;
 }
-
-.formDialogFooter {
-    position: static !important;
-    margin: 0 -1em !important;
-}


### PR DESCRIPTION
**Changes**
Removes what appears to be a hack for an old iOS layout issue. I tested iOS 10 and iOS 13 and it looks fine without this and removing it fixes an issue where the footer content could overflow the footer container.

![IMG_4165](https://user-images.githubusercontent.com/3450688/87690212-29777c00-c757-11ea-8e7c-66520110c469.PNG)

**Issues**
N/A
