### PR TITLE
Overhaul issue templates

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -2,4 +2,4 @@ version: 1
 update_configs:
   - package_manager: "javascript"
     directory: "/"
-    update_schedule: "weekly"
+    update_schedule: "live"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,6 @@
 .ci             @dkanada @EraYaN
 .github         @jellyfin/core
-build.sh        @joshuaboniface
+fedora          @joshuaboniface
+debian          @joshuaboniface
+.copr           @joshuaboniface
 deployment      @joshuaboniface

--- a/.github/ISSUE_TEMPLATE/1-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.md
@@ -1,16 +1,13 @@
 ---
 name: Bug report
-about: Create a bug report
-title: ''
+about: You have noticed a general issue or regression, and would like to report it
 labels: bug
-assignees: ''
-
 ---
 
 **Describe the bug**
 <!-- A clear and concise description of what the bug is. -->
 
-**To Reproduce**
+**Steps to Reproduce**
 <!-- Steps to reproduce the behavior: -->
 1. Go to '...'
 2. Click on '....'
@@ -27,9 +24,9 @@ assignees: ''
 <!-- If applicable, add screenshots to help explain your problem. -->
 
 **System (please complete the following information):**
- - OS: [e.g. Docker, Debian, Windows]
+ - Platform: [e.g. Linux, Windows, iPhone, Tizen]
  - Browser: [e.g. Firefox, Chrome, Safari]
- - Jellyfin Version: [e.g. 10.0.1]
+ - Jellyfin Version: [e.g. 10.6.0]
 
 **Additional context**
 <!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/1-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.md
@@ -1,20 +1,20 @@
 ---
-name: Bug report
+name: Bug Report
 about: You have noticed a general issue or regression, and would like to report it
 labels: bug
 ---
 
-**Describe the bug**
+**Describe The Bug**
 <!-- A clear and concise description of what the bug is. -->
 
-**Steps to Reproduce**
+**Steps To Reproduce**
 <!-- Steps to reproduce the behavior: -->
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
+**Expected Behavior**
 <!-- A clear and concise description of what you expected to happen. -->
 
 **Logs**
@@ -28,5 +28,5 @@ labels: bug
  - Browser: [e.g. Firefox, Chrome, Safari]
  - Jellyfin Version: [e.g. 10.6.0]
 
-**Additional context**
+**Additional Context**
 <!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/2-playback-issue.md
+++ b/.github/ISSUE_TEMPLATE/2-playback-issue.md
@@ -1,10 +1,10 @@
 ---
-name: Playback issue
+name: Playback Issue
 about: You have playback issues with some files
 labels: playback
 ---
 
-**Describe the bug**
+**Describe The Bug**
 <!-- A clear and concise description of what the bug is. -->
 
 **Media Information**
@@ -18,5 +18,5 @@ labels: playback
  - Browser: [e.g. Firefox, Chrome, Safari]
  - Jellyfin Version: [e.g. 10.6.0]
 
-**Additional context**
+**Additional Context**
 <!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/2-playback-issue.md
+++ b/.github/ISSUE_TEMPLATE/2-playback-issue.md
@@ -1,0 +1,22 @@
+---
+name: Playback issue
+about: You have playback issues with some files
+labels: playback
+---
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is. -->
+
+**Media Information**
+<!-- Please paste any ffprobe or MediaInfo logs. -->
+
+**Screenshots**
+<!-- Add screenshots from the Playback Data and Media Info. -->
+
+**System (please complete the following information):**
+ - Platform: [e.g. Linux, Windows, iPhone, Tizen]
+ - Browser: [e.g. Firefox, Chrome, Safari]
+ - Jellyfin Version: [e.g. 10.6.0]
+
+**Additional context**
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/3-technical-discussion.md
+++ b/.github/ISSUE_TEMPLATE/3-technical-discussion.md
@@ -1,5 +1,5 @@
 ---
-name: Technical discussion
+name: Technical Discussion
 about: You want to discuss technical aspects of changes you intend to make
 labels: enhancement
 ---

--- a/.github/ISSUE_TEMPLATE/3-technical-discussion.md
+++ b/.github/ISSUE_TEMPLATE/3-technical-discussion.md
@@ -1,0 +1,13 @@
+---
+name: Technical discussion
+about: You want to discuss technical aspects of changes you intend to make
+labels: enhancement
+---
+
+<!-- Explain the change and the motivations behind it.
+
+For example, if you plan to rely on a new dependency, explain why and what
+it brings to the project.
+
+If you plan to make significant changes, go roughly over the steps you intend
+to take and how you would divide the change in PRs of a manageable size. -->

