### PR TITLE
Fix non-ES6 import [10.6.z]

### DIFF
--- a/src/controllers/dashboard/plugins/add.js
+++ b/src/controllers/dashboard/plugins/add.js
@@ -66,7 +66,7 @@ define(['jQuery', 'loading', 'libraryMenu', 'globalize', 'connectionManager', 'e
     }
 
     function alertText(options) {
-        require(['alert'], function ({default: alert}) {
+        require(['alert'], function (alert) {
             alert(options);
         });
     }


### PR DESCRIPTION
Error after backporting of #1656

**Changes**
Fix non-ES6 import

**Issues**
Runtime error in web - no alert to restart the server.
