### PR TITLE
Fix usage of ES6 import hacks

### DIFF
--- a/src/components/appRouter.js
+++ b/src/components/appRouter.js
@@ -1,6 +1,7 @@
 define(['loading', 'globalize', 'events', 'viewManager', 'skinManager', 'backdrop', 'browser', 'page', 'appSettings', 'apphost', 'connectionManager'], function (loading, globalize, events, viewManager, skinManager, backdrop, browser, page, appSettings, appHost, connectionManager) {
     'use strict';
 
+    browser = browser.default || browser;
     loading = loading.default || loading;
 
     var appRouter = {

--- a/src/components/apphost.js
+++ b/src/components/apphost.js
@@ -1,6 +1,8 @@
 define(['appSettings', 'browser', 'events', 'htmlMediaHelper', 'webSettings', 'globalize'], function (appSettings, browser, events, htmlMediaHelper, webSettings, globalize) {
     'use strict';
 
+    browser = browser.default || browser;
+
     function getBaseProfileOptions(item) {
         var disableHlsVideoAudioCodecs = [];
 

--- a/src/components/guide/guide.js
+++ b/src/components/guide/guide.js
@@ -1,6 +1,7 @@
 define(['require', 'inputManager', 'browser', 'globalize', 'connectionManager', 'scrollHelper', 'serverNotifications', 'loading', 'datetime', 'focusManager', 'playbackManager', 'userSettings', 'imageLoader', 'events', 'layoutManager', 'itemShortcuts', 'dom', 'css!./guide.css', 'programStyles', 'material-icons', 'scrollStyles', 'emby-programcell', 'emby-button', 'paper-icon-button-light', 'emby-tabs', 'emby-scroller', 'flexStyles', 'webcomponents'], function (require, inputManager, browser, globalize, connectionManager, scrollHelper, serverNotifications, loading, datetime, focusManager, playbackManager, userSettings, imageLoader, events, layoutManager, itemShortcuts, dom) {
     'use strict';
 
+    browser = browser.default || browser;
     loading = loading.default || loading;
 
     function showViewSettings(instance) {

--- a/src/components/imageeditor/imageeditor.js
+++ b/src/components/imageeditor/imageeditor.js
@@ -19,8 +19,6 @@ import 'css!./imageeditor';
 
     const enableFocusTransform = !browser.slow && !browser.edge;
 
-    loading = loading.default || loading;
-
     let currentItem;
     let hasChanges = false;
 

--- a/src/components/layoutManager.js
+++ b/src/components/layoutManager.js
@@ -1,6 +1,8 @@
 define(['browser', 'appSettings', 'events'], function (browser, appSettings, events) {
     'use strict';
 
+    browser = browser.default || browser;
+
     function setLayout(instance, layout, selectedLayout) {
         if (layout === selectedLayout) {
             instance[layout] = true;

--- a/src/components/skinManager.js
+++ b/src/components/skinManager.js
@@ -1,6 +1,8 @@
 define(['apphost', 'userSettings', 'browser', 'events', 'backdrop', 'globalize', 'require', 'appSettings'], function (appHost, userSettings, browser, events, backdrop, globalize, require, appSettings) {
     'use strict';
 
+    browser = browser.default || browser;
+
     var themeStyleElement;
     var currentThemeId;
 

--- a/src/components/slideshow/slideshow.js
+++ b/src/components/slideshow/slideshow.js
@@ -5,6 +5,8 @@
 define(['dialogHelper', 'inputManager', 'connectionManager', 'layoutManager', 'focusManager', 'browser', 'apphost', 'dom', 'css!./style', 'material-icons', 'paper-icon-button-light'], function (dialogHelper, inputManager, connectionManager, layoutManager, focusManager, browser, appHost, dom) {
     'use strict';
 
+    browser = browser.default || browser;
+
     /**
      * Name of transition event.
      */

--- a/src/components/tunerPicker.js
+++ b/src/components/tunerPicker.js
@@ -1,6 +1,7 @@
 define(['dialogHelper', 'dom', 'layoutManager', 'connectionManager', 'globalize', 'loading', 'browser', 'focusManager', 'scrollHelper', 'material-icons', 'formDialogStyle', 'emby-button', 'emby-itemscontainer', 'cardStyle'], function (dialogHelper, dom, layoutManager, connectionManager, globalize, loading, browser, focusManager, scrollHelper) {
     'use strict';
 
+    browser = browser.default || browser;
     loading = loading.default || loading;
 
     var enableFocusTransform = !browser.slow && !browser.edge;

--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -29,8 +29,6 @@ import 'emby-select';
 
 /* eslint-disable indent */
 
-    loading = loading.default || loading;
-
     function getPromise(apiClient, params) {
         const id = params.id;
 

--- a/src/controllers/livetvsettings.js
+++ b/src/controllers/livetvsettings.js
@@ -3,8 +3,6 @@ import loading from 'loading';
 import globalize from 'globalize';
 import 'emby-button';
 
-loading = loading.default || loading;
-
 function loadPage(page, config) {
     $('.liveTvSettingsForm', page).show();
     $('.noLiveTvServices', page).hide();

--- a/src/libraries/navdrawer/navdrawer.js
+++ b/src/libraries/navdrawer/navdrawer.js
@@ -1,6 +1,8 @@
 define(["browser", "dom", "css!./navdrawer", "scrollStyles"], function (browser, dom) {
     "use strict";
 
+    browser = browser.default || browser;
+
     return function (options) {
         function getTouches(e) {
             return e.changedTouches || e.targetTouches || e.touches;

--- a/src/libraries/scroller.js
+++ b/src/libraries/scroller.js
@@ -1,6 +1,8 @@
 define(['browser', 'layoutManager', 'dom', 'focusManager', 'ResizeObserver', 'scrollStyles'], function (browser, layoutManager, dom, focusManager, ResizeObserver) {
     'use strict';
 
+    browser = browser.default || browser;
+
     /**
 * Return type of the value.
 *

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -1,6 +1,8 @@
 define(['browser'], function (browser) {
     'use strict';
 
+    browser = browser.default || browser;
+
     function canPlayH264(videoTestElement) {
         return !!(videoTestElement.canPlayType && videoTestElement.canPlayType('video/mp4; codecs="avc1.42E01E, mp4a.40.2"').replace(/no/, ''));
     }

--- a/src/scripts/libraryMenu.js
+++ b/src/scripts/libraryMenu.js
@@ -1,6 +1,8 @@
 define(['dom', 'layoutManager', 'inputManager', 'connectionManager', 'events', 'viewManager', 'libraryBrowser', 'appRouter', 'apphost', 'playbackManager', 'syncPlayManager', 'groupSelectionMenu', 'browser', 'globalize', 'scripts/imagehelper', 'paper-icon-button-light', 'material-icons', 'scrollStyles', 'flexStyles'], function (dom, layoutManager, inputManager, connectionManager, events, viewManager, libraryBrowser, appRouter, appHost, playbackManager, syncPlayManager, groupSelectionMenu, browser, globalize, imageHelper) {
     'use strict';
 
+    browser = browser.default || browser;
+
     function renderHeader() {
         var html = '';
         html += '<div class="flex align-items-center flex-grow headerTop">';

--- a/src/scripts/mouseManager.js
+++ b/src/scripts/mouseManager.js
@@ -1,6 +1,8 @@
 define(['inputManager', 'focusManager', 'browser', 'layoutManager', 'events', 'dom'], function (inputManager, focusManager, browser, layoutManager, events, dom) {
     'use strict';
 
+    browser = browser.default || browser;
+
     var self = {};
 
     var lastMouseInputTime = new Date().getTime();


### PR DESCRIPTION
**Changes**
Add ES6 import hack for `browser`.
Remove ES6 import hack for `loading`.

**Issues**
All instances of `browser` in non-ES6 modules are broken.
`loading` import hack in ES6 modules throws a runtime error.
Fixes jellyfin/jellyfin-tizen#44