### PR TITLE
Hitting space to check/uncheck checkboxes doesn't work on firefox

### DIFF
--- a/src/elements/emby-checkbox/emby-checkbox.js
+++ b/src/elements/emby-checkbox/emby-checkbox.js
@@ -10,8 +10,10 @@ import 'webcomponents';
     function onKeyDown(e) {
         // Don't submit form on enter
         // Real (non-emulator) Tizen does nothing on Space
-        if (e.keyCode === 13 || e.keyCode === 32) {
+        if ((e.keyCode === 13 || e.keyCode === 32) && !browser.firefox) {
             e.preventDefault();
+
+            this.checked = !this.checked;
 
             this.dispatchEvent(new CustomEvent('change', {
                 bubbles: true

--- a/src/elements/emby-checkbox/emby-checkbox.js
+++ b/src/elements/emby-checkbox/emby-checkbox.js
@@ -10,7 +10,7 @@ import 'webcomponents';
     function onKeyDown(e) {
         // Don't submit form on enter
         // Real (non-emulator) Tizen does nothing on Space
-        if ((e.keyCode === 13 || e.keyCode === 32) && !browser.firefox) {
+        if (e.keyCode === 13 || (e.keyCode === 32 && browser.tizen)) {
             e.preventDefault();
 
             this.checked = !this.checked;

--- a/src/elements/emby-checkbox/emby-checkbox.js
+++ b/src/elements/emby-checkbox/emby-checkbox.js
@@ -13,8 +13,6 @@ import 'webcomponents';
         if (e.keyCode === 13 || e.keyCode === 32) {
             e.preventDefault();
 
-            this.checked = !this.checked;
-
             this.dispatchEvent(new CustomEvent('change', {
                 bubbles: true
             }));

--- a/src/elements/emby-radio/emby-radio.js
+++ b/src/elements/emby-radio/emby-radio.js
@@ -9,7 +9,7 @@ import 'webcomponents';
     function onKeyDown(e) {
         // Don't submit form on enter
         // Real (non-emulator) Tizen does nothing on Space
-        if (e.keyCode === 13 || e.keyCode === 32) {
+        if (e.keyCode === 13 || (e.keyCode === 32 && browser.tizen)) {
             e.preventDefault();
 
             if (!this.checked) {

--- a/src/elements/emby-radio/emby-radio.js
+++ b/src/elements/emby-radio/emby-radio.js
@@ -1,6 +1,7 @@
 import layoutManager from 'layoutManager';
 import 'css!./emby-radio';
 import 'webcomponents';
+import browser from 'browser';
 
 /* eslint-disable indent */
 


### PR DESCRIPTION
**Changes**
It seems like checking/unchecking behaviour is already working correctly on the Firefox.
So when `this.checked = !this.checked` was called it just reset the checkbox to previous value.

**Issues**
Solves #1797