### PR TITLE
Reorder CSS loading

### DIFF
--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -384,11 +384,15 @@ function initClient() {
                             return response.text();
                         })
                         .then(function(css) {
-                            // Inject the branding css as a dom element in body so it will take
-                            // precedence over other stylesheets
-                            var style = document.createElement('style');
-                            style.appendChild(document.createTextNode(css));
-                            document.body.appendChild(style);
+                            let style = document.querySelector('#cssBranding');
+                            if (!style) {
+                                // Inject the branding css as a dom element in body so it will take
+                                // precedence over other stylesheets
+                                style = document.createElement('style');
+                                style.id = 'cssBranding';
+                                document.body.appendChild(style);
+                            }
+                            style.textContent = css;
                         })
                         .catch(function(err) {
                             console.warn('Error applying custom css', err);

--- a/src/scripts/themeManager.js
+++ b/src/scripts/themeManager.js
@@ -1,13 +1,12 @@
 import * as webSettings from 'webSettings';
 
-var themeStyleElement;
+var themeStyleElement = document.querySelector('#cssTheme');
 var currentThemeId;
 
 function unloadTheme() {
     var elem = themeStyleElement;
     if (elem) {
-        elem.parentNode.removeChild(elem);
-        themeStyleElement = null;
+        elem.removeAttribute('href');
         currentThemeId = null;
     }
 }
@@ -45,15 +44,26 @@ function setTheme(id) {
             var linkUrl = info.stylesheetPath;
             unloadTheme();
 
-            var link = document.createElement('link');
-            link.setAttribute('rel', 'stylesheet');
-            link.setAttribute('type', 'text/css');
-            link.onload = function () {
+            let link = themeStyleElement;
+
+            if (!link) {
+                // Inject the theme css as a dom element in body so it will take
+                // precedence over other stylesheets
+                link = document.createElement('link');
+                link.id = 'cssTheme';
+                link.setAttribute('rel', 'stylesheet');
+                link.setAttribute('type', 'text/css');
+                document.body.appendChild(link);
+            }
+
+            const onLoad = function (e) {
+                e.target.removeEventListener('load', onLoad);
                 resolve();
             };
 
+            link.addEventListener('load', onLoad);
+
             link.setAttribute('href', linkUrl);
-            document.head.appendChild(link);
             themeStyleElement = link;
             currentThemeId = info.themeId;
         });


### PR DESCRIPTION
1. Base CSS, element CSS, etc. in head
2. Theme CSS in body
3. Branding CSS in body

It seems to work without placeholders (in `index.html`).
What is better?
- placeholders and remove creation
- no placeholder for branding CSS - will be appended
- no placeholders

**Changes**
Reorder CSS loading

**Issues**
White navdrawer.
_In fact, this can be fixed by removing `background-color` for `touch-menu-la`._

I am not sure, but this approach might help to reload theme without full reload.