### PR TITLE
Fix layout of login and selectserver pages

### DIFF
--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -133,3 +133,13 @@ div[data-role=page] {
 .w-100 {
     width: 100%;
 }
+
+.margin-auto-x {
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.margin-auto-y {
+    margin-top: auto;
+    margin-bottom: auto;
+}

--- a/src/forgotpassword.html
+++ b/src/forgotpassword.html
@@ -1,5 +1,5 @@
 <div data-role="page" id="forgotPasswordPage" class="page standalonePage forgotPasswordPage">
-    <div>
+    <div class="padded-left padded-right padded-bottom-page">
         <form class="forgotPasswordForm" style="text-align: center; margin: 0 auto;">
             <div style="text-align: left;">
                 <h1>${HeaderForgotPassword}</h1>

--- a/src/forgotpasswordpin.html
+++ b/src/forgotpasswordpin.html
@@ -1,5 +1,5 @@
 <div data-role="page" class="page standalonePage forgotPasswordPinPage">
-    <div>
+    <div class="padded-left padded-right padded-bottom-page">
         <form class="forgotPasswordPinForm" style="text-align: center; margin: 0 auto;">
             <div style="text-align: left;">
                 <h2>${HeaderPasswordReset}</h2>

--- a/src/login.html
+++ b/src/login.html
@@ -1,6 +1,6 @@
-<div id="loginPage" data-role="page" class="page standalonePage flex flex-direction-column align-items-center justify-content-center" data-backbutton="false">
-    <div class="padded-left padded-right padded-bottom-page">
-        <form class="manualLoginForm hide">
+<div id="loginPage" data-role="page" class="page standalonePage flex flex-direction-column" data-backbutton="false">
+    <div class="padded-left padded-right padded-bottom-page margin-auto-y">
+        <form class="manualLoginForm margin-auto-x hide">
             <div class="padded-left padded-right flex align-items-center justify-content-center">
                 <h1 class="sectionTitle">${HeaderPleaseSignIn}</h1>
             </div>

--- a/src/selectserver.html
+++ b/src/selectserver.html
@@ -1,15 +1,17 @@
-<div id="selectServerPage" data-role="page" class="page noSecondaryNavPage standalonePage pageContainer fullWidthContent vertical flex flex-direction-column align-items-center justify-content-center">
-    <div class="verticalSection flex-shrink-zero w-100 flex flex-direction-column">
-        <div class="padded-left padded-right flex align-items-center justify-content-center">
-            <h1 class="sectionTitle sectionTitle-cards">${HeaderSelectServer}</h1>
+<div id="selectServerPage" data-role="page" class="page noSecondaryNavPage standalonePage pageContainer fullWidthContent vertical flex flex-direction-column">
+    <div class="margin-auto-y">
+        <div class="verticalSection flex-shrink-zero w-100 flex flex-direction-column">
+            <div class="padded-left padded-right flex align-items-center justify-content-center">
+                <h1 class="sectionTitle sectionTitle-cards">${HeaderSelectServer}</h1>
+            </div>
+            <div class="padded-top padded-bottom-focusscale flex-grow flex" data-horizontal="true" data-centerfocus="card">
+                <div is="emby-itemscontainer" class="scrollSlider focuscontainer-x servers flex-grow" style="display: block; text-align: center;" data-hovermenu="false" data-multiselect="false"></div>
+            </div>
         </div>
-        <div class="padded-top padded-bottom-focusscale flex-grow flex" data-horizontal="true" data-centerfocus="card">
-            <div is="emby-itemscontainer" class="scrollSlider focuscontainer-x servers flex-grow" style="display: block; text-align: center;" data-hovermenu="false" data-multiselect="false"></div>
+        <div class="padded-top padded-left padded-right flex flex-shrink-zero justify-content-center verticalSection flex-wrap-wrap margin-auto-x">
+            <a is="emby-linkbutton" href="addserver.html" class="raised cancel btnAddServer flex-shrink-zero" style="margin: .25em;">
+                <span>${ButtonAddServer}</span>
+            </a>
         </div>
-    </div>
-    <div class="padded-top padded-left padded-right flex flex-shrink-zero justify-content-center verticalSection flex-wrap-wrap" style="margin-left:auto;margin-right:auto;">
-        <a is="emby-linkbutton" href="addserver.html" class="raised block cancel btnAddServer flex-shrink-zero" style="margin: .25em;">
-            <span>${ButtonAddServer}</span>
-        </a>
     </div>
 </div>


### PR DESCRIPTION
After #1594, visual login page became inoperable in some cases.
- On Mobile with small screen, it is impossible to scroll visual login page.
- On Desktop (and TV?), card container shrinks and cards became very small.

Select Server page usually doesn't have many servers. But who knows?

To change form width, we can alter this https://github.com/jellyfin/jellyfin-web/blob/3250378c3c434341ab3b8929d484762d29d43b0d/src/assets/css/site.css#L88-L93

**Changes**
Replace `align-items-center` and `justify-content-center` with `margin-*: auto`.
Add container for select server content.

**Issues**
Impossible to scroll visual login page on mobile with small screen.
Cards is too small on desktop.

**Screenshots**
<details>
<summary>Desktop</summary>

<details>
<summary>Visual Login</summary>

Before
![desktop-old-1](https://user-images.githubusercontent.com/56478732/88461236-8cc98280-ceaa-11ea-8a2c-0911ec27c6ec.png)

After
![desktop-new-1](https://user-images.githubusercontent.com/56478732/88461238-918e3680-ceaa-11ea-97a4-f24e1c1e5956.png)
</details>

<details>
<summary>Manual Login</summary>

Before
![desktop-old-2](https://user-images.githubusercontent.com/56478732/88461255-af5b9b80-ceaa-11ea-9dc5-a87e1c9bdc31.png)

After
![desktop-new-2](https://user-images.githubusercontent.com/56478732/88461256-b2ef2280-ceaa-11ea-9491-6fd5ae0f615b.png)

</details>

<details>
<summary>Select Server</summary>

Before
![desktop-old-3](https://user-images.githubusercontent.com/56478732/88461291-f21d7380-ceaa-11ea-9fb9-08789ea1e4cf.png)

After
![desktop-new-3](https://user-images.githubusercontent.com/56478732/88461292-f47fcd80-ceaa-11ea-92ca-45c5b43ec58a.png)
</details>
</details>

<details>
<summary>Mobile</summary>

<details>
<summary>Visual Login</summary>

Before
![mobile-old-1](https://user-images.githubusercontent.com/56478732/88461303-05304380-ceab-11ea-9fa0-9550ae593d47.png)

After
![mobile-new-1](https://user-images.githubusercontent.com/56478732/88461305-07929d80-ceab-11ea-8f4c-dfa4fe459e44.png)
</details>

<details>
<summary>Manual Login</summary>

Before
![mobile-old-2](https://user-images.githubusercontent.com/56478732/88461308-0f524200-ceab-11ea-891c-3286d80c7131.png)

After
![mobile-new-2](https://user-images.githubusercontent.com/56478732/88461311-124d3280-ceab-11ea-9d23-8017c4500477.png)
</details>

<details>
<summary>Select Server</summary>

Before
![mobile-old-3](https://user-images.githubusercontent.com/56478732/88461313-18431380-ceab-11ea-8d1c-52cf008b51ca.png)

After
![mobile-new-3](https://user-images.githubusercontent.com/56478732/88461314-1b3e0400-ceab-11ea-8a8b-a591e036159f.png)
</details>
</details>