### PR TITLE
Improve NativeShell integration

### DIFF
--- a/src/components/playback/mediasession.js
+++ b/src/components/playback/mediasession.js
@@ -1,5 +1,6 @@
 import playbackManager from 'playbackManager';
 import nowPlayingHelper from 'nowPlayingHelper';
+import shell from 'shell';
 import events from 'events';
 /* eslint-disable indent */
 
@@ -127,8 +128,7 @@ import events from 'events';
             });
         } else {
             const itemImageUrl = seriesImageUrl(item, { maxHeight: 3000 }) || imageUrl(item, { maxHeight: 3000 });
-
-            window.NativeShell.updateMediaSession({
+            shell.updateMediaSession({
                 action: eventName,
                 isLocalPlayer: isLocalPlayer,
                 itemId: itemId,
@@ -182,7 +182,7 @@ import events from 'events';
              /* eslint-disable-next-line compat/compat */
             navigator.mediaSession.metadata = null;
         } else {
-            window.NativeShell.hideMediaSession();
+            shell.hideMediaSession();
         }
     }
 

--- a/src/scripts/fileDownloader.js
+++ b/src/scripts/fileDownloader.js
@@ -1,11 +1,8 @@
 import multiDownload from 'multi-download';
+import shell from 'shell';
 
 export function download(items) {
-    if (window.NativeShell) {
-        items.map(function (item) {
-            window.NativeShell.downloadFile(item);
-        });
-    } else {
+    if (!shell.downloadFiles(items)) {
         multiDownload(items.map(function (item) {
             return item.url;
         }));

--- a/src/scripts/shell.js
+++ b/src/scripts/shell.js
@@ -1,20 +1,43 @@
 // TODO: This seems like a good candidate for deprecation
 export default {
-    openUrl: function (url, target) {
+    enableFullscreen: function() {
+        window.NativeShell?.enableFullscreen();
+    },
+    disableFullscreen: function() {
+        window.NativeShell?.disableFullscreen();
+    },
+    openUrl: function(url, target) {
         if (window.NativeShell) {
             window.NativeShell.openUrl(url, target);
         } else {
             window.open(url, target || '_blank');
         }
     },
-    enableFullscreen: function () {
-        if (window.NativeShell) {
-            window.NativeShell.enableFullscreen();
-        }
+    updateMediaSession(mediaInfo) {
+        window.NativeShell?.updateMediaSession(mediaInfo);
     },
-    disableFullscreen: function () {
+    hideMediaSession() {
+        window.NativeShell?.hideMediaSession();
+    },
+    /**
+     * Notify the NativeShell about volume level changes.
+     * Useful for e.g. remote playback.
+     */
+    updateVolumeLevel(volume) {
+        window.NativeShell?.updateVolumeLevel(volume);
+    },
+    /**
+     * Download specified files with NativeShell if possible
+     *
+     * @returns true on success
+     */
+    downloadFiles(items) {
         if (window.NativeShell) {
-            window.NativeShell.disableFullscreen();
+            items.map(function(item) {
+                window.NativeShell.downloadFile(item);
+            });
+            return true;
         }
+        return false;
     }
 };


### PR DESCRIPTION
**Changes**
- Move NativeShell calls into shell.js where possible to better group them
- Add "updateVolumeLevel" API (not used yet)

Regarding the `updateVolumeLevel()`: I've tried a few places where I could put it, but they either didn't work at all (cause they were probably the wrong place for remote/session playback) or the `player.getVolume()` wasn't updated yet at that point. If someone could point me to a callback where I could call that function, then I could integrate this as well. :smile:

**Issues**
- Related to #1417 