### PR TITLE
Consider Meta Key (⌘/⊞) as a modifier

### DIFF
--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1134,7 +1134,7 @@ import 'css!assets/css/videoosd';
             clickedElement = e.target;
 
             const key = keyboardnavigation.getKeyName(e);
-            const isKeyModified = e.ctrlKey || e.altKey;
+            const isKeyModified = e.ctrlKey || e.altKey || e.metaKey;
 
             if (!currentVisibleMenu && 32 === e.keyCode) {
                 playbackManager.playPause(currentPlayer);


### PR DESCRIPTION
In a previous commit, number seek navigation was disabled when the ALT and CTRL
modifiers were active. Macs allow tab switching with the COMMAND key and
a number. This commit adds the meta key (COMMAND and WINDOWS)
to the set of modifiers which will prevent number seek navigation.

This fixes #1698 