### PR TITLE
Use NodeList instead of HTMLCollection

### DIFF
--- a/src/components/images/imageLoader.js
+++ b/src/components/images/imageLoader.js
@@ -120,7 +120,7 @@ import 'css!./style';
 
     export function lazyChildren(elem) {
         if (userSettings.enableBlurhash()) {
-            for (const lazyElem of elem.getElementsByClassName('lazy')) {
+            for (const lazyElem of elem.querySelectorAll('.lazy')) {
                 const blurhashstr = lazyElem.getAttribute('data-blurhash');
                 if (!lazyElem.classList.contains('blurhashed', 'non-blurhashable') && blurhashstr) {
                     itemBlurhashing(lazyElem, blurhashstr);


### PR DESCRIPTION
`getElementsByClassName` -> `HTMLCollection` has no iterator on webOS3 or just not polyfilled.
`querySelectorAll` -> `NodeList` has iterator on webOS3 or polyfilled.

**Changes**
Use NodeList instead of HTMLCollection

**Issues**
Fixes jellyfin/jellyfin-webos#29
