### PR TITLE
Fix tabs always focusing the active tab in TV layout

### DIFF
--- a/src/elements/emby-tabs/emby-tabs.js
+++ b/src/elements/emby-tabs/emby-tabs.js
@@ -12,7 +12,7 @@ import 'scrollStyles';
     const buttonClass = 'emby-tab-button';
     const activeButtonClass = buttonClass + '-active';
 
-    function setActiveTabButton(tabs, newButton, oldButton, animate) {
+    function setActiveTabButton(tabs, newButton) {
         newButton.classList.add(activeButtonClass);
     }
 
@@ -77,7 +77,7 @@ import 'scrollStyles';
 
             const previousIndex = current ? parseInt(current.getAttribute('data-index')) : null;
 
-            setActiveTabButton(tabs, tabButton, current, true);
+            setActiveTabButton(tabs, tabButton);
 
             const index = parseInt(tabButton.getAttribute('data-index'));
 
@@ -99,6 +99,15 @@ import 'scrollStyles';
                 tabs.scroller.toCenter(tabButton, false);
             }
         }
+    }
+
+    function onFocusOut(e) {
+        const parentContainer = e.target.parentNode;
+        const previousFocus = parentContainer.querySelector('.lastFocused');
+        if (previousFocus) {
+            previousFocus.classList.remove('lastFocused');
+        }
+        e.target.classList.add('lastFocused');
     }
 
     function initScroller(tabs) {
@@ -146,13 +155,18 @@ import 'scrollStyles';
         dom.addEventListener(this, 'click', onClick, {
             passive: true
         });
+
+        dom.addEventListener(this, 'focusout', onFocusOut);
     };
 
-    EmbyTabs.focus = function () {
-        const selected = this.querySelector('.' + activeButtonClass);
+    EmbyTabs.focus = function onFocusIn() {
+        const selectedTab = this.querySelector('.' + activeButtonClass);
+        const lastFocused = this.querySelector('.lastFocused');
 
-        if (selected) {
-            focusManager.focus(selected);
+        if (lastFocused) {
+            focusManager.focus(lastFocused);
+        } else if (selectedTab) {
+            focusManager.focus(selectedTab);
         } else {
             focusManager.autoFocus(this);
         }


### PR DESCRIPTION
**Changes**

Fix the weird behavior on tabs when using LRUD navigation.

Previously, the `emby-tabs` element tried to find the currently active tab and selected it by default. If it couldn't find an active tab, it would use autoFocus to find the proper tab to focus (usually the first one).

Now, when moving focus around tabs, the last tab selected will get a specific class applied (they're cleaned up on each move) and the `EmbyTabs.focus` method (Container focus method called when coming from another element) will first look for the last focused tab, then for the active one, then fall back to `autoFocus`.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
