### PR TITLE
Fix typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
           "src/controllers/session/forgotPassword/index.js",
           "src/controllers/session/redeemPassword/index.js",
           "src/controllers/session/login/index.js",
-          "src/controllers/sessopm/selectServer/index.js",
+          "src/controllers/session/selectServer/index.js",
           "src/controllers/dashboard/apikeys.js",
           "src/controllers/dashboard/dashboard.js",
           "src/controllers/dashboard/devices/device.js",


### PR DESCRIPTION
Typo a085bb52696bb76e6b16e3936c43a54c8e3f8247

**Changes**
Fix typo in package.json

**Issue**
`Uncaught ReferenceError: exports is not defined` on `selectServer` page.
