### PR TITLE
Fix event source for inputManager in case of multiple open dialogs

### DIFF
--- a/src/scripts/inputManager.js
+++ b/src/scripts/inputManager.js
@@ -66,9 +66,12 @@ import appHost from 'apphost';
         if (!sourceElement) {
             sourceElement = document.activeElement || window;
 
-            const dlg = document.querySelector('.dialogContainer .dialog.opened');
+            const dialogs = document.querySelectorAll('.dialogContainer .dialog.opened');
 
-            if (dlg && (!sourceElement || !dlg.contains(sourceElement))) {
+            // Suppose the top open dialog is active
+            const dlg = dialogs.length ? dialogs[dialogs.length - 1] : null;
+
+            if (dlg && !dlg.contains(sourceElement)) {
                 sourceElement = dlg;
             }
         }


### PR DESCRIPTION
With TV layout, open Photo library, then `More` (settings), then `Image Type` - keyboard navigation is broken.
That's because we have multiple open dialogs and event source is selected wrong.

**Changes**
Fix event source for `inputManager` in case of multiple open dialogs

**Issues**
Keyboard navigation is broken in case of multiple open dialogs.
