### PR TITLE
Adjust target browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -269,7 +269,7 @@
     "last 2 Chrome versions",
     "last 2 ChromeAndroid versions",
     "last 2 Safari versions",
-    "last 2 iOS versions",
+    "iOS > 10",
     "last 2 Edge versions",
     "Chrome 27",
     "Chrome 38",
@@ -277,6 +277,7 @@
     "Chrome 53",
     "Chrome 56",
     "Chrome 63",
+    "Edge 18",
     "Firefox ESR"
   ],
   "scripts": {


### PR DESCRIPTION
**Changes**

Adjusts our supported iOS versions to match the Expo app and adds Edge 18 explicitly.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
