### PR TITLE
Get and tag with actual release version in CI

### DIFF
--- a/.ci/azure-pipelines-package.yml
+++ b/.ci/azure-pipelines-package.yml
@@ -59,7 +59,15 @@ jobs:
   pool:
     vmImage: 'ubuntu-latest'
 
+  variables:
+  - name: JellyfinVersion
+    value: 0.0.0
+
   steps:
+  - script: echo '##vso[task.setvariable variable=JellyfinVersion]$( awk -F "/" "{ print $NF }" <<<"$(Build.SourceBranch)" | sed "s/^v//" )'
+    displayName: Set release version (stable)
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')  
+
   - task: Docker@2
     displayName: 'Push Unstable Image'
     condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/master')
@@ -84,7 +92,7 @@ jobs:
       containerRegistry: Docker Hub
       tags: |
         stable-$(Build.BuildNumber)
-        stable
+        $(JellyfinVersion)
 
 - job: CollectArtifacts
   displayName: 'Collect Artifacts'


### PR DESCRIPTION
**Changes**
Ensures that the intermediate Docker images have the proper version in their names for the collect script to handle.

**Issues**
N/A
