### PR TITLE
Fix themes not loading unless signed in

### DIFF
--- a/src/scripts/autoThemes.js
+++ b/src/scripts/autoThemes.js
@@ -3,6 +3,10 @@ import skinManager from 'skinManager';
 import connectionManager from 'connectionManager';
 import events from 'events';
 
+// Set the default theme when loading
+skinManager.setTheme(userSettings.theme());
+
+// Set the user's prefered theme when signing in
 events.on(connectionManager, 'localusersignedin', function (e, user) {
     skinManager.setTheme(userSettings.theme());
 });

--- a/src/scripts/settings/webSettings.js
+++ b/src/scripts/settings/webSettings.js
@@ -1,21 +1,41 @@
+
 let data;
 
-function getConfig() {
+async function getConfig() {
     if (data) return Promise.resolve(data);
-    return fetch('config.json?nocache=' + new Date().getUTCMilliseconds()).then(response => {
-        data = response.json();
+    try {
+        const response = await fetch('config.json', {
+            cache: 'no-cache'
+        });
+
+        if (!response.ok) {
+            throw new Error('network response was not ok');
+        }
+
+        data = await response.json();
+
         return data;
-    }).catch(error => {
-        console.warn('web config file is missing so the template will be used');
+    } catch (error) {
+        console.warn('failed to fetch the web config file:', error);
         return getDefaultConfig();
-    });
+    }
 }
 
-function getDefaultConfig() {
-    return fetch('config.template.json').then(function (response) {
+async function getDefaultConfig() {
+    try {
+        const response = await fetch('config.template.json', {
+            cache: 'no-cache'
+        });
+
+        if (!response.ok) {
+            throw new Error('network response was not ok');
+        }
+
         data = response.json();
         return data;
-    });
+    } catch (error) {
+        console.error('failed to fetch the default web config file:', error);
+    }
 }
 
 export function getMultiServer() {
@@ -29,6 +49,7 @@ export function getMultiServer() {
 
 export function getThemes() {
     return getConfig().then(config => {
+        console.warn(config.themes);
         return config.themes;
     }).catch(error => {
         console.log('cannot get web config:', error);

--- a/src/scripts/settings/webSettings.js
+++ b/src/scripts/settings/webSettings.js
@@ -1,4 +1,3 @@
-
 let data;
 
 async function getConfig() {

--- a/src/scripts/settings/webSettings.js
+++ b/src/scripts/settings/webSettings.js
@@ -31,7 +31,7 @@ async function getDefaultConfig() {
             throw new Error('network response was not ok');
         }
 
-        data = response.json();
+        data = await response.json();
         return data;
     } catch (error) {
         console.error('failed to fetch the default web config file:', error);
@@ -49,7 +49,6 @@ export function getMultiServer() {
 
 export function getThemes() {
     return getConfig().then(config => {
-        console.warn(config.themes);
         return config.themes;
     }).catch(error => {
         console.log('cannot get web config:', error);


### PR DESCRIPTION
**Changes**

autoTheme was only setting a theme when a user logs in.

This loads a theme once the autoTheme is loaded up, in addition to registering the event like before.

It also updates the syntax of parts of webSettings to use async/await, and adds checks for the cases where the fetch results are not good.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
