### PR TITLE
Fix injecting of view with embedded script

### DIFF
--- a/src/components/viewContainer.js
+++ b/src/components/viewContainer.js
@@ -54,8 +54,8 @@ import 'css!components/viewManager/viewContainer';
 
                 if (currentPage) {
                     if (newViewInfo.hasScript && window.$) {
-                        view = $(view).appendTo(mainAnimatedPages)[0];
                         mainAnimatedPages.removeChild(currentPage);
+                        view = $(view).appendTo(mainAnimatedPages)[0];
                     } else {
                         mainAnimatedPages.replaceChild(view, currentPage);
                     }


### PR DESCRIPTION
_MusicBrainz plugin as example_
MusicBrainz plugin fields aren't updated if you open configuration page twice (open, back, open).
That's (probably) because embedded script is still alive when you open page second time, and variable `MusicBrainzPluginConfig` is going to be defined second time.
https://github.com/jellyfin/jellyfin/blob/b7421db5fea50e684334806a4ecc8d9f943d754a/MediaBrowser.Providers/Plugins/MusicBrainz/Configuration/config.html#L35-L37

**Changes**
Change injection order: remove, then append.

**Issues**
Plugin configuration fields aren't updated.
