### PR TITLE
Rework CSS breakpoints and structure

### DIFF
--- a/src/assets/css/dashboard.css
+++ b/src/assets/css/dashboard.css
@@ -47,16 +47,6 @@ progress[aria-valuenow]::before {
     margin-bottom: 2.2em !important;
 }
 
-@media all and (min-width: 50em) {
-    .type-interior > div[data-role=content],
-    .type-interior > .ui-panel-content-wrap > div[data-role=content] {
-        padding-right: 0;
-        padding-left: 0;
-        padding-top: 0;
-        overflow: hidden;
-    }
-}
-
 .dashboardDocument .dashboardEntryHeaderButton,
 .dashboardDocument .lnkManageServer {
     display: none !important;
@@ -163,22 +153,6 @@ div[data-role=controlgroup] a.ui-btn-active {
     padding-top: 9em !important;
 }
 
-@media all and (min-width: 40em) {
-    .content-primary {
-        padding-top: 4.6em;
-    }
-
-    .withTabs .content-primary {
-        padding-top: 10em !important;
-    }
-}
-
-@media all and (min-width: 84em) {
-    .withTabs .content-primary {
-        padding-top: 7em !important;
-    }
-}
-
 .content-primary ul:first-child {
     margin-top: 0;
 }
@@ -244,33 +218,6 @@ div[data-role=controlgroup] a.ui-btn-active {
     resize: none;
 }
 
-@media all and (min-width: 70em) {
-    .dashboardSections {
-        -webkit-flex-wrap: wrap;
-        flex-wrap: wrap;
-        -webkit-box-orient: horizontal;
-        -webkit-box-direction: normal;
-        -webkit-flex-direction: row;
-        flex-direction: row;
-    }
-
-    .dashboardColumn-2-60 {
-        width: 46%;
-    }
-
-    .dashboardColumn-2-40 {
-        width: 27%;
-    }
-
-    .dashboardSection {
-        padding: 0 1.5em;
-    }
-
-    .activeRecordingItems > .card {
-        width: 25%;
-    }
-}
-
 .wizardContent {
     max-width: 62em;
     padding: 0.5em 2em 1em;
@@ -302,18 +249,6 @@ div[data-role=controlgroup] a.ui-btn-active {
     background-size: cover;
     background-repeat: no-repeat;
     background-position: center;
-}
-
-@media all and (min-width: 40em) {
-    .activeSession {
-        width: 100% !important;
-    }
-}
-
-@media all and (min-width: 50em) {
-    .activeSession {
-        width: 50% !important;
-    }
 }
 
 .sessionCardFooter {
@@ -406,18 +341,6 @@ div[data-role=controlgroup] a.ui-btn-active {
     background-color: #dd4919;
 }
 
-@media all and (max-width: 34.375em) {
-    .sessionAppName {
-        max-width: 160px;
-    }
-}
-
-@media all and (max-width: 31.25em) {
-    .sessionAppName {
-        max-width: 150px;
-    }
-}
-
 .disabledUser {
     -webkit-filter: grayscale(100%);
     filter: grayscale(100%);
@@ -472,4 +395,63 @@ div[data-role=controlgroup] a.ui-btn-active {
 .ui-bar-a {
     text-align: center;
     padding: 0 20px;
+}
+
+@media all and (max-width: 576px) {
+    .sessionAppName {
+        max-width: 160px;
+    }
+}
+
+@media all and (min-width: 768px) {
+    .type-interior > div[data-role=content],
+    .type-interior > .ui-panel-content-wrap > div[data-role=content] {
+        padding-right: 0;
+        padding-left: 0;
+        padding-top: 0;
+        overflow: hidden;
+    }
+
+    .activeSession {
+        width: 50% !important;
+    }
+
+    .content-primary {
+        padding-top: 4.6em;
+    }
+
+    .withTabs .content-primary {
+        padding-top: 10em !important;
+    }
+}
+
+@media all and (min-width: 1200px) {
+    .withTabs .content-primary {
+        padding-top: 7em !important;
+    }
+
+    .dashboardSections {
+        -webkit-flex-wrap: wrap;
+        flex-wrap: wrap;
+        -webkit-box-orient: horizontal;
+        -webkit-box-direction: normal;
+        -webkit-flex-direction: row;
+        flex-direction: row;
+    }
+
+    .dashboardColumn-2-60 {
+        width: 46%;
+    }
+
+    .dashboardColumn-2-40 {
+        width: 27%;
+    }
+
+    .dashboardSection {
+        padding: 0 1.5em;
+    }
+
+    .activeRecordingItems > .card {
+        width: 25%;
+    }
 }

--- a/src/assets/css/fonts.sized.css
+++ b/src/assets/css/fonts.sized.css
@@ -16,16 +16,3 @@ h3 {
     font-weight: 400;
     font-size: 1.17em;
 }
-
-@media all and (min-height: 720px) {
-    html {
-        font-size: 20px;
-    }
-}
-
-/* This is supposed to be 1080p, but had to reduce the min height to account for possible browser chrome */
-@media all and (min-height: 1000px) {
-    html {
-        font-size: 27px;
-    }
-}

--- a/src/assets/css/librarybrowser.css
+++ b/src/assets/css/librarybrowser.css
@@ -240,7 +240,7 @@
     padding-bottom: 10vh;
 }
 
-@media all and (min-width: 40em) {
+@media all and (min-width: 768px) {
     .dashboardDocument .adminDrawerLogo,
     .dashboardDocument .mainDrawerButton {
         display: none !important;
@@ -265,9 +265,14 @@
     .dashboardDocument .skinBody {
         left: 20em;
     }
+
+    .detailPageContent {
+        padding-left: 5%;
+        padding-right: 5%;
+    }
 }
 
-@media all and (max-width: 100em) {
+@media all and (max-width: 1400px) {
     .withSectionTabs .headerTop {
         padding-bottom: 0.55em;
     }
@@ -281,7 +286,7 @@
     }
 }
 
-@media all and (min-width: 100em) {
+@media all and (min-width: 1400px) {
     .headerTop {
         padding: 0.8em 0.8em;
     }
@@ -322,7 +327,7 @@
     white-space: nowrap;
 }
 
-@media all and (max-width: 37.5em) {
+@media all and (max-width: 576px) {
     .headerSelectedPlayer {
         display: none;
     }
@@ -464,13 +469,8 @@
 .detailPageContent {
     display: flex;
     flex-direction: column;
-    padding-left: 32.45vw;
+    padding-left: 2%;
     padding-right: 2%;
-}
-
-.layout-mobile .detailPageContent {
-    padding-left: 5%;
-    padding-right: 5%;
 }
 
 .layout-desktop .detailPageContent .emby-scroller,
@@ -624,17 +624,21 @@
     z-index: 2;
 }
 
-.layout-mobile .detailPagePrimaryContainer {
-    display: block;
-    position: relative;
-    padding: 0.5em 3.3% 0.5em;
-}
-
 .layout-tv #itemDetailPage:not(.noBackdrop) .detailPagePrimaryContainer,
 .layout-desktop #itemDetailPage:not(.noBackdrop) .detailPagePrimaryContainer {
     position: relative;
     top: 0;
-    padding-left: 32.45vw;
+}
+
+@media screen and (min-width: 768px) {
+    .layout-tv #itemDetailPage:not(.noBackdrop) .detailPagePrimaryContainer,
+    .layout-desktop #itemDetailPage:not(.noBackdrop) .detailPagePrimaryContainer {
+        padding-left: 32.45vw;
+    }
+
+    .detailPageContent {
+        padding-left: 32.45vw;
+    }
 }
 
 .layout-desktop .detailRibbon,
@@ -671,10 +675,6 @@
 
 .layout-mobile .detailPageSecondaryContainer {
     margin: 1em 0;
-}
-
-.layout-mobile .detailImageContainer {
-    display: none;
 }
 
 .detailImageContainer .card {
@@ -716,7 +716,7 @@
     display: none;
 }
 
-@media all and (max-width: 68.75em) {
+@media all and (max-width: 768px) {
     .detailLogo {
         display: none;
     }
@@ -743,7 +743,7 @@ div.itemDetailGalleryLink.defaultCardBackground {
     transform: translateY(-50%);
 }
 
-@media all and (max-width: 62.5em) {
+@media all and (max-width: 992px) {
     .detailPageWrapperContainer {
         position: relative;
     }
@@ -768,7 +768,7 @@ div.itemDetailGalleryLink.defaultCardBackground {
     }
 }
 
-@media all and (max-width: 75em) {
+@media all and (max-width: 1200px) {
     .lnkSibling {
         display: none !important;
     }
@@ -789,7 +789,7 @@ div.itemDetailGalleryLink.defaultCardBackground {
     font-size: 3.5em;
 }
 
-@media all and (max-width: 62.5em) {
+@media all and (max-width: 992px) {
     .parentName {
         margin-bottom: 0;
     }
@@ -799,13 +799,13 @@ div.itemDetailGalleryLink.defaultCardBackground {
     }
 }
 
-@media all and (min-width: 31.25em) {
+@media all and (min-width: 576px) {
     .mobileDetails {
         display: none;
     }
 }
 
-@media all and (max-width: 31.25em) {
+@media all and (max-width: 576px) {
     .desktopDetails {
         display: none !important;
     }
@@ -847,21 +847,7 @@ div.itemDetailGalleryLink.defaultCardBackground {
     padding: 0.5em 0.7em !important;
 }
 
-@media all and (min-width: 29em) {
-    .detailButton {
-        padding-left: 0.75em !important;
-        padding-right: 0.75em !important;
-    }
-}
-
-@media all and (min-width: 32em) {
-    .detailButton {
-        padding-left: 0.8em !important;
-        padding-right: 0.8em !important;
-    }
-}
-
-@media all and (min-width: 35em) {
+@media all and (min-width: 576px) {
     .detailButton {
         padding-left: 0.85em !important;
         padding-right: 0.85em !important;
@@ -902,7 +888,7 @@ div.itemDetailGalleryLink.defaultCardBackground {
     font-weight: 400;
 }
 
-@media all and (max-width: 62.5em) {
+@media all and (max-width: 1200px) {
     .mainDetailButtons {
         margin-left: -0.5em;
     }
@@ -912,7 +898,7 @@ div.itemDetailGalleryLink.defaultCardBackground {
     }
 }
 
-@media all and (min-width: 100em) {
+@media all and (min-width: 1400px) {
     .detailFloatingButton {
         display: none !important;
     }
@@ -927,13 +913,23 @@ div.itemDetailGalleryLink.defaultCardBackground {
     }
 }
 
-@media all and (max-width: 50em) {
+@media all and (max-width: 768px) {
     .editorMenuLink {
         display: none;
     }
+
+    .detailImageContainer {
+        display: none;
+    }
+
+    .detailPagePrimaryContainer {
+        display: block;
+        position: relative;
+        padding: 0.5em 3.3% 0.5em;
+    }
 }
 
-@media all and (max-width: 31.25em) {
+@media all and (max-width: 576px) {
     .mobileDetails .itemMiscInfo {
         text-align: center;
         -webkit-box-pack: center;
@@ -1007,7 +1003,7 @@ div.itemDetailGalleryLink.defaultCardBackground {
     margin: 0 auto;
 }
 
-@media all and (max-height: 31.25em) {
+@media all and (max-height: 576px) {
     .itemBackdrop {
         height: 52vh;
     }
@@ -1149,7 +1145,7 @@ div:not(.sectionTitleContainer-cards) > .sectionTitle-cards {
     margin-bottom: -1em;
 }
 
-@media all and (min-height: 31.25em) {
+@media all and (min-height: 576px) {
     .padded-right-withalphapicker {
         padding-right: 7.5%;
     }
@@ -1176,13 +1172,13 @@ div:not(.sectionTitleContainer-cards) > .sectionTitle-cards {
     justify-content: center;
 }
 
-@media all and (min-width: 40em) {
+@media all and (min-width: 768px) {
     .listIconButton-autohide {
         display: none !important;
     }
 }
 
-@media all and (max-width: 40em) {
+@media all and (max-width: 768px) {
     .listTextButton-autohide {
         display: none !important;
     }
@@ -1257,7 +1253,7 @@ div:not(.sectionTitleContainer-cards) > .sectionTitle-cards {
     -webkit-box-orient: vertical;
 }
 
-@media all and (min-width: 40em) {
+@media all and (min-width: 768px) {
     .detail-clamp-text {
         -webkit-line-clamp: 6;
     }

--- a/src/assets/css/librarybrowser.css
+++ b/src/assets/css/librarybrowser.css
@@ -240,97 +240,9 @@
     padding-bottom: 10vh;
 }
 
-@media all and (min-width: 768px) {
-    .dashboardDocument .adminDrawerLogo,
-    .dashboardDocument .mainDrawerButton {
-        display: none !important;
-    }
-
-    .dashboardDocument .mainDrawer {
-        z-index: inherit !important;
-        left: 0 !important;
-        top: 0 !important;
-        -webkit-transform: none !important;
-        transform: none !important;
-        -webkit-box-shadow: none !important;
-        box-shadow: none !important;
-        width: 20.205em !important;
-        font-size: 94%;
-    }
-
-    .dashboardDocument .mainDrawer-scrollContainer {
-        margin-top: 5em !important;
-    }
-
-    .dashboardDocument .skinBody {
-        left: 20em;
-    }
-
-    .detailPageContent {
-        padding-left: 5%;
-        padding-right: 5%;
-    }
-}
-
-@media all and (max-width: 1400px) {
-    .withSectionTabs .headerTop {
-        padding-bottom: 0.55em;
-    }
-
-    .sectionTabs {
-        font-size: 83.5%;
-    }
-
-    .layout-tv .sectionTabs {
-        width: 100%;
-    }
-}
-
-@media all and (min-width: 1400px) {
-    .headerTop {
-        padding: 0.8em 0.8em;
-    }
-
-    .headerTabs {
-        -webkit-align-self: center;
-        align-self: center;
-        width: auto;
-        -webkit-box-align: center;
-        -webkit-align-items: center;
-        align-items: center;
-        -webkit-box-pack: center;
-        -webkit-justify-content: center;
-        justify-content: center;
-        position: relative;
-        margin-top: -4.3em;
-    }
-
-    .libraryPage:not(.noSecondaryNavPage) {
-        padding-top: 4.6em !important;
-    }
-
-    .pageWithAbsoluteTabs:not(.noSecondaryNavPage) {
-        padding-top: 6.7em !important;
-    }
-
-    .absolutePageTabContent {
-        top: 5.7em !important;
-    }
-
-    .dashboardDocument .mainDrawer-scrollContainer {
-        margin-top: 4.65em !important;
-    }
-}
-
 .headerSelectedPlayer {
     max-width: 10em;
     white-space: nowrap;
-}
-
-@media all and (max-width: 576px) {
-    .headerSelectedPlayer {
-        display: none;
-    }
 }
 
 .hidingAnimatedTab {
@@ -630,17 +542,6 @@
     top: 0;
 }
 
-@media screen and (min-width: 768px) {
-    .layout-tv #itemDetailPage:not(.noBackdrop) .detailPagePrimaryContainer,
-    .layout-desktop #itemDetailPage:not(.noBackdrop) .detailPagePrimaryContainer {
-        padding-left: 32.45vw;
-    }
-
-    .detailPageContent {
-        padding-left: 32.45vw;
-    }
-}
-
 .layout-desktop .detailRibbon,
 .layout-tv .detailRibbon {
     margin-top: -7.2em;
@@ -716,12 +617,6 @@
     display: none;
 }
 
-@media all and (max-width: 768px) {
-    .detailLogo {
-        display: none;
-    }
-}
-
 .itemDetailImage {
     width: 100% !important;
     -webkit-box-shadow: 0 0.1em 0.5em 0 rgba(0, 0, 0, 0.75);
@@ -743,37 +638,6 @@ div.itemDetailGalleryLink.defaultCardBackground {
     transform: translateY(-50%);
 }
 
-@media all and (max-width: 992px) {
-    .detailPageWrapperContainer {
-        position: relative;
-    }
-
-    .layout-desktop .itemBackdrop,
-    .layout-tv .itemBackdrop {
-        height: 40vh;
-    }
-
-    .layout-desktop .detailPageWrapperContainer,
-    .layout-tv .detailPageWrapperContainer {
-        margin-top: 0.1em;
-    }
-
-    .layout-desktop .detailImageContainer .card,
-    .layout-tv .detailImageContainer .card {
-        top: 10%;
-    }
-
-    .btnPlaySimple {
-        display: none !important;
-    }
-}
-
-@media all and (max-width: 1200px) {
-    .lnkSibling {
-        display: none !important;
-    }
-}
-
 .emby-button.detailFloatingButton {
     position: absolute;
     background-color: rgba(0, 0, 0, 0.5);
@@ -787,28 +651,6 @@ div.itemDetailGalleryLink.defaultCardBackground {
 
 .emby-button.detailFloatingButton .material-icons {
     font-size: 3.5em;
-}
-
-@media all and (max-width: 992px) {
-    .parentName {
-        margin-bottom: 0;
-    }
-
-    .itemDetailPage {
-        padding-top: 0 !important;
-    }
-}
-
-@media all and (min-width: 576px) {
-    .mobileDetails {
-        display: none;
-    }
-}
-
-@media all and (max-width: 576px) {
-    .desktopDetails {
-        display: none !important;
-    }
 }
 
 .empty {
@@ -847,13 +689,6 @@ div.itemDetailGalleryLink.defaultCardBackground {
     padding: 0.5em 0.7em !important;
 }
 
-@media all and (min-width: 576px) {
-    .detailButton {
-        padding-left: 0.85em !important;
-        padding-right: 0.85em !important;
-    }
-}
-
 .detailButton-content {
     display: -webkit-box;
     display: -webkit-flex;
@@ -886,60 +721,6 @@ div.itemDetailGalleryLink.defaultCardBackground {
     margin-top: 0.7em;
     font-size: 80%;
     font-weight: 400;
-}
-
-@media all and (max-width: 1200px) {
-    .mainDetailButtons {
-        margin-left: -0.5em;
-    }
-
-    .detailButtonHideonMobile {
-        display: none !important;
-    }
-}
-
-@media all and (min-width: 1400px) {
-    .detailFloatingButton {
-        display: none !important;
-    }
-
-    .personBackdrop {
-        display: none !important;
-    }
-
-    .mainDetailButtons {
-        font-size: 108%;
-        margin: 1.25em 0;
-    }
-}
-
-@media all and (max-width: 768px) {
-    .editorMenuLink {
-        display: none;
-    }
-
-    .detailImageContainer {
-        display: none;
-    }
-
-    .detailPagePrimaryContainer {
-        display: block;
-        position: relative;
-        padding: 0.5em 3.3% 0.5em;
-    }
-}
-
-@media all and (max-width: 576px) {
-    .mobileDetails .itemMiscInfo {
-        text-align: center;
-        -webkit-box-pack: center;
-        -webkit-justify-content: center;
-        justify-content: center;
-    }
-
-    .itemMiscInfo .endsAt {
-        display: none;
-    }
 }
 
 .detailVerticalSection .emby-scrollbuttons {
@@ -1001,12 +782,6 @@ div.itemDetailGalleryLink.defaultCardBackground {
 
 .itemsContainer {
     margin: 0 auto;
-}
-
-@media all and (max-height: 576px) {
-    .itemBackdrop {
-        height: 52vh;
-    }
 }
 
 .listViewUserDataButtons {
@@ -1145,12 +920,6 @@ div:not(.sectionTitleContainer-cards) > .sectionTitle-cards {
     margin-bottom: -1em;
 }
 
-@media all and (min-height: 576px) {
-    .padded-right-withalphapicker {
-        padding-right: 7.5%;
-    }
-}
-
 .searchfields-icon {
     color: #aaa;
 }
@@ -1170,18 +939,6 @@ div:not(.sectionTitleContainer-cards) > .sectionTitle-cards {
     -webkit-box-pack: center;
     -webkit-justify-content: center;
     justify-content: center;
-}
-
-@media all and (min-width: 768px) {
-    .listIconButton-autohide {
-        display: none !important;
-    }
-}
-
-@media all and (max-width: 768px) {
-    .listTextButton-autohide {
-        display: none !important;
-    }
 }
 
 .itemsViewSettingsContainer > .button-flat {
@@ -1253,8 +1010,219 @@ div:not(.sectionTitleContainer-cards) > .sectionTitle-cards {
     -webkit-box-orient: vertical;
 }
 
+@media all and (min-width: 576px) {
+    .mobileDetails {
+        display: none;
+    }
+
+    .detailButton {
+        padding-left: 0.85em !important;
+        padding-right: 0.85em !important;
+    }
+}
+
+@media all and (max-width: 576px) {
+    .headerSelectedPlayer {
+        display: none;
+    }
+
+    .mobileDetails .itemMiscInfo {
+        text-align: center;
+        -webkit-box-pack: center;
+        -webkit-justify-content: center;
+        justify-content: center;
+    }
+
+    .itemMiscInfo .endsAt {
+        display: none;
+    }
+
+    .desktopDetails {
+        display: none !important;
+    }
+}
+
+@media all and (max-width: 768px) {
+    .detailLogo {
+        display: none;
+    }
+
+    .editorMenuLink {
+        display: none;
+    }
+
+    .detailImageContainer {
+        display: none;
+    }
+
+    .detailPagePrimaryContainer {
+        display: block;
+        position: relative;
+        padding: 0.5em 3.3% 0.5em;
+    }
+
+    .listTextButton-autohide {
+        display: none !important;
+    }
+}
+
+@media all and (min-height: 576px) {
+    .padded-right-withalphapicker {
+        padding-right: 7.5%;
+    }
+}
+
 @media all and (min-width: 768px) {
     .detail-clamp-text {
         -webkit-line-clamp: 6;
+    }
+
+    .dashboardDocument .adminDrawerLogo,
+    .dashboardDocument .mainDrawerButton {
+        display: none !important;
+    }
+
+    .dashboardDocument .mainDrawer {
+        z-index: inherit !important;
+        left: 0 !important;
+        top: 0 !important;
+        -webkit-transform: none !important;
+        transform: none !important;
+        -webkit-box-shadow: none !important;
+        box-shadow: none !important;
+        width: 20.205em !important;
+        font-size: 94%;
+    }
+
+    .dashboardDocument .mainDrawer-scrollContainer {
+        margin-top: 5em !important;
+    }
+
+    .dashboardDocument .skinBody {
+        left: 20em;
+    }
+
+    .detailPageContent {
+        padding-left: 32.45vw;
+        padding-right: 5%;
+    }
+
+    .layout-tv #itemDetailPage:not(.noBackdrop) .detailPagePrimaryContainer,
+    .layout-desktop #itemDetailPage:not(.noBackdrop) .detailPagePrimaryContainer {
+        padding-left: 32.45vw;
+    }
+
+    .listIconButton-autohide {
+        display: none !important;
+    }
+}
+
+@media all and (max-width: 992px) {
+    .detailPageWrapperContainer {
+        position: relative;
+    }
+
+    .layout-desktop .itemBackdrop,
+    .layout-tv .itemBackdrop {
+        height: 40vh;
+    }
+
+    .layout-desktop .detailPageWrapperContainer,
+    .layout-tv .detailPageWrapperContainer {
+        margin-top: 0.1em;
+    }
+
+    .layout-desktop .detailImageContainer .card,
+    .layout-tv .detailImageContainer .card {
+        top: 10%;
+    }
+
+    .btnPlaySimple {
+        display: none !important;
+    }
+
+    .parentName {
+        margin-bottom: 0;
+    }
+
+    .itemDetailPage {
+        padding-top: 0 !important;
+    }
+}
+
+@media all and (max-width: 1200px) {
+    .lnkSibling {
+        display: none !important;
+    }
+
+    .mainDetailButtons {
+        margin-left: -0.5em;
+    }
+
+    .detailButtonHideonMobile {
+        display: none !important;
+    }
+}
+
+@media all and (max-width: 1400px) {
+    .withSectionTabs .headerTop {
+        padding-bottom: 0.55em;
+    }
+
+    .sectionTabs {
+        font-size: 83.5%;
+    }
+
+    .layout-tv .sectionTabs {
+        width: 100%;
+    }
+}
+
+@media all and (min-width: 1400px) {
+    .headerTop {
+        padding: 0.8em 0.8em;
+    }
+
+    .headerTabs {
+        -webkit-align-self: center;
+        align-self: center;
+        width: auto;
+        -webkit-box-align: center;
+        -webkit-align-items: center;
+        align-items: center;
+        -webkit-box-pack: center;
+        -webkit-justify-content: center;
+        justify-content: center;
+        position: relative;
+        margin-top: -4.3em;
+    }
+
+    .libraryPage:not(.noSecondaryNavPage) {
+        padding-top: 4.6em !important;
+    }
+
+    .pageWithAbsoluteTabs:not(.noSecondaryNavPage) {
+        padding-top: 6.7em !important;
+    }
+
+    .absolutePageTabContent {
+        top: 5.7em !important;
+    }
+
+    .dashboardDocument .mainDrawer-scrollContainer {
+        margin-top: 4.65em !important;
+    }
+
+    .detailFloatingButton {
+        display: none !important;
+    }
+
+    .personBackdrop {
+        display: none !important;
+    }
+
+    .mainDetailButtons {
+        font-size: 108%;
+        margin: 1.25em 0;
     }
 }

--- a/src/assets/css/livetv.css
+++ b/src/assets/css/livetv.css
@@ -2,7 +2,7 @@
     padding-bottom: 15em;
 }
 
-@media all and (min-width: 62.5em) {
+@media all and (min-width: 992px) {
     #guideTab {
         padding-left: 0.5em;
     }

--- a/src/assets/css/metadataeditor.css
+++ b/src/assets/css/metadataeditor.css
@@ -51,7 +51,7 @@
     margin-right: 0.4em;
 }
 
-@media all and (min-width: 50em) {
+@media all and (min-width: 768px) {
     .editPageSidebar {
         position: fixed;
         top: 5.2em;
@@ -68,7 +68,7 @@
     }
 }
 
-@media all and (min-width: 112.5em) {
+@media all and (min-width: 1400px) {
     .editPageSidebar {
         width: 25%;
     }

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -85,7 +85,7 @@ div[data-role=page] {
     padding-bottom: 5em !important;
 }
 
-@media all and (min-width: 50em) {
+@media all and (min-width: 768px) {
     .readOnlyContent,
     form {
         max-width: 54em;

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -85,13 +85,6 @@ div[data-role=page] {
     padding-bottom: 5em !important;
 }
 
-@media all and (min-width: 768px) {
-    .readOnlyContent,
-    form {
-        max-width: 54em;
-    }
-}
-
 .headerHelpButton {
     margin-left: 1.25em !important;
     padding-bottom: 0.4em !important;
@@ -142,4 +135,11 @@ div[data-role=page] {
 .margin-auto-y {
     margin-top: auto;
     margin-bottom: auto;
+}
+
+@media all and (min-width: 768px) {
+    .readOnlyContent,
+    form {
+        max-width: 54em;
+    }
 }

--- a/src/assets/css/videoosd.css
+++ b/src/assets/css/videoosd.css
@@ -60,7 +60,7 @@
     }
 }
 
-@media all and (max-height: 50em) and (orientation: landscape) {
+@media all and (max-height: 768px) and (orientation: landscape) {
     .chapterThumb {
         height: 30vh;
         min-width: 30vh;
@@ -253,7 +253,7 @@
     position: fixed;
 }
 
-@media all and (max-width: 30em) {
+@media all and (max-width: 576px) {
     .btnFastForward,
     .btnRewind,
     .osdMediaInfo,
@@ -262,27 +262,27 @@
     }
 }
 
-@media all and (max-width: 33.75em) {
+@media all and (max-width: 576px) {
     .videoOsdBottom .paper-icon-button-light {
         margin: 0;
     }
 }
 
-@media all and (max-width: 43em) {
+@media all and (max-width: 768px) {
     .videoOsdBottom .volumeButtons,
     .osdMediaStatus span {
         display: none !important;
     }
 }
 
-@media all and (max-width: 50em) {
+@media all and (max-width: 768px) {
     .videoOsdBottom .btnFastForward,
     .videoOsdBottom .btnRewind {
         display: none !important;
     }
 }
 
-@media all and (max-width: 75em) {
+@media all and (max-width: 1200px) {
     .videoOsdBottom .endsAtText {
         display: none !important;
     }

--- a/src/assets/css/videoosd.css
+++ b/src/assets/css/videoosd.css
@@ -53,20 +53,6 @@
     min-width: 20vh;
 }
 
-@media all and (orientation: portrait) {
-    .chapterThumb {
-        height: 30vw;
-        min-width: 30vw;
-    }
-}
-
-@media all and (max-height: 768px) and (orientation: landscape) {
-    .chapterThumb {
-        height: 30vh;
-        min-width: 30vh;
-    }
-}
-
 .chapterThumbTextContainer {
     position: absolute;
     bottom: 0;
@@ -260,9 +246,7 @@
     .osdPoster {
         display: none !important;
     }
-}
 
-@media all and (max-width: 576px) {
     .videoOsdBottom .paper-icon-button-light {
         margin: 0;
     }
@@ -273,9 +257,7 @@
     .osdMediaStatus span {
         display: none !important;
     }
-}
 
-@media all and (max-width: 768px) {
     .videoOsdBottom .btnFastForward,
     .videoOsdBottom .btnRewind {
         display: none !important;
@@ -285,5 +267,19 @@
 @media all and (max-width: 1200px) {
     .videoOsdBottom .endsAtText {
         display: none !important;
+    }
+}
+
+@media all and (max-height: 768px) and (orientation: landscape) {
+    .chapterThumb {
+        height: 30vh;
+        min-width: 30vh;
+    }
+}
+
+@media all and (orientation: portrait) {
+    .chapterThumb {
+        height: 30vw;
+        min-width: 30vw;
     }
 }

--- a/src/components/alphaPicker/style.css
+++ b/src/components/alphaPicker/style.css
@@ -43,7 +43,7 @@
     flex-grow: 1;
 }
 
-@media all and (max-height: 50em) {
+@media all and (max-height: 768px) {
     .alphaPicker-fixed {
         bottom: 5em;
     }
@@ -54,13 +54,13 @@
     }
 }
 
-@media all and (max-height: 49em) {
+@media all and (max-height: 768px) {
     .alphaPicker-vertical {
         font-size: 94%;
     }
 }
 
-@media all and (max-height: 44em) {
+@media all and (max-height: 768px) {
     .alphaPicker-vertical {
         font-size: 90%;
     }
@@ -111,13 +111,13 @@
     right: 0.4em;
 }
 
-@media all and (min-width: 62.5em) {
+@media all and (min-width: 992px) {
     .alphaPicker-fixed-right {
         right: 1em;
     }
 }
 
-@media all and (max-height: 31.25em) {
+@media all and (max-height: 500px) {
     .alphaPicker-fixed {
         display: none !important;
     }

--- a/src/components/alphaPicker/style.css
+++ b/src/components/alphaPicker/style.css
@@ -43,46 +43,6 @@
     flex-grow: 1;
 }
 
-@media all and (max-height: 768px) {
-    .alphaPicker-fixed {
-        bottom: 5em;
-    }
-
-    .alphaPickerButton-vertical {
-        padding-top: 1px !important;
-        padding-bottom: 1px !important;
-    }
-}
-
-@media all and (max-height: 768px) {
-    .alphaPicker-vertical {
-        font-size: 94%;
-    }
-}
-
-@media all and (max-height: 768px) {
-    .alphaPicker-vertical {
-        font-size: 90%;
-    }
-
-    .alphaPickerButton-vertical {
-        padding-top: 0 !important;
-        padding-bottom: 0 !important;
-    }
-}
-
-@media all and (max-height: 37em) {
-    .alphaPicker-vertical {
-        font-size: 82%;
-    }
-}
-
-@media all and (max-height: 32em) {
-    .alphaPicker-vertical {
-        font-size: 74%;
-    }
-}
-
 .alphaPicker-vertical.alphaPicker-tv {
     font-size: 86%;
 }
@@ -109,6 +69,27 @@
 
 .alphaPicker-fixed-right {
     right: 0.4em;
+}
+
+@media all and (max-height: 576px) {
+    .alphaPicker-vertical {
+        font-size: 82%;
+    }
+}
+
+@media all and (max-height: 768px) {
+    .alphaPicker-fixed {
+        bottom: 5em;
+    }
+
+    .alphaPicker-vertical {
+        font-size: 90%;
+    }
+
+    .alphaPickerButton-vertical {
+        padding-top: 0 !important;
+        padding-bottom: 0 !important;
+    }
 }
 
 @media all and (min-width: 992px) {

--- a/src/components/cardbuilder/card.css
+++ b/src/components/cardbuilder/card.css
@@ -120,7 +120,7 @@ button::-moz-focus-inner {
     margin-bottom: 1.8em !important;
 }
 
-@media (max-width: 50em) {
+@media (max-width: 768px) {
     .cardBox-bottompadded {
         margin-bottom: 1.2em !important;
     }
@@ -541,7 +541,7 @@ button::-moz-focus-inner {
     }
 }
 
-@media (min-width: 75em) {
+@media (min-width: 1200px) {
     .backdropCard {
         width: 25%;
     }
@@ -701,7 +701,7 @@ button::-moz-focus-inner {
     }
 }
 
-@media (min-width: 75em) {
+@media (min-width: 1200px) {
     .overflowBackdropCard,
     .overflowSmallBackdropCard {
         width: 23.1vw;

--- a/src/components/dialogHelper/dialoghelper.css
+++ b/src/components/dialogHelper/dialoghelper.css
@@ -112,24 +112,6 @@
     }
 }
 
-@media all and (max-width: 1280px), all and (max-height: 720px) {
-    .dialog-fixedSize,
-    .dialog-fullscreen-lowres {
-        position: fixed !important;
-        top: 0 !important;
-        bottom: 0 !important;
-        left: 0 !important;
-        right: 0 !important;
-        margin: 0 !important;
-        box-shadow: none;
-    }
-
-    .dialog-small {
-        width: 60%;
-        height: 80%;
-    }
-}
-
 .noScroll {
     overflow-x: hidden !important;
     overflow-y: hidden !important;
@@ -151,4 +133,22 @@
 
 .dialogBackdropOpened {
     opacity: 0.5;
+}
+
+@media all and (max-width: 1280px), all and (max-height: 720px) {
+    .dialog-fixedSize,
+    .dialog-fullscreen-lowres {
+        position: fixed !important;
+        top: 0 !important;
+        bottom: 0 !important;
+        left: 0 !important;
+        right: 0 !important;
+        margin: 0 !important;
+        box-shadow: none;
+    }
+
+    .dialog-small {
+        width: 60%;
+        height: 80%;
+    }
 }

--- a/src/components/dialogHelper/dialoghelper.css
+++ b/src/components/dialogHelper/dialoghelper.css
@@ -112,7 +112,7 @@
     }
 }
 
-@media all and (max-width: 80em), all and (max-height: 45em) {
+@media all and (max-width: 1280px), all and (max-height: 720px) {
     .dialog-fixedSize,
     .dialog-fullscreen-lowres {
         position: fixed !important;
@@ -123,9 +123,7 @@
         margin: 0 !important;
         box-shadow: none;
     }
-}
 
-@media all and (min-width: 80em) and (min-height: 45em) {
     .dialog-small {
         width: 60%;
         height: 80%;

--- a/src/components/formdialog.css
+++ b/src/components/formdialog.css
@@ -106,7 +106,7 @@
     padding-right: 2em;
 }
 
-@media all and (min-width: 50em) {
+@media all and (min-width: 768px) {
     .formDialogFooterItem {
         max-width: 80%;
     }
@@ -117,7 +117,7 @@
     }
 }
 
-@media all and (min-width: 80em) {
+@media all and (min-width: 1200px) {
     .formDialogFooterItem {
         max-width: 70%;
     }

--- a/src/components/guide/guide.css
+++ b/src/components/guide/guide.css
@@ -96,27 +96,6 @@
     width: 1800vw;
 }
 
-@media all and (min-width: 576px) {
-    .channelPrograms,
-    .timeslotHeadersInner {
-        width: 1400vw;
-    }
-}
-
-@media all and (min-width: 768px) {
-    .channelPrograms,
-    .timeslotHeadersInner {
-        width: 1200vw;
-    }
-}
-
-@media all and (min-width: 1200px) {
-    .channelPrograms,
-    .timeslotHeadersInner {
-        width: 810vw;
-    }
-}
-
 .timeslotHeader {
     display: inline-flex;
     align-items: center;
@@ -171,27 +150,6 @@
     width: 24vw;
 }
 
-@media all and (min-width: 576px) {
-    .channelsContainer,
-    .guide-channelTimeslotHeader {
-        width: 16vw;
-    }
-}
-
-@media all and (min-width: 768px) {
-    .channelsContainer,
-    .guide-channelTimeslotHeader {
-        width: 14vw;
-    }
-}
-
-@media all and (min-width: 1200px) {
-    .channelsContainer,
-    .guide-channelTimeslotHeader {
-        width: 12vw;
-    }
-}
-
 .btnGuideViewSettings {
     margin: 0;
     flex-shrink: 0;
@@ -203,15 +161,6 @@
 
 .selectDateIcon {
     flex-shrink: 0;
-}
-
-@media all and (max-width: 768px) {
-    .newTvProgram,
-    .liveTvProgram,
-    .premiereTvProgram,
-    .guideHdIcon {
-        display: none;
-    }
 }
 
 .channelPrograms + .channelPrograms,
@@ -347,22 +296,6 @@
     background-position: right center;
 }
 
-@media all and (min-width: 992px) {
-    .guideChannelName {
-        max-width: 40%;
-    }
-}
-
-@media all and (max-width: 992px) {
-    .guideChannelNumber {
-        display: none;
-    }
-
-    .guideChannelImage {
-        width: 70%;
-    }
-}
-
 .channelsContainer {
     display: flex;
     flex-shrink: 0;
@@ -419,4 +352,65 @@
 .guide-date-tab-button.show-focus:focus {
     border-radius: 0.15em !important;
     transform: none !important;
+}
+
+@media all and (min-width: 576px) {
+    .channelPrograms,
+    .timeslotHeadersInner {
+        width: 1400vw;
+    }
+
+    .channelsContainer,
+    .guide-channelTimeslotHeader {
+        width: 16vw;
+    }
+}
+
+@media all and (min-width: 768px) {
+    .channelsContainer,
+    .guide-channelTimeslotHeader {
+        width: 14vw;
+    }
+
+    .channelPrograms,
+    .timeslotHeadersInner {
+        width: 1200vw;
+    }
+}
+
+@media all and (max-width: 768px) {
+    .newTvProgram,
+    .liveTvProgram,
+    .premiereTvProgram,
+    .guideHdIcon {
+        display: none;
+    }
+}
+
+@media all and (min-width: 992px) {
+    .guideChannelName {
+        max-width: 40%;
+    }
+}
+
+@media all and (max-width: 992px) {
+    .guideChannelNumber {
+        display: none;
+    }
+
+    .guideChannelImage {
+        width: 70%;
+    }
+}
+
+@media all and (min-width: 1200px) {
+    .channelsContainer,
+    .guide-channelTimeslotHeader {
+        width: 12vw;
+    }
+
+    .channelPrograms,
+    .timeslotHeadersInner {
+        width: 810vw;
+    }
 }

--- a/src/components/guide/guide.css
+++ b/src/components/guide/guide.css
@@ -96,21 +96,21 @@
     width: 1800vw;
 }
 
-@media all and (min-width: 37.5em) {
+@media all and (min-width: 576px) {
     .channelPrograms,
     .timeslotHeadersInner {
         width: 1400vw;
     }
 }
 
-@media all and (min-width: 50em) {
+@media all and (min-width: 768px) {
     .channelPrograms,
     .timeslotHeadersInner {
         width: 1200vw;
     }
 }
 
-@media all and (min-width: 80em) {
+@media all and (min-width: 1200px) {
     .channelPrograms,
     .timeslotHeadersInner {
         width: 810vw;
@@ -171,28 +171,21 @@
     width: 24vw;
 }
 
-@media all and (min-width: 31.25em) {
+@media all and (min-width: 576px) {
     .channelsContainer,
     .guide-channelTimeslotHeader {
         width: 16vw;
     }
 }
 
-@media all and (min-width: 37.5em) {
-    .channelsContainer,
-    .guide-channelTimeslotHeader {
-        width: 16vw;
-    }
-}
-
-@media all and (min-width: 50em) {
+@media all and (min-width: 768px) {
     .channelsContainer,
     .guide-channelTimeslotHeader {
         width: 14vw;
     }
 }
 
-@media all and (min-width: 80em) {
+@media all and (min-width: 1200px) {
     .channelsContainer,
     .guide-channelTimeslotHeader {
         width: 12vw;
@@ -212,7 +205,7 @@
     flex-shrink: 0;
 }
 
-@media all and (max-width: 50em) {
+@media all and (max-width: 768px) {
     .newTvProgram,
     .liveTvProgram,
     .premiereTvProgram,
@@ -354,13 +347,13 @@
     background-position: right center;
 }
 
-@media all and (min-width: 62.5em) {
+@media all and (min-width: 992px) {
     .guideChannelName {
         max-width: 40%;
     }
 }
 
-@media all and (max-width: 62.5em) {
+@media all and (max-width: 992px) {
     .guideChannelNumber {
         display: none;
     }
@@ -395,12 +388,6 @@
     flex-shrink: 0;
     display: flex;
     align-items: center;
-}
-
-@media all and (max-width: 50em), all and (max-height: 37.5em) {
-    .tvGuideHeader {
-        padding-left: 0;
-    }
 }
 
 .guideRequiresUnlock {

--- a/src/components/homesections/homesections.css
+++ b/src/components/homesections/homesections.css
@@ -3,12 +3,6 @@
     margin: 0.5em !important;
 }
 
-@media all and (max-width: 768px) {
-    .homeLibraryButton {
-        width: 46% !important;
-    }
-}
-
 .homeLibraryIcon {
     margin-left: 0.5em;
     margin-right: 0.5em;
@@ -21,4 +15,10 @@
     -o-text-overflow: ellipsis;
     text-overflow: ellipsis;
     overflow: hidden;
+}
+
+@media all and (max-width: 768px) {
+    .homeLibraryButton {
+        width: 46% !important;
+    }
 }

--- a/src/components/homesections/homesections.css
+++ b/src/components/homesections/homesections.css
@@ -3,7 +3,7 @@
     margin: 0.5em !important;
 }
 
-@media all and (max-width: 50em) {
+@media all and (max-width: 768px) {
     .homeLibraryButton {
         width: 46% !important;
     }

--- a/src/components/listview/listview.css
+++ b/src/components/listview/listview.css
@@ -164,7 +164,7 @@
     padding: 0.2em;
 }
 
-@media all and (max-width: 64em) {
+@media all and (max-width: 992px) {
     .listItemImage-large {
         width: 22vw;
         height: 16vw;
@@ -256,7 +256,7 @@
     margin-top: 0.2em;
 }
 
-@media all and (max-width: 50em) {
+@media all and (max-width: 768px) {
     .listItem .endsAt,
     .listItem .criticRating,
     .listItem-overview {
@@ -264,7 +264,7 @@
     }
 }
 
-@media all and (min-width: 50em) {
+@media all and (min-width: 768px) {
     .listItem-bottomoverview {
         display: none !important;
     }

--- a/src/components/listview/listview.css
+++ b/src/components/listview/listview.css
@@ -164,29 +164,6 @@
     padding: 0.2em;
 }
 
-@media all and (max-width: 992px) {
-    .listItemImage-large {
-        width: 22vw;
-        height: 16vw;
-        margin-right: 0 !important;
-    }
-
-    .listItemIndicators,
-    .listItemImageButton {
-        font-size: 0.6em !important;
-    }
-
-    .listItemBody {
-        padding-left: 0.75em;
-    }
-}
-
-@media all and (max-width: 50em) {
-    .listItemBody {
-        padding-right: 0.5em;
-    }
-}
-
 .listItemImage-large-tv {
     width: 30vw !important;
     height: 20vw !important;
@@ -256,11 +233,19 @@
     margin-top: 0.2em;
 }
 
+.listItemCheckboxContainer {
+    width: auto !important;
+}
+
 @media all and (max-width: 768px) {
     .listItem .endsAt,
     .listItem .criticRating,
     .listItem-overview {
         display: none !important;
+    }
+
+    .listItemBody {
+        padding-right: 0.5em;
     }
 }
 
@@ -270,6 +255,19 @@
     }
 }
 
-.listItemCheckboxContainer {
-    width: auto !important;
+@media all and (max-width: 992px) {
+    .listItemImage-large {
+        width: 22vw;
+        height: 16vw;
+        margin-right: 0 !important;
+    }
+
+    .listItemIndicators,
+    .listItemImageButton {
+        font-size: 0.6em !important;
+    }
+
+    .listItemBody {
+        padding-left: 0.75em;
+    }
 }

--- a/src/components/nowPlayingBar/nowPlayingBar.css
+++ b/src/components/nowPlayingBar/nowPlayingBar.css
@@ -121,33 +121,6 @@
     height: 1.2em !important;
 }
 
-@media all and (max-width: 1200px) {
-    .nowPlayingBarRight .nowPlayingBarUserDataButtons {
-        display: none;
-    }
-}
-
-@media all and (max-width: 992px) {
-    .toggleRepeatButton {
-        display: none !important;
-    }
-
-    .nowPlayingBar .btnShuffleQueue {
-        display: none !important;
-    }
-}
-
-@media all and (max-width: 1200px) {
-    .nowPlayingBarCenter .nowPlayingBarCurrentTime,
-    .nowPlayingBarCenter .stopButton {
-        display: none !important;
-    }
-
-    .nowPlayingBarInfoContainer {
-        width: 45%;
-    }
-}
-
 .layout-mobile .nowPlayingBarRight button:not(.playPauseButton, .nextTrackButton) {
     display: none;
 }
@@ -163,12 +136,18 @@
 }
 
 @media all and (max-width: 992px) {
+    .toggleRepeatButton {
+        display: none !important;
+    }
+
+    .nowPlayingBar .btnShuffleQueue {
+        display: none !important;
+    }
+
     .nowPlayingBarCenter {
         display: none !important;
     }
-}
 
-@media all and (max-width: 992px) {
     .nowPlayingBarRight .nowPlayingBarVolumeSliderContainer {
         display: none !important;
     }
@@ -178,9 +157,17 @@
     }
 }
 
-@media all and (max-width: 24em) {
-    .nowPlayingBar .muteButton,
-    .nowPlayingBar .unmuteButton {
+@media all and (max-width: 1200px) {
+    .nowPlayingBarCenter .nowPlayingBarCurrentTime,
+    .nowPlayingBarCenter .stopButton {
+        display: none !important;
+    }
+
+    .nowPlayingBarInfoContainer {
+        width: 45%;
+    }
+
+    .nowPlayingBarRight .nowPlayingBarUserDataButtons {
         display: none;
     }
 }

--- a/src/components/nowPlayingBar/nowPlayingBar.css
+++ b/src/components/nowPlayingBar/nowPlayingBar.css
@@ -121,13 +121,13 @@
     height: 1.2em !important;
 }
 
-@media all and (max-width: 70em) {
+@media all and (max-width: 1200px) {
     .nowPlayingBarRight .nowPlayingBarUserDataButtons {
         display: none;
     }
 }
 
-@media all and (max-width: 66em) {
+@media all and (max-width: 992px) {
     .toggleRepeatButton {
         display: none !important;
     }
@@ -137,7 +137,7 @@
     }
 }
 
-@media all and (max-width: 80em) {
+@media all and (max-width: 1200px) {
     .nowPlayingBarCenter .nowPlayingBarCurrentTime,
     .nowPlayingBarCenter .stopButton {
         display: none !important;
@@ -162,13 +162,13 @@
     display: none;
 }
 
-@media all and (max-width: 56em) {
+@media all and (max-width: 992px) {
     .nowPlayingBarCenter {
         display: none !important;
     }
 }
 
-@media all and (max-width: 60em) {
+@media all and (max-width: 992px) {
     .nowPlayingBarRight .nowPlayingBarVolumeSliderContainer {
         display: none !important;
     }

--- a/src/components/remotecontrol/remotecontrol.css
+++ b/src/components/remotecontrol/remotecontrol.css
@@ -257,16 +257,41 @@
     display: none;
 }
 
-@media all and (min-width: 992px) {
-    .nowPlayingPage {
-        padding: 8em 0 0 0 !important;
-    }
+.nowPlayingTime {
+    display: flex;
+    -webkit-box-align: center;
+    -webkit-align-items: center;
+    align-items: center;
+    margin: 0 1em;
 }
 
-@media all and (min-width: 1200px) {
-    .nowPlayingPageImageContainer {
-        margin-right: 0.75em;
-    }
+.nowPlayingNavButtonContainer {
+    width: 30em;
+}
+
+.smallBackdropPosterItem .cardOverlayInner > div {
+    white-space: nowrap;
+    -o-text-overflow: ellipsis;
+    text-overflow: ellipsis;
+    overflow: hidden;
+}
+
+.playlistIndexIndicatorImage {
+    -webkit-background-size: initial initial !important;
+    background-size: initial !important;
+    background-image: url(../../assets/img/equalizer.gif) !important;
+}
+
+.playlistIndexIndicatorImage > * {
+    display: none;
+}
+
+.hideVideoButtons .videoButton {
+    display: none;
+}
+
+.nowPlayingVolumeSliderContainer {
+    width: 9em;
 }
 
 @media all and (orientation: portrait) and (max-width: 768px) {
@@ -430,43 +455,6 @@
     }
 }
 
-.nowPlayingTime {
-    display: flex;
-    -webkit-box-align: center;
-    -webkit-align-items: center;
-    align-items: center;
-    margin: 0 1em;
-}
-
-.nowPlayingNavButtonContainer {
-    width: 30em;
-}
-
-.smallBackdropPosterItem .cardOverlayInner > div {
-    white-space: nowrap;
-    -o-text-overflow: ellipsis;
-    text-overflow: ellipsis;
-    overflow: hidden;
-}
-
-.playlistIndexIndicatorImage {
-    -webkit-background-size: initial initial !important;
-    background-size: initial !important;
-    background-image: url(../../assets/img/equalizer.gif) !important;
-}
-
-.playlistIndexIndicatorImage > * {
-    display: none;
-}
-
-.hideVideoButtons .videoButton {
-    display: none;
-}
-
-.nowPlayingVolumeSliderContainer {
-    width: 9em;
-}
-
 @media all and (max-width: 992px) {
     .nowPlayingSecondaryButtons .repeatToggleButton,
     .nowPlayingInfoButtons .playlist .listItemMediaInfo,
@@ -476,5 +464,17 @@
 
     .navigationSection .collapseContent .material-icons {
         font-size: 4em;
+    }
+}
+
+@media all and (min-width: 992px) {
+    .nowPlayingPage {
+        padding: 8em 0 0 0 !important;
+    }
+}
+
+@media all and (min-width: 1200px) {
+    .nowPlayingPageImageContainer {
+        margin-right: 0.75em;
     }
 }

--- a/src/components/remotecontrol/remotecontrol.css
+++ b/src/components/remotecontrol/remotecontrol.css
@@ -257,19 +257,19 @@
     display: none;
 }
 
-@media all and (min-width: 63em) {
+@media all and (min-width: 992px) {
     .nowPlayingPage {
         padding: 8em 0 0 0 !important;
     }
 }
 
-@media all and (min-width: 80em) {
+@media all and (min-width: 1200px) {
     .nowPlayingPageImageContainer {
         margin-right: 0.75em;
     }
 }
 
-@media all and (orientation: portrait) and (max-width: 43em) {
+@media all and (orientation: portrait) and (max-width: 768px) {
     .remoteControlContent {
         padding-left: 7.3% !important;
         padding-right: 7.3% !important;
@@ -467,7 +467,7 @@
     width: 9em;
 }
 
-@media all and (max-width: 63em) {
+@media all and (max-width: 992px) {
     .nowPlayingSecondaryButtons .repeatToggleButton,
     .nowPlayingInfoButtons .playlist .listItemMediaInfo,
     .nowPlayingInfoButtons .btnStop {

--- a/src/components/upnextdialog/upnextdialog.css
+++ b/src/components/upnextdialog/upnextdialog.css
@@ -36,25 +36,6 @@
     color: #fff;
 }
 
-@media all and (orientation: landscape) {
-    .upNextDialog {
-        flex-direction: row;
-    }
-
-    .upNextDialog-poster {
-        max-width: initial;
-        max-height: initial;
-        width: 10%;
-        margin-bottom: 0;
-    }
-}
-
-@media all and (max-width: 768px) {
-    .upNextDialog-overview {
-        display: none !important;
-    }
-}
-
 .upNextDialog-poster-img {
     position: absolute;
     bottom: 0;
@@ -70,4 +51,23 @@
     -webkit-user-drag: none;
     -webkit-user-select: none;
     -ms-user-select: none;
+}
+
+@media all and (max-width: 768px) {
+    .upNextDialog-overview {
+        display: none !important;
+    }
+}
+
+@media all and (orientation: landscape) {
+    .upNextDialog {
+        flex-direction: row;
+    }
+
+    .upNextDialog-poster {
+        max-width: initial;
+        max-height: initial;
+        width: 10%;
+        margin-bottom: 0;
+    }
 }

--- a/src/components/upnextdialog/upnextdialog.css
+++ b/src/components/upnextdialog/upnextdialog.css
@@ -49,7 +49,7 @@
     }
 }
 
-@media all and (max-width: 50em) {
+@media all and (max-width: 768px) {
     .upNextDialog-overview {
         display: none !important;
     }

--- a/src/index.html
+++ b/src/index.html
@@ -137,8 +137,7 @@
         }
 
         @media screen
-            and (min-device-width: 992px)
-            and (-webkit-min-device-pixel-ratio: 1) {
+            and (min-device-width: 992px) {
             .splashLogo {
                 background-image: url(assets/img/banner-light.png);
             }

--- a/src/music.html
+++ b/src/music.html
@@ -1,8 +1,7 @@
 <div id="musicRecommendedPage" data-dom-cache="true" data-role="page" class="page libraryPage backdropPage pageWithAbsoluteTabs withTabs" data-backdroptype="musicartist">
 
     <style>
-        @media all and (max-width: 32em) {
-
+        @media all and (max-width: 576px) {
             .paging {
                 width: 100%;
             }

--- a/src/themes/blueradiance/theme.css
+++ b/src/themes/blueradiance/theme.css
@@ -58,12 +58,6 @@ html {
     opacity: 0.86;
 }
 
-@media (orientation: portrait) {
-    .backgroundContainer {
-        background-position: 30% top;
-    }
-}
-
 .paper-icon-button-light:hover:not(:disabled) {
     color: #00a4dc;
     background-color: rgba(0, 164, 220, 0.2);
@@ -481,4 +475,10 @@ html {
 
 .metadataSidebarIcon {
     color: #00a4dc;
+}
+
+@media (orientation: portrait) {
+    .backgroundContainer {
+        background-position: 30% top;
+    }
 }

--- a/src/themes/purplehaze/theme.css
+++ b/src/themes/purplehaze/theme.css
@@ -53,12 +53,6 @@ html {
     opacity: 0.86;
 }
 
-@media (orientation: portrait) {
-    .backgroundContainer {
-        background-position: 30% top;
-    }
-}
-
 .paper-icon-button-light:hover:not(:disabled) {
     color: rgb(12, 232, 214);
     background-color: rgba(0, 164, 220, 0.2);
@@ -628,4 +622,10 @@ a[data-role=button] {
     padding-bottom: 100%;
     contain: strict;
     border-radius: 50% !important;
+}
+
+@media (orientation: portrait) {
+    .backgroundContainer {
+        background-position: 30% top;
+    }
 }


### PR DESCRIPTION
**Changes**

This starts implementing the improvements discussed in [this post](https://github.com/jellyfin/jellyfin-web/issues/836#issuecomment-654989680).

A few things are done:

* **Replace most existing breakpoints with the ones listed in the post linked above**
  The method used to select the proper replacement is to multiply the existing value by 16 (The number of pixels in 1em for media queries) then pick the closest one. In some cases, an arbitrary choice is made depending on the intended devices.
* **Remove obsolete queries**
  I spotted one or two queries that resolved to 800x600, which doesn't make sense in this day and age. They've been removed.
* **Merge duplicate queries (in progress)**
  In keeping with the idea of a "mobile-first" approach to design (which is common nowadays), this PR moves all the queries to the end of their files. Eventually, the goal is to rewrite the CSS to define the mobile layout first, then override it for different resolutions without relying too much on the `layout-mobile` class.
* **Minor changes to existing style**
  To start reaping the benefits of this change immediately, a few minor edits have been made to the existing style. It mostly amounts to changing some properties on some specific breakpoints or hiding elements at different resolutions.

**Issues**

Not really an issue, but worth a mention: the card sizes are a goddamn mess. They've been left largely untouched, due to needed some changes in JS code as well as CSS. They'll get a cleanup in a future PR.
