### PR TITLE
Remove jQuery - Part 1

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -71,7 +71,7 @@ module.exports = {
         'jquery/no-in-array': 'error',
         'jquery/no-is-array': 'error',
         'jquery/no-is-function': 'error',
-        //'jquery/no-is': 'error',
+        'jquery/no-is': 'error',
     },
     overrides: [
         {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -67,7 +67,7 @@ module.exports = {
         'jquery/no-grep': 'error',
         'jquery/no-has': 'error',
         'jquery/no-hide': 'error',
-        //'jquery/no-html': 'error',
+        'jquery/no-html': 'error',
         'jquery/no-in-array': 'error',
         'jquery/no-is-array': 'error',
         'jquery/no-is-function': 'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -88,7 +88,7 @@ module.exports = {
         'jquery/no-submit': 'error',
         'jquery/no-text': 'error',
         'jquery/no-toggle': 'error',
-        //'jquery/no-trigger': 'error',
+        'jquery/no-trigger': 'error',
         'jquery/no-trim': 'error',
         'jquery/no-val': 'error',
         'jquery/no-when': 'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -90,7 +90,7 @@ module.exports = {
         'jquery/no-toggle': 'error',
         //'jquery/no-trigger': 'error',
         'jquery/no-trim': 'error',
-        //'jquery/no-val': 'error',
+        'jquery/no-val': 'error',
         'jquery/no-when': 'error',
         'jquery/no-wrap': 'error'
     },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -72,6 +72,14 @@ module.exports = {
         'jquery/no-is-array': 'error',
         'jquery/no-is-function': 'error',
         'jquery/no-is': 'error',
+        'jquery/no-merge': 'error',
+        'jquery/no-param': 'error',
+        'jquery/no-parent': 'error',
+        'jquery/no-parents': 'error',
+        'jquery/no-parse-html': 'error',
+        //'jquery/no-prop': 'error',
+        'jquery/no-proxy': 'error',
+        'jquery/no-ready': 'error',
     },
     overrides: [
         {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,8 @@ module.exports = {
     plugins: [
         'promise',
         'import',
-        'eslint-comments'
+        'eslint-comments',
+        'jquery'
     ],
     env: {
         node: true,
@@ -43,7 +44,14 @@ module.exports = {
         'quotes': ['error', 'single', { 'avoidEscape': true, 'allowTemplateLiterals': false }],
         'semi': ['error'],
         'space-before-blocks': ['error'],
-        'space-infix-ops': 'error'
+        'space-infix-ops': 'error',
+        // jQuery Reemoval
+        'jquery/no-ajax': 'error',
+        'jquery/no-ajax-events': 'error',
+        'jquery/no-animate': 'error',
+        'jquery/no-attr': 'error',
+        'jquery/no-bind': 'error',
+        'jquery/no-class': 'error',
     },
     overrides: [
         {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -65,6 +65,13 @@ module.exports = {
         'jquery/no-find': 'error',
         'jquery/no-global-eval': 'error',
         'jquery/no-grep': 'error',
+        'jquery/no-has': 'error',
+        'jquery/no-hide': 'error',
+        //'jquery/no-html': 'error',
+        'jquery/no-in-array': 'error',
+        'jquery/no-is-array': 'error',
+        'jquery/no-is-function': 'error',
+        //'jquery/no-is': 'error',
     },
     overrides: [
         {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,7 +45,7 @@ module.exports = {
         'semi': ['error'],
         'space-before-blocks': ['error'],
         'space-infix-ops': 'error',
-        // jQuery Reemoval
+        // jQuery Removal
         'jquery/no-ajax': 'error',
         'jquery/no-ajax-events': 'error',
         'jquery/no-animate': 'error',
@@ -80,6 +80,19 @@ module.exports = {
         //'jquery/no-prop': 'error',
         'jquery/no-proxy': 'error',
         'jquery/no-ready': 'error',
+        'jquery/no-serialize': 'error',
+        //'jquery/no-show': 'error',
+        'jquery/no-size': 'error',
+        //'jquery/no-sizzle': 'error',
+        'jquery/no-slide': 'error',
+        'jquery/no-submit': 'error',
+        'jquery/no-text': 'error',
+        'jquery/no-toggle': 'error',
+        //'jquery/no-trigger': 'error',
+        'jquery/no-trim': 'error',
+        //'jquery/no-val': 'error',
+        'jquery/no-when': 'error',
+        'jquery/no-wrap': 'error'
     },
     overrides: [
         {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -77,7 +77,7 @@ module.exports = {
         'jquery/no-parent': 'error',
         'jquery/no-parents': 'error',
         'jquery/no-parse-html': 'error',
-        //'jquery/no-prop': 'error',
+        'jquery/no-prop': 'error',
         'jquery/no-proxy': 'error',
         'jquery/no-ready': 'error',
         'jquery/no-serialize': 'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,6 +52,11 @@ module.exports = {
         'jquery/no-attr': 'error',
         'jquery/no-bind': 'error',
         'jquery/no-class': 'error',
+        'jquery/no-clone': 'error',
+        'jquery/no-closest': 'error',
+        'jquery/no-css': 'error',
+        'jquery/no-data': 'error',
+        'jquery/no-deferred': 'error',
     },
     overrides: [
         {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -60,6 +60,11 @@ module.exports = {
         'jquery/no-delegate': 'error',
         'jquery/no-each': 'error',
         'jquery/no-extend': 'error',
+        'jquery/no-fade': 'error',
+        'jquery/no-filter': 'error',
+        'jquery/no-find': 'error',
+        'jquery/no-global-eval': 'error',
+        'jquery/no-grep': 'error',
     },
     overrides: [
         {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -81,7 +81,7 @@ module.exports = {
         'jquery/no-proxy': 'error',
         'jquery/no-ready': 'error',
         'jquery/no-serialize': 'error',
-        //'jquery/no-show': 'error',
+        'jquery/no-show': 'error',
         'jquery/no-size': 'error',
         //'jquery/no-sizzle': 'error',
         'jquery/no-slide': 'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,6 +57,9 @@ module.exports = {
         'jquery/no-css': 'error',
         'jquery/no-data': 'error',
         'jquery/no-deferred': 'error',
+        'jquery/no-delegate': 'error',
+        'jquery/no-each': 'error',
+        'jquery/no-extend': 'error',
     },
     overrides: [
         {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -83,7 +83,7 @@ module.exports = {
         'jquery/no-serialize': 'error',
         'jquery/no-show': 'error',
         'jquery/no-size': 'error',
-        //'jquery/no-sizzle': 'error',
+        'jquery/no-sizzle': 'error',
         'jquery/no-slide': 'error',
         'jquery/no-submit': 'error',
         'jquery/no-text': 'error',

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "eslint-plugin-compat": "^3.5.1",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-import": "^2.21.2",
+    "eslint-plugin-jquery": "^1.5.1",
     "eslint-plugin-promise": "^4.2.1",
     "file-loader": "^6.0.0",
     "gulp": "^4.0.2",

--- a/src/components/mediaLibraryCreator/mediaLibraryCreator.js
+++ b/src/components/mediaLibraryCreator/mediaLibraryCreator.js
@@ -52,7 +52,7 @@ define(['loading', 'dialogHelper', 'dom', 'jQuery', 'components/libraryoptionsed
     }
 
     function initEditor(page, collectionTypeOptions) {
-        const selectCollectionType = $('#selectCollectionType', page);
+        const selectCollectionType = page.querySelector('#selectCollectionType');
         selectCollectionType.innerHTML = getCollectionTypeOptionsHtml(collectionTypeOptions);
 
         selectCollectionType.value = '';
@@ -76,7 +76,7 @@ define(['loading', 'dialogHelper', 'dom', 'jQuery', 'components/libraryoptionsed
                     var folderOption = collectionTypeOptions.filter(function (i) {
                         return i.value == value;
                     })[0];
-                    $('.collectionTypeFieldDescription', dlg).innerHTML = folderOption.message || '';
+                    dlg.querySelector('.collectionTypeFieldDescription').innerHTML = folderOption.message || '';
                 }
             }
         });

--- a/src/components/mediaLibraryCreator/mediaLibraryCreator.js
+++ b/src/components/mediaLibraryCreator/mediaLibraryCreator.js
@@ -56,7 +56,7 @@ define(['loading', 'dialogHelper', 'dom', 'jQuery', 'components/libraryoptionsed
 
         $('#selectCollectionType', page).val('').on('change', function () {
             var value = this.value;
-            var dlg = $(this).parents('.dialog')[0];
+            var dlg = this.closest('.dialog');
             libraryoptionseditor.setContentType(dlg.querySelector('.libraryOptions'), value == 'mixed' ? '' : value);
 
             if (value) {

--- a/src/components/mediaLibraryCreator/mediaLibraryCreator.js
+++ b/src/components/mediaLibraryCreator/mediaLibraryCreator.js
@@ -174,7 +174,7 @@ define(['loading', 'dialogHelper', 'dom', 'jQuery', 'components/libraryoptionsed
 
     function initLibraryOptions(dlg) {
         libraryoptionseditor.embed(dlg.querySelector('.libraryOptions')).then(function () {
-            $('#selectCollectionType', dlg).trigger('change');
+            dlg.querySelector('#selectCollectionType').dispatchEvent(new Event('change'));
             onToggleAdvancedChange.call(dlg.querySelector('.chkAdvanced'));
         });
     }

--- a/src/components/mediaLibraryCreator/mediaLibraryCreator.js
+++ b/src/components/mediaLibraryCreator/mediaLibraryCreator.js
@@ -52,7 +52,9 @@ define(['loading', 'dialogHelper', 'dom', 'jQuery', 'components/libraryoptionsed
     }
 
     function initEditor(page, collectionTypeOptions) {
-        $('#selectCollectionType', page).html(getCollectionTypeOptionsHtml(collectionTypeOptions)).val('').on('change', function () {
+        $('#selectCollectionType', page).innerHTML = getCollectionTypeOptionsHtml(collectionTypeOptions);
+
+        $('#selectCollectionType', page).val('').on('change', function () {
             var value = this.value;
             var dlg = $(this).parents('.dialog')[0];
             libraryoptionseditor.setContentType(dlg.querySelector('.libraryOptions'), value == 'mixed' ? '' : value);
@@ -72,7 +74,7 @@ define(['loading', 'dialogHelper', 'dom', 'jQuery', 'components/libraryoptionsed
                     var folderOption = collectionTypeOptions.filter(function (i) {
                         return i.value == value;
                     })[0];
-                    $('.collectionTypeFieldDescription', dlg).html(folderOption.message || '');
+                    $('.collectionTypeFieldDescription', dlg).innerHTML = folderOption.message || '';
                 }
             }
         });

--- a/src/components/mediaLibraryCreator/mediaLibraryCreator.js
+++ b/src/components/mediaLibraryCreator/mediaLibraryCreator.js
@@ -20,8 +20,8 @@ define(['loading', 'dialogHelper', 'dom', 'jQuery', 'components/libraryoptionsed
         isCreating = true;
         loading.show();
         var dlg = dom.parentWithClass(this, 'dlg-librarycreator');
-        var name = $('#txtValue', dlg).val();
-        var type = $('#selectCollectionType', dlg).val();
+        var name = dlg.querySelector('#txtValue').value;
+        var type = dlg.querySelector('#selectCollectionType').value;
 
         if (type == 'mixed') {
             type = null;
@@ -52,9 +52,11 @@ define(['loading', 'dialogHelper', 'dom', 'jQuery', 'components/libraryoptionsed
     }
 
     function initEditor(page, collectionTypeOptions) {
-        $('#selectCollectionType', page).innerHTML = getCollectionTypeOptionsHtml(collectionTypeOptions);
+        const selectCollectionType = $('#selectCollectionType', page);
+        selectCollectionType.innerHTML = getCollectionTypeOptionsHtml(collectionTypeOptions);
 
-        $('#selectCollectionType', page).val('').on('change', function () {
+        selectCollectionType.value = '';
+        selectCollectionType.on('change', function () {
             var value = this.value;
             var dlg = this.closest('.dialog');
             libraryoptionseditor.setContentType(dlg.querySelector('.libraryOptions'), value == 'mixed' ? '' : value);
@@ -70,7 +72,7 @@ define(['loading', 'dialogHelper', 'dom', 'jQuery', 'components/libraryoptionsed
 
                 if (index != -1) {
                     var name = this.options[index].innerHTML.replace('*', '').replace('&amp;', '&');
-                    $('#txtValue', dlg).val(name);
+                    dlg.querySelector('#txtValue').value = name;
                     var folderOption = collectionTypeOptions.filter(function (i) {
                         return i.value == value;
                     })[0];

--- a/src/components/tvproviders/schedulesdirect.js
+++ b/src/components/tvproviders/schedulesdirect.js
@@ -9,7 +9,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox', 'listViewStyle', 'emb
                     return i.Id === providerId;
                 })[0] || {};
                 listingsId = info.ListingsId;
-                $('#selectListing', page).val(info.ListingsId || '');
+                page.querySelector('#selectListing').value = info.ListingsId || '';
                 page.querySelector('.txtUser').value = info.Username || '';
                 page.querySelector('.txtPass').value = '';
                 page.querySelector('.txtZipCode').value = info.ZipCode || '';
@@ -139,7 +139,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox', 'listViewStyle', 'emb
         }
 
         function submitListingsForm() {
-            var selectedListingsId = $('#selectListing', page).val();
+            var selectedListingsId = page.querySelector('#selectListing').value;
 
             if (!selectedListingsId) {
                 return void Dashboard.alert({
@@ -154,7 +154,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox', 'listViewStyle', 'emb
                     return i.Id === id;
                 })[0];
                 info.ZipCode = page.querySelector('.txtZipCode').value;
-                info.Country = $('#selectCountry', page).val();
+                info.Country = page.querySelector('#selectCountry').value;
                 info.ListingsId = selectedListingsId;
                 info.EnableAllTuners = page.querySelector('.chkAllTuners').checked;
 
@@ -204,7 +204,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox', 'listViewStyle', 'emb
                 url: ApiClient.getUrl('LiveTv/ListingProviders/Lineups', {
                     Id: providerId,
                     Location: value,
-                    Country: $('#selectCountry', page).val()
+                    Country: page.querySelector('#selectCountry').value
                 }),
                 dataType: 'json'
             }).then(function (result) {
@@ -213,7 +213,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox', 'listViewStyle', 'emb
                 });
 
                 if (listingsId) {
-                    $('#selectListing', page).val(listingsId);
+                    page.querySelector('#selectListing', page).value = listingsId;
                 }
 
                 loading.hide();

--- a/src/components/tvproviders/schedulesdirect.js
+++ b/src/components/tvproviders/schedulesdirect.js
@@ -63,7 +63,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox', 'listViewStyle', 'emb
 
                     return 0;
                 });
-                const selectCountry = $('#selectCountry', page);
+                const selectCountry = page.querySelector('#selectCountry');
                 selectCountry.innerHtml = countryList.map(function (c) {
                     return '<option value="' + c.value + '">' + c.name + '</option>';
                 }).join('');
@@ -194,7 +194,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox', 'listViewStyle', 'emb
 
         function refreshListings(value) {
             if (!value) {
-                $('#selectListing', page).innerHtml = '';
+                page.querySelector('#selectListing').innerHtml = '';
                 return;
             }
 
@@ -208,7 +208,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox', 'listViewStyle', 'emb
                 }),
                 dataType: 'json'
             }).then(function (result) {
-                $('#selectListing', page).innerHtml = result.map(function (o) {
+                page.querySelector('#selectListing').innerHtml = result.map(function (o) {
                     return '<option value="' + o.Id + '">' + o.Name + '</option>';
                 });
 
@@ -299,7 +299,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox', 'listViewStyle', 'emb
                     page.querySelector('.selectTunersSection').classList.remove('hide');
                 }
             });
-            $('.createAccountHelp', page).innerHtml = globalize.translate('MessageCreateAccountAt', '<a is="emby-linkbutton" class="button-link" href="http://www.schedulesdirect.org" target="_blank">http://www.schedulesdirect.org</a>');
+            page.querySelector('.createAccountHelp').innerHtml = globalize.translate('MessageCreateAccountAt', '<a is="emby-linkbutton" class="button-link" href="http://www.schedulesdirect.org" target="_blank">http://www.schedulesdirect.org</a>');
             reload();
         };
     };

--- a/src/components/tvproviders/schedulesdirect.js
+++ b/src/components/tvproviders/schedulesdirect.js
@@ -155,11 +155,17 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox', 'listViewStyle', 'emb
                 info.Country = $('#selectCountry', page).val();
                 info.ListingsId = selectedListingsId;
                 info.EnableAllTuners = page.querySelector('.chkAllTuners').checked;
-                info.EnabledTuners = info.EnableAllTuners ? [] : $('.chkTuner', page).get().filter(function (i) {
-                    return i.checked;
-                }).map(function (i) {
-                    return i.getAttribute('data-id');
-                });
+
+                let enabledTuners = [];
+                if (!info.EnableAllTuners) {
+                    enabledTuners = Array.prototype.filter.call(page.querySelectorAll('.chkTuner'), (tuner) => {
+                        return tuner.checked;
+                    }).map((tuner) => {
+                        return tuner.getAttribute('data-id');
+                    });
+                }
+
+                info.EnabledTuners = enabledTuners;
                 ApiClient.ajax({
                     type: 'POST',
                     url: ApiClient.getUrl('LiveTv/ListingProviders', {

--- a/src/components/tvproviders/schedulesdirect.js
+++ b/src/components/tvproviders/schedulesdirect.js
@@ -63,9 +63,11 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox', 'listViewStyle', 'emb
 
                     return 0;
                 });
-                $('#selectCountry', page).html(countryList.map(function (c) {
+                const selectCountry = $('#selectCountry', page);
+                selectCountry.innerHtml = countryList.map(function (c) {
                     return '<option value="' + c.value + '">' + c.name + '</option>';
-                }).join('')).val(info.Country || '');
+                }).join('');
+                selectCountry.val(info.Country || '');
                 $(page.querySelector('.txtZipCode')).trigger('change');
             }, function () { // ApiClient.getJSON() error handler
                 Dashboard.alert({
@@ -192,7 +194,8 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox', 'listViewStyle', 'emb
 
         function refreshListings(value) {
             if (!value) {
-                return void $('#selectListing', page).html('');
+                $('#selectListing', page).innerHtml = '';
+                return;
             }
 
             loading.show();
@@ -205,9 +208,9 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox', 'listViewStyle', 'emb
                 }),
                 dataType: 'json'
             }).then(function (result) {
-                $('#selectListing', page).html(result.map(function (o) {
+                $('#selectListing', page).innerHtml = result.map(function (o) {
                     return '<option value="' + o.Id + '">' + o.Name + '</option>';
-                }));
+                });
 
                 if (listingsId) {
                     $('#selectListing', page).val(listingsId);
@@ -296,7 +299,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox', 'listViewStyle', 'emb
                     page.querySelector('.selectTunersSection').classList.remove('hide');
                 }
             });
-            $('.createAccountHelp', page).html(globalize.translate('MessageCreateAccountAt', '<a is="emby-linkbutton" class="button-link" href="http://www.schedulesdirect.org" target="_blank">http://www.schedulesdirect.org</a>'));
+            $('.createAccountHelp', page).innerHtml = globalize.translate('MessageCreateAccountAt', '<a is="emby-linkbutton" class="button-link" href="http://www.schedulesdirect.org" target="_blank">http://www.schedulesdirect.org</a>');
             reload();
         };
     };

--- a/src/components/tvproviders/schedulesdirect.js
+++ b/src/components/tvproviders/schedulesdirect.js
@@ -68,7 +68,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox', 'listViewStyle', 'emb
                     return '<option value="' + c.value + '">' + c.name + '</option>';
                 }).join('');
                 selectCountry.val(info.Country || '');
-                $(page.querySelector('.txtZipCode')).trigger('change');
+                page.querySelector('.txtZipCode').dispatchEvent(new Event('change'));
             }, function () { // ApiClient.getJSON() error handler
                 Dashboard.alert({
                     message: globalize.translate('ErrorGettingTvLineups')

--- a/src/components/tvproviders/xmltv.js
+++ b/src/components/tvproviders/xmltv.js
@@ -69,11 +69,17 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox', 'emby-input', 'listVi
                 info.NewsCategories = getCategories(page.querySelector('.txtNews'));
                 info.SportsCategories = getCategories(page.querySelector('.txtSports'));
                 info.EnableAllTuners = page.querySelector('.chkAllTuners').checked;
-                info.EnabledTuners = info.EnableAllTuners ? [] : $('.chkTuner', page).get().filter(function (tuner) {
-                    return tuner.checked;
-                }).map(function (tuner) {
-                    return tuner.getAttribute('data-id');
-                });
+
+                let enabledTuners = [];
+                if (!info.EnableAllTuners) {
+                    enabledTuners = Array.prototype.filter.call(page.querySelectorAll('.chkTuner'), (tuner) => {
+                        return tuner.checked;
+                    }).map((tuner) => {
+                        return tuner.getAttribute('data-id');
+                    });
+                }
+                info.EnabledTuners = enabledTuners;
+
                 ApiClient.ajax({
                     type: 'POST',
                     url: ApiClient.getUrl('LiveTv/ListingProviders', {

--- a/src/components/tvproviders/xmltv.js
+++ b/src/components/tvproviders/xmltv.js
@@ -142,7 +142,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox', 'emby-input', 'listVi
         }
 
         function onSelectPathClick(e) {
-            var page = $(e.target).parents('.xmltvForm')[0];
+            var page = e.target.closest('.xmltvForm');
 
             require(['directorybrowser'], function (directoryBrowser) {
                 var picker = new directoryBrowser();

--- a/src/controllers/dashboard/dlna/profile.js
+++ b/src/controllers/dashboard/dlna/profile.js
@@ -389,9 +389,9 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         currentSubProfile.VideoCodec = page.querySelector('#txtTranscodingVideoCodec').value;
         currentSubProfile.Protocol = page.querySelector('#selectTranscodingProtocol').value;
         currentSubProfile.Context = 'Streaming';
-        currentSubProfile.EnableMpegtsM2TsMode = $('#chkEnableMpegtsM2TsMode', page).matches(':checked');
-        currentSubProfile.EstimateContentLength = $('#chkEstimateContentLength', page).matches(':checked');
-        currentSubProfile.TranscodeSeekInfo = $('#chkReportByteRangeRequests', page).matches(':checked') ? 'Bytes' : 'Auto';
+        currentSubProfile.EnableMpegtsM2TsMode = page.querySelector('#chkEnableMpegtsM2TsMode').matches(':checked');
+        currentSubProfile.EstimateContentLength = page.querySelector('#chkEstimateContentLength').matches(':checked');
+        currentSubProfile.TranscodeSeekInfo = page.querySelector('#chkReportByteRangeRequests').matches(':checked') ? 'Bytes' : 'Auto';
 
         if (isSubProfileNew) {
             currentProfile.TranscodingProfiles.push(currentSubProfile);

--- a/src/controllers/dashboard/dlna/profile.js
+++ b/src/controllers/dashboard/dlna/profile.js
@@ -373,7 +373,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         popup.querySelector('#chkEnableMpegtsM2TsMode').checked = transcodingProfile.EnableMpegtsM2TsMode || false;
         popup.querySelector('#chkEstimateContentLength').checked = transcodingProfile.EstimateContentLength || false;
         popup.querySelector('#chkReportByteRangeRequests').checked = transcodingProfile.TranscodeSeekInfo === 'Bytes';
-        $('.radioTabButton', popup).first().trigger('click');
+        popup.querySelector('.radioTabButton').dispatchEvent(new Event('click'));
         openPopup(popup[0]);
     }
 
@@ -808,7 +808,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         $('.subtitleProfileForm').off('submit', DlnaProfilePage.onSubtitleProfileFormSubmit).on('submit', DlnaProfilePage.onSubtitleProfileFormSubmit);
     }).on('pageshow', '#dlnaProfilePage', function () {
         var page = this;
-        $('#radioInfo', page).trigger('click');
+        page.querySelector('#radioInfo').dispatchEvent(new Event('click'));
         loadProfile(page);
     });
     window.DlnaProfilePage = {

--- a/src/controllers/dashboard/dlna/profile.js
+++ b/src/controllers/dashboard/dlna/profile.js
@@ -68,7 +68,8 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         var usersHtml = '<option></option>' + users.map(function (u) {
             return '<option value="' + u.Id + '">' + u.Name + '</option>';
         }).join('');
-        $('#selectUser', page).html(usersHtml).val(profile.UserId || '');
+        $('#selectUser', page).innerHtml = usersHtml;
+        $('#selectUser', page).val(profile.UserId || '');
         renderSubProfiles(page, profile);
     }
 
@@ -86,7 +87,9 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
             index++;
             return li;
         }).join('') + '</div>';
-        var elem = $('.httpHeaderIdentificationList', page).html(html).trigger('create');
+        var elem = $('.httpHeaderIdentificationList', page);
+        elem.innerHtml = html;
+        elem.trigger('create');
         $('.btnDeleteIdentificationHeader', elem).on('click', function () {
             var itemIndex = parseInt(this.getAttribute('data-index'));
             currentProfile.Identification.Headers.splice(itemIndex, 1);
@@ -139,7 +142,9 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
             li += '<button type="button" is="paper-icon-button-light" class="btnDeleteXmlAttribute listItemButton" data-index="0"><span class="material-icons delete"></span></button>';
             return li += '</div>';
         }).join('') + '</div>';
-        var elem = $('.xmlDocumentAttributeList', page).html(html).trigger('create');
+        var elem = $('.xmlDocumentAttributeList', page);
+        elem.innerHtml = html;
+        elem.trigger('create');
         $('.btnDeleteXmlAttribute', elem).on('click', function () {
             var itemIndex = parseInt(this.getAttribute('data-index'));
             currentProfile.XmlRootAttributes.splice(itemIndex, 1);
@@ -183,7 +188,9 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
             index++;
             return li;
         }).join('') + '</div>';
-        var elem = $('.subtitleProfileList', page).html(html).trigger('create');
+        var elem = $('.subtitleProfileList', page);
+        elem.innerHtml = html;
+        elem.trigger('create');
         $('.btnDeleteProfile', elem).on('click', function () {
             var itemIndex = parseInt(this.getAttribute('data-index'));
             currentProfile.SubtitleProfiles.splice(itemIndex, 1);
@@ -275,7 +282,9 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         }
 
         html += '</ul>';
-        var elem = $('.directPlayProfiles', page).html(html).trigger('create');
+        var elem = $('.directPlayProfiles', page);
+        elem.innerHtml = html;
+        elem.trigger('create');
         $('.btnDeleteProfile', elem).on('click', function () {
             var index = this.getAttribute('data-profileindex');
             deleteDirectPlayProfile(page, index);
@@ -336,7 +345,9 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         }
 
         html += '</ul>';
-        var elem = $('.transcodingProfiles', page).html(html).trigger('create');
+        var elem = $('.transcodingProfiles', page);
+        elem.innerHtml = html;
+        elem.trigger('create');
         $('.btnDeleteProfile', elem).on('click', function () {
             var index = this.getAttribute('data-profileindex');
             deleteTranscodingProfile(page, index);
@@ -420,7 +431,9 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         }
 
         html += '</ul>';
-        var elem = $('.containerProfiles', page).html(html).trigger('create');
+        var elem = $('.containerProfiles', page);
+        elem.innerHtml(html);
+        elem.trigger('create');
         $('.btnDeleteProfile', elem).on('click', function () {
             var index = this.getAttribute('data-profileindex');
             deleteContainerProfile(page, index);
@@ -492,7 +505,9 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         }
 
         html += '</ul>';
-        var elem = $('.codecProfiles', page).html(html).trigger('create');
+        var elem = $('.codecProfiles', page);
+        elem.innerHtml(html);
+        elem.trigger('create');
         $('.btnDeleteProfile', elem).on('click', function () {
             var index = this.getAttribute('data-profileindex');
             deleteCodecProfile(page, index);
@@ -572,7 +587,9 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         }
 
         html += '</ul>';
-        var elem = $('.mediaProfiles', page).html(html).trigger('create');
+        var elem = $('.mediaProfiles', page);
+        elem.innerHtml = html;
+        elem.trigger('create');
         $('.btnDeleteProfile', elem).on('click', function () {
             var index = this.getAttribute('data-profileindex');
             deleteResponseProfile(page, index);

--- a/src/controllers/dashboard/dlna/profile.js
+++ b/src/controllers/dashboard/dlna/profile.js
@@ -723,7 +723,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         });
         $('#selectDirectPlayProfileType', page).on('change', function () {
             if ('Video' == this.value) {
-                $('#fldDirectPlayVideoCodec', page).show();
+                page.querySelector('#fldDirectPlayVideoCodec').classList.remove('hide');
             } else {
                 page.querySelector('#fldDirectPlayVideoCodec').classList.add('hide');
             }
@@ -731,14 +731,14 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
             if ('Photo' == this.value) {
                 page.querySelector('#fldDirectPlayAudioCodec').classList.add('hide');
             } else {
-                $('#fldDirectPlayAudioCodec', page).show();
+                page.querySelector('#fldDirectPlayAudioCodec').classList.remove('hide');
             }
         });
         $('#selectTranscodingProfileType', page).on('change', function () {
             if ('Video' == this.value) {
-                $('#fldTranscodingVideoCodec', page).show();
-                $('#fldTranscodingProtocol', page).show();
-                $('#fldEnableMpegtsM2TsMode', page).show();
+                page.querySelector('#fldTranscodingVideoCodec').classList.remove('hide');
+                page.querySelector('#fldTranscodingProtocol').classList.remove('hide');
+                page.querySelector('#fldEnableMpegtsM2TsMode').classList.remove('hide');
             } else {
                 page.querySelector('#fldTranscodingVideoCodec').classList.add('hide');
                 page.querySelector('#fldTranscodingProtocol').classList.add('hide');
@@ -750,14 +750,14 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
                 page.querySelector('#fldEstimateContentLength').classList.add('hide');
                 page.querySelector('#fldReportByteRangeRequests').classList.add('hide');
             } else {
-                $('#fldTranscodingAudioCodec', page).show();
-                $('#fldEstimateContentLength', page).show();
-                $('#fldReportByteRangeRequests', page).show();
+                page.querySelector('#fldTranscodingAudioCodec').classList.remove('hide');
+                page.querySelector('#fldEstimateContentLength').classList.remove('hide');
+                page.querySelector('#fldReportByteRangeRequests').classList.remove('hide');
             }
         });
         $('#selectResponseProfileType', page).on('change', function () {
             if ('Video' == this.value) {
-                $('#fldResponseProfileVideoCodec', page).show();
+                page.querySelector('#fldResponseProfileVideoCodec').classList.remove('hide');
             } else {
                 page.querySelector('#fldResponseProfileVideoCodec').classList.add('hide');
             }
@@ -765,7 +765,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
             if ('Photo' == this.value) {
                 page.querySelector('#fldResponseProfileAudioCodec').classList.add('hide');
             } else {
-                $('#fldResponseProfileAudioCodec', page).show();
+                page.querySelector('#fldResponseProfileAudioCodec').classList.remove('hide');
             }
         });
         $('.btnAddDirectPlayProfile', page).on('click', function () {

--- a/src/controllers/dashboard/dlna/profile.js
+++ b/src/controllers/dashboard/dlna/profile.js
@@ -23,8 +23,8 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         for (const checkbox of page.querySelectorAll('.chkMediaType')) {
             checkbox.checked = -1 != (profile.SupportedMediaTypes || '').split(',').indexOf(checkbox.getAttribute('data-value'));
         }
-        $('#chkEnableAlbumArtInDidl', page).prop('checked', profile.EnableAlbumArtInDidl);
-        $('#chkEnableSingleImageLimit', page).prop('checked', profile.EnableSingleAlbumArtLimit);
+        page.querySelector('#chkEnableAlbumArtInDidl').checked = profile.EnableAlbumArtInDidl;
+        page.querySelector('#chkEnableSingleImageLimit').checked = profile.EnableSingleAlbumArtLimit;
         renderXmlDocumentAttributes(page, profile.XmlRootAttributes || []);
         var idInfo = profile.Identification || {};
         renderIdentificationHeaders(page, idInfo.Headers || []);
@@ -370,9 +370,9 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         popup.querySelector('#txtTranscodingAudioCodec').value = transcodingProfile.AudioCodec || '';
         popup.querySelector('#txtTranscodingVideoCodec').value = transcodingProfile.VideoCodec || '';
         popup.querySelector('#selectTranscodingProtocol').value = transcodingProfile.Protocol || 'Http';
-        $('#chkEnableMpegtsM2TsMode', popup).prop('checked', transcodingProfile.EnableMpegtsM2TsMode || false);
-        $('#chkEstimateContentLength', popup).prop('checked', transcodingProfile.EstimateContentLength || false);
-        $('#chkReportByteRangeRequests', popup).prop('checked', 'Bytes' == transcodingProfile.TranscodeSeekInfo);
+        popup.querySelector('#chkEnableMpegtsM2TsMode').checked = transcodingProfile.EnableMpegtsM2TsMode || false;
+        popup.querySelector('#chkEstimateContentLength').checked = transcodingProfile.EstimateContentLength || false;
+        popup.querySelector('#chkReportByteRangeRequests').checked = transcodingProfile.TranscodeSeekInfo === 'Bytes';
         $('.radioTabButton', popup).first().trigger('click');
         openPopup(popup[0]);
     }

--- a/src/controllers/dashboard/dlna/profile.js
+++ b/src/controllers/dashboard/dlna/profile.js
@@ -809,39 +809,39 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
     window.DlnaProfilePage = {
         onSubmit: function () {
             loading.show();
-            saveProfile($(this).parents('.page'), currentProfile);
+            saveProfile(this.closest('.page'), currentProfile);
             return false;
         },
         onDirectPlayFormSubmit: function () {
-            saveDirectPlayProfile($(this).parents('.page'));
+            saveDirectPlayProfile(this.closest('.page'));
             return false;
         },
         onTranscodingProfileFormSubmit: function () {
-            saveTranscodingProfile($(this).parents('.page'));
+            saveTranscodingProfile(this.closest('.page'));
             return false;
         },
         onContainerProfileFormSubmit: function () {
-            saveContainerProfile($(this).parents('.page'));
+            saveContainerProfile(this.closest('.page'));
             return false;
         },
         onCodecProfileFormSubmit: function () {
-            saveCodecProfile($(this).parents('.page'));
+            saveCodecProfile(this.closest('.page'));
             return false;
         },
         onResponseProfileFormSubmit: function () {
-            saveResponseProfile($(this).parents('.page'));
+            saveResponseProfile(this.closest('.page'));
             return false;
         },
         onIdentificationHeaderFormSubmit: function () {
-            saveIdentificationHeader($(this).parents('.page'));
+            saveIdentificationHeader(this.closest('.page'));
             return false;
         },
         onXmlAttributeFormSubmit: function () {
-            saveXmlDocumentAttribute($(this).parents('.page'));
+            saveXmlDocumentAttribute(this.closest('.page'));
             return false;
         },
         onSubtitleProfileFormSubmit: function () {
-            saveSubtitleProfile($(this).parents('.page'));
+            saveSubtitleProfile(this.closest('.page'));
             return false;
         }
     };

--- a/src/controllers/dashboard/dlna/profile.js
+++ b/src/controllers/dashboard/dlna/profile.js
@@ -20,9 +20,9 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
 
     function renderProfile(page, profile, users) {
         $('#txtName', page).val(profile.Name);
-        $('.chkMediaType', page).each(function () {
-            this.checked = -1 != (profile.SupportedMediaTypes || '').split(',').indexOf(this.getAttribute('data-value'));
-        });
+        for (const checkbox of page.querySelectorAll('.chkMediaType')) {
+            checkbox.checked = -1 != (profile.SupportedMediaTypes || '').split(',').indexOf(checkbox.getAttribute('data-value'));
+        }
         $('#chkEnableAlbumArtInDidl', page).prop('checked', profile.EnableAlbumArtInDidl);
         $('#chkEnableSingleImageLimit', page).prop('checked', profile.EnableSingleAlbumArtLimit);
         renderXmlDocumentAttributes(page, profile.XmlRootAttributes || []);

--- a/src/controllers/dashboard/dlna/profile.js
+++ b/src/controllers/dashboard/dlna/profile.js
@@ -87,7 +87,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
             index++;
             return li;
         }).join('') + '</div>';
-        var elem = $('.httpHeaderIdentificationList', page);
+        var elem = page.querySelector('.httpHeaderIdentificationList');
         elem.innerHtml = html;
         elem.trigger('create');
         $('.btnDeleteIdentificationHeader', elem).on('click', function () {
@@ -142,7 +142,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
             li += '<button type="button" is="paper-icon-button-light" class="btnDeleteXmlAttribute listItemButton" data-index="0"><span class="material-icons delete"></span></button>';
             return li += '</div>';
         }).join('') + '</div>';
-        var elem = $('.xmlDocumentAttributeList', page);
+        var elem = page.querySelector('.xmlDocumentAttributeList');
         elem.innerHtml = html;
         elem.trigger('create');
         $('.btnDeleteXmlAttribute', elem).on('click', function () {
@@ -188,7 +188,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
             index++;
             return li;
         }).join('') + '</div>';
-        var elem = $('.subtitleProfileList', page);
+        var elem = page.querySelector('.subtitleProfileList');
         elem.innerHtml = html;
         elem.trigger('create');
         $('.btnDeleteProfile', elem).on('click', function () {
@@ -282,7 +282,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         }
 
         html += '</ul>';
-        var elem = $('.directPlayProfiles', page);
+        var elem = page.querySelector('.directPlayProfiles');
         elem.innerHtml = html;
         elem.trigger('create');
         $('.btnDeleteProfile', elem).on('click', function () {
@@ -346,7 +346,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         }
 
         html += '</ul>';
-        var elem = $('.transcodingProfiles', page);
+        var elem = page.querySelector('.transcodingProfiles');
         elem.innerHtml = html;
         elem.trigger('create');
         $('.btnDeleteProfile', elem).on('click', function () {
@@ -433,7 +433,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         }
 
         html += '</ul>';
-        var elem = $('.containerProfiles', page);
+        var elem = page.querySelector('.containerProfiles');
         elem.innerHtml = html;
         elem.trigger('create');
         $('.btnDeleteProfile', elem).on('click', function () {
@@ -508,7 +508,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         }
 
         html += '</ul>';
-        var elem = $('.codecProfiles', page);
+        var elem = page.querySelector('.codecProfiles');
         elem.innerHtml = html;
         elem.trigger('create');
         $('.btnDeleteProfile', elem).on('click', function () {
@@ -591,7 +591,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         }
 
         html += '</ul>';
-        var elem = $('.mediaProfiles', page);
+        var elem = page.querySelector('.mediaProfiles');
         elem.innerHtml = html;
         elem.trigger('create');
         $('.btnDeleteProfile', elem).on('click', function () {

--- a/src/controllers/dashboard/dlna/profile.js
+++ b/src/controllers/dashboard/dlna/profile.js
@@ -373,7 +373,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         $('#chkEnableMpegtsM2TsMode', popup).prop('checked', transcodingProfile.EnableMpegtsM2TsMode || false);
         $('#chkEstimateContentLength', popup).prop('checked', transcodingProfile.EstimateContentLength || false);
         $('#chkReportByteRangeRequests', popup).prop('checked', 'Bytes' == transcodingProfile.TranscodeSeekInfo);
-        $('.radioTabButton:first', popup).trigger('click');
+        $('.radioTabButton', popup).first().trigger('click');
         openPopup(popup[0]);
     }
 

--- a/src/controllers/dashboard/dlna/profile.js
+++ b/src/controllers/dashboard/dlna/profile.js
@@ -695,8 +695,10 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
     $(document).on('pageinit', '#dlnaProfilePage', function () {
         var page = this;
         $('.radioTabButton', page).on('click', function () {
-            $(this).siblings().removeClass('ui-btn-active');
-            $(this).addClass('ui-btn-active');
+            for (const sibling of this.parentNode.children) {
+                if (sibling !== this) sibling.classList.remove('ui-btn-active');
+            }
+            this.classList.add('ui-btn-active');
             var value = 'A' == this.tagName ? this.getAttribute('data-value') : this.value;
             var elem = $('.' + value, page);
             elem.siblings('.tabContent').hide();

--- a/src/controllers/dashboard/dlna/profile.js
+++ b/src/controllers/dashboard/dlna/profile.js
@@ -432,7 +432,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
 
         html += '</ul>';
         var elem = $('.containerProfiles', page);
-        elem.innerHtml(html);
+        elem.innerHtml = html;
         elem.trigger('create');
         $('.btnDeleteProfile', elem).on('click', function () {
             var index = this.getAttribute('data-profileindex');
@@ -506,7 +506,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
 
         html += '</ul>';
         var elem = $('.codecProfiles', page);
-        elem.innerHtml(html);
+        elem.innerHtml = html;
         elem.trigger('create');
         $('.btnDeleteProfile', elem).on('click', function () {
             var index = this.getAttribute('data-profileindex');

--- a/src/controllers/dashboard/dlna/profile.js
+++ b/src/controllers/dashboard/dlna/profile.js
@@ -708,11 +708,11 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
             if ('Video' == this.value) {
                 $('#fldDirectPlayVideoCodec', page).show();
             } else {
-                $('#fldDirectPlayVideoCodec', page).hide();
+                page.querySelector('#fldDirectPlayVideoCodec').classList.add('hide');
             }
 
             if ('Photo' == this.value) {
-                $('#fldDirectPlayAudioCodec', page).hide();
+                page.querySelector('#fldDirectPlayAudioCodec').classList.add('hide');
             } else {
                 $('#fldDirectPlayAudioCodec', page).show();
             }
@@ -723,15 +723,15 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
                 $('#fldTranscodingProtocol', page).show();
                 $('#fldEnableMpegtsM2TsMode', page).show();
             } else {
-                $('#fldTranscodingVideoCodec', page).hide();
-                $('#fldTranscodingProtocol', page).hide();
-                $('#fldEnableMpegtsM2TsMode', page).hide();
+                page.querySelector('#fldTranscodingVideoCodec').classList.add('hide');
+                page.querySelector('#fldTranscodingProtocol').classList.add('hide');
+                page.querySelector('#fldEnableMpegtsM2TsMode').classList.add('hide');
             }
 
             if ('Photo' == this.value) {
-                $('#fldTranscodingAudioCodec', page).hide();
-                $('#fldEstimateContentLength', page).hide();
-                $('#fldReportByteRangeRequests', page).hide();
+                page.querySelector('#fldTranscodingAudioCodec').classList.add('hide');
+                page.querySelector('#fldEstimateContentLength').classList.add('hide');
+                page.querySelector('#fldReportByteRangeRequests').classList.add('hide');
             } else {
                 $('#fldTranscodingAudioCodec', page).show();
                 $('#fldEstimateContentLength', page).show();
@@ -742,11 +742,11 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
             if ('Video' == this.value) {
                 $('#fldResponseProfileVideoCodec', page).show();
             } else {
-                $('#fldResponseProfileVideoCodec', page).hide();
+                page.querySelector('#fldResponseProfileVideoCodec').classList.add('hide');
             }
 
             if ('Photo' == this.value) {
-                $('#fldResponseProfileAudioCodec', page).hide();
+                page.querySelector('#fldResponseProfileAudioCodec').classList.add('hide');
             } else {
                 $('#fldResponseProfileAudioCodec', page).show();
             }

--- a/src/controllers/dashboard/dlna/profile.js
+++ b/src/controllers/dashboard/dlna/profile.js
@@ -387,9 +387,9 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         currentSubProfile.VideoCodec = $('#txtTranscodingVideoCodec', page).val();
         currentSubProfile.Protocol = $('#selectTranscodingProtocol', page).val();
         currentSubProfile.Context = 'Streaming';
-        currentSubProfile.EnableMpegtsM2TsMode = $('#chkEnableMpegtsM2TsMode', page).is(':checked');
-        currentSubProfile.EstimateContentLength = $('#chkEstimateContentLength', page).is(':checked');
-        currentSubProfile.TranscodeSeekInfo = $('#chkReportByteRangeRequests', page).is(':checked') ? 'Bytes' : 'Auto';
+        currentSubProfile.EnableMpegtsM2TsMode = $('#chkEnableMpegtsM2TsMode', page).matches(':checked');
+        currentSubProfile.EstimateContentLength = $('#chkEstimateContentLength', page).matches(':checked');
+        currentSubProfile.TranscodeSeekInfo = $('#chkReportByteRangeRequests', page).matches(':checked') ? 'Bytes' : 'Auto';
 
         if (isSubProfileNew) {
             currentProfile.TranscodingProfiles.push(currentSubProfile);
@@ -664,8 +664,8 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
 
     function updateProfile(page, profile) {
         profile.Name = $('#txtName', page).val();
-        profile.EnableAlbumArtInDidl = $('#chkEnableAlbumArtInDidl', page).is(':checked');
-        profile.EnableSingleAlbumArtLimit = $('#chkEnableSingleImageLimit', page).is(':checked');
+        profile.EnableAlbumArtInDidl = $('#chkEnableAlbumArtInDidl', page).matches(':checked');
+        profile.EnableSingleAlbumArtLimit = $('#chkEnableSingleImageLimit', page).matches(':checked');
         profile.SupportedMediaTypes = $('.chkMediaType:checked', page).get().map(function (c) {
             return c.getAttribute('data-value');
         }).join(',');
@@ -692,9 +692,9 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         profile.MaxAlbumArtHeight = $('#txtAlbumArtMaxHeight', page).val();
         profile.MaxIconWidth = $('#txtIconMaxWidth', page).val();
         profile.MaxIconHeight = $('#txtIconMaxHeight', page).val();
-        profile.RequiresPlainFolders = $('#chkRequiresPlainFolders', page).is(':checked');
-        profile.RequiresPlainVideoItems = $('#chkRequiresPlainVideoItems', page).is(':checked');
-        profile.IgnoreTranscodeByteRangeRequests = $('#chkIgnoreTranscodeByteRangeRequests', page).is(':checked');
+        profile.RequiresPlainFolders = $('#chkRequiresPlainFolders', page).matches(':checked');
+        profile.RequiresPlainVideoItems = $('#chkRequiresPlainVideoItems', page).matches(':checked');
+        profile.IgnoreTranscodeByteRangeRequests = $('#chkIgnoreTranscodeByteRangeRequests', page).matches(':checked');
         profile.MaxStreamingBitrate = $('#txtMaxAllowedBitrate', page).val();
         profile.MusicStreamingTranscodingBitrate = $('#txtMusicStreamingTranscodingBitrate', page).val();
         profile.ProtocolInfo = $('#txtProtocolInfo', page).val();

--- a/src/controllers/dashboard/dlna/profile.js
+++ b/src/controllers/dashboard/dlna/profile.js
@@ -19,7 +19,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
     }
 
     function renderProfile(page, profile, users) {
-        $('#txtName', page).val(profile.Name);
+        page.querySelector('#txtName').value = profile.Name;
         for (const checkbox of page.querySelectorAll('.chkMediaType')) {
             checkbox.checked = -1 != (profile.SupportedMediaTypes || '').split(',').indexOf(checkbox.getAttribute('data-value'));
         }
@@ -29,37 +29,37 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         var idInfo = profile.Identification || {};
         renderIdentificationHeaders(page, idInfo.Headers || []);
         renderSubtitleProfiles(page, profile.SubtitleProfiles || []);
-        $('#txtInfoFriendlyName', page).val(profile.FriendlyName || '');
-        $('#txtInfoModelName', page).val(profile.ModelName || '');
-        $('#txtInfoModelNumber', page).val(profile.ModelNumber || '');
-        $('#txtInfoModelDescription', page).val(profile.ModelDescription || '');
-        $('#txtInfoModelUrl', page).val(profile.ModelUrl || '');
-        $('#txtInfoManufacturer', page).val(profile.Manufacturer || '');
-        $('#txtInfoManufacturerUrl', page).val(profile.ManufacturerUrl || '');
-        $('#txtInfoSerialNumber', page).val(profile.SerialNumber || '');
-        $('#txtIdFriendlyName', page).val(idInfo.FriendlyName || '');
-        $('#txtIdModelName', page).val(idInfo.ModelName || '');
-        $('#txtIdModelNumber', page).val(idInfo.ModelNumber || '');
-        $('#txtIdModelDescription', page).val(idInfo.ModelDescription || '');
-        $('#txtIdModelUrl', page).val(idInfo.ModelUrl || '');
-        $('#txtIdManufacturer', page).val(idInfo.Manufacturer || '');
-        $('#txtIdManufacturerUrl', page).val(idInfo.ManufacturerUrl || '');
-        $('#txtIdSerialNumber', page).val(idInfo.SerialNumber || '');
-        $('#txtIdDeviceDescription', page).val(idInfo.DeviceDescription || '');
-        $('#txtAlbumArtPn', page).val(profile.AlbumArtPn || '');
-        $('#txtAlbumArtMaxWidth', page).val(profile.MaxAlbumArtWidth || '');
-        $('#txtAlbumArtMaxHeight', page).val(profile.MaxAlbumArtHeight || '');
-        $('#txtIconMaxWidth', page).val(profile.MaxIconWidth || '');
-        $('#txtIconMaxHeight', page).val(profile.MaxIconHeight || '');
-        $('#chkIgnoreTranscodeByteRangeRequests', page).prop('checked', profile.IgnoreTranscodeByteRangeRequests);
-        $('#txtMaxAllowedBitrate', page).val(profile.MaxStreamingBitrate || '');
-        $('#txtMusicStreamingTranscodingBitrate', page).val(profile.MusicStreamingTranscodingBitrate || '');
-        $('#chkRequiresPlainFolders', page).prop('checked', profile.RequiresPlainFolders);
-        $('#chkRequiresPlainVideoItems', page).prop('checked', profile.RequiresPlainVideoItems);
-        $('#txtProtocolInfo', page).val(profile.ProtocolInfo || '');
-        $('#txtXDlnaCap', page).val(profile.XDlnaCap || '');
-        $('#txtXDlnaDoc', page).val(profile.XDlnaDoc || '');
-        $('#txtSonyAggregationFlags', page).val(profile.SonyAggregationFlags || '');
+        page.querySelector('#txtInfoFriendlyName').value = profile.FriendlyName || '';
+        page.querySelector('#txtInfoModelName').value = profile.ModelName || '';
+        page.querySelector('#txtInfoModelNumber').value = profile.ModelNumber || '';
+        page.querySelector('#txtInfoModelDescription').value = profile.ModelDescription || '';
+        page.querySelector('#txtInfoModelUrl').value = profile.ModelUrl || '';
+        page.querySelector('#txtInfoManufacturer').value = profile.Manufacturer || '';
+        page.querySelector('#txtInfoManufacturerUrl').value = profile.ManufacturerUrl || '';
+        page.querySelector('#txtInfoSerialNumber').value = profile.SerialNumber || '';
+        page.querySelector('#txtIdFriendlyName').value = idInfo.FriendlyName || '';
+        page.querySelector('#txtIdModelName').value = idInfo.ModelName || '';
+        page.querySelector('#txtIdModelNumber').value = idInfo.ModelNumber || '';
+        page.querySelector('#txtIdModelDescription').value = idInfo.ModelDescription || '';
+        page.querySelector('#txtIdModelUrl').value = idInfo.ModelUrl || '';
+        page.querySelector('#txtIdManufacturer').value = idInfo.Manufacturer || '';
+        page.querySelector('#txtIdManufacturerUrl').value = idInfo.ManufacturerUrl || '';
+        page.querySelector('#txtIdSerialNumber').value = idInfo.SerialNumber || '';
+        page.querySelector('#txtIdDeviceDescription').value = idInfo.DeviceDescription || '';
+        page.querySelector('#txtAlbumArtPn').value = profile.AlbumArtPn || '';
+        page.querySelector('#txtAlbumArtMaxWidth').value = profile.MaxAlbumArtWidth || '';
+        page.querySelector('#txtAlbumArtMaxHeight').value = profile.MaxAlbumArtHeight || '';
+        page.querySelector('#txtIconMaxWidth').value = profile.MaxIconWidth || '';
+        page.querySelector('#txtIconMaxHeight').value = profile.MaxIconHeight || '';
+        page.querySelector('#chkIgnoreTranscodeByteRangeRequests').checked = profile.IgnoreTranscodeByteRangeRequests;
+        page.querySelector('#txtMaxAllowedBitrate').value = profile.MaxStreamingBitrate || '';
+        page.querySelector('#txtMusicStreamingTranscodingBitrate').value = profile.MusicStreamingTranscodingBitrate || '';
+        page.querySelector('#chkRequiresPlainFolders').checked = profile.RequiresPlainFolders;
+        page.querySelector('#chkRequiresPlainVideoItems').checked = profile.RequiresPlainVideoItems;
+        page.querySelector('#txtProtocolInfo').value = profile.ProtocolInfo || '';
+        page.querySelector('#txtXDlnaCap').value = profile.XDlnaCap || '';
+        page.querySelector('#txtXDlnaDoc').value = profile.XDlnaDoc || '';
+        page.querySelector('#txtSonyAggregationFlags').value = profile.SonyAggregationFlags || '';
         profile.DirectPlayProfiles = profile.DirectPlayProfiles || [];
         profile.TranscodingProfiles = profile.TranscodingProfiles || [];
         profile.ContainerProfiles = profile.ContainerProfiles || [];
@@ -68,8 +68,8 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         var usersHtml = '<option></option>' + users.map(function (u) {
             return '<option value="' + u.Id + '">' + u.Name + '</option>';
         }).join('');
-        $('#selectUser', page).innerHtml = usersHtml;
-        $('#selectUser', page).val(profile.UserId || '');
+        page.querySelector('#selectUser').innerHtml = usersHtml;
+        page.querySelector('#selectUser').value = profile.UserId || '';
         renderSubProfiles(page, profile);
     }
 
@@ -110,16 +110,16 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         header = header || {};
         currentSubProfile = header;
         var popup = $('#identificationHeaderPopup', page);
-        $('#txtIdentificationHeaderName', popup).val(header.Name || '');
-        $('#txtIdentificationHeaderValue', popup).val(header.Value || '');
-        $('#selectMatchType', popup).val(header.Match || 'Equals');
+        popup.querySelector('#txtIdentificationHeaderName').value = header.Name || '';
+        popup.querySelector('#txtIdentificationHeaderValue').value = header.Value || '';
+        popup.querySelector('#selectMatchType').value = header.Match || 'Equals';
         openPopup(popup[0]);
     }
 
     function saveIdentificationHeader(page) {
-        currentSubProfile.Name = $('#txtIdentificationHeaderName', page).val();
-        currentSubProfile.Value = $('#txtIdentificationHeaderValue', page).val();
-        currentSubProfile.Match = $('#selectMatchType', page).val();
+        currentSubProfile.Name = page.querySelector('#txtIdentificationHeaderName').value;
+        currentSubProfile.Value = page.querySelector('#txtIdentificationHeaderValue').value;
+        currentSubProfile.Match = page.querySelector('#selectMatchType').value;
 
         if (isSubProfileNew) {
             currentProfile.Identification = currentProfile.Identification || {};
@@ -157,14 +157,14 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         attribute = attribute || {};
         currentSubProfile = attribute;
         var popup = $('#xmlAttributePopup', page);
-        $('#txtXmlAttributeName', popup).val(attribute.Name || '');
-        $('#txtXmlAttributeValue', popup).val(attribute.Value || '');
+        popup.querySelector('#txtXmlAttributeName').value = attribute.Name || '';
+        popup.querySelector('#txtXmlAttributeValue').value = attribute.Value || '';
         openPopup(popup[0]);
     }
 
     function saveXmlDocumentAttribute(page) {
-        currentSubProfile.Name = $('#txtXmlAttributeName', page).val();
-        currentSubProfile.Value = $('#txtXmlAttributeValue', page).val();
+        currentSubProfile.Name = page.querySelector('#txtXmlAttributeName').value;
+        currentSubProfile.Value = page.querySelector('#txtXmlAttributeValue').value;
 
         if (isSubProfileNew) {
             currentProfile.XmlRootAttributes.push(currentSubProfile);
@@ -207,16 +207,16 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         profile = profile || {};
         currentSubProfile = profile;
         var popup = $('#subtitleProfilePopup', page);
-        $('#txtSubtitleProfileFormat', popup).val(profile.Format || '');
-        $('#selectSubtitleProfileMethod', popup).val(profile.Method || '');
-        $('#selectSubtitleProfileDidlMode', popup).val(profile.DidlMode || '');
+        popup.querySelector('#txtSubtitleProfileFormat').value = profile.Format || '';
+        popup.querySelector('#selectSubtitleProfileMethod').value = profile.Method || '';
+        popup.querySelector('#selectSubtitleProfileDidlMode').value = profile.DidlMode || '';
         openPopup(popup[0]);
     }
 
     function saveSubtitleProfile(page) {
-        currentSubProfile.Format = $('#txtSubtitleProfileFormat', page).val();
-        currentSubProfile.Method = $('#selectSubtitleProfileMethod', page).val();
-        currentSubProfile.DidlMode = $('#selectSubtitleProfileDidlMode', page).val();
+        currentSubProfile.Format = page.querySelector('#txtSubtitleProfileFormat').value;
+        currentSubProfile.Method = page.querySelector('#selectSubtitleProfileMethod').value;
+        currentSubProfile.DidlMode = page.querySelector('#selectSubtitleProfileDidlMode').value;
 
         if (isSubProfileNew) {
             currentProfile.SubtitleProfiles.push(currentSubProfile);
@@ -236,10 +236,10 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
     }
 
     function saveDirectPlayProfile(page) {
-        currentSubProfile.Type = $('#selectDirectPlayProfileType', page).val();
-        currentSubProfile.Container = $('#txtDirectPlayContainer', page).val();
-        currentSubProfile.AudioCodec = $('#txtDirectPlayAudioCodec', page).val();
-        currentSubProfile.VideoCodec = $('#txtDirectPlayVideoCodec', page).val();
+        currentSubProfile.Type = page.querySelector('#selectDirectPlayProfileType').value;
+        currentSubProfile.Container = page.querySelector('#txtDirectPlayContainer').value;
+        currentSubProfile.AudioCodec = page.querySelector('#txtDirectPlayAudioCodec').value;
+        currentSubProfile.VideoCodec = page.querySelector('#txtDirectPlayVideoCodec').value;
 
         if (isSubProfileNew) {
             currentProfile.DirectPlayProfiles.push(currentSubProfile);
@@ -305,10 +305,11 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         directPlayProfile = directPlayProfile || {};
         currentSubProfile = directPlayProfile;
         var popup = $('#popupEditDirectPlayProfile', page);
-        $('#selectDirectPlayProfileType', popup).val(directPlayProfile.Type || 'Video').trigger('change');
-        $('#txtDirectPlayContainer', popup).val(directPlayProfile.Container || '');
-        $('#txtDirectPlayAudioCodec', popup).val(directPlayProfile.AudioCodec || '');
-        $('#txtDirectPlayVideoCodec', popup).val(directPlayProfile.VideoCodec || '');
+        popup.querySelector('#selectDirectPlayProfileType').value = directPlayProfile.Type || 'Video';
+        popup.querySelector('#selectDirectPlayProfileType').trigger('change');
+        popup.querySelector('#txtDirectPlayContainer').value = directPlayProfile.Container || '';
+        popup.querySelector('#txtDirectPlayAudioCodec').value = directPlayProfile.AudioCodec || '';
+        popup.querySelector('#txtDirectPlayVideoCodec').value = directPlayProfile.VideoCodec || '';
         openPopup(popup[0]);
     }
 
@@ -363,11 +364,12 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         transcodingProfile = transcodingProfile || {};
         currentSubProfile = transcodingProfile;
         var popup = $('#transcodingProfilePopup', page);
-        $('#selectTranscodingProfileType', popup).val(transcodingProfile.Type || 'Video').trigger('change');
-        $('#txtTranscodingContainer', popup).val(transcodingProfile.Container || '');
-        $('#txtTranscodingAudioCodec', popup).val(transcodingProfile.AudioCodec || '');
-        $('#txtTranscodingVideoCodec', popup).val(transcodingProfile.VideoCodec || '');
-        $('#selectTranscodingProtocol', popup).val(transcodingProfile.Protocol || 'Http');
+        popup.querySelector('#selectTranscodingProfileType').value = transcodingProfile.Type || 'Video';
+        popup.querySelector('#selectTranscodingProfileType').trigger('change');
+        popup.querySelector('#txtTranscodingContainer').value = transcodingProfile.Container || '';
+        popup.querySelector('#txtTranscodingAudioCodec').value = transcodingProfile.AudioCodec || '';
+        popup.querySelector('#txtTranscodingVideoCodec').value = transcodingProfile.VideoCodec || '';
+        popup.querySelector('#selectTranscodingProtocol').value = transcodingProfile.Protocol || 'Http';
         $('#chkEnableMpegtsM2TsMode', popup).prop('checked', transcodingProfile.EnableMpegtsM2TsMode || false);
         $('#chkEstimateContentLength', popup).prop('checked', transcodingProfile.EstimateContentLength || false);
         $('#chkReportByteRangeRequests', popup).prop('checked', 'Bytes' == transcodingProfile.TranscodeSeekInfo);
@@ -381,11 +383,11 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
     }
 
     function saveTranscodingProfile(page) {
-        currentSubProfile.Type = $('#selectTranscodingProfileType', page).val();
-        currentSubProfile.Container = $('#txtTranscodingContainer', page).val();
-        currentSubProfile.AudioCodec = $('#txtTranscodingAudioCodec', page).val();
-        currentSubProfile.VideoCodec = $('#txtTranscodingVideoCodec', page).val();
-        currentSubProfile.Protocol = $('#selectTranscodingProtocol', page).val();
+        currentSubProfile.Type = page.querySelector('#selectTranscodingProfileType').value;
+        currentSubProfile.Container = page.querySelector('#txtTranscodingContainer').value;
+        currentSubProfile.AudioCodec = page.querySelector('#txtTranscodingAudioCodec').value;
+        currentSubProfile.VideoCodec = page.querySelector('#txtTranscodingVideoCodec').value;
+        currentSubProfile.Protocol = page.querySelector('#selectTranscodingProtocol').value;
         currentSubProfile.Context = 'Streaming';
         currentSubProfile.EnableMpegtsM2TsMode = $('#chkEnableMpegtsM2TsMode', page).matches(':checked');
         currentSubProfile.EstimateContentLength = $('#chkEstimateContentLength', page).matches(':checked');
@@ -454,15 +456,16 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         containerProfile = containerProfile || {};
         currentSubProfile = containerProfile;
         var popup = $('#containerProfilePopup', page);
-        $('#selectContainerProfileType', popup).val(containerProfile.Type || 'Video').trigger('change');
-        $('#txtContainerProfileContainer', popup).val(containerProfile.Container || '');
-        $('.radioTabButton:first', popup).trigger('click');
+        popup.querySelector('#selectContainerProfileType').value = containerProfile.Type || 'Video';
+        popup.querySelector('#selectContainerProfileType').trigger('change');
+        popup.querySelector('#txtContainerProfileContainer').value = containerProfile.Container || '';
+        popup.querySelector('.radioTabButton:first').trigger('click');
         openPopup(popup[0]);
     }
 
     function saveContainerProfile(page) {
-        currentSubProfile.Type = $('#selectContainerProfileType', page).val();
-        currentSubProfile.Container = $('#txtContainerProfileContainer', page).val();
+        currentSubProfile.Type = page.querySelector('#selectContainerProfileType').value;
+        currentSubProfile.Container = page.querySelector('#txtContainerProfileContainer').value;
 
         if (isSubProfileNew) {
             currentProfile.ContainerProfiles.push(currentSubProfile);
@@ -528,15 +531,16 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         codecProfile = codecProfile || {};
         currentSubProfile = codecProfile;
         var popup = $('#codecProfilePopup', page);
-        $('#selectCodecProfileType', popup).val(codecProfile.Type || 'Video').trigger('change');
-        $('#txtCodecProfileCodec', popup).val(codecProfile.Codec || '');
-        $('.radioTabButton:first', popup).trigger('click');
+        popup.querySelector('#selectCodecProfileType').value = codecProfile.Type || 'Video';
+        popup.querySelector('#selectCodecProfileType').trigger('change');
+        popup.querySelector('#txtCodecProfileCodec').value = codecProfile.Codec || '';
+        popup.querySelector('.radioTabButton:first').trigger('click');
         openPopup(popup[0]);
     }
 
     function saveCodecProfile(page) {
-        currentSubProfile.Type = $('#selectCodecProfileType', page).val();
-        currentSubProfile.Codec = $('#txtCodecProfileCodec', page).val();
+        currentSubProfile.Type = page.querySelector('#selectCodecProfileType').value;
+        currentSubProfile.Codec = page.querySelector('#txtCodecProfileCodec').value;
 
         if (isSubProfileNew) {
             currentProfile.CodecProfiles.push(currentSubProfile);
@@ -610,19 +614,20 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         responseProfile = responseProfile || {};
         currentSubProfile = responseProfile;
         var popup = $('#responseProfilePopup', page);
-        $('#selectResponseProfileType', popup).val(responseProfile.Type || 'Video').trigger('change');
-        $('#txtResponseProfileContainer', popup).val(responseProfile.Container || '');
-        $('#txtResponseProfileAudioCodec', popup).val(responseProfile.AudioCodec || '');
-        $('#txtResponseProfileVideoCodec', popup).val(responseProfile.VideoCodec || '');
-        $('.radioTabButton:first', popup).trigger('click');
+        popup.querySelector('#selectResponseProfileType').value = responseProfile.Type || 'Video';
+        popup.querySelector('#selectResponseProfileType').trigger('change');
+        popup.querySelector('#txtResponseProfileContainer').value = responseProfile.Container || '';
+        popup.querySelector('#txtResponseProfileAudioCodec').value = responseProfile.AudioCodec || '';
+        popup.querySelector('#txtResponseProfileVideoCodec').value = responseProfile.VideoCodec || '';
+        popup.querySelector('.radioTabButton:first').trigger('click');
         openPopup(popup[0]);
     }
 
     function saveResponseProfile(page) {
-        currentSubProfile.Type = $('#selectResponseProfileType', page).val();
-        currentSubProfile.Container = $('#txtResponseProfileContainer', page).val();
-        currentSubProfile.AudioCodec = $('#txtResponseProfileAudioCodec', page).val();
-        currentSubProfile.VideoCodec = $('#txtResponseProfileVideoCodec', page).val();
+        currentSubProfile.Type = page.querySelector('#selectResponseProfileType').value;
+        currentSubProfile.Container = page.querySelector('#txtResponseProfileContainer').value;
+        currentSubProfile.AudioCodec = page.querySelector('#txtResponseProfileAudioCodec').value;
+        currentSubProfile.VideoCodec = page.querySelector('#txtResponseProfileVideoCodec').value;
 
         if (isSubProfileNew) {
             currentProfile.ResponseProfiles.push(currentSubProfile);
@@ -663,45 +668,45 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
     }
 
     function updateProfile(page, profile) {
-        profile.Name = $('#txtName', page).val();
-        profile.EnableAlbumArtInDidl = $('#chkEnableAlbumArtInDidl', page).matches(':checked');
-        profile.EnableSingleAlbumArtLimit = $('#chkEnableSingleImageLimit', page).matches(':checked');
+        profile.Name = page.querySelector('#txtName').value;
+        profile.EnableAlbumArtInDidl = page.querySelector('#chkEnableAlbumArtInDidl').matches(':checked');
+        profile.EnableSingleAlbumArtLimit = page.querySelector('#chkEnableSingleImageLimit').matches(':checked');
         profile.SupportedMediaTypes = $('.chkMediaType:checked', page).get().map(function (c) {
             return c.getAttribute('data-value');
         }).join(',');
         profile.Identification = profile.Identification || {};
-        profile.FriendlyName = $('#txtInfoFriendlyName', page).val();
-        profile.ModelName = $('#txtInfoModelName', page).val();
-        profile.ModelNumber = $('#txtInfoModelNumber', page).val();
-        profile.ModelDescription = $('#txtInfoModelDescription', page).val();
-        profile.ModelUrl = $('#txtInfoModelUrl', page).val();
-        profile.Manufacturer = $('#txtInfoManufacturer', page).val();
-        profile.ManufacturerUrl = $('#txtInfoManufacturerUrl', page).val();
-        profile.SerialNumber = $('#txtInfoSerialNumber', page).val();
-        profile.Identification.FriendlyName = $('#txtIdFriendlyName', page).val();
-        profile.Identification.ModelName = $('#txtIdModelName', page).val();
-        profile.Identification.ModelNumber = $('#txtIdModelNumber', page).val();
-        profile.Identification.ModelDescription = $('#txtIdModelDescription', page).val();
-        profile.Identification.ModelUrl = $('#txtIdModelUrl', page).val();
-        profile.Identification.Manufacturer = $('#txtIdManufacturer', page).val();
-        profile.Identification.ManufacturerUrl = $('#txtIdManufacturerUrl', page).val();
-        profile.Identification.SerialNumber = $('#txtIdSerialNumber', page).val();
-        profile.Identification.DeviceDescription = $('#txtIdDeviceDescription', page).val();
-        profile.AlbumArtPn = $('#txtAlbumArtPn', page).val();
-        profile.MaxAlbumArtWidth = $('#txtAlbumArtMaxWidth', page).val();
-        profile.MaxAlbumArtHeight = $('#txtAlbumArtMaxHeight', page).val();
-        profile.MaxIconWidth = $('#txtIconMaxWidth', page).val();
-        profile.MaxIconHeight = $('#txtIconMaxHeight', page).val();
-        profile.RequiresPlainFolders = $('#chkRequiresPlainFolders', page).matches(':checked');
-        profile.RequiresPlainVideoItems = $('#chkRequiresPlainVideoItems', page).matches(':checked');
-        profile.IgnoreTranscodeByteRangeRequests = $('#chkIgnoreTranscodeByteRangeRequests', page).matches(':checked');
-        profile.MaxStreamingBitrate = $('#txtMaxAllowedBitrate', page).val();
-        profile.MusicStreamingTranscodingBitrate = $('#txtMusicStreamingTranscodingBitrate', page).val();
-        profile.ProtocolInfo = $('#txtProtocolInfo', page).val();
-        profile.XDlnaCap = $('#txtXDlnaCap', page).val();
-        profile.XDlnaDoc = $('#txtXDlnaDoc', page).val();
-        profile.SonyAggregationFlags = $('#txtSonyAggregationFlags', page).val();
-        profile.UserId = $('#selectUser', page).val();
+        profile.FriendlyName = page.querySelector('#txtInfoFriendlyName').value;
+        profile.ModelName = page.querySelector('#txtInfoModelName').value;
+        profile.ModelNumber = page.querySelector('#txtInfoModelNumber').value;
+        profile.ModelDescription = page.querySelector('#txtInfoModelDescription').value;
+        profile.ModelUrl = page.querySelector('#txtInfoModelUrl').value;
+        profile.Manufacturer = page.querySelector('#txtInfoManufacturer').value;
+        profile.ManufacturerUrl = page.querySelector('#txtInfoManufacturerUrl').value;
+        profile.SerialNumber = page.querySelector('#txtInfoSerialNumber').value;
+        profile.Identification.FriendlyName = page.querySelector('#txtIdFriendlyName').value;
+        profile.Identification.ModelName = page.querySelector('#txtIdModelName').value;
+        profile.Identification.ModelNumber = page.querySelector('#txtIdModelNumber').value;
+        profile.Identification.ModelDescription = page.querySelector('#txtIdModelDescription').value;
+        profile.Identification.ModelUrl = page.querySelector('#txtIdModelUrl').value;
+        profile.Identification.Manufacturer = page.querySelector('#txtIdManufacturer').value;
+        profile.Identification.ManufacturerUrl = page.querySelector('#txtIdManufacturerUrl').value;
+        profile.Identification.SerialNumber = page.querySelector('#txtIdSerialNumber').value;
+        profile.Identification.DeviceDescription = page.querySelector('#txtIdDeviceDescription').value;
+        profile.AlbumArtPn = page.querySelector('#txtAlbumArtPn').value;
+        profile.MaxAlbumArtWidth = page.querySelector('#txtAlbumArtMaxWidth').value;
+        profile.MaxAlbumArtHeight = page.querySelector('#txtAlbumArtMaxHeight').value;
+        profile.MaxIconWidth = page.querySelector('#txtIconMaxWidth').value;
+        profile.MaxIconHeight = page.querySelector('#txtIconMaxHeight').value;
+        profile.RequiresPlainFolders = page.querySelector('#chkRequiresPlainFolders').matches(':checked');
+        profile.RequiresPlainVideoItems = page.querySelector('#chkRequiresPlainVideoItems').matches(':checked');
+        profile.IgnoreTranscodeByteRangeRequests = page.querySelector('#chkIgnoreTranscodeByteRangeRequests').matches(':checked');
+        profile.MaxStreamingBitrate = page.querySelector('#txtMaxAllowedBitrate').value;
+        profile.MusicStreamingTranscodingBitrate = page.querySelector('#txtMusicStreamingTranscodingBitrate').value;
+        profile.ProtocolInfo = page.querySelector('#txtProtocolInfo').value;
+        profile.XDlnaCap = page.querySelector('#txtXDlnaCap').value;
+        profile.XDlnaDoc = page.querySelector('#txtXDlnaDoc').value;
+        profile.SonyAggregationFlags = page.querySelector('#txtSonyAggregationFlags').value;
+        profile.UserId = page.querySelector('#selectUser').value;
     }
 
     var currentProfile;

--- a/src/controllers/dashboard/dlna/profile.js
+++ b/src/controllers/dashboard/dlna/profile.js
@@ -89,7 +89,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         }).join('') + '</div>';
         var elem = page.querySelector('.httpHeaderIdentificationList');
         elem.innerHtml = html;
-        elem.trigger('create');
+        elem.dispatchEvent(new Event('create'));
         $('.btnDeleteIdentificationHeader', elem).on('click', function () {
             var itemIndex = parseInt(this.getAttribute('data-index'));
             currentProfile.Identification.Headers.splice(itemIndex, 1);
@@ -144,7 +144,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         }).join('') + '</div>';
         var elem = page.querySelector('.xmlDocumentAttributeList');
         elem.innerHtml = html;
-        elem.trigger('create');
+        elem.dispatchEvent(new Event('create'));
         $('.btnDeleteXmlAttribute', elem).on('click', function () {
             var itemIndex = parseInt(this.getAttribute('data-index'));
             currentProfile.XmlRootAttributes.splice(itemIndex, 1);
@@ -190,7 +190,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         }).join('') + '</div>';
         var elem = page.querySelector('.subtitleProfileList');
         elem.innerHtml = html;
-        elem.trigger('create');
+        elem.dispatchEvent(new Event('create'));
         $('.btnDeleteProfile', elem).on('click', function () {
             var itemIndex = parseInt(this.getAttribute('data-index'));
             currentProfile.SubtitleProfiles.splice(itemIndex, 1);
@@ -284,7 +284,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         html += '</ul>';
         var elem = page.querySelector('.directPlayProfiles');
         elem.innerHtml = html;
-        elem.trigger('create');
+        elem.dispatchEvent(new Event('create'));
         $('.btnDeleteProfile', elem).on('click', function () {
             var index = this.getAttribute('data-profileindex');
             deleteDirectPlayProfile(page, index);
@@ -306,7 +306,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         currentSubProfile = directPlayProfile;
         var popup = $('#popupEditDirectPlayProfile', page);
         popup.querySelector('#selectDirectPlayProfileType').value = directPlayProfile.Type || 'Video';
-        popup.querySelector('#selectDirectPlayProfileType').trigger('change');
+        popup.querySelector('#selectDirectPlayProfileType').dispatchEvent(new Event('change'));
         popup.querySelector('#txtDirectPlayContainer').value = directPlayProfile.Container || '';
         popup.querySelector('#txtDirectPlayAudioCodec').value = directPlayProfile.AudioCodec || '';
         popup.querySelector('#txtDirectPlayVideoCodec').value = directPlayProfile.VideoCodec || '';
@@ -348,7 +348,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         html += '</ul>';
         var elem = page.querySelector('.transcodingProfiles');
         elem.innerHtml = html;
-        elem.trigger('create');
+        elem.dispatchEvent(new Event('create'));
         $('.btnDeleteProfile', elem).on('click', function () {
             var index = this.getAttribute('data-profileindex');
             deleteTranscodingProfile(page, index);
@@ -365,7 +365,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         currentSubProfile = transcodingProfile;
         var popup = $('#transcodingProfilePopup', page);
         popup.querySelector('#selectTranscodingProfileType').value = transcodingProfile.Type || 'Video';
-        popup.querySelector('#selectTranscodingProfileType').trigger('change');
+        popup.querySelector('#selectTranscodingProfileType').dispatchEvent(new Event('change'));
         popup.querySelector('#txtTranscodingContainer').value = transcodingProfile.Container || '';
         popup.querySelector('#txtTranscodingAudioCodec').value = transcodingProfile.AudioCodec || '';
         popup.querySelector('#txtTranscodingVideoCodec').value = transcodingProfile.VideoCodec || '';
@@ -435,7 +435,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         html += '</ul>';
         var elem = page.querySelector('.containerProfiles');
         elem.innerHtml = html;
-        elem.trigger('create');
+        elem.dispatchEvent(new Event('create'));
         $('.btnDeleteProfile', elem).on('click', function () {
             var index = this.getAttribute('data-profileindex');
             deleteContainerProfile(page, index);
@@ -457,9 +457,9 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         currentSubProfile = containerProfile;
         var popup = $('#containerProfilePopup', page);
         popup.querySelector('#selectContainerProfileType').value = containerProfile.Type || 'Video';
-        popup.querySelector('#selectContainerProfileType').trigger('change');
+        popup.querySelector('#selectContainerProfileType').dispatchEvent(new Event('change'));
         popup.querySelector('#txtContainerProfileContainer').value = containerProfile.Container || '';
-        popup.querySelector('.radioTabButton:first').trigger('click');
+        popup.querySelector('.radioTabButton:first').dispatchEvent(new Event('click'));
         openPopup(popup[0]);
     }
 
@@ -510,7 +510,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         html += '</ul>';
         var elem = page.querySelector('.codecProfiles');
         elem.innerHtml = html;
-        elem.trigger('create');
+        elem.dispatchEvent(new Event('create'));
         $('.btnDeleteProfile', elem).on('click', function () {
             var index = this.getAttribute('data-profileindex');
             deleteCodecProfile(page, index);
@@ -532,9 +532,9 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         currentSubProfile = codecProfile;
         var popup = $('#codecProfilePopup', page);
         popup.querySelector('#selectCodecProfileType').value = codecProfile.Type || 'Video';
-        popup.querySelector('#selectCodecProfileType').trigger('change');
+        popup.querySelector('#selectCodecProfileType').dispatchEvent(new Event('change'));
         popup.querySelector('#txtCodecProfileCodec').value = codecProfile.Codec || '';
-        popup.querySelector('.radioTabButton:first').trigger('click');
+        popup.querySelector('.radioTabButton:first').dispatchEvent(new Event('click'));
         openPopup(popup[0]);
     }
 
@@ -593,7 +593,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         html += '</ul>';
         var elem = page.querySelector('.mediaProfiles');
         elem.innerHtml = html;
-        elem.trigger('create');
+        elem.dispatchEvent(new Event('create'));
         $('.btnDeleteProfile', elem).on('click', function () {
             var index = this.getAttribute('data-profileindex');
             deleteResponseProfile(page, index);
@@ -615,11 +615,11 @@ define(['jQuery', 'loading', 'globalize', 'emby-select', 'emby-button', 'emby-in
         currentSubProfile = responseProfile;
         var popup = $('#responseProfilePopup', page);
         popup.querySelector('#selectResponseProfileType').value = responseProfile.Type || 'Video';
-        popup.querySelector('#selectResponseProfileType').trigger('change');
+        popup.querySelector('#selectResponseProfileType').dispatchEvent(new Event('change'));
         popup.querySelector('#txtResponseProfileContainer').value = responseProfile.Container || '';
         popup.querySelector('#txtResponseProfileAudioCodec').value = responseProfile.AudioCodec || '';
         popup.querySelector('#txtResponseProfileVideoCodec').value = responseProfile.VideoCodec || '';
-        popup.querySelector('.radioTabButton:first').trigger('click');
+        popup.querySelector('.radioTabButton:first').dispatchEvent(new Event('click'));
         openPopup(popup[0]);
     }
 

--- a/src/controllers/dashboard/dlna/settings.js
+++ b/src/controllers/dashboard/dlna/settings.js
@@ -11,7 +11,9 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
         var usersHtml = users.map(function (u) {
             return '<option value="' + u.Id + '">' + u.Name + '</option>';
         }).join('');
-        $('#selectUser', page).html(usersHtml).val(config.DefaultUserId || '');
+        const elem = $('#selectUser', page);
+        elem.innerHtml = usersHtml;
+        elem.val(config.DefaultUserId || '');
         loading.hide();
     }
 

--- a/src/controllers/dashboard/dlna/settings.js
+++ b/src/controllers/dashboard/dlna/settings.js
@@ -4,10 +4,10 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
     function loadPage(page, config, users) {
         page.querySelector('#chkEnablePlayTo').checked = config.EnablePlayTo;
         page.querySelector('#chkEnableDlnaDebugLogging').checked = config.EnableDebugLog;
-        $('#txtClientDiscoveryInterval', page).val(config.ClientDiscoveryIntervalSeconds);
+        page.querySelector('#txtClientDiscoveryInterval').value = config.ClientDiscoveryIntervalSeconds;
         $('#chkEnableServer', page).prop('checked', config.EnableServer);
         $('#chkBlastAliveMessages', page).prop('checked', config.BlastAliveMessages);
-        $('#txtBlastInterval', page).val(config.BlastAliveMessageIntervalSeconds);
+        page.querySelector('#txtBlastInterval').value = config.BlastAliveMessageIntervalSeconds;
         var usersHtml = users.map(function (u) {
             return '<option value="' + u.Id + '">' + u.Name + '</option>';
         }).join('');
@@ -23,11 +23,11 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
         ApiClient.getNamedConfiguration('dlna').then(function (config) {
             config.EnablePlayTo = form.querySelector('#chkEnablePlayTo').checked;
             config.EnableDebugLog = form.querySelector('#chkEnableDlnaDebugLogging').checked;
-            config.ClientDiscoveryIntervalSeconds = $('#txtClientDiscoveryInterval', form).val();
+            config.ClientDiscoveryIntervalSeconds = form.querySelector('#txtClientDiscoveryInterval').value;
             config.EnableServer = $('#chkEnableServer', form).matches(':checked');
             config.BlastAliveMessages = $('#chkBlastAliveMessages', form).matches(':checked');
-            config.BlastAliveMessageIntervalSeconds = $('#txtBlastInterval', form).val();
-            config.DefaultUserId = $('#selectUser', form).val();
+            config.BlastAliveMessageIntervalSeconds = form.querySelector('#txtBlastInterval').value;
+            config.DefaultUserId = form.querySelector('#selectUser', form).value;
             ApiClient.updateNamedConfiguration('dlna', config).then(Dashboard.processServerConfigurationUpdateResult);
         });
         return false;

--- a/src/controllers/dashboard/dlna/settings.js
+++ b/src/controllers/dashboard/dlna/settings.js
@@ -5,8 +5,8 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
         page.querySelector('#chkEnablePlayTo').checked = config.EnablePlayTo;
         page.querySelector('#chkEnableDlnaDebugLogging').checked = config.EnableDebugLog;
         page.querySelector('#txtClientDiscoveryInterval').value = config.ClientDiscoveryIntervalSeconds;
-        $('#chkEnableServer', page).prop('checked', config.EnableServer);
-        $('#chkBlastAliveMessages', page).prop('checked', config.BlastAliveMessages);
+        page.querySelector('#chkEnableServer').checked = config.EnableServer;
+        page.querySelector('#chkBlastAliveMessages').checked = config.BlastAliveMessages;
         page.querySelector('#txtBlastInterval').value = config.BlastAliveMessageIntervalSeconds;
         var usersHtml = users.map(function (u) {
             return '<option value="' + u.Id + '">' + u.Name + '</option>';

--- a/src/controllers/dashboard/dlna/settings.js
+++ b/src/controllers/dashboard/dlna/settings.js
@@ -24,8 +24,8 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
             config.EnablePlayTo = form.querySelector('#chkEnablePlayTo').checked;
             config.EnableDebugLog = form.querySelector('#chkEnableDlnaDebugLogging').checked;
             config.ClientDiscoveryIntervalSeconds = form.querySelector('#txtClientDiscoveryInterval').value;
-            config.EnableServer = $('#chkEnableServer', form).matches(':checked');
-            config.BlastAliveMessages = $('#chkBlastAliveMessages', form).matches(':checked');
+            config.EnableServer = form.querySelector('#chkEnableServer').matches(':checked');
+            config.BlastAliveMessages = form.querySelector('#chkBlastAliveMessages').matches(':checked');
             config.BlastAliveMessageIntervalSeconds = form.querySelector('#txtBlastInterval').value;
             config.DefaultUserId = form.querySelector('#selectUser', form).value;
             ApiClient.updateNamedConfiguration('dlna', config).then(Dashboard.processServerConfigurationUpdateResult);

--- a/src/controllers/dashboard/dlna/settings.js
+++ b/src/controllers/dashboard/dlna/settings.js
@@ -24,8 +24,8 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
             config.EnablePlayTo = form.querySelector('#chkEnablePlayTo').checked;
             config.EnableDebugLog = form.querySelector('#chkEnableDlnaDebugLogging').checked;
             config.ClientDiscoveryIntervalSeconds = $('#txtClientDiscoveryInterval', form).val();
-            config.EnableServer = $('#chkEnableServer', form).is(':checked');
-            config.BlastAliveMessages = $('#chkBlastAliveMessages', form).is(':checked');
+            config.EnableServer = $('#chkEnableServer', form).matches(':checked');
+            config.BlastAliveMessages = $('#chkBlastAliveMessages', form).matches(':checked');
             config.BlastAliveMessageIntervalSeconds = $('#txtBlastInterval', form).val();
             config.DefaultUserId = $('#selectUser', form).val();
             ApiClient.updateNamedConfiguration('dlna', config).then(Dashboard.processServerConfigurationUpdateResult);

--- a/src/controllers/dashboard/dlna/settings.js
+++ b/src/controllers/dashboard/dlna/settings.js
@@ -11,7 +11,7 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
         var usersHtml = users.map(function (u) {
             return '<option value="' + u.Id + '">' + u.Name + '</option>';
         }).join('');
-        const elem = $('#selectUser', page);
+        const elem = page.querySelector('#selectUser');
         elem.innerHtml = usersHtml;
         elem.val(config.DefaultUserId || '');
         loading.hide();

--- a/src/controllers/dashboard/encodingsettings.js
+++ b/src/controllers/dashboard/encodingsettings.js
@@ -8,12 +8,12 @@ define(['jQuery', 'loading', 'globalize', 'dom', 'libraryMenu'], function ($, lo
         page.querySelector('#chkDecodingColorDepth10Hevc').checked = config.EnableDecodingColorDepth10Hevc;
         page.querySelector('#chkDecodingColorDepth10Vp9').checked = config.EnableDecodingColorDepth10Vp9;
         page.querySelector('#chkHardwareEncoding').checked = config.EnableHardwareEncoding;
-        $('#selectVideoDecoder', page).val(config.HardwareAccelerationType);
-        $('#selectThreadCount', page).val(config.EncodingThreadCount);
-        $('#txtDownMixAudioBoost', page).val(config.DownMixAudioBoost);
+        page.querySelector('#selectVideoDecoder').value = config.HardwareAccelerationType;
+        page.querySelector('#selectThreadCount').value = config.EncodingThreadCount;
+        page.querySelector('#txtDownMixAudioBoost').value = config.DownMixAudioBoost;
         page.querySelector('.txtEncoderPath').value = config.EncoderAppPathDisplay || '';
-        $('#txtTranscodingTempPath', page).val(systemInfo.TranscodingTempPath || '');
-        $('#txtVaapiDevice', page).val(config.VaapiDevice || '');
+        page.querySelector('#txtTranscodingTempPath').value = systemInfo.TranscodingTempPath || '';
+        page.querySelector('#txtVaapiDevice').value = config.VaapiDevice || '';
         page.querySelector('#selectEncoderPreset').value = config.EncoderPreset || '';
         page.querySelector('#txtH264Crf').value = config.H264Crf || '';
         page.querySelector('#selectDeinterlaceMethod').value = config.DeinterlaceMethod || '';
@@ -54,13 +54,13 @@ define(['jQuery', 'loading', 'globalize', 'dom', 'libraryMenu'], function ($, lo
         var onDecoderConfirmed = function () {
             loading.show();
             ApiClient.getNamedConfiguration('encoding').then(function (config) {
-                config.DownMixAudioBoost = $('#txtDownMixAudioBoost', form).val();
-                config.TranscodingTempPath = $('#txtTranscodingTempPath', form).val();
-                config.EncodingThreadCount = $('#selectThreadCount', form).val();
-                config.HardwareAccelerationType = $('#selectVideoDecoder', form).val();
-                config.VaapiDevice = $('#txtVaapiDevice', form).val();
+                config.DownMixAudioBoost = form.querySelector('#txtDownMixAudioBoost').value;
+                config.TranscodingTempPath = form.querySelector('#txtTranscodingTempPath').value;
+                config.EncodingThreadCount = form.querySelector('#selectThreadCount').value;
+                config.HardwareAccelerationType = form.querySelector('#selectVideoDecoder').value;
+                config.VaapiDevice = form.querySelector('#txtVaapiDevice').value;
                 config.EncoderPreset = form.querySelector('#selectEncoderPreset').value;
-                config.H264Crf = parseInt(form.querySelector('#txtH264Crf').value || '0');
+                config.H264Crf = parseInt(form.querySelector('#txtH264Crf').value || '0', 10);
                 config.DeinterlaceMethod = form.querySelector('#selectDeinterlaceMethod').value;
                 config.EnableSubtitleExtraction = form.querySelector('#chkEnableSubtitleExtraction').checked;
                 config.EnableThrottling = form.querySelector('#chkEnableThrottling').checked;
@@ -84,7 +84,7 @@ define(['jQuery', 'loading', 'globalize', 'dom', 'libraryMenu'], function ($, lo
             });
         };
 
-        if ($('#selectVideoDecoder', form).val()) {
+        if (form.querySelector('#selectVideoDecoder').value) {
             require(['alert'], function (alert) {
                 alert({
                     title: globalize.translate('TitleHardwareAcceleration'),
@@ -156,7 +156,7 @@ define(['jQuery', 'loading', 'globalize', 'dom', 'libraryMenu'], function ($, lo
                     includeFiles: true,
                     callback: function (path) {
                         if (path) {
-                            $('.txtEncoderPath', page).val(path);
+                            page.querySelector('.txtEncoderPath').value = path;
                         }
 
                         picker.close();
@@ -170,7 +170,7 @@ define(['jQuery', 'loading', 'globalize', 'dom', 'libraryMenu'], function ($, lo
                 picker.show({
                     callback: function (path) {
                         if (path) {
-                            $('#txtTranscodingTempPath', page).val(path);
+                            page.querySelector('#txtTranscodingTempPath').value = path;
                         }
 
                         picker.close();

--- a/src/controllers/dashboard/general.js
+++ b/src/controllers/dashboard/general.js
@@ -6,9 +6,11 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox', 'emby-textarea', 'emb
         page.querySelector('#txtCachePath').value = systemInfo.CachePath || '';
         $('#txtMetadataPath', page).val(systemInfo.InternalMetadataPath || '');
         $('#txtMetadataNetworkPath', page).val(systemInfo.MetadataNetworkPath || '');
-        $('#selectLocalizationLanguage', page).html(languageOptions.map(function (language) {
+        const elem = $('#selectLocalizationLanguage', page);
+        elem.innerHtml = languageOptions.map(function (language) {
             return '<option value="' + language.Value + '">' + language.Name + '</option>';
-        })).val(config.UICulture);
+        });
+        elem.val(config.UICulture);
         currentLanguage = config.UICulture;
 
         loading.hide();

--- a/src/controllers/dashboard/general.js
+++ b/src/controllers/dashboard/general.js
@@ -4,8 +4,8 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox', 'emby-textarea', 'emb
     function loadPage(page, config, languageOptions, systemInfo) {
         page.querySelector('#txtServerName').value = systemInfo.ServerName;
         page.querySelector('#txtCachePath').value = systemInfo.CachePath || '';
-        $('#txtMetadataPath', page).val(systemInfo.InternalMetadataPath || '');
-        $('#txtMetadataNetworkPath', page).val(systemInfo.MetadataNetworkPath || '');
+        page.querySelector('#txtMetadataPath').value = systemInfo.InternalMetadataPath || '';
+        page.querySelector('#txtMetadataNetworkPath').value = systemInfo.MetadataNetworkPath || '';
         const elem = $('#selectLocalizationLanguage', page);
         elem.innerHtml = languageOptions.map(function (language) {
             return '<option value="' + language.Value + '">' + language.Name + '</option>';
@@ -20,11 +20,11 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox', 'emby-textarea', 'emb
         loading.show();
         var form = this;
         ApiClient.getServerConfiguration().then(function (config) {
-            config.ServerName = $('#txtServerName', form).val();
-            config.UICulture = $('#selectLocalizationLanguage', form).val();
+            config.ServerName = form.querySelector('#txtServerName').value;
+            config.UICulture = form.querySelector('#selectLocalizationLanguage').value;
             config.CachePath = form.querySelector('#txtCachePath').value;
-            config.MetadataPath = $('#txtMetadataPath', form).val();
-            config.MetadataNetworkPath = $('#txtMetadataNetworkPath', form).val();
+            config.MetadataPath = form.querySelector('#txtMetadataPath').value;
+            config.MetadataNetworkPath = form.querySelector('#txtMetadataNetworkPath').value;
             var requiresReload = config.UICulture !== currentLanguage;
             ApiClient.updateServerConfiguration(config).then(function() {
                 ApiClient.getNamedConfiguration(brandingConfigKey).then(function(brandingConfig) {
@@ -79,15 +79,15 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox', 'emby-textarea', 'emb
             require(['directorybrowser'], function (directoryBrowser) {
                 var picker = new directoryBrowser();
                 picker.show({
-                    path: $('#txtMetadataPath', view).val(),
-                    networkSharePath: $('#txtMetadataNetworkPath', view).val(),
+                    path: view.querySelector('#txtMetadataPath').value,
+                    networkSharePath: view.querySelector('#txtMetadataNetworkPath').value,
                     callback: function (path, networkPath) {
                         if (path) {
-                            $('#txtMetadataPath', view).val(path);
+                            view.querySelector('#txtMetadataPath').value = path;
                         }
 
                         if (networkPath) {
-                            $('#txtMetadataNetworkPath', view).val(networkPath);
+                            view.querySelector('#txtMetadataNetworkPath').value = networkPath;
                         }
 
                         picker.close();

--- a/src/controllers/dashboard/general.js
+++ b/src/controllers/dashboard/general.js
@@ -19,7 +19,6 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox', 'emby-textarea', 'emb
     function onSubmit() {
         loading.show();
         var form = this;
-        $(form).parents('.page');
         ApiClient.getServerConfiguration().then(function (config) {
             config.ServerName = $('#txtServerName', form).val();
             config.UICulture = $('#selectLocalizationLanguage', form).val();

--- a/src/controllers/dashboard/general.js
+++ b/src/controllers/dashboard/general.js
@@ -6,7 +6,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox', 'emby-textarea', 'emb
         page.querySelector('#txtCachePath').value = systemInfo.CachePath || '';
         page.querySelector('#txtMetadataPath').value = systemInfo.InternalMetadataPath || '';
         page.querySelector('#txtMetadataNetworkPath').value = systemInfo.MetadataNetworkPath || '';
-        const elem = $('#selectLocalizationLanguage', page);
+        const elem = page.querySelector('#selectLocalizationLanguage');
         elem.innerHtml = languageOptions.map(function (language) {
             return '<option value="' + language.Value + '">' + language.Name + '</option>';
         });

--- a/src/controllers/dashboard/librarydisplay.js
+++ b/src/controllers/dashboard/librarydisplay.js
@@ -43,7 +43,7 @@ define(['globalize', 'loading', 'libraryMenu', 'emby-checkbox', 'emby-button', '
                 ApiClient.updateServerConfiguration(config).then(Dashboard.processServerConfigurationUpdateResult);
             });
             ApiClient.getNamedConfiguration('metadata').then(function(config) {
-                config.UseFileCreationTimeForDateAdded = '1' === $('#selectDateAdded', form).val();
+                config.UseFileCreationTimeForDateAdded = form.querySelector('#selectDateAdded').value === '1';
                 ApiClient.updateNamedConfiguration('metadata', config);
             });
 

--- a/src/controllers/dashboard/mediaLibrary.js
+++ b/src/controllers/dashboard/mediaLibrary.js
@@ -180,7 +180,7 @@ define(['jQuery', 'apphost', 'scripts/taskbutton', 'loading', 'libraryMenu', 'gl
             addVirtualFolder(page);
         });
         $('.editLibrary', divVirtualFolders).on('click', function () {
-            var card = $(this).parents('.card')[0];
+            var card = this.closest('.card');
             var index = parseInt(card.getAttribute('data-index'));
             var virtualFolder = virtualFolders[index];
 

--- a/src/controllers/dashboard/metadatanfo.js
+++ b/src/controllers/dashboard/metadatanfo.js
@@ -6,7 +6,7 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
         html += users.map(function (user) {
             return '<option value="' + user.Id + '">' + user.Name + '</option>';
         }).join('');
-        const elem = $('#selectUser', page);
+        const elem = page.querySelector('#selectUser');
         elem.innerHtml = html;
         elem.val(config.UserId || '');
         page.querySelector('#selectReleaseDateFormat').value = config.ReleaseDateFormat;

--- a/src/controllers/dashboard/metadatanfo.js
+++ b/src/controllers/dashboard/metadatanfo.js
@@ -6,7 +6,9 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
         html += users.map(function (user) {
             return '<option value="' + user.Id + '">' + user.Name + '</option>';
         }).join('');
-        $('#selectUser', page).html(html).val(config.UserId || '');
+        const elem = $('#selectUser', page);
+        elem.innerHtml = html;
+        elem.val(config.UserId || '');
         $('#selectReleaseDateFormat', page).val(config.ReleaseDateFormat);
         page.querySelector('#chkSaveImagePaths').checked = config.SaveImagePathsInNfo;
         page.querySelector('#chkEnablePathSubstitution').checked = config.EnablePathSubstitution;

--- a/src/controllers/dashboard/metadatanfo.js
+++ b/src/controllers/dashboard/metadatanfo.js
@@ -9,7 +9,7 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
         const elem = $('#selectUser', page);
         elem.innerHtml = html;
         elem.val(config.UserId || '');
-        $('#selectReleaseDateFormat', page).val(config.ReleaseDateFormat);
+        page.querySelector('#selectReleaseDateFormat').value = config.ReleaseDateFormat;
         page.querySelector('#chkSaveImagePaths').checked = config.SaveImagePathsInNfo;
         page.querySelector('#chkEnablePathSubstitution').checked = config.EnablePathSubstitution;
         page.querySelector('#chkEnableExtraThumbs').checked = config.EnableExtraThumbsDuplication;
@@ -20,8 +20,8 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
         loading.show();
         var form = this;
         ApiClient.getNamedConfiguration(metadataKey).then(function (config) {
-            config.UserId = $('#selectUser', form).val() || null;
-            config.ReleaseDateFormat = $('#selectReleaseDateFormat', form).val();
+            config.UserId = form.querySelector('#selectUser').value || null;
+            config.ReleaseDateFormat = form.querySelector('#selectReleaseDateFormat').value;
             config.SaveImagePathsInNfo = form.querySelector('#chkSaveImagePaths').checked;
             config.EnablePathSubstitution = form.querySelector('#chkEnablePathSubstitution').checked;
             config.EnableExtraThumbsDuplication = form.querySelector('#chkEnableExtraThumbs').checked;

--- a/src/controllers/dashboard/notifications/notification.js
+++ b/src/controllers/dashboard/notifications/notification.js
@@ -98,7 +98,7 @@ define(['jQuery', 'emby-checkbox'], function ($) {
     }
 
     function onSubmit() {
-        save($(this).parents('.page'));
+        save(this.closest('.page'));
         return false;
     }
 

--- a/src/controllers/dashboard/notifications/notification.js
+++ b/src/controllers/dashboard/notifications/notification.js
@@ -9,7 +9,8 @@ define(['jQuery', 'emby-checkbox'], function ($) {
             return '<label><input is="emby-checkbox" class="' + cssClass + '" type="checkbox" data-itemid="' + u.Id + '"' + checkedHtml + '/><span>' + u.Name + '</span></label>';
         }).join('');
         html += '</div>';
-        elem.html(html).trigger('create');
+        elem.innerHtml = html;
+        elem.dispatchEvent(new Event('create'));
     }
 
     function reload(page) {
@@ -52,7 +53,7 @@ define(['jQuery', 'emby-checkbox'], function ($) {
             fillItems($('.servicesList', page), services, 'chkService', 'chkService', notificationConfig.DisabledServices);
             page.querySelector('#chkEnabled').checked = notificationConfig.Enabled || false;
             page.querySelector('#selectUsers').value = notificationConfig.SendToUserMode;
-            page.querySelector('#selectUsers').trigger('change');
+            page.querySelector('#selectUsers').dispatchEvent(new Event('change'));
         });
     }
 

--- a/src/controllers/dashboard/notifications/notification.js
+++ b/src/controllers/dashboard/notifications/notification.js
@@ -37,7 +37,7 @@ define(['jQuery', 'emby-checkbox'], function ($) {
                 page.querySelector('.monitorUsers').classList.add('hide');
             }
 
-            $('.notificationType', page).innerHtml = typeInfo.Name || 'Unknown Notification';
+            page.querySelector('.notificationType').innerHtml = typeInfo.Name || 'Unknown Notification';
 
             if (!notificationConfig) {
                 notificationConfig = {

--- a/src/controllers/dashboard/notifications/notification.js
+++ b/src/controllers/dashboard/notifications/notification.js
@@ -73,7 +73,7 @@ define(['jQuery', 'emby-checkbox'], function ($) {
                 notificationOptions.Options.push(notificationConfig);
             }
 
-            notificationConfig.Enabled = $('#chkEnabled', page).is(':checked');
+            notificationConfig.Enabled = $('#chkEnabled', page).matches(':checked');
             notificationConfig.SendToUserMode = $('#selectUsers', page).val();
             notificationConfig.DisabledMonitorUsers = Array.prototype.filter.call(page.querySelectorAll('.chkMonitor'), function (c) {
                 return !c.checked;

--- a/src/controllers/dashboard/notifications/notification.js
+++ b/src/controllers/dashboard/notifications/notification.js
@@ -50,8 +50,9 @@ define(['jQuery', 'emby-checkbox'], function ($) {
             fillItems($('.monitorUsersList', page), users, 'chkMonitor', 'chkMonitor', notificationConfig.DisabledMonitorUsers);
             fillItems($('.sendToUsersList', page), users, 'chkSendTo', 'chkSendTo', notificationConfig.SendToUsers, true);
             fillItems($('.servicesList', page), services, 'chkService', 'chkService', notificationConfig.DisabledServices);
-            $('#chkEnabled', page).prop('checked', notificationConfig.Enabled || false);
-            $('#selectUsers', page).val(notificationConfig.SendToUserMode).trigger('change');
+            page.querySelector('#chkEnabled').checked = notificationConfig.Enabled || false;
+            page.querySelector('#selectUsers').value = notificationConfig.SendToUserMode;
+            page.querySelector('#selectUsers').trigger('change');
         });
     }
 
@@ -73,8 +74,8 @@ define(['jQuery', 'emby-checkbox'], function ($) {
                 notificationOptions.Options.push(notificationConfig);
             }
 
-            notificationConfig.Enabled = $('#chkEnabled', page).matches(':checked');
-            notificationConfig.SendToUserMode = $('#selectUsers', page).val();
+            notificationConfig.Enabled = page.querySelector('#chkEnabled').matches(':checked');
+            notificationConfig.SendToUserMode = page.querySelector('#selectUsers').value;
             notificationConfig.DisabledMonitorUsers = Array.prototype.filter.call(page.querySelectorAll('.chkMonitor'), function (c) {
                 return !c.checked;
             }).map(function (c) {

--- a/src/controllers/dashboard/notifications/notification.js
+++ b/src/controllers/dashboard/notifications/notification.js
@@ -36,7 +36,7 @@ define(['jQuery', 'emby-checkbox'], function ($) {
                 page.querySelector('.monitorUsers').classList.add('hide');
             }
 
-            $('.notificationType', page).html(typeInfo.Name || 'Unknown Notification');
+            $('.notificationType', page).innerHtml = typeInfo.Name || 'Unknown Notification';
 
             if (!notificationConfig) {
                 notificationConfig = {

--- a/src/controllers/dashboard/notifications/notification.js
+++ b/src/controllers/dashboard/notifications/notification.js
@@ -33,7 +33,7 @@ define(['jQuery', 'emby-checkbox'], function ($) {
             if (typeInfo.IsBasedOnUserEvent) {
                 $('.monitorUsers', page).show();
             } else {
-                $('.monitorUsers', page).hide();
+                page.querySelector('.monitorUsers').classList.add('hide');
             }
 
             $('.notificationType', page).html(typeInfo.Name || 'Unknown Notification');
@@ -109,7 +109,7 @@ define(['jQuery', 'emby-checkbox'], function ($) {
             if ('Custom' == this.value) {
                 $('.selectCustomUsers', page).show();
             } else {
-                $('.selectCustomUsers', page).hide();
+                page.querySelector('.selectCustomUsers').classList.add('hide');
             }
         });
         $('.notificationSettingForm').off('submit', onSubmit).on('submit', onSubmit);

--- a/src/controllers/dashboard/notifications/notification.js
+++ b/src/controllers/dashboard/notifications/notification.js
@@ -75,17 +75,17 @@ define(['jQuery', 'emby-checkbox'], function ($) {
 
             notificationConfig.Enabled = $('#chkEnabled', page).is(':checked');
             notificationConfig.SendToUserMode = $('#selectUsers', page).val();
-            notificationConfig.DisabledMonitorUsers = $('.chkMonitor', page).get().filter(function (c) {
+            notificationConfig.DisabledMonitorUsers = Array.prototype.filter.call(page.querySelectorAll('.chkMonitor'), function (c) {
                 return !c.checked;
             }).map(function (c) {
                 return c.getAttribute('data-itemid');
             });
-            notificationConfig.SendToUsers = $('.chkSendTo', page).get().filter(function (c) {
+            notificationConfig.SendToUsers = Array.prototype.filter.call(page.querySelectorAll('.chkSendTo'), function (c) {
                 return c.checked;
             }).map(function (c) {
                 return c.getAttribute('data-itemid');
             });
-            notificationConfig.DisabledServices = $('.chkService', page).get().filter(function (c) {
+            notificationConfig.DisabledServices = Array.prototype.filter.call(page.querySelectorAll('.chkService'), function (c) {
                 return !c.checked;
             }).map(function (c) {
                 return c.getAttribute('data-itemid');

--- a/src/controllers/dashboard/notifications/notification.js
+++ b/src/controllers/dashboard/notifications/notification.js
@@ -31,7 +31,7 @@ define(['jQuery', 'emby-checkbox'], function ($) {
             })[0] || {};
 
             if (typeInfo.IsBasedOnUserEvent) {
-                $('.monitorUsers', page).show();
+                page.querySelector('.monitorUsers').classList.remove('hide');
             } else {
                 page.querySelector('.monitorUsers').classList.add('hide');
             }
@@ -107,7 +107,7 @@ define(['jQuery', 'emby-checkbox'], function ($) {
         var page = this;
         $('#selectUsers', page).on('change', function () {
             if ('Custom' == this.value) {
-                $('.selectCustomUsers', page).show();
+                page.querySelector('.selectCustomUsers').classList.remove('hide');
             } else {
                 page.querySelector('.selectCustomUsers').classList.add('hide');
             }

--- a/src/controllers/dashboard/playback.js
+++ b/src/controllers/dashboard/playback.js
@@ -2,9 +2,9 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
     'use strict';
 
     function loadPage(page, config) {
-        $('#txtMinResumePct', page).val(config.MinResumePct);
-        $('#txtMaxResumePct', page).val(config.MaxResumePct);
-        $('#txtMinResumeDuration', page).val(config.MinResumeDurationSeconds);
+        page.querySelector('#txtMinResumePct', page).value = config.MinResumePct;
+        page.querySelector('#txtMaxResumePct', page).value = config.MaxResumePct;
+        page.querySelector('#txtMinResumeDuration', page).value = config.MinResumeDurationSeconds;
         loading.hide();
     }
 
@@ -12,9 +12,9 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
         loading.show();
         var form = this;
         ApiClient.getServerConfiguration().then(function (config) {
-            config.MinResumePct = $('#txtMinResumePct', form).val();
-            config.MaxResumePct = $('#txtMaxResumePct', form).val();
-            config.MinResumeDurationSeconds = $('#txtMinResumeDuration', form).val();
+            config.MinResumePct = form.querySelector('#txtMinResumePct').value;
+            config.MaxResumePct = form.querySelector('#txtMaxResumePct').value;
+            config.MinResumeDurationSeconds = form.querySelector('#txtMinResumeDuration').value;
 
             ApiClient.updateServerConfiguration(config).then(Dashboard.processServerConfigurationUpdateResult);
         });

--- a/src/controllers/dashboard/plugins/add.js
+++ b/src/controllers/dashboard/plugins/add.js
@@ -114,7 +114,7 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize', 'connectionManager', 'e
     return function (view, params) {
         $('.addPluginForm', view).on('submit', function () {
             loading.show();
-            var page = $(this).parents('#addPluginPage')[0];
+            var page = this.closest('#addPluginPage');
             var name = params.name;
             var guid = params.guid;
             ApiClient.getInstalledPlugins().then(function (plugins) {

--- a/src/controllers/dashboard/plugins/add.js
+++ b/src/controllers/dashboard/plugins/add.js
@@ -25,7 +25,9 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize', 'connectionManager', 'e
         var selectmenu = $('#selectVersion', page).html(html);
 
         if (!installedPlugin) {
-            $('#pCurrentVersion', page).hide().html('');
+            const currentVersion = page.querySelector('#pCurrentVersion');
+            currentVersion.classList.add('hide');
+            currentVersion.innerHtml = '';
         }
 
         var packageVersion = packageInfo.versions[0];
@@ -49,7 +51,7 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize', 'connectionManager', 'e
         if (pkg.overview) {
             $('#overview', page).show().html(pkg.overview);
         } else {
-            $('#overview', page).hide();
+            page.querySelector('#overview').classList.add('hide');
         }
 
         $('#description', page).html(pkg.description);
@@ -59,7 +61,9 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize', 'connectionManager', 'e
             var currentVersionText = globalize.translate('MessageYouHaveVersionInstalled', '<strong>' + installedPlugin.Version + '</strong>');
             $('#pCurrentVersion', page).show().html(currentVersionText);
         } else {
-            $('#pCurrentVersion', page).hide().html('');
+            const currentVersion = page.querySelector('#pCurrentVersion');
+            currentVersion.classList.add('hide');
+            currentVersion.innerHtml = '';
         }
 
         loading.hide();

--- a/src/controllers/dashboard/plugins/add.js
+++ b/src/controllers/dashboard/plugins/add.js
@@ -11,7 +11,7 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize', 'connectionManager', 'e
             html += '<div style="margin-bottom:1.5em;">' + version.changelog + '</div>';
         }
 
-        $('#revisionHistory', page).html(html);
+        $('#revisionHistory', page).innerHtml = html;
     }
 
     function populateVersions(packageInfo, page, installedPlugin) {
@@ -22,7 +22,8 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize', 'connectionManager', 'e
             html += '<option value="' + version.version + '">' + version.version + '</option>';
         }
 
-        var selectmenu = $('#selectVersion', page).html(html);
+        var selectmenu = $('#selectVersion', page);
+        selectmenu.innerHtml = html;
 
         if (!installedPlugin) {
             const currentVersion = page.querySelector('#pCurrentVersion');
@@ -44,22 +45,26 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize', 'connectionManager', 'e
         populateVersions(pkg, page, installedPlugin);
         populateHistory(pkg, page);
 
-        $('.pluginName', page).html(pkg.name);
+        $('.pluginName', page).innerHtml = pkg.name;
         page.querySelector('#btnInstallDiv').classList.remove('hide');
         page.querySelector('#pSelectVersion').classList.remove('hide');
 
         if (pkg.overview) {
-            $('#overview', page).show().html(pkg.overview);
+            const overview = $('#overview', page);
+            overview.show();
+            overview.innerHtml = pkg.overview;
         } else {
             page.querySelector('#overview').classList.add('hide');
         }
 
-        $('#description', page).html(pkg.description);
-        $('#developer', page).html(pkg.owner);
+        $('#description', page).innerHtml = pkg.description;
+        $('#developer', page).innerHtml = pkg.owner;
 
         if (installedPlugin) {
             var currentVersionText = globalize.translate('MessageYouHaveVersionInstalled', '<strong>' + installedPlugin.Version + '</strong>');
-            $('#pCurrentVersion', page).show().html(currentVersionText);
+            const currentVersion = $('#pCurrentVersion', page);
+            currentVersion.show();
+            currentVersion.innerHtml = currentVersionText;
         } else {
             const currentVersion = page.querySelector('#pCurrentVersion');
             currentVersion.classList.add('hide');
@@ -76,7 +81,7 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize', 'connectionManager', 'e
     }
 
     function performInstallation(page, name, guid, version) {
-        var developer = $('#developer', page).html().toLowerCase();
+        var developer = $('#developer', page).innerHtml.toLowerCase();
 
         var alertCallback = function () {
             loading.show();

--- a/src/controllers/dashboard/plugins/add.js
+++ b/src/controllers/dashboard/plugins/add.js
@@ -43,8 +43,8 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize', 'connectionManager', 'e
         populateHistory(pkg, page);
 
         $('.pluginName', page).html(pkg.name);
-        $('#btnInstallDiv', page).removeClass('hide');
-        $('#pSelectVersion', page).removeClass('hide');
+        page.querySelector('#btnInstallDiv').classList.remove('hide');
+        page.querySelector('#pSelectVersion').classList.remove('hide');
 
         if (pkg.overview) {
             $('#overview', page).show().html(pkg.overview);

--- a/src/controllers/dashboard/plugins/add.js
+++ b/src/controllers/dashboard/plugins/add.js
@@ -11,7 +11,7 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize', 'connectionManager', 'e
             html += '<div style="margin-bottom:1.5em;">' + version.changelog + '</div>';
         }
 
-        $('#revisionHistory', page).innerHtml = html;
+        page.querySelector('#revisionHistory').innerHtml = html;
     }
 
     function populateVersions(packageInfo, page, installedPlugin) {
@@ -22,7 +22,7 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize', 'connectionManager', 'e
             html += '<option value="' + version.version + '">' + version.version + '</option>';
         }
 
-        var selectmenu = $('#selectVersion', page);
+        var selectmenu = page.querySelector$('#selectVersion');
         selectmenu.innerHtml = html;
 
         if (!installedPlugin) {
@@ -45,13 +45,13 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize', 'connectionManager', 'e
         populateVersions(pkg, page, installedPlugin);
         populateHistory(pkg, page);
 
-        $('.pluginName', page).innerHtml = pkg.name;
+        page.querySelector('.pluginName').innerHtml = pkg.name;
         page.querySelector('#btnInstallDiv').classList.remove('hide');
         page.querySelector('#pSelectVersion').classList.remove('hide');
 
         if (pkg.overview) {
-            const overview = $('#overview', page);
-            overview.show();
+            const overview = page.querySelector('#overview');
+            overview.classList.remove('hide');
             overview.innerHtml = pkg.overview;
         } else {
             page.querySelector('#overview').classList.add('hide');
@@ -62,8 +62,8 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize', 'connectionManager', 'e
 
         if (installedPlugin) {
             var currentVersionText = globalize.translate('MessageYouHaveVersionInstalled', '<strong>' + installedPlugin.Version + '</strong>');
-            const currentVersion = $('#pCurrentVersion', page);
-            currentVersion.show();
+            const currentVersion = page.querySelector('#pCurrentVersion');
+            currentVersion.classList.remove('hide');
             currentVersion.innerHtml = currentVersionText;
         } else {
             const currentVersion = page.querySelector('#pCurrentVersion');
@@ -81,7 +81,7 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize', 'connectionManager', 'e
     }
 
     function performInstallation(page, name, guid, version) {
-        var developer = $('#developer', page).innerHtml.toLowerCase();
+        var developer = page.querySelector('#developer').innerHtml.toLowerCase();
 
         var alertCallback = function () {
             loading.show();

--- a/src/controllers/dashboard/plugins/add.js
+++ b/src/controllers/dashboard/plugins/add.js
@@ -57,8 +57,8 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize', 'connectionManager', 'e
             page.querySelector('#overview').classList.add('hide');
         }
 
-        $('#description', page).innerHtml = pkg.description;
-        $('#developer', page).innerHtml = pkg.owner;
+        page.querySelector('#description').innerHtml = pkg.description;
+        page.querySelector('#developer').innerHtml = pkg.owner;
 
         if (installedPlugin) {
             var currentVersionText = globalize.translate('MessageYouHaveVersionInstalled', '<strong>' + installedPlugin.Version + '</strong>');

--- a/src/controllers/dashboard/plugins/add.js
+++ b/src/controllers/dashboard/plugins/add.js
@@ -122,7 +122,7 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize', 'connectionManager', 'e
                     return plugin.Name == name;
                 })[0];
 
-                var version = $('#selectVersion', page).val();
+                var version = page.querySelector('#selectVersion').value;
                 if (installedPlugin) {
                     if (installedPlugin.Version === version) {
                         loading.hide();

--- a/src/controllers/dashboard/scheduledtasks/scheduledtask.js
+++ b/src/controllers/dashboard/scheduledtasks/scheduledtask.js
@@ -124,7 +124,7 @@ define(['jQuery', 'loading', 'datetime', 'dom', 'globalize', 'emby-input', 'emby
             return datetime.getDisplayTime(now);
         },
         showAddTriggerPopup: function (view) {
-            $('#selectTriggerType', view).val('DailyTrigger');
+            view.querySelector('#selectTriggerType').value = 'DailyTrigger';
             view.querySelector('#selectTriggerType').dispatchEvent(new CustomEvent('change', {}));
             view.querySelector('#popupAddTrigger').classList.remove('hide');
         },
@@ -180,21 +180,21 @@ define(['jQuery', 'loading', 'datetime', 'dom', 'globalize', 'emby-input', 'emby
         },
         getTriggerToAdd: function (page) {
             var trigger = {
-                Type: $('#selectTriggerType', page).val()
+                Type: page.querySelector('#selectTriggerType', page).val()
             };
 
             if (trigger.Type == 'DailyTrigger') {
-                trigger.TimeOfDayTicks = $('#selectTimeOfDay', page).val();
+                trigger.TimeOfDayTicks = page.querySelector('#selectTimeOfDay').value;
             } else if (trigger.Type == 'WeeklyTrigger') {
-                trigger.DayOfWeek = $('#selectDayOfWeek', page).val();
-                trigger.TimeOfDayTicks = $('#selectTimeOfDay', page).val();
+                trigger.DayOfWeek = page.querySelector('#selectDayOfWeek').value;
+                trigger.TimeOfDayTicks = page.querySelector('#selectTimeOfDay').value;
             } else if (trigger.Type == 'SystemEventTrigger') {
-                trigger.SystemEvent = $('#selectSystemEvent', page).val();
+                trigger.SystemEvent = page.querySelector('#selectSystemEvent').value;
             } else if (trigger.Type == 'IntervalTrigger') {
-                trigger.IntervalTicks = $('#selectInterval', page).val();
+                trigger.IntervalTicks = page.querySelector('#selectInterval').value;
             }
 
-            var timeLimit = $('#txtTimeLimit', page).val() || '0';
+            var timeLimit = page.querySelector('#txtTimeLimit', page).value || '0';
             timeLimit = parseFloat(timeLimit) * 3600000;
 
             trigger.MaxRuntimeMs = timeLimit || null;

--- a/src/controllers/dashboard/scheduledtasks/scheduledtask.js
+++ b/src/controllers/dashboard/scheduledtasks/scheduledtask.js
@@ -148,33 +148,33 @@ define(['jQuery', 'loading', 'datetime', 'dom', 'globalize', 'emby-input', 'emby
         refreshTriggerFields: function (page, triggerType) {
             if (triggerType == 'DailyTrigger') {
                 $('#fldTimeOfDay', page).show();
-                $('#fldDayOfWeek', page).hide();
-                $('#fldSelectSystemEvent', page).hide();
-                $('#fldSelectInterval', page).hide();
+                $('#fldDayOfWeek', page).classList.add('hide');
+                $('#fldSelectSystemEvent', page).classList.add('hide');
+                $('#fldSelectInterval', page).classList.add('hide');
                 page.querySelector('#selectTimeOfDay').setAttribute('required', 'required');
             } else if (triggerType == 'WeeklyTrigger') {
                 $('#fldTimeOfDay', page).show();
                 $('#fldDayOfWeek', page).show();
-                $('#fldSelectSystemEvent', page).hide();
-                $('#fldSelectInterval', page).hide();
+                $('#fldSelectSystemEvent', page).classList.add('hide');
+                $('#fldSelectInterval', page).classList.add('hide');
                 page.querySelector('#selectTimeOfDay').setAttribute('required', 'required');
             } else if (triggerType == 'SystemEventTrigger') {
-                $('#fldTimeOfDay', page).hide();
-                $('#fldDayOfWeek', page).hide();
+                $('#fldTimeOfDay', page).classList.add('hide');
+                $('#fldDayOfWeek', page).classList.add('hide');
                 $('#fldSelectSystemEvent', page).show();
-                $('#fldSelectInterval', page).hide();
+                $('#fldSelectInterval', page).classList.add('hide');
                 $('#selectTimeOfDay', page).removeAttr('required');
             } else if (triggerType == 'IntervalTrigger') {
-                $('#fldTimeOfDay', page).hide();
-                $('#fldDayOfWeek', page).hide();
-                $('#fldSelectSystemEvent', page).hide();
+                $('#fldTimeOfDay', page).classList.add('hide');
+                $('#fldDayOfWeek', page).classList.add('hide');
+                $('#fldSelectSystemEvent', page).classList.add('hide');
                 $('#fldSelectInterval', page).show();
                 $('#selectTimeOfDay', page).removeAttr('required');
             } else if (triggerType == 'StartupTrigger') {
-                $('#fldTimeOfDay', page).hide();
-                $('#fldDayOfWeek', page).hide();
-                $('#fldSelectSystemEvent', page).hide();
-                $('#fldSelectInterval', page).hide();
+                $('#fldTimeOfDay', page).classList.add('hide');
+                $('#fldDayOfWeek', page).classList.add('hide');
+                $('#fldSelectSystemEvent', page).classList.add('hide');
+                $('#fldSelectInterval', page).classList.add('hide');
                 $('#selectTimeOfDay', page).removeAttr('required');
             }
         },

--- a/src/controllers/dashboard/scheduledtasks/scheduledtask.js
+++ b/src/controllers/dashboard/scheduledtasks/scheduledtask.js
@@ -126,7 +126,7 @@ define(['jQuery', 'loading', 'datetime', 'dom', 'globalize', 'emby-input', 'emby
         showAddTriggerPopup: function (view) {
             $('#selectTriggerType', view).val('DailyTrigger');
             view.querySelector('#selectTriggerType').dispatchEvent(new CustomEvent('change', {}));
-            $('#popupAddTrigger', view).removeClass('hide');
+            view.querySelector('#popupAddTrigger').classList.remove('hide');
         },
         confirmDeleteTrigger: function (view, index) {
             require(['confirm'], function (confirm) {
@@ -151,13 +151,13 @@ define(['jQuery', 'loading', 'datetime', 'dom', 'globalize', 'emby-input', 'emby
                 $('#fldDayOfWeek', page).hide();
                 $('#fldSelectSystemEvent', page).hide();
                 $('#fldSelectInterval', page).hide();
-                $('#selectTimeOfDay', page).attr('required', 'required');
+                page.querySelector('#selectTimeOfDay').setAttribute('required', 'required');
             } else if (triggerType == 'WeeklyTrigger') {
                 $('#fldTimeOfDay', page).show();
                 $('#fldDayOfWeek', page).show();
                 $('#fldSelectSystemEvent', page).hide();
                 $('#fldSelectInterval', page).hide();
-                $('#selectTimeOfDay', page).attr('required', 'required');
+                page.querySelector('#selectTimeOfDay').setAttribute('required', 'required');
             } else if (triggerType == 'SystemEventTrigger') {
                 $('#fldTimeOfDay', page).hide();
                 $('#fldDayOfWeek', page).hide();
@@ -209,7 +209,7 @@ define(['jQuery', 'loading', 'datetime', 'dom', 'globalize', 'emby-input', 'emby
             ApiClient.getScheduledTask(id).then(function (task) {
                 task.Triggers.push(ScheduledTaskPage.getTriggerToAdd(view));
                 ApiClient.updateScheduledTaskTriggers(task.Id, task.Triggers).then(function () {
-                    $('#popupAddTrigger').addClass('hide');
+                    document.querySelector('#popupAddTrigger').classList.add('hide');
                     ScheduledTaskPage.refreshScheduledTask(view);
                 });
             });

--- a/src/controllers/dashboard/scheduledtasks/scheduledtask.js
+++ b/src/controllers/dashboard/scheduledtasks/scheduledtask.js
@@ -218,7 +218,7 @@ define(['jQuery', 'loading', 'datetime', 'dom', 'globalize', 'emby-input', 'emby
 
         view.querySelector('.addTriggerForm').addEventListener('submit', onSubmit);
         fillTimeOfDay(view.querySelector('#selectTimeOfDay'));
-        $(view.querySelector('#popupAddTrigger').parentNode).trigger('create');
+        view.querySelector('#popupAddTrigger').parentNode.dispatchEvent(new Event('create'));
         view.querySelector('.selectTriggerType').addEventListener('change', function () {
             ScheduledTaskPage.refreshTriggerFields(view, this.value);
         });

--- a/src/controllers/dashboard/scheduledtasks/scheduledtask.js
+++ b/src/controllers/dashboard/scheduledtasks/scheduledtask.js
@@ -32,8 +32,8 @@ define(['jQuery', 'loading', 'datetime', 'dom', 'globalize', 'emby-input', 'emby
             });
         },
         loadScheduledTask: function (view, task) {
-            $('.taskName', view).html(task.Name);
-            $('#pTaskDescription', view).html(task.Description);
+            $('.taskName', view).innerHtml = task.Name;
+            $('#pTaskDescription', view).innerHtml = task.Description;
 
             require(['listViewStyle'], function () {
                 ScheduledTaskPage.loadTaskTriggers(view, task);

--- a/src/controllers/dashboard/scheduledtasks/scheduledtask.js
+++ b/src/controllers/dashboard/scheduledtasks/scheduledtask.js
@@ -147,35 +147,35 @@ define(['jQuery', 'loading', 'datetime', 'dom', 'globalize', 'emby-input', 'emby
         },
         refreshTriggerFields: function (page, triggerType) {
             if (triggerType == 'DailyTrigger') {
-                $('#fldTimeOfDay', page).show();
-                $('#fldDayOfWeek', page).classList.add('hide');
-                $('#fldSelectSystemEvent', page).classList.add('hide');
-                $('#fldSelectInterval', page).classList.add('hide');
+                page.querySelector('#fldTimeOfDay').classList.remove('hide');
+                page.querySelector('#fldDayOfWeek').classList.add('hide');
+                page.querySelector('#fldSelectSystemEvent').classList.add('hide');
+                page.querySelector('#fldSelectInterval').classList.add('hide');
                 page.querySelector('#selectTimeOfDay').setAttribute('required', 'required');
             } else if (triggerType == 'WeeklyTrigger') {
-                $('#fldTimeOfDay', page).show();
-                $('#fldDayOfWeek', page).show();
-                $('#fldSelectSystemEvent', page).classList.add('hide');
-                $('#fldSelectInterval', page).classList.add('hide');
+                page.querySelector('#fldTimeOfDay').classList.remove('hide');
+                page.querySelector('#fldDayOfWeek').classList.remove('hide');
+                page.querySelector('#fldSelectSystemEvent').classList.add('hide');
+                page.querySelector('#fldSelectInterval').classList.add('hide');
                 page.querySelector('#selectTimeOfDay').setAttribute('required', 'required');
             } else if (triggerType == 'SystemEventTrigger') {
-                $('#fldTimeOfDay', page).classList.add('hide');
-                $('#fldDayOfWeek', page).classList.add('hide');
-                $('#fldSelectSystemEvent', page).show();
-                $('#fldSelectInterval', page).classList.add('hide');
-                $('#selectTimeOfDay', page).removeAttr('required');
+                page.querySelector('#fldTimeOfDay').classList.add('hide');
+                page.querySelector('#fldDayOfWeek').classList.add('hide');
+                page.querySelector('#fldSelectSystemEvent').classList.remove('hide');
+                page.querySelector('#fldSelectInterval').classList.add('hide');
+                page.querySelector('#selectTimeOfDay').removeAttribute('required');
             } else if (triggerType == 'IntervalTrigger') {
-                $('#fldTimeOfDay', page).classList.add('hide');
-                $('#fldDayOfWeek', page).classList.add('hide');
-                $('#fldSelectSystemEvent', page).classList.add('hide');
-                $('#fldSelectInterval', page).show();
-                $('#selectTimeOfDay', page).removeAttr('required');
+                page.querySelector('#fldTimeOfDay').classList.add('hide');
+                page.querySelector('#fldDayOfWeek').classList.add('hide');
+                page.querySelector('#fldSelectSystemEvent').classList.add('hide');
+                page.querySelector('#fldSelectInterval').classList.remove('hide');
+                page.querySelector('#selectTimeOfDay').removeAttribute('required');
             } else if (triggerType == 'StartupTrigger') {
-                $('#fldTimeOfDay', page).classList.add('hide');
-                $('#fldDayOfWeek', page).classList.add('hide');
-                $('#fldSelectSystemEvent', page).classList.add('hide');
-                $('#fldSelectInterval', page).classList.add('hide');
-                $('#selectTimeOfDay', page).removeAttr('required');
+                page.querySelector('#fldTimeOfDay').classList.add('hide');
+                page.querySelector('#fldDayOfWeek').classList.add('hide');
+                page.querySelector('#fldSelectSystemEvent').classList.add('hide');
+                page.querySelector('#fldSelectInterval').classList.add('hide');
+                page.querySelector('#selectTimeOfDay').removeAttribute('required');
             }
         },
         getTriggerToAdd: function (page) {

--- a/src/controllers/dashboard/scheduledtasks/scheduledtask.js
+++ b/src/controllers/dashboard/scheduledtasks/scheduledtask.js
@@ -32,8 +32,8 @@ define(['jQuery', 'loading', 'datetime', 'dom', 'globalize', 'emby-input', 'emby
             });
         },
         loadScheduledTask: function (view, task) {
-            $('.taskName', view).innerHtml = task.Name;
-            $('#pTaskDescription', view).innerHtml = task.Description;
+            view.querySelector('.taskName').innerHtml = task.Name;
+            view.querySelector('#pTaskDescription').innerHtml = task.Description;
 
             require(['listViewStyle'], function () {
                 ScheduledTaskPage.loadTaskTriggers(view, task);

--- a/src/controllers/dashboard/scheduledtasks/scheduledtasks.js
+++ b/src/controllers/dashboard/scheduledtasks/scheduledtasks.js
@@ -111,7 +111,8 @@ define(['jQuery', 'loading', 'events', 'globalize', 'serverNotifications', 'date
             setTaskButtonIcon(elem, 'play_arrow');
             elem.title = globalize.translate('ButtonStart');
         }
-        $(elem).parents('.listItem')[0].setAttribute('data-status', state);
+        const listItem = elem.closest('.listItem');
+        listItem.setAttribute('data-status', state);
     }
 
     return function(view, params) {

--- a/src/controllers/dashboard/streaming.js
+++ b/src/controllers/dashboard/streaming.js
@@ -2,7 +2,7 @@ define(['jQuery', 'libraryMenu', 'loading', 'globalize'], function ($, libraryMe
     'use strict';
 
     function loadPage(page, config) {
-        $('#txtRemoteClientBitrateLimit', page).val(config.RemoteClientBitrateLimit / 1e6 || '');
+        page.querySelector('#txtRemoteClientBitrateLimit').value = config.RemoteClientBitrateLimit / 1e6 || '';
         loading.hide();
     }
 
@@ -10,7 +10,7 @@ define(['jQuery', 'libraryMenu', 'loading', 'globalize'], function ($, libraryMe
         loading.show();
         var form = this;
         ApiClient.getServerConfiguration().then(function (config) {
-            config.RemoteClientBitrateLimit = parseInt(1e6 * parseFloat($('#txtRemoteClientBitrateLimit', form).val() || '0'));
+            config.RemoteClientBitrateLimit = parseInt(1e6 * parseFloat(form.querySelector('#txtRemoteClientBitrateLimit').value || '0'));
             ApiClient.updateServerConfiguration(config).then(Dashboard.processServerConfigurationUpdateResult);
         });
 

--- a/src/controllers/dashboard/users/useredit.js
+++ b/src/controllers/dashboard/users/useredit.js
@@ -29,7 +29,7 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
             const deleteAccess = $('.deleteAccess', page);
             deleteAccess.innerHtml = html;
             deleteAccess.trigger('create');
-            $('#chkEnableDeleteAllFolders', page).prop('checked', user.Policy.EnableContentDeletion);
+            page.querySelector('#chkEnableDeleteAllFolders').checked = user.Policy.EnableContentDeletion;
         });
     }
 
@@ -81,29 +81,29 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
             page.querySelector('.disabledUserBanner').classList.add('hide');
         }
 
-        $('#txtUserName', page).prop('disabled', '').removeAttr('disabled');
+        page.querySelector('#txtUserName').removeAttribute('disabled');
         page.querySelector('#fldConnectInfo').classList.remove('hide');
         page.querySelector('.lnkEditUserPreferences').setAttribute('href', `mypreferencesmenu.html?userId=${user.Id}`);
         libraryMenu.setTitle(user.Name);
         page.querySelector('.username').innerHTML = user.Name;
         page.querySelector('#txtUserName').value = user.Name;
-        $('#chkIsAdmin', page).prop('checked', user.Policy.IsAdministrator);
-        $('#chkDisabled', page).prop('checked', user.Policy.IsDisabled);
-        $('#chkIsHidden', page).prop('checked', user.Policy.IsHidden);
-        $('#chkRemoteControlSharedDevices', page).prop('checked', user.Policy.EnableSharedDeviceControl);
-        $('#chkEnableRemoteControlOtherUsers', page).prop('checked', user.Policy.EnableRemoteControlOfOtherUsers);
-        $('#chkEnableDownloading', page).prop('checked', user.Policy.EnableContentDownloading);
-        $('#chkManageLiveTv', page).prop('checked', user.Policy.EnableLiveTvManagement);
-        $('#chkEnableLiveTvAccess', page).prop('checked', user.Policy.EnableLiveTvAccess);
-        $('#chkEnableMediaPlayback', page).prop('checked', user.Policy.EnableMediaPlayback);
-        $('#chkEnableAudioPlaybackTranscoding', page).prop('checked', user.Policy.EnableAudioPlaybackTranscoding);
-        $('#chkEnableVideoPlaybackTranscoding', page).prop('checked', user.Policy.EnableVideoPlaybackTranscoding);
-        $('#chkEnableVideoPlaybackRemuxing', page).prop('checked', user.Policy.EnablePlaybackRemuxing);
-        $('#chkForceRemoteSourceTranscoding', page).prop('checked', user.Policy.ForceRemoteSourceTranscoding);
-        $('#chkRemoteAccess', page).prop('checked', null == user.Policy.EnableRemoteAccess || user.Policy.EnableRemoteAccess);
-        $('#chkEnableSyncTranscoding', page).prop('checked', user.Policy.EnableSyncTranscoding);
-        $('#chkEnableConversion', page).prop('checked', user.Policy.EnableMediaConversion || false);
-        $('#chkEnableSharing', page).prop('checked', user.Policy.EnablePublicSharing);
+        page.querySelector('#chkIsAdmin').checked = user.Policy.IsAdministrator;
+        page.querySelector('#chkDisabled').checked = user.Policy.IsDisabled;
+        page.querySelector('#chkIsHidden').checked = user.Policy.IsHidden;
+        page.querySelector('#chkRemoteControlSharedDevices').checked = user.Policy.EnableSharedDeviceControl;
+        page.querySelector('#chkEnableRemoteControlOtherUsers').checked = user.Policy.EnableRemoteControlOfOtherUsers;
+        page.querySelector('#chkEnableDownloading').checked = user.Policy.EnableContentDownloading;
+        page.querySelector('#chkManageLiveTv').checked = user.Policy.EnableLiveTvManagement;
+        page.querySelector('#chkEnableLiveTvAccess').checked = user.Policy.EnableLiveTvAccess;
+        page.querySelector('#chkEnableMediaPlayback').checked = user.Policy.EnableMediaPlayback;
+        page.querySelector('#chkEnableAudioPlaybackTranscoding').checked = user.Policy.EnableAudioPlaybackTranscoding;
+        page.querySelector('#chkEnableVideoPlaybackTranscoding').checked = user.Policy.EnableVideoPlaybackTranscoding;
+        page.querySelector('#chkEnableVideoPlaybackRemuxing').checked = user.Policy.EnablePlaybackRemuxing;
+        page.querySelector('#chkForceRemoteSourceTranscoding').checked = user.Policy.ForceRemoteSourceTranscoding;
+        page.querySelector('#chkRemoteAccess').checked = null == user.Policy.EnableRemoteAccess || user.Policy.EnableRemoteAccess;
+        page.querySelector('#chkEnableSyncTranscoding').checked = user.Policy.EnableSyncTranscoding;
+        page.querySelector('#chkEnableConversion').checked = user.Policy.EnableMediaConversion || false;
+        page.querySelector('#chkEnableSharing').checked = user.Policy.EnablePublicSharing;
         page.querySelector('#txtRemoteClientBitrateLimit').value = user.Policy.RemoteClientBitrateLimit / 1e6 || '';
         page.querySelector('#txtLoginAttemptsBeforeLockout').value = user.Policy.LoginAttemptsBeforeLockout || '0';
         page.querySelector('#selectSyncPlayAccess').value = user.Policy.SyncPlayAccess;

--- a/src/controllers/dashboard/users/useredit.js
+++ b/src/controllers/dashboard/users/useredit.js
@@ -26,7 +26,9 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
                 html += '<label><input type="checkbox" is="emby-checkbox" class="chkFolder" data-id="' + folder.Id + '" ' + checkedAttribute + '><span>' + folder.Name + '</span></label>';
             }
 
-            $('.deleteAccess', page).html(html).trigger('create');
+            const deleteAccess = $('.deleteAccess', page);
+            deleteAccess.innerHtml = html;
+            deleteAccess.trigger('create');
             $('#chkEnableDeleteAllFolders', page).prop('checked', user.Policy.EnableContentDeletion);
         });
     }

--- a/src/controllers/dashboard/users/useredit.js
+++ b/src/controllers/dashboard/users/useredit.js
@@ -26,7 +26,7 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
                 html += '<label><input type="checkbox" is="emby-checkbox" class="chkFolder" data-id="' + folder.Id + '" ' + checkedAttribute + '><span>' + folder.Name + '</span></label>';
             }
 
-            const deleteAccess = $('.deleteAccess', page);
+            const deleteAccess = page.querySelector('.deleteAccess');
             deleteAccess.innerHtml = html;
             deleteAccess.trigger('create');
             page.querySelector('#chkEnableDeleteAllFolders').checked = user.Policy.EnableContentDeletion;
@@ -121,28 +121,28 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
 
     function saveUser(user, page) {
         user.Name = page.querySelector('#txtUserName').value;
-        user.Policy.IsAdministrator = $('#chkIsAdmin', page).matches(':checked');
-        user.Policy.IsHidden = $('#chkIsHidden', page).matches(':checked');
-        user.Policy.IsDisabled = $('#chkDisabled', page).matches(':checked');
-        user.Policy.EnableRemoteControlOfOtherUsers = $('#chkEnableRemoteControlOtherUsers', page).matches(':checked');
-        user.Policy.EnableLiveTvManagement = $('#chkManageLiveTv', page).matches(':checked');
-        user.Policy.EnableLiveTvAccess = $('#chkEnableLiveTvAccess', page).matches(':checked');
-        user.Policy.EnableSharedDeviceControl = $('#chkRemoteControlSharedDevices', page).matches(':checked');
-        user.Policy.EnableMediaPlayback = $('#chkEnableMediaPlayback', page).matches(':checked');
-        user.Policy.EnableAudioPlaybackTranscoding = $('#chkEnableAudioPlaybackTranscoding', page).matches(':checked');
-        user.Policy.EnableVideoPlaybackTranscoding = $('#chkEnableVideoPlaybackTranscoding', page).matches(':checked');
-        user.Policy.EnablePlaybackRemuxing = $('#chkEnableVideoPlaybackRemuxing', page).matches(':checked');
-        user.Policy.ForceRemoteSourceTranscoding = $('#chkForceRemoteSourceTranscoding', page).matches(':checked');
-        user.Policy.EnableContentDownloading = $('#chkEnableDownloading', page).matches(':checked');
-        user.Policy.EnableSyncTranscoding = $('#chkEnableSyncTranscoding', page).matches(':checked');
-        user.Policy.EnableMediaConversion = $('#chkEnableConversion', page).matches(':checked');
-        user.Policy.EnablePublicSharing = $('#chkEnableSharing', page).matches(':checked');
-        user.Policy.EnableRemoteAccess = $('#chkRemoteAccess', page).matches(':checked');
+        user.Policy.IsAdministrator = page.querySelector('#chkIsAdmin').matches(':checked');
+        user.Policy.IsHidden = page.querySelector('#chkIsHidden').matches(':checked');
+        user.Policy.IsDisabled = page.querySelector('#chkDisabled').matches(':checked');
+        user.Policy.EnableRemoteControlOfOtherUsers = page.querySelector('#chkEnableRemoteControlOtherUsers').matches(':checked');
+        user.Policy.EnableLiveTvManagement = page.querySelector('#chkManageLiveTv').matches(':checked');
+        user.Policy.EnableLiveTvAccess = page.querySelector('#chkEnableLiveTvAccess').matches(':checked');
+        user.Policy.EnableSharedDeviceControl = page.querySelector('#chkRemoteControlSharedDevices').matches(':checked');
+        user.Policy.EnableMediaPlayback = page.querySelector('#chkEnableMediaPlayback').matches(':checked');
+        user.Policy.EnableAudioPlaybackTranscoding = page.querySelector('#chkEnableAudioPlaybackTranscoding').matches(':checked');
+        user.Policy.EnableVideoPlaybackTranscoding = page.querySelector('#chkEnableVideoPlaybackTranscoding').matches(':checked');
+        user.Policy.EnablePlaybackRemuxing = page.querySelector('#chkEnableVideoPlaybackRemuxing').matches(':checked');
+        user.Policy.ForceRemoteSourceTranscoding = page.querySelector('#chkForceRemoteSourceTranscoding').matches(':checked');
+        user.Policy.EnableContentDownloading = page.querySelectorpage.querySelector('#chkEnableDownloading').matches(':checked');
+        user.Policy.EnableSyncTranscoding = page.querySelector('#chkEnableSyncTranscoding').matches(':checked');
+        user.Policy.EnableMediaConversion = page.querySelector('#chkEnableConversion').matches(':checked');
+        user.Policy.EnablePublicSharing = page.querySelector('#chkEnableSharing').matches(':checked');
+        user.Policy.EnableRemoteAccess = page.querySelector('#chkRemoteAccess').matches(':checked');
         user.Policy.RemoteClientBitrateLimit = parseInt(1e6 * parseFloat(page.querySelector('#txtRemoteClientBitrateLimit').value || '0'));
         user.Policy.LoginAttemptsBeforeLockout = parseInt(page.querySelector('#txtLoginAttemptsBeforeLockout').value || '0');
         user.Policy.AuthenticationProviderId = page.querySelector('.selectLoginProvider').value;
         user.Policy.PasswordResetProviderId = page.querySelector('.selectPasswordResetProvider').value;
-        user.Policy.EnableContentDeletion = $('#chkEnableDeleteAllFolders', page).matches(':checked');
+        user.Policy.EnableContentDeletion = page.querySelector('#chkEnableDeleteAllFolders').matches(':checked');
         user.Policy.EnableContentDeletionFromFolders = user.Policy.EnableContentDeletion ? [] : Array.prototype.filter.call(page.querySelectorAll('.chkFolder'), function (c) {
             return c.checked;
         }).map(function (c) {

--- a/src/controllers/dashboard/users/useredit.js
+++ b/src/controllers/dashboard/users/useredit.js
@@ -141,7 +141,7 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
         user.Policy.AuthenticationProviderId = page.querySelector('.selectLoginProvider').value;
         user.Policy.PasswordResetProviderId = page.querySelector('.selectPasswordResetProvider').value;
         user.Policy.EnableContentDeletion = $('#chkEnableDeleteAllFolders', page).is(':checked');
-        user.Policy.EnableContentDeletionFromFolders = user.Policy.EnableContentDeletion ? [] : $('.chkFolder', page).get().filter(function (c) {
+        user.Policy.EnableContentDeletionFromFolders = user.Policy.EnableContentDeletion ? [] : Array.prototype.filter.call(page.querySelectorAll('.chkFolder'), function (c) {
             return c.checked;
         }).map(function (c) {
             return c.getAttribute('data-id');

--- a/src/controllers/dashboard/users/useredit.js
+++ b/src/controllers/dashboard/users/useredit.js
@@ -86,7 +86,7 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
         page.querySelector('.lnkEditUserPreferences').setAttribute('href', `mypreferencesmenu.html?userId=${user.Id}`);
         libraryMenu.setTitle(user.Name);
         page.querySelector('.username').innerHTML = user.Name;
-        $('#txtUserName', page).val(user.Name);
+        page.querySelector('#txtUserName').value = user.Name;
         $('#chkIsAdmin', page).prop('checked', user.Policy.IsAdministrator);
         $('#chkDisabled', page).prop('checked', user.Policy.IsDisabled);
         $('#chkIsHidden', page).prop('checked', user.Policy.IsHidden);
@@ -104,9 +104,9 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
         $('#chkEnableSyncTranscoding', page).prop('checked', user.Policy.EnableSyncTranscoding);
         $('#chkEnableConversion', page).prop('checked', user.Policy.EnableMediaConversion || false);
         $('#chkEnableSharing', page).prop('checked', user.Policy.EnablePublicSharing);
-        $('#txtRemoteClientBitrateLimit', page).val(user.Policy.RemoteClientBitrateLimit / 1e6 || '');
-        $('#txtLoginAttemptsBeforeLockout', page).val(user.Policy.LoginAttemptsBeforeLockout || '0');
-        $('#selectSyncPlayAccess').val(user.Policy.SyncPlayAccess);
+        page.querySelector('#txtRemoteClientBitrateLimit').value = user.Policy.RemoteClientBitrateLimit / 1e6 || '';
+        page.querySelector('#txtLoginAttemptsBeforeLockout').value = user.Policy.LoginAttemptsBeforeLockout || '0';
+        page.querySelector('#selectSyncPlayAccess').value = user.Policy.SyncPlayAccess;
         loading.hide();
     }
 
@@ -120,7 +120,7 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
     }
 
     function saveUser(user, page) {
-        user.Name = $('#txtUserName', page).val();
+        user.Name = page.querySelector('#txtUserName').value;
         user.Policy.IsAdministrator = $('#chkIsAdmin', page).matches(':checked');
         user.Policy.IsHidden = $('#chkIsHidden', page).matches(':checked');
         user.Policy.IsDisabled = $('#chkDisabled', page).matches(':checked');
@@ -138,8 +138,8 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
         user.Policy.EnableMediaConversion = $('#chkEnableConversion', page).matches(':checked');
         user.Policy.EnablePublicSharing = $('#chkEnableSharing', page).matches(':checked');
         user.Policy.EnableRemoteAccess = $('#chkRemoteAccess', page).matches(':checked');
-        user.Policy.RemoteClientBitrateLimit = parseInt(1e6 * parseFloat($('#txtRemoteClientBitrateLimit', page).val() || '0'));
-        user.Policy.LoginAttemptsBeforeLockout = parseInt($('#txtLoginAttemptsBeforeLockout', page).val() || '0');
+        user.Policy.RemoteClientBitrateLimit = parseInt(1e6 * parseFloat(page.querySelector('#txtRemoteClientBitrateLimit').value || '0'));
+        user.Policy.LoginAttemptsBeforeLockout = parseInt(page.querySelector('#txtLoginAttemptsBeforeLockout').value || '0');
         user.Policy.AuthenticationProviderId = page.querySelector('.selectLoginProvider').value;
         user.Policy.PasswordResetProviderId = page.querySelector('.selectPasswordResetProvider').value;
         user.Policy.EnableContentDeletion = $('#chkEnableDeleteAllFolders', page).matches(':checked');

--- a/src/controllers/dashboard/users/useredit.js
+++ b/src/controllers/dashboard/users/useredit.js
@@ -76,13 +76,13 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
         });
 
         if (user.Policy.IsDisabled) {
-            $('.disabledUserBanner', page).show();
+            page.querySelector('.disabledUserBanner').classList.remove('hide');
         } else {
-            $('.disabledUserBanner', page).classList.add('hide');
+            page.querySelector('.disabledUserBanner').classList.add('hide');
         }
 
         $('#txtUserName', page).prop('disabled', '').removeAttr('disabled');
-        $('#fldConnectInfo', page).show();
+        page.querySelector('#fldConnectInfo').classList.remove('hide');
         page.querySelector('.lnkEditUserPreferences').setAttribute('href', `mypreferencesmenu.html?userId=${user.Id}`);
         libraryMenu.setTitle(user.Name);
         page.querySelector('.username').innerHTML = user.Name;
@@ -184,9 +184,9 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
         var page = this;
         $('#chkEnableDeleteAllFolders', this).on('change', function () {
             if (this.checked) {
-                $('.deleteAccess', page).classList.add('hide');
+                page.querySelector('.deleteAccess').classList.add('hide');
             } else {
-                $('.deleteAccess', page).show();
+                page.querySelector('.deleteAccess').classList.remove('hide');
             }
         });
         ApiClient.getServerConfiguration().then(function (config) {

--- a/src/controllers/dashboard/users/useredit.js
+++ b/src/controllers/dashboard/users/useredit.js
@@ -28,7 +28,7 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
 
             const deleteAccess = page.querySelector('.deleteAccess');
             deleteAccess.innerHtml = html;
-            deleteAccess.trigger('create');
+            deleteAccess.dispatchEvent(new Event('create'));
             page.querySelector('#chkEnableDeleteAllFolders').checked = user.Policy.EnableContentDeletion;
         });
     }

--- a/src/controllers/dashboard/users/useredit.js
+++ b/src/controllers/dashboard/users/useredit.js
@@ -81,7 +81,7 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
 
         $('#txtUserName', page).prop('disabled', '').removeAttr('disabled');
         $('#fldConnectInfo', page).show();
-        $('.lnkEditUserPreferences', page).attr('href', 'mypreferencesmenu.html?userId=' + user.Id);
+        page.querySelector('.lnkEditUserPreferences').setAttribute('href', `mypreferencesmenu.html?userId=${user.Id}`);
         libraryMenu.setTitle(user.Name);
         page.querySelector('.username').innerHTML = user.Name;
         $('#txtUserName', page).val(user.Name);

--- a/src/controllers/dashboard/users/useredit.js
+++ b/src/controllers/dashboard/users/useredit.js
@@ -76,7 +76,7 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
         if (user.Policy.IsDisabled) {
             $('.disabledUserBanner', page).show();
         } else {
-            $('.disabledUserBanner', page).hide();
+            $('.disabledUserBanner', page).classList.add('hide');
         }
 
         $('#txtUserName', page).prop('disabled', '').removeAttr('disabled');
@@ -182,7 +182,7 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
         var page = this;
         $('#chkEnableDeleteAllFolders', this).on('change', function () {
             if (this.checked) {
-                $('.deleteAccess', page).hide();
+                $('.deleteAccess', page).classList.add('hide');
             } else {
                 $('.deleteAccess', page).show();
             }

--- a/src/controllers/dashboard/users/useredit.js
+++ b/src/controllers/dashboard/users/useredit.js
@@ -157,7 +157,7 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
     }
 
     function onSubmit() {
-        var page = $(this).parents('.page')[0];
+        var page = this.closest('.page')[0];
         loading.show();
         getUser().then(function (result) {
             saveUser(result, page);

--- a/src/controllers/dashboard/users/useredit.js
+++ b/src/controllers/dashboard/users/useredit.js
@@ -121,28 +121,28 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
 
     function saveUser(user, page) {
         user.Name = $('#txtUserName', page).val();
-        user.Policy.IsAdministrator = $('#chkIsAdmin', page).is(':checked');
-        user.Policy.IsHidden = $('#chkIsHidden', page).is(':checked');
-        user.Policy.IsDisabled = $('#chkDisabled', page).is(':checked');
-        user.Policy.EnableRemoteControlOfOtherUsers = $('#chkEnableRemoteControlOtherUsers', page).is(':checked');
-        user.Policy.EnableLiveTvManagement = $('#chkManageLiveTv', page).is(':checked');
-        user.Policy.EnableLiveTvAccess = $('#chkEnableLiveTvAccess', page).is(':checked');
-        user.Policy.EnableSharedDeviceControl = $('#chkRemoteControlSharedDevices', page).is(':checked');
-        user.Policy.EnableMediaPlayback = $('#chkEnableMediaPlayback', page).is(':checked');
-        user.Policy.EnableAudioPlaybackTranscoding = $('#chkEnableAudioPlaybackTranscoding', page).is(':checked');
-        user.Policy.EnableVideoPlaybackTranscoding = $('#chkEnableVideoPlaybackTranscoding', page).is(':checked');
-        user.Policy.EnablePlaybackRemuxing = $('#chkEnableVideoPlaybackRemuxing', page).is(':checked');
-        user.Policy.ForceRemoteSourceTranscoding = $('#chkForceRemoteSourceTranscoding', page).is(':checked');
-        user.Policy.EnableContentDownloading = $('#chkEnableDownloading', page).is(':checked');
-        user.Policy.EnableSyncTranscoding = $('#chkEnableSyncTranscoding', page).is(':checked');
-        user.Policy.EnableMediaConversion = $('#chkEnableConversion', page).is(':checked');
-        user.Policy.EnablePublicSharing = $('#chkEnableSharing', page).is(':checked');
-        user.Policy.EnableRemoteAccess = $('#chkRemoteAccess', page).is(':checked');
+        user.Policy.IsAdministrator = $('#chkIsAdmin', page).matches(':checked');
+        user.Policy.IsHidden = $('#chkIsHidden', page).matches(':checked');
+        user.Policy.IsDisabled = $('#chkDisabled', page).matches(':checked');
+        user.Policy.EnableRemoteControlOfOtherUsers = $('#chkEnableRemoteControlOtherUsers', page).matches(':checked');
+        user.Policy.EnableLiveTvManagement = $('#chkManageLiveTv', page).matches(':checked');
+        user.Policy.EnableLiveTvAccess = $('#chkEnableLiveTvAccess', page).matches(':checked');
+        user.Policy.EnableSharedDeviceControl = $('#chkRemoteControlSharedDevices', page).matches(':checked');
+        user.Policy.EnableMediaPlayback = $('#chkEnableMediaPlayback', page).matches(':checked');
+        user.Policy.EnableAudioPlaybackTranscoding = $('#chkEnableAudioPlaybackTranscoding', page).matches(':checked');
+        user.Policy.EnableVideoPlaybackTranscoding = $('#chkEnableVideoPlaybackTranscoding', page).matches(':checked');
+        user.Policy.EnablePlaybackRemuxing = $('#chkEnableVideoPlaybackRemuxing', page).matches(':checked');
+        user.Policy.ForceRemoteSourceTranscoding = $('#chkForceRemoteSourceTranscoding', page).matches(':checked');
+        user.Policy.EnableContentDownloading = $('#chkEnableDownloading', page).matches(':checked');
+        user.Policy.EnableSyncTranscoding = $('#chkEnableSyncTranscoding', page).matches(':checked');
+        user.Policy.EnableMediaConversion = $('#chkEnableConversion', page).matches(':checked');
+        user.Policy.EnablePublicSharing = $('#chkEnableSharing', page).matches(':checked');
+        user.Policy.EnableRemoteAccess = $('#chkRemoteAccess', page).matches(':checked');
         user.Policy.RemoteClientBitrateLimit = parseInt(1e6 * parseFloat($('#txtRemoteClientBitrateLimit', page).val() || '0'));
         user.Policy.LoginAttemptsBeforeLockout = parseInt($('#txtLoginAttemptsBeforeLockout', page).val() || '0');
         user.Policy.AuthenticationProviderId = page.querySelector('.selectLoginProvider').value;
         user.Policy.PasswordResetProviderId = page.querySelector('.selectPasswordResetProvider').value;
-        user.Policy.EnableContentDeletion = $('#chkEnableDeleteAllFolders', page).is(':checked');
+        user.Policy.EnableContentDeletion = $('#chkEnableDeleteAllFolders', page).matches(':checked');
         user.Policy.EnableContentDeletionFromFolders = user.Policy.EnableContentDeletion ? [] : Array.prototype.filter.call(page.querySelectorAll('.chkFolder'), function (c) {
             return c.checked;
         }).map(function (c) {

--- a/src/controllers/dashboard/users/userlibraryaccess.js
+++ b/src/controllers/dashboard/users/userlibraryaccess.js
@@ -120,7 +120,7 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
     }
 
     function onSubmit() {
-        var page = $(this).parents('.page');
+        var page = this.closest('.page');
         loading.show();
         var userId = getParameterByName('userId');
         ApiClient.getUser(userId).then(function (result) {

--- a/src/controllers/dashboard/users/userlibraryaccess.js
+++ b/src/controllers/dashboard/users/userlibraryaccess.js
@@ -66,7 +66,7 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
         html += '</div>';
         const deviceAccess = $('.deviceAccess', page);
         deviceAccess.show();
-        deviceAccess.innerHtml(html);
+        deviceAccess.innerHtml = html;
         $('#chkEnableAllDevices', page).prop('checked', user.Policy.EnableAllDevices);
 
         if (user.Policy.IsAdministrator) {

--- a/src/controllers/dashboard/users/userlibraryaccess.js
+++ b/src/controllers/dashboard/users/userlibraryaccess.js
@@ -39,8 +39,8 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
         }
 
         html += '</div>';
-        const channelAccess = $('.channelAccess', page);
-        channelAccess.show();
+        const channelAccess = page.querySelector('.channelAccess');
+        channelAccess.classList.remove('hide');
         channelAccess.innerHtml = html;
 
         if (channels.length) {
@@ -64,8 +64,8 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
         }
 
         html += '</div>';
-        const deviceAccess = $('.deviceAccess', page);
-        deviceAccess.show();
+        const deviceAccess = page.querySelector('.deviceAccess');
+        deviceAccess.classList.remove('hide');
         deviceAccess.innerHtml = html;
         page.querySelector('#chkEnableAllDevices').checked = user.Policy.EnableAllDevices;
 
@@ -94,19 +94,19 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
     }
 
     function saveUser(user, page) {
-        user.Policy.EnableAllFolders = $('#chkEnableAllFolders', page).matches(':checked');
+        user.Policy.EnableAllFolders = page.querySelector('#chkEnableAllFolders').matches(':checked');
         user.Policy.EnabledFolders = user.Policy.EnableAllFolders ? [] : Array.prototype.filter.call(page.querySelectorAll('.chkFolder'), function (c) {
             return c.checked;
         }).map(function (c) {
             return c.getAttribute('data-id');
         });
-        user.Policy.EnableAllChannels = $('#chkEnableAllChannels', page).matches(':checked');
+        user.Policy.EnableAllChannels = page.querySelector('#chkEnableAllChannels').matches(':checked');
         user.Policy.EnabledChannels = user.Policy.EnableAllChannels ? [] : Array.prototype.filter.call(page.querySelectorAll('.chkChannel'), function (c) {
             return c.checked;
         }).map(function (c) {
             return c.getAttribute('data-id');
         });
-        user.Policy.EnableAllDevices = $('#chkEnableAllDevices', page).matches(':checked');
+        user.Policy.EnableAllDevices = page.querySelector('#chkEnableAllDevices').matches(':checked');
         user.Policy.EnabledDevices = user.Policy.EnableAllDevices ? [] : Array.prototype.filter.call(page.querySelectorAll('.chkDevice'), function (c) {
             return c.checked;
         }).map(function (c) {

--- a/src/controllers/dashboard/users/userlibraryaccess.js
+++ b/src/controllers/dashboard/users/userlibraryaccess.js
@@ -158,11 +158,9 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
         if (userId) {
             promise1 = ApiClient.getUser(userId);
         } else {
-            var deferred = $.Deferred();
-            deferred.resolveWith(null, [{
+            promise1 = Promise.resolve({
                 Configuration: {}
-            }]);
-            promise1 = deferred.promise();
+            });
         }
 
         var promise2 = Dashboard.getCurrentUser();

--- a/src/controllers/dashboard/users/userlibraryaccess.js
+++ b/src/controllers/dashboard/users/userlibraryaccess.js
@@ -94,19 +94,19 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
     }
 
     function saveUser(user, page) {
-        user.Policy.EnableAllFolders = $('#chkEnableAllFolders', page).is(':checked');
+        user.Policy.EnableAllFolders = $('#chkEnableAllFolders', page).matches(':checked');
         user.Policy.EnabledFolders = user.Policy.EnableAllFolders ? [] : Array.prototype.filter.call(page.querySelectorAll('.chkFolder'), function (c) {
             return c.checked;
         }).map(function (c) {
             return c.getAttribute('data-id');
         });
-        user.Policy.EnableAllChannels = $('#chkEnableAllChannels', page).is(':checked');
+        user.Policy.EnableAllChannels = $('#chkEnableAllChannels', page).matches(':checked');
         user.Policy.EnabledChannels = user.Policy.EnableAllChannels ? [] : Array.prototype.filter.call(page.querySelectorAll('.chkChannel'), function (c) {
             return c.checked;
         }).map(function (c) {
             return c.getAttribute('data-id');
         });
-        user.Policy.EnableAllDevices = $('#chkEnableAllDevices', page).is(':checked');
+        user.Policy.EnableAllDevices = $('#chkEnableAllDevices', page).matches(':checked');
         user.Policy.EnabledDevices = user.Policy.EnableAllDevices ? [] : Array.prototype.filter.call(page.querySelectorAll('.chkDevice'), function (c) {
             return c.checked;
         }).map(function (c) {

--- a/src/controllers/dashboard/users/userlibraryaccess.js
+++ b/src/controllers/dashboard/users/userlibraryaccess.js
@@ -39,7 +39,9 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
         }
 
         html += '</div>';
-        $('.channelAccess', page).show().html(html);
+        const channelAccess = $('.channelAccess', page);
+        channelAccess.show();
+        channelAccess.innerHtml = html;
 
         if (channels.length) {
             $('.channelAccessContainer', page).show();
@@ -62,7 +64,9 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
         }
 
         html += '</div>';
-        $('.deviceAccess', page).show().html(html);
+        const deviceAccess = $('.deviceAccess', page);
+        deviceAccess.show();
+        deviceAccess.innerHtml(html);
         $('#chkEnableAllDevices', page).prop('checked', user.Policy.EnableAllDevices);
 
         if (user.Policy.IsAdministrator) {

--- a/src/controllers/dashboard/users/userlibraryaccess.js
+++ b/src/controllers/dashboard/users/userlibraryaccess.js
@@ -44,7 +44,7 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
         if (channels.length) {
             $('.channelAccessContainer', page).show();
         } else {
-            $('.channelAccessContainer', page).hide();
+            $('.channelAccessContainer', page).classList.add('hide');
         }
 
         $('#chkEnableAllChannels', page).prop('checked', user.Policy.EnableAllChannels);
@@ -129,14 +129,14 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
         var page = this;
         $('#chkEnableAllDevices', page).on('change', function () {
             if (this.checked) {
-                $('.deviceAccessListContainer', page).hide();
+                $('.deviceAccessListContainer', page).classList.add('hide');
             } else {
                 $('.deviceAccessListContainer', page).show();
             }
         });
         $('#chkEnableAllChannels', page).on('change', function () {
             if (this.checked) {
-                $('.channelAccessListContainer', page).hide();
+                $('.channelAccessListContainer', page).classList.add('hide');
             } else {
                 $('.channelAccessListContainer', page).show();
             }

--- a/src/controllers/dashboard/users/userlibraryaccess.js
+++ b/src/controllers/dashboard/users/userlibraryaccess.js
@@ -44,9 +44,9 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
         channelAccess.innerHtml = html;
 
         if (channels.length) {
-            $('.channelAccessContainer', page).show();
+            page.querySelector('.channelAccessContainer').classList.remove('hide');
         } else {
-            $('.channelAccessContainer', page).classList.add('hide');
+            page.querySelector('.channelAccessContainer').classList.add('hide');
         }
 
         $('#chkEnableAllChannels', page).prop('checked', user.Policy.EnableAllChannels);
@@ -133,16 +133,16 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
         var page = this;
         $('#chkEnableAllDevices', page).on('change', function () {
             if (this.checked) {
-                $('.deviceAccessListContainer', page).classList.add('hide');
+                page.querySelector('.deviceAccessListContainer').classList.add('hide');
             } else {
-                $('.deviceAccessListContainer', page).show();
+                page.querySelector('.deviceAccessListContainer').classList.remove('hide');
             }
         });
         $('#chkEnableAllChannels', page).on('change', function () {
             if (this.checked) {
-                $('.channelAccessListContainer', page).classList.add('hide');
+                page.querySelector('.channelAccessListContainer').classList.add('hide');
             } else {
-                $('.channelAccessListContainer', page).show();
+                page.querySelector('.channelAccessListContainer').classList.remove('hide');
             }
         });
         page.querySelector('#chkEnableAllFolders').addEventListener('change', function () {

--- a/src/controllers/dashboard/users/userlibraryaccess.js
+++ b/src/controllers/dashboard/users/userlibraryaccess.js
@@ -91,19 +91,19 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
 
     function saveUser(user, page) {
         user.Policy.EnableAllFolders = $('#chkEnableAllFolders', page).is(':checked');
-        user.Policy.EnabledFolders = user.Policy.EnableAllFolders ? [] : $('.chkFolder', page).get().filter(function (c) {
+        user.Policy.EnabledFolders = user.Policy.EnableAllFolders ? [] : Array.prototype.filter.call(page.querySelectorAll('.chkFolder'), function (c) {
             return c.checked;
         }).map(function (c) {
             return c.getAttribute('data-id');
         });
         user.Policy.EnableAllChannels = $('#chkEnableAllChannels', page).is(':checked');
-        user.Policy.EnabledChannels = user.Policy.EnableAllChannels ? [] : $('.chkChannel', page).get().filter(function (c) {
+        user.Policy.EnabledChannels = user.Policy.EnableAllChannels ? [] : Array.prototype.filter.call(page.querySelectorAll('.chkChannel'), function (c) {
             return c.checked;
         }).map(function (c) {
             return c.getAttribute('data-id');
         });
         user.Policy.EnableAllDevices = $('#chkEnableAllDevices', page).is(':checked');
-        user.Policy.EnabledDevices = user.Policy.EnableAllDevices ? [] : $('.chkDevice', page).get().filter(function (c) {
+        user.Policy.EnabledDevices = user.Policy.EnableAllDevices ? [] : Array.prototype.filter.call(page.querySelectorAll('.chkDevice'), function (c) {
             return c.checked;
         }).map(function (c) {
             return c.getAttribute('data-id');

--- a/src/controllers/dashboard/users/userlibraryaccess.js
+++ b/src/controllers/dashboard/users/userlibraryaccess.js
@@ -49,7 +49,7 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
             page.querySelector('.channelAccessContainer').classList.add('hide');
         }
 
-        $('#chkEnableAllChannels', page).prop('checked', user.Policy.EnableAllChannels);
+        page.querySelector('#chkEnableAllChannels').checked = user.Policy.EnableAllChannels;
     }
 
     function loadDevices(page, user, devices) {
@@ -67,7 +67,7 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize'], function ($, loading, 
         const deviceAccess = $('.deviceAccess', page);
         deviceAccess.show();
         deviceAccess.innerHtml = html;
-        $('#chkEnableAllDevices', page).prop('checked', user.Policy.EnableAllDevices);
+        page.querySelector('#chkEnableAllDevices').checked = user.Policy.EnableAllDevices;
 
         if (user.Policy.IsAdministrator) {
             page.querySelector('.deviceAccessContainer').classList.add('hide');

--- a/src/controllers/dashboard/users/usernew.js
+++ b/src/controllers/dashboard/users/usernew.js
@@ -32,7 +32,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox'], function ($, loading
         const channelAccess = $('.channelAccess', page);
         channelAccess.show();
         channelAccess.innerHtml = html;
-        channelAccess.trigger('create');
+        channelAccess.dispatchEvent(new Event('create'));
 
         if (channels.length) {
             page.querySelector('.channelAccessContainer').classList.remove('hide');

--- a/src/controllers/dashboard/users/usernew.js
+++ b/src/controllers/dashboard/users/usernew.js
@@ -15,7 +15,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox'], function ($, loading
         const folderAccess = $('.folderAccess', page);
         folderAccess.innerHtml = html;
         folderAccess.trigger('create');
-        $('#chkEnableAllFolders', page).prop('checked', false);
+        page.querySelector('#chkEnableAllFolders').checked = false;
     }
 
     function loadChannels(page, channels) {
@@ -40,7 +40,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox'], function ($, loading
             page.querySelector('.channelAccessContainer').classList.add('hide');
         }
 
-        $('#chkEnableAllChannels', page).prop('checked', false);
+        page.querySelector('#chkEnableAllChannels').checked = false;
     }
 
     function loadUser(page) {

--- a/src/controllers/dashboard/users/usernew.js
+++ b/src/controllers/dashboard/users/usernew.js
@@ -12,7 +12,9 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox'], function ($, loading
         }
 
         html += '</div>';
-        $('.folderAccess', page).html(html).trigger('create');
+        const folderAccess = $('.folderAccess', page);
+        folderAccess.innerHtml = html;
+        folderAccess.trigger('create');
         $('#chkEnableAllFolders', page).prop('checked', false);
     }
 
@@ -27,7 +29,10 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox'], function ($, loading
         }
 
         html += '</div>';
-        $('.channelAccess', page).show().html(html).trigger('create');
+        const channelAccess = $('.channelAccess', page);
+        channelAccess.show();
+        channelAccess.innerHtml = html;
+        channelAccess.trigger('create');
 
         if (channels.length) {
             $('.channelAccessContainer', page).show();

--- a/src/controllers/dashboard/users/usernew.js
+++ b/src/controllers/dashboard/users/usernew.js
@@ -44,8 +44,8 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox'], function ($, loading
     }
 
     function loadUser(page) {
-        $('#txtUsername', page).val('');
-        $('#txtPassword', page).val('');
+        page.querySelector('#txtUsername').value = '';
+        page.querySelector('#txtPassword').value = '';
         loading.show();
         var promiseFolders = ApiClient.getJSON(ApiClient.getUrl('Library/MediaFolders', {
             IsHidden: false
@@ -60,8 +60,8 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox'], function ($, loading
 
     function saveUser(page) {
         var user = {};
-        user.Name = $('#txtUsername', page).val();
-        user.Password = $('#txtPassword', page).val();
+        user.Name = page.querySelector('#txtUsername').value;
+        user.Password = page.querySelector('#txtPassword').value;
         ApiClient.createUser(user).then(function (user) {
             user.Policy.EnableAllFolders = $('#chkEnableAllFolders', page).matches(':checked');
             user.Policy.EnabledFolders = [];

--- a/src/controllers/dashboard/users/usernew.js
+++ b/src/controllers/dashboard/users/usernew.js
@@ -29,8 +29,8 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox'], function ($, loading
         }
 
         html += '</div>';
-        const channelAccess = $('.channelAccess', page);
-        channelAccess.show();
+        const channelAccess = page.querySelector('.channelAccess');
+        channelAccess.classList.remove('hide');
         channelAccess.innerHtml = html;
         channelAccess.dispatchEvent(new Event('create'));
 

--- a/src/controllers/dashboard/users/usernew.js
+++ b/src/controllers/dashboard/users/usernew.js
@@ -32,7 +32,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox'], function ($, loading
         if (channels.length) {
             $('.channelAccessContainer', page).show();
         } else {
-            $('.channelAccessContainer', page).hide();
+            $('.channelAccessContainer', page).classList.add('hide');
         }
 
         $('#chkEnableAllChannels', page).prop('checked', false);
@@ -107,14 +107,14 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox'], function ($, loading
         var page = this;
         $('#chkEnableAllChannels', page).on('change', function () {
             if (this.checked) {
-                $('.channelAccessListContainer', page).hide();
+                $('.channelAccessListContainer', page).classList.add('hide');
             } else {
                 $('.channelAccessListContainer', page).show();
             }
         });
         $('#chkEnableAllFolders', page).on('change', function () {
             if (this.checked) {
-                $('.folderAccessListContainer', page).hide();
+                $('.folderAccessListContainer', page).classList.add('hide');
             } else {
                 $('.folderAccessListContainer', page).show();
             }

--- a/src/controllers/dashboard/users/usernew.js
+++ b/src/controllers/dashboard/users/usernew.js
@@ -98,7 +98,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox'], function ($, loading
     }
 
     function onSubmit() {
-        var page = $(this).parents('.page')[0];
+        var page = this.closest('.page');
         loading.show();
         saveUser(page);
         return false;

--- a/src/controllers/dashboard/users/usernew.js
+++ b/src/controllers/dashboard/users/usernew.js
@@ -12,9 +12,9 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox'], function ($, loading
         }
 
         html += '</div>';
-        const folderAccess = $('.folderAccess', page);
+        const folderAccess = page.querySelector('.folderAccess');
         folderAccess.innerHtml = html;
-        folderAccess.trigger('create');
+        folderAccess.dispatchEvent(new Event('create'));
         page.querySelector('#chkEnableAllFolders').checked = false;
     }
 
@@ -63,7 +63,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox'], function ($, loading
         user.Name = page.querySelector('#txtUsername').value;
         user.Password = page.querySelector('#txtPassword').value;
         ApiClient.createUser(user).then(function (user) {
-            user.Policy.EnableAllFolders = $('#chkEnableAllFolders', page).matches(':checked');
+            user.Policy.EnableAllFolders = page.querySelector('#chkEnableAllFolders').matches(':checked');
             user.Policy.EnabledFolders = [];
 
             if (!user.Policy.EnableAllFolders) {

--- a/src/controllers/dashboard/users/usernew.js
+++ b/src/controllers/dashboard/users/usernew.js
@@ -35,9 +35,9 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox'], function ($, loading
         channelAccess.trigger('create');
 
         if (channels.length) {
-            $('.channelAccessContainer', page).show();
+            page.querySelector('.channelAccessContainer').classList.remove('hide');
         } else {
-            $('.channelAccessContainer', page).classList.add('hide');
+            page.querySelector('.channelAccessContainer').classList.add('hide');
         }
 
         $('#chkEnableAllChannels', page).prop('checked', false);
@@ -112,16 +112,16 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox'], function ($, loading
         var page = this;
         $('#chkEnableAllChannels', page).on('change', function () {
             if (this.checked) {
-                $('.channelAccessListContainer', page).classList.add('hide');
+                page.querySelector('.channelAccessListContainer').classList.add('hide');
             } else {
-                $('.channelAccessListContainer', page).show();
+                page.querySelector('.channelAccessListContainer').classList.remove('hide');
             }
         });
         $('#chkEnableAllFolders', page).on('change', function () {
             if (this.checked) {
-                $('.folderAccessListContainer', page).classList.add('hide');
+                page.querySelector('.folderAccessListContainer').classList.add('hide');
             } else {
-                $('.folderAccessListContainer', page).show();
+                page.querySelector('.folderAccessListContainer').classList.remove('hide');
             }
         });
         $('.newUserProfileForm').off('submit', onSubmit).on('submit', onSubmit);

--- a/src/controllers/dashboard/users/usernew.js
+++ b/src/controllers/dashboard/users/usernew.js
@@ -62,7 +62,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox'], function ($, loading
             user.Policy.EnabledFolders = [];
 
             if (!user.Policy.EnableAllFolders) {
-                user.Policy.EnabledFolders = $('.chkFolder', page).get().filter(function (i) {
+                user.Policy.EnabledFolders = Array.prototype.filter.call(page.querySelectorAll('.chkFolder'), function (i) {
                     return i.checked;
                 }).map(function (i) {
                     return i.getAttribute('data-id');
@@ -73,7 +73,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox'], function ($, loading
             user.Policy.EnabledChannels = [];
 
             if (!user.Policy.EnableAllChannels) {
-                user.Policy.EnabledChannels = $('.chkChannel', page).get().filter(function (i) {
+                user.Policy.EnabledChannels = Array.prototype.filter.call(page.querySelectorAll('.chkChannel'), function (i) {
                     return i.checked;
                 }).map(function (i) {
                     return i.getAttribute('data-id');

--- a/src/controllers/dashboard/users/usernew.js
+++ b/src/controllers/dashboard/users/usernew.js
@@ -63,7 +63,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox'], function ($, loading
         user.Name = $('#txtUsername', page).val();
         user.Password = $('#txtPassword', page).val();
         ApiClient.createUser(user).then(function (user) {
-            user.Policy.EnableAllFolders = $('#chkEnableAllFolders', page).is(':checked');
+            user.Policy.EnableAllFolders = $('#chkEnableAllFolders', page).matches(':checked');
             user.Policy.EnabledFolders = [];
 
             if (!user.Policy.EnableAllFolders) {
@@ -74,7 +74,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-checkbox'], function ($, loading
                 });
             }
 
-            user.Policy.EnableAllChannels = $('#chkEnableAllChannels', page).is(':checked');
+            user.Policy.EnableAllChannels = $('#chkEnableAllChannels', page).matches(':checked');
             user.Policy.EnabledChannels = [];
 
             if (!user.Policy.EnableAllChannels) {

--- a/src/controllers/dashboard/users/userparentalcontrol.js
+++ b/src/controllers/dashboard/users/userparentalcontrol.js
@@ -165,7 +165,7 @@ define(['jQuery', 'datetime', 'loading', 'libraryMenu', 'globalize', 'listViewSt
 
     function saveUser(user, page) {
         user.Policy.MaxParentalRating = $('#selectMaxParentalRating', page).val() || null;
-        user.Policy.BlockUnratedItems = $('.chkUnratedItem', page).get().filter(function (i) {
+        user.Policy.BlockUnratedItems = Array.prototype.filter.call(page.querySelectorAll('.chkUnratedItem'), function (i) {
             return i.checked;
         }).map(function (i) {
             return i.getAttribute('data-itemtype');

--- a/src/controllers/dashboard/users/userparentalcontrol.js
+++ b/src/controllers/dashboard/users/userparentalcontrol.js
@@ -90,7 +90,7 @@ define(['jQuery', 'datetime', 'loading', 'libraryMenu', 'globalize', 'listViewSt
             }
         }
 
-        $('#selectMaxParentalRating', page).val(ratingValue);
+        page.querySelector('#selectMaxParentalRating').value = ratingValue;
 
         if (user.Policy.IsAdministrator) {
             page.querySelector('.accessScheduleSection').classList.add('hide');
@@ -168,7 +168,7 @@ define(['jQuery', 'datetime', 'loading', 'libraryMenu', 'globalize', 'listViewSt
     }
 
     function saveUser(user, page) {
-        user.Policy.MaxParentalRating = $('#selectMaxParentalRating', page).val() || null;
+        user.Policy.MaxParentalRating = page.querySelector('#selectMaxParentalRating').value || null;
         user.Policy.BlockUnratedItems = Array.prototype.filter.call(page.querySelectorAll('.chkUnratedItem'), function (i) {
             return i.checked;
         }).map(function (i) {

--- a/src/controllers/dashboard/users/userparentalcontrol.js
+++ b/src/controllers/dashboard/users/userparentalcontrol.js
@@ -244,7 +244,7 @@ define(['jQuery', 'datetime', 'loading', 'libraryMenu', 'globalize', 'listViewSt
 
     window.UserParentalControlPage = {
         onSubmit: function () {
-            var page = $(this).parents('.page');
+            var page = this.closest('.page');
             loading.show();
             var userId = getParameterByName('userId');
             ApiClient.getUser(userId).then(function (result) {

--- a/src/controllers/dashboard/users/userparentalcontrol.js
+++ b/src/controllers/dashboard/users/userparentalcontrol.js
@@ -93,9 +93,9 @@ define(['jQuery', 'datetime', 'loading', 'libraryMenu', 'globalize', 'listViewSt
         $('#selectMaxParentalRating', page).val(ratingValue);
 
         if (user.Policy.IsAdministrator) {
-            $('.accessScheduleSection', page).classList.add('hide');
+            page.querySelector('.accessScheduleSection').classList.add('hide');
         } else {
-            $('.accessScheduleSection', page).show();
+            page.querySelector('.accessScheduleSection').classList.remove('hide');
         }
 
         renderAccessSchedule(page, user.Policy.AccessSchedules || []);

--- a/src/controllers/dashboard/users/userparentalcontrol.js
+++ b/src/controllers/dashboard/users/userparentalcontrol.js
@@ -30,7 +30,7 @@ define(['jQuery', 'datetime', 'loading', 'libraryMenu', 'globalize', 'listViewSt
             html += "<option value='" + rating.Value + "'>" + rating.Name + '</option>';
         }
 
-        $('#selectMaxParentalRating', page).html(html);
+        $('#selectMaxParentalRating', page).innerHtml = html;
     }
 
     function loadUnratedItems(page, user) {
@@ -67,7 +67,9 @@ define(['jQuery', 'datetime', 'loading', 'libraryMenu', 'globalize', 'listViewSt
         }
 
         html += '</div>';
-        $('.blockUnratedItems', page).html(html).trigger('create');
+        const blockUnratedItems = $('.blockUnratedItems', page);
+        blockUnratedItems.innerHtml = html;
+        blockUnratedItems.trigger('create');
     }
 
     function loadUser(page, user, allParentalRatings) {
@@ -116,7 +118,9 @@ define(['jQuery', 'datetime', 'loading', 'libraryMenu', 'globalize', 'listViewSt
             html = '<div class="paperList">' + html + '</div>';
         }
 
-        var elem = $('.blockedTags', page).html(html).trigger('create');
+        var elem = $('.blockedTags', page);
+        elem.innerHtml = html;
+        elem.trigger('create');
         $('.btnDeleteTag', elem).on('click', function () {
             var tag = this.getAttribute('data-tag');
             var newTags = tags.filter(function (t) {

--- a/src/controllers/dashboard/users/userparentalcontrol.js
+++ b/src/controllers/dashboard/users/userparentalcontrol.js
@@ -91,7 +91,7 @@ define(['jQuery', 'datetime', 'loading', 'libraryMenu', 'globalize', 'listViewSt
         $('#selectMaxParentalRating', page).val(ratingValue);
 
         if (user.Policy.IsAdministrator) {
-            $('.accessScheduleSection', page).hide();
+            $('.accessScheduleSection', page).classList.add('hide');
         } else {
             $('.accessScheduleSection', page).show();
         }

--- a/src/controllers/dashboard/users/userparentalcontrol.js
+++ b/src/controllers/dashboard/users/userparentalcontrol.js
@@ -30,7 +30,7 @@ define(['jQuery', 'datetime', 'loading', 'libraryMenu', 'globalize', 'listViewSt
             html += "<option value='" + rating.Value + "'>" + rating.Name + '</option>';
         }
 
-        $('#selectMaxParentalRating', page).innerHtml = html;
+        page.querySelector('#selectMaxParentalRating').innerHtml = html;
     }
 
     function loadUnratedItems(page, user) {
@@ -67,9 +67,9 @@ define(['jQuery', 'datetime', 'loading', 'libraryMenu', 'globalize', 'listViewSt
         }
 
         html += '</div>';
-        const blockUnratedItems = $('.blockUnratedItems', page);
+        const blockUnratedItems = page.querySelector('.blockUnratedItems');
         blockUnratedItems.innerHtml = html;
-        blockUnratedItems.trigger('create');
+        blockUnratedItems.dispatchEvent(new Event('create'));
     }
 
     function loadUser(page, user, allParentalRatings) {
@@ -118,9 +118,9 @@ define(['jQuery', 'datetime', 'loading', 'libraryMenu', 'globalize', 'listViewSt
             html = '<div class="paperList">' + html + '</div>';
         }
 
-        var elem = $('.blockedTags', page);
+        var elem = page.querySelector('.blockedTags');
         elem.innerHtml = html;
-        elem.trigger('create');
+        elem.dispatchEvent(new Event('create'));
         $('.btnDeleteTag', elem).on('click', function () {
             var tag = this.getAttribute('data-tag');
             var newTags = tags.filter(function (t) {

--- a/src/controllers/livetvsettings.js
+++ b/src/controllers/livetvsettings.js
@@ -3,7 +3,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-button'], function ($, loading, 
 
     function loadPage(page, config) {
         $('.liveTvSettingsForm', page).show();
-        $('.noLiveTvServices', page).hide();
+        $('.noLiveTvServices', page).classList.add('hide');
         $('#selectGuideDays', page).val(config.GuideDays || '');
         $('#txtPrePaddingMinutes', page).val(config.PrePaddingSeconds / 60);
         $('#txtPostPaddingMinutes', page).val(config.PostPaddingSeconds / 60);

--- a/src/controllers/livetvsettings.js
+++ b/src/controllers/livetvsettings.js
@@ -2,8 +2,8 @@ define(['jQuery', 'loading', 'globalize', 'emby-button'], function ($, loading, 
     'use strict';
 
     function loadPage(page, config) {
-        $('.liveTvSettingsForm', page).show();
-        $('.noLiveTvServices', page).classList.add('hide');
+        page.querySelector('.liveTvSettingsForm').classList.remove('hide');
+        page.querySelector('.noLiveTvServices').classList.add('hide');
         $('#selectGuideDays', page).val(config.GuideDays || '');
         $('#txtPrePaddingMinutes', page).val(config.PrePaddingSeconds / 60);
         $('#txtPostPaddingMinutes', page).val(config.PostPaddingSeconds / 60);

--- a/src/controllers/livetvsettings.js
+++ b/src/controllers/livetvsettings.js
@@ -4,9 +4,9 @@ define(['jQuery', 'loading', 'globalize', 'emby-button'], function ($, loading, 
     function loadPage(page, config) {
         page.querySelector('.liveTvSettingsForm').classList.remove('hide');
         page.querySelector('.noLiveTvServices').classList.add('hide');
-        $('#selectGuideDays', page).val(config.GuideDays || '');
-        $('#txtPrePaddingMinutes', page).val(config.PrePaddingSeconds / 60);
-        $('#txtPostPaddingMinutes', page).val(config.PostPaddingSeconds / 60);
+        page.querySelector('#selectGuideDays').value = config.GuideDays || '';
+        page.querySelector('#txtPrePaddingMinutes').value = config.PrePaddingSeconds / 60;
+        page.querySelector('#txtPostPaddingMinutes').value = config.PostPaddingSeconds / 60;
         page.querySelector('#txtRecordingPath').value = config.RecordingPath || '';
         page.querySelector('#txtMovieRecordingPath').value = config.MovieRecordingPath || '';
         page.querySelector('#txtSeriesRecordingPath').value = config.SeriesRecordingPath || '';
@@ -19,7 +19,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-button'], function ($, loading, 
         loading.show();
         var form = this;
         ApiClient.getNamedConfiguration('livetv').then(function (config) {
-            config.GuideDays = $('#selectGuideDays', form).val() || null;
+            config.GuideDays = form.querySelector('#selectGuideDays').value || null;
             var recordingPath = form.querySelector('#txtRecordingPath').value || null;
             var movieRecordingPath = form.querySelector('#txtMovieRecordingPath').value || null;
             var seriesRecordingPath = form.querySelector('#txtSeriesRecordingPath').value || null;
@@ -28,10 +28,10 @@ define(['jQuery', 'loading', 'globalize', 'emby-button'], function ($, loading, 
             config.MovieRecordingPath = movieRecordingPath;
             config.SeriesRecordingPath = seriesRecordingPath;
             config.RecordingEncodingFormat = 'mkv';
-            config.PrePaddingSeconds = 60 * $('#txtPrePaddingMinutes', form).val();
-            config.PostPaddingSeconds = 60 * $('#txtPostPaddingMinutes', form).val();
-            config.RecordingPostProcessor = $('#txtPostProcessor', form).val();
-            config.RecordingPostProcessorArguments = $('#txtPostProcessorArguments', form).val();
+            config.PrePaddingSeconds = 60 * form.querySelector('#txtPrePaddingMinutes').value;
+            config.PostPaddingSeconds = 60 * form.querySelector('#txtPostPaddingMinutes').value;
+            config.RecordingPostProcessor = form.querySelector('#txtPostProcessor').value;
+            config.RecordingPostProcessorArguments = form.querySelector('#txtPostProcessorArguments').value;
             ApiClient.updateNamedConfiguration('livetv', config).then(function () {
                 Dashboard.processServerConfigurationUpdateResult();
                 showSaveMessage(recordingPathChanged);
@@ -63,7 +63,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-button'], function ($, loading, 
                 picker.show({
                     callback: function (path) {
                         if (path) {
-                            $('#txtRecordingPath', page).val(path);
+                            page.querySelector('#txtRecordingPath').value = path;
                         }
 
                         picker.close();
@@ -78,7 +78,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-button'], function ($, loading, 
                 picker.show({
                     callback: function (path) {
                         if (path) {
-                            $('#txtMovieRecordingPath', page).val(path);
+                            page.querySelector('#txtMovieRecordingPath').value = path;
                         }
 
                         picker.close();
@@ -93,7 +93,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-button'], function ($, loading, 
                 picker.show({
                     callback: function (path) {
                         if (path) {
-                            $('#txtSeriesRecordingPath', page).val(path);
+                            page.querySelector('#txtSeriesRecordingPath').value = path;
                         }
 
                         picker.close();
@@ -109,7 +109,7 @@ define(['jQuery', 'loading', 'globalize', 'emby-button'], function ($, loading, 
                     includeFiles: true,
                     callback: function (path) {
                         if (path) {
-                            $('#txtPostProcessor', page).val(path);
+                            page.querySelector('#txtPostProcessor').value = path;
                         }
 
                         picker.close();

--- a/src/controllers/livetvstatus.js
+++ b/src/controllers/livetvstatus.js
@@ -119,7 +119,8 @@ define(['jQuery', 'globalize', 'scripts/taskbutton', 'dom', 'libraryMenu', 'layo
             html += '</div>';
         }
 
-        var elem = $('.providerList', page).html(html);
+        var elem = $('.providerList', page);
+        elem.innerHtml = html;
         $('.btnOptions', elem).on('click', function () {
             var id = this.getAttribute('data-id');
             showProviderOptions(page, id, this);

--- a/src/controllers/livetvstatus.js
+++ b/src/controllers/livetvstatus.js
@@ -119,7 +119,7 @@ define(['jQuery', 'globalize', 'scripts/taskbutton', 'dom', 'libraryMenu', 'layo
             html += '</div>';
         }
 
-        var elem = $('.providerList', page);
+        var elem = page.querySelector('.providerList');
         elem.innerHtml = html;
         $('.btnOptions', elem).on('click', function () {
             var id = this.getAttribute('data-id');

--- a/src/controllers/livetvstatus.js
+++ b/src/controllers/livetvstatus.js
@@ -79,8 +79,8 @@ define(['jQuery', 'globalize', 'scripts/taskbutton', 'dom', 'libraryMenu', 'layo
             type: 'POST',
             url: ApiClient.getUrl('LiveTv/TunerHosts'),
             data: JSON.stringify({
-                Type: $('#selectTunerDeviceType', page).val(),
-                Url: $('#txtDevicePath', page).val()
+                Type: page.querySelector('#selectTunerDeviceType').value,
+                Url: page.querySelector('#txtDevicePath').value
             }),
             contentType: 'application/json'
         }).then(function () {

--- a/src/controllers/wizard/start.js
+++ b/src/controllers/wizard/start.js
@@ -2,9 +2,11 @@ define(['jQuery', 'loading', 'emby-button', 'emby-select'], function ($, loading
     'use strict';
 
     function loadPage(page, config, languageOptions) {
-        $('#selectLocalizationLanguage', page).html(languageOptions.map(function (l) {
+        const selectLocalizationLanguage = $('#selectLocalizationLanguage', page);
+        selectLocalizationLanguage.innerHtml = languageOptions.map(function (l) {
             return '<option value="' + l.Value + '">' + l.Name + '</option>';
-        })).val(config.UICulture);
+        });
+        selectLocalizationLanguage.val(config.UICulture);
         loading.hide();
     }
 

--- a/src/controllers/wizard/start.js
+++ b/src/controllers/wizard/start.js
@@ -14,7 +14,7 @@ define(['jQuery', 'loading', 'emby-button', 'emby-select'], function ($, loading
         loading.show();
         var apiClient = ApiClient;
         apiClient.getJSON(apiClient.getUrl('Startup/Configuration')).then(function (config) {
-            config.UICulture = $('#selectLocalizationLanguage', page).val();
+            config.UICulture = page.querySelector('#selectLocalizationLanguage').value;
             apiClient.ajax({
                 type: 'POST',
                 data: config,

--- a/src/controllers/wizard/start.js
+++ b/src/controllers/wizard/start.js
@@ -26,7 +26,7 @@ define(['jQuery', 'loading', 'emby-button', 'emby-select'], function ($, loading
     }
 
     function onSubmit() {
-        save($(this).parents('.page'));
+        save(this.closest('.page'));
         return false;
     }
 

--- a/src/controllers/wizard/start.js
+++ b/src/controllers/wizard/start.js
@@ -2,7 +2,7 @@ define(['jQuery', 'loading', 'emby-button', 'emby-select'], function ($, loading
     'use strict';
 
     function loadPage(page, config, languageOptions) {
-        const selectLocalizationLanguage = $('#selectLocalizationLanguage', page);
+        const selectLocalizationLanguage = page.querySelector('#selectLocalizationLanguage');
         selectLocalizationLanguage.innerHtml = languageOptions.map(function (l) {
             return '<option value="' + l.Value + '">' + l.Name + '</option>';
         });

--- a/src/elements/emby-itemscontainer/emby-itemscontainer.js
+++ b/src/elements/emby-itemscontainer/emby-itemscontainer.js
@@ -24,7 +24,6 @@ define(['itemShortcuts', 'inputManager', 'connectionManager', 'playbackManager',
     }
 
     function onContextMenu(e) {
-        var itemsContainer = this;
         var target = e.target;
         var card = dom.parentWithAttribute(target, 'data-id');
 

--- a/src/elements/emby-textarea/emby-textarea.js
+++ b/src/elements/emby-textarea/emby-textarea.js
@@ -55,7 +55,7 @@ define(['layoutManager', 'browser', 'css!./emby-textarea', 'webcomponents', 'emb
                 newHeight = textarea.scrollHeight/* - offset*/;
                 hasGrown = true;
             }
-            $('.customCssContainer').css('height', newHeight + 'px');
+            document.querySelector('.customCssContainer').style.height = `${newHeight}px`;
             textarea.style.height = newHeight + 'px';
         }
 

--- a/src/legacy/fnchecked.js
+++ b/src/legacy/fnchecked.js
@@ -1,6 +1,7 @@
 define(['jQuery'], function($) {
     'use strict';
     $.fn.checked = function(value) {
+        /* eslint-disable-next-line jquery/no-each */
         return !0 === value || !1 === value ? $(this).each(function() {
             this.checked = value;
         }) : this.length && this[0].checked;

--- a/src/scripts/editorsidebar.js
+++ b/src/scripts/editorsidebar.js
@@ -207,7 +207,7 @@ define(['datetime', 'jQuery', 'globalize', 'material-icons'], function (datetime
     }
 
     function onNodeOpen(event, data) {
-        var page = $(this).parents('.page')[0];
+        var page = this.closest('.page');
         var node = data.node;
         if (node.children) {
             loadNodesToLoad(page, node);
@@ -219,7 +219,7 @@ define(['datetime', 'jQuery', 'globalize', 'material-icons'], function (datetime
     }
 
     function onNodeLoad(event, data) {
-        var page = $(this).parents('.page')[0];
+        var page = this.closest('.page');
         var node = data.node;
         if (node.children) {
             loadNodesToLoad(page, node);

--- a/src/scripts/libraryBrowser.js
+++ b/src/scripts/libraryBrowser.js
@@ -63,12 +63,6 @@ define(['userSettings', 'globalize'], function (userSettings, globalize) {
                             bubbles: true,
                             cancelable: false
                         }));
-
-                        if (!dispatchEvent) {
-                            if (window.$) {
-                                $(button).trigger('layoutchange', [id]);
-                            }
-                        }
                     }
                 });
             });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3945,6 +3945,11 @@ eslint-plugin-import@^2.21.2:
     resolve "^1.17.0"
     tsconfig-paths "^3.9.0"
 
+eslint-plugin-jquery@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jquery/-/eslint-plugin-jquery-1.5.1.tgz#d6bac643acf9484ce76394e27e2b07baca06662e"
+  integrity sha512-L7v1eaK5t80C0lvUXPFP9MKnBOqPSKhCOYyzy4LZ0+iK+TJwN8S9gAkzzP1AOhypRIwA88HF6phQ9C7jnOpW8w==
+
 eslint-plugin-promise@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz#845fd8b2260ad8f82564c1222fce44ad71d9418a"


### PR DESCRIPTION
**Changes**

Replaces the following jQuery functions with native equivalents

* $.attr()
* $.addClass()
* $.removeClass()
* $.css()
* $.deferred
* $.each()
* $.filter()
* $.hide()
* $.html()
* $.is()
* $.parents()
* $.show()
* $.val()
* $.prop()
* $.trigger()

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
