### PR TITLE
Set background color on blurhash image load

### DIFF
--- a/src/components/images/imageLoader.js
+++ b/src/components/images/imageLoader.js
@@ -87,7 +87,9 @@ import 'css!./style';
             requestAnimationFrame(() => {
                 if (elem.tagName !== 'IMG') {
                     elem.style.backgroundImage = "url('" + url + "')";
-                    elem.style.backgroundColor = '#fff';
+                    if (!elem.classList.contains('non-blurhashable')) {
+                        elem.style.backgroundColor = '#fff';
+                    }
                 } else {
                     elem.setAttribute('src', url);
                 }

--- a/src/components/images/imageLoader.js
+++ b/src/components/images/imageLoader.js
@@ -87,7 +87,7 @@ import 'css!./style';
             requestAnimationFrame(() => {
                 if (elem.tagName !== 'IMG') {
                     elem.style.backgroundImage = "url('" + url + "')";
-                    if (!elem.classList.contains('non-blurhashable')) {
+                    if (elem.classList.contains('blurhashed')) {
                         elem.style.backgroundColor = '#fff';
                     }
                 } else {

--- a/src/components/images/imageLoader.js
+++ b/src/components/images/imageLoader.js
@@ -87,6 +87,7 @@ import 'css!./style';
             requestAnimationFrame(() => {
                 if (elem.tagName !== 'IMG') {
                     elem.style.backgroundImage = "url('" + url + "')";
+                    elem.style.backgroundColor = '#fff';
                 } else {
                     elem.setAttribute('src', url);
                 }
@@ -108,6 +109,7 @@ import 'css!./style';
         if (elem.tagName !== 'IMG') {
             url = elem.style.backgroundImage.slice(4, -1).replace(/"/g, '');
             elem.style.backgroundImage = 'none';
+            elem.style.backgroundColor = null;
         } else {
             url = elem.getAttribute('src');
             elem.setAttribute('src', '');


### PR DESCRIPTION
**Changes**
This fixes an issue where images with transparent backgrounds are not well supported by the blurhash loader.

![Screenshot_2020-08-19 Jellyfin](https://user-images.githubusercontent.com/3450688/90667209-777f1400-e21c-11ea-86fa-23547d4d42fd.png)

The blurhash images seem to use white as the background for transparent images, so I set the background color of the image button element to be white when the background image is set and remove it when the image is removed.

**Issues**
N/A
