### PR TITLE
Fix required track count for subtitle selector to appear

### DIFF
--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -251,7 +251,7 @@ define(['loading', 'appRouter', 'layoutManager', 'connectionManager', 'userSetti
             return 'Video' === m.Type;
         });
 
-        // This only makes sence on Video items
+        // This only makes sense on Video items
         if (videoTracks.length) {
             var selected = -1 === selectedId ? ' selected' : '';
             select.innerHTML = '<option value="-1">' + globalize.translate('Off') + '</option>' + tracks.map(function (v) {
@@ -259,7 +259,7 @@ define(['loading', 'appRouter', 'layoutManager', 'connectionManager', 'userSetti
                 return '<option value="' + v.Index + '" ' + selected + '>' + v.DisplayTitle + '</option>';
             }).join('');
 
-            if (tracks.length > 1) {
+            if (tracks.length > 0) {
                 select.removeAttribute('disabled');
             } else {
                 select.setAttribute('disabled', 'disabled');


### PR DESCRIPTION
Since [this commit](https://github.com/jellyfin/jellyfin-web/commit/e14f4315a8dfd8d11521f2cba55106dc58826821#diff-377130a94664e544e5660699e34bbd86R259) the subtitle selector was getting disabled for videos with both 0 or 1 subtitle track available, thus making it impossible to start playback of the latter without subs.

**Before:**
![before1](https://user-images.githubusercontent.com/46846000/88218780-d161dd80-cc60-11ea-9326-5ad88329c4e3.png)

**After:**
![after1](https://user-images.githubusercontent.com/46846000/88218791-d6bf2800-cc60-11ea-8290-1ab50021cca9.png)
