### PR TITLE
Update apiclient to 1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "hls.js": "^0.14.3",
     "howler": "^2.2.0",
     "intersection-observer": "^0.11.0",
-    "jellyfin-apiclient": "^1.3.0",
+    "jellyfin-apiclient": "^1.4.1",
     "jellyfin-noto": "https://github.com/jellyfin/jellyfin-noto",
     "jquery": "^3.5.1",
     "jstree": "^3.3.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6300,10 +6300,10 @@ isurl@^1.0.0-alpha5:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
 
-jellyfin-apiclient@^1.3.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/jellyfin-apiclient/-/jellyfin-apiclient-1.4.0.tgz#d8fedc88cc177597290687be31e38de3cd0d035a"
-  integrity sha512-v2lcSZwcbKh3YSrZkBwNM7tisxvUJHZawz0xpxIobEI6MHrQLo4oDdm1zHXN6Mku9uzbuBpbAV1tA6XJwVVTyA==
+jellyfin-apiclient@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jellyfin-apiclient/-/jellyfin-apiclient-1.4.1.tgz#5e544a19bc001b16669eb7ecf46bb7d652365e41"
+  integrity sha512-BTTRucQ4tCLyiZ9kR9nAoxqxYp5/z+MCzkayy9vmMZ5C7jlVVsnxAXuuZjoa+AgXMjohXcM5Ci54myfJM1pRkA==
 
 "jellyfin-noto@https://github.com/jellyfin/jellyfin-noto":
   version "1.0.3"


### PR DESCRIPTION
**Changes**

Updates the apiclient to 1.4.1 to add access token validation to the login process.

**Issues**

Should fix or mitigate https://github.com/jellyfin/jellyfin/issues/3608