--- a/.github/ISSUE_TEMPLATE/4-meta-issue.md
+++ b/.github/ISSUE_TEMPLATE/4-meta-issue.md
@@ -1,0 +1,9 @@
+---
+name: Meta issue
+about: You want to track a number of other issues as part of a larger project
+labels: meta
+---
+
+* [ ] Issue 1 [#123]
+* [ ] Issue 2 [#456]
+* [ ] ...

--- a/.github/ISSUE_TEMPLATE/4-meta-issue.md
+++ b/.github/ISSUE_TEMPLATE/4-meta-issue.md
@@ -1,5 +1,5 @@
 ---
-name: Meta issue
+name: Meta Issue
 about: You want to track a number of other issues as part of a larger project
 labels: meta
 ---

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
-  - name: You have a feature request
+  - name: Feature Request
     url: https://features.jellyfin.org/
     about: Please head over to our feature request hub to vote on or submit a feature.
-  - name: You need help with Jellyfin
+  - name: Help Or Question
     url: https://matrix.to/#/#jellyfin-troubleshooting:matrix.org
     about: Please join the troubleshooting Matrix channel to get some help.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://features.jellyfin.org/
     about: Please head over to our feature request hub to vote on or submit a feature.
   - name: You need help with Jellyfin
-    url: https://matrix.to/#/#jellyfin-troubleshooting:matrix.org%22
+    url: https://matrix.to/#/#jellyfin-troubleshooting:matrix.org
     about: Please join the troubleshooting Matrix channel to get some help.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: You have a feature request
+    url: https://features.jellyfin.org/
+    about: Please head over to our feature request hub to vote on or submit a feature.
+  - name: You need help with Jellyfin
+    url: https://matrix.to/#/#jellyfin-troubleshooting:matrix.org%22
+    about: Please join the troubleshooting Matrix channel to get some help.

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -13,8 +13,8 @@ question in these venues:
 If you didn't find an answer in the resources above, contributors and other
 users are reachable through the following channels:
 
-* [#jellyfin-troubleshooting:matrix.org](https://matrix.to/#/#jellyfin-troubleshooting:matrix.org%22) or [on IRC](https://webchat.freenode.net/#jellyfin)
-* [#jellyfin:matrix.org on Matrix](https://matrix.to/#/#jellyfin:matrix.org) or [on IRC](https://webchat.freenode.net/#jellyfin-troubleshooting)
+* #jellyfin on [Matrix](https://matrix.to/#/#jellyfin:matrix.org%22) or [IRC](https://webchat.freenode.net/#jellyfin)
+* #jellyfin-troubleshooting on [Matrix](https://matrix.to/#/#jellyfin-troubleshooting:matrix.org) or [IRC](https://webchat.freenode.net/#jellyfin-troubleshooting)
 * [/r/jellyfin on Reddit](https://www.reddit.com/r/jellyfin)
 
 GitHub issues are for tracking enhancements and bugs, not general support.

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -19,6 +19,6 @@ users are reachable through the following channels:
 
 GitHub issues are for tracking enhancements and bugs, not general support.
 
-The open source license grants you the freedom to use Jellyfin. It does not
-guarantee commitments of other people's time. Please be respectful and manage
-your expectations.
+The open source license grants you the freedom to use Jellyfin.
+It does not guarantee commitments of other people's time.
+Please be respectful and manage your expectations.

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,24 @@
+# Support
+
+Jellyfin contributors have limited availability to address general support
+questions. Please make sure you are using the latest version of Jellyfin.
+
+When looking for support or information, please first search for your
+question in these venues:
+
+* [Jellyfin Forum](https://forum.jellyfin.org/)
+* [Jellyfin Documentation](https://jellyfin.org/docs/)
+* [Open or ****closed**** issues in the Jellyfin GitHub organization](https://github.com/issues?q=sort%3Aupdated-desc+org%3Ajellyfin+is%3Aissue+)
+
+If you didn't find an answer in the resources above, contributors and other
+users are reachable through the following channels:
+
+* [#jellyfin-troubleshooting:matrix.org](https://matrix.to/#/#jellyfin-troubleshooting:matrix.org%22) or [on IRC](https://webchat.freenode.net/#jellyfin)
+* [#jellyfin:matrix.org on Matrix](https://matrix.to/#/#jellyfin:matrix.org) or [on IRC](https://webchat.freenode.net/#jellyfin-troubleshooting)
+* [/r/jellyfin on Reddit](https://www.reddit.com/r/jellyfin)
+
+GitHub issues are for tracking enhancements and bugs, not general support.
+
+The open source license grants you the freedom to use Jellyfin. It does not
+guarantee commitments of other people's time. Please be respectful and manage
+your expectations.

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -6,9 +6,9 @@ questions. Please make sure you are using the latest version of Jellyfin.
 When looking for support or information, please first search for your
 question in these venues:
 
-* [Jellyfin Forum](https://forum.jellyfin.org/)
-* [Jellyfin Documentation](https://jellyfin.org/docs/)
-* [Open or ****closed**** issues in the Jellyfin GitHub organization](https://github.com/issues?q=sort%3Aupdated-desc+org%3Ajellyfin+is%3Aissue+)
+* [Jellyfin Forum](https://forum.jellyfin.org)
+* [Jellyfin Documentation](https://docs.jellyfin.org)
+* [Open or **closed** issues in the organization](https://github.com/issues?q=sort%3Aupdated-desc+org%3Ajellyfin+is%3Aissue+)
 
 If you didn't find an answer in the resources above, contributors and other
 users are reachable through the following channels:


### PR DESCRIPTION
**Changes**

Most of this is based on how Node.js handles issues.

* Adds SUPPORT.md, pointing to the relevant support resources
* Disables blank issues
* Adds a link to the Feature Request Hub to the new issue dialog
* Adds link to the Troubleshooting Matrix channel to the new issue dialog
* Reworks the issue templates into 4 templates:
  * **Bug report** covers general issues
  * **Playback issue** is specific to media playback issues
  * **Technical discussion** is a more free-form template for discussing technical subjects (#889 would be a good example)
  * **Meta issue** provides a list of issues or tasks to track as part of a larger project (When Github Projects are not applicable)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
