### PR TITLE
Add start script as alias for serve

### DIFF
--- a/package.json
+++ b/package.json
@@ -318,6 +318,7 @@
     "Firefox ESR"
   ],
   "scripts": {
+    "start": "yarn serve",
     "serve": "gulp serve --development",
     "prepare": "gulp --production",
     "build:development": "gulp --development",


### PR DESCRIPTION
**Changes**
Adds a `start` script that just runs `serve` since `start` is the default for running a node app.

https://docs.npmjs.com/misc/scripts#default-values
https://classic.yarnpkg.com/en/docs/package-json#toc-scripts

**Issues**
N/A
