### PR TITLE
Fix fullscreen video in iOS Safari

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -18,6 +18,11 @@ define(['events', 'datetime', 'appSettings', 'itemHelper', 'pluginManager', 'pla
             screenfull.on('change', function () {
                 events.trigger(player, 'fullscreenchange');
             });
+        } else {
+            // iOS Safari
+            document.addEventListener('webkitfullscreenchange', function () {
+                events.trigger(player, 'fullscreenchange');
+            }, false);
         }
     }
 
@@ -1399,6 +1404,11 @@ define(['events', 'datetime', 'appSettings', 'itemHelper', 'pluginManager', 'pla
                 return player.isFullscreen();
             }
 
+            if (!screenfull.isEnabled) {
+                // iOS Safari
+                return document.webkitIsFullScreen;
+            }
+
             return screenfull.isFullscreen;
         };
 
@@ -1410,6 +1420,16 @@ define(['events', 'datetime', 'appSettings', 'itemHelper', 'pluginManager', 'pla
 
             if (screenfull.isEnabled) {
                 screenfull.toggle();
+            } else {
+                // iOS Safari
+                if (document.webkitIsFullScreen && document.webkitCancelFullscreen) {
+                    document.webkitCancelFullscreen();
+                } else {
+                    const elem = document.querySelector('video');
+                    if (elem && elem.webkitEnterFullscreen) {
+                        elem.webkitEnterFullscreen();
+                    }
+                }
             }
         };
 

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -554,6 +554,11 @@ define(['browser', 'require', 'events', 'apphost', 'loading', 'dom', 'playbackMa
 
             if (screenfull.isEnabled) {
                 screenfull.exit();
+            } else {
+                // iOS Safari
+                if (document.webkitIsFullScreen && document.webkitCancelFullscreen) {
+                    document.webkitCancelFullscreen();
+                }
             }
         };
 


### PR DESCRIPTION
**Changes**
Fixes a regression caused by switching to the screenfull library for fullscreen support. Screenfull does not support iOS because the behavior is non-standard and only works on video elements. We previously had a workaround in place for this, so it is a regression.

**Issues**
I don't see any logged for this yet...
