### PR TITLE
Remove extraneous pageContainer element from videoOSD

### DIFF
--- a/src/assets/css/videoosd.css
+++ b/src/assets/css/videoosd.css
@@ -7,7 +7,6 @@
 }
 
 .osdPoster img,
-.pageContainer,
 .videoOsdBottom {
     bottom: 0;
     left: 0;
@@ -246,11 +245,6 @@
     -webkit-animation: spin 4s linear infinite;
     -moz-animation: spin 4s linear infinite;
     animation: spin 4s linear infinite;
-}
-
-.pageContainer {
-    top: 0;
-    position: fixed;
 }
 
 @media all and (max-width: 30em) {

--- a/src/controllers/playback/video/index.html
+++ b/src/controllers/playback/video/index.html
@@ -1,5 +1,4 @@
 <div id="videoOsdPage" data-role="page" class="page libraryPage" data-backbutton="true">
-    <div class="pageContainer flex"></div>
     <div class="upNextContainer hide"></div>
     <div class="videoOsdBottom videoOsdBottom-maincontrols">
         <div class="osdPoster"></div>


### PR DESCRIPTION
**Changes**
Removes the pageContainer element - there are some remaining references to pageContainer within styles, but that may be necessary for the pageContainer in the server selection page.

**Issues**
Fixes #1786 