### PR TITLE
Skip number key navigation when key is modified with alt/ctrl

### DIFF
--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1131,6 +1131,7 @@ import 'css!assets/css/videoosd';
             clickedElement = e.target;
 
             const key = keyboardnavigation.getKeyName(e);
+            const isKeyModified = e.ctrlKey || e.altKey;
 
             if (!currentVisibleMenu && 32 === e.keyCode) {
                 playbackManager.playPause(currentPlayer);
@@ -1235,8 +1236,10 @@ import 'css!assets/css/videoosd';
                 case '7':
                 case '8':
                 case '9': {
-                    const percent = parseInt(key, 10) * 10;
-                    playbackManager.seekPercent(percent, currentPlayer);
+                    if (!isKeyModified) {
+                        const percent = parseInt(key, 10) * 10;
+                        playbackManager.seekPercent(percent, currentPlayer);
+                    }
                     break;
                 }
             }


### PR DESCRIPTION
Pressing a number key during jellyfin playback seeks to the corresponding % (e.g. 9 skips to 90% through the video). Browsers use CTRL+# and ALT+# to switch tabs.

Jellyfin's behaviour was previously not changed when the ALT/CTRL modifiers were active, so switch tabs would also seek playback.