### PR TITLE
Add support for seeking with milliseconds

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -3664,6 +3664,14 @@ define(['events', 'datetime', 'appSettings', 'itemHelper', 'pluginManager', 'pla
         this.seek(parseInt(ticks), player);
     };
 
+    PlaybackManager.prototype.seekMs = function (ms, player) {
+
+        player = player || this._currentPlayer;
+
+        var ticks = ms * 10000;
+        this.seek(ticks, player);
+    };
+
     PlaybackManager.prototype.playTrailers = function (item) {
 
         var player = this._currentPlayer;

--- a/src/scripts/inputManager.js
+++ b/src/scripts/inputManager.js
@@ -201,6 +201,9 @@ import appHost from 'apphost';
             'rewind': () => {
                 playbackManager.rewind();
             },
+            'seek': () => {
+                playbackManager.seekMs(options);
+            },
             'togglefullscreen': () => {
                 playbackManager.toggleFullscreen();
             },


### PR DESCRIPTION
Needed for the media notification seekbar in jellyfin-android (available on Android 10+).
The relevant change needed in jellyfin-android is already merged.

See jellyfin/jellyfin-android#319.