### PR TITLE
Fix TV channel logo size

### DIFF
--- a/src/components/cardbuilder/card.css
+++ b/src/components/cardbuilder/card.css
@@ -239,33 +239,9 @@ button::-moz-focus-inner {
     border: none;
 }
 
-.cardImage-img {
-    max-height: 100%;
-    max-width: 100%;
-
-    /* This is simply for lazy image purposes, to ensure the image is visible sooner when scrolling */
-    min-height: 70%;
-    min-width: 70%;
-    margin: auto;
-}
-
-.coveredImage-img {
-    width: 100%;
-    height: 100%;
-}
-
-.coveredImage-noscale-img {
-    max-height: none;
-    max-width: none;
-}
-
 .coveredImage {
     background-size: cover;
     background-position: center center;
-}
-
-.coveredImage-noScale {
-    background-size: cover;
 }
 
 .cardFooter {

--- a/src/components/cardbuilder/card.css
+++ b/src/components/cardbuilder/card.css
@@ -244,6 +244,10 @@ button::-moz-focus-inner {
     background-position: center center;
 }
 
+.coveredImage.coveredImage-contain {
+    background-size: contain;
+}
+
 .cardFooter {
     padding: 0.3em 0.3em 0.5em 0.3em;
     position: relative;

--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -1211,10 +1211,6 @@ import 'programStyles';
 
             if (coveredImage) {
                 cardImageContainerClass += ' coveredImage';
-
-                if (item.MediaType === 'Photo' || item.Type === 'PhotoAlbum' || item.Type === 'Folder' || item.ProgramInfo || item.Type === 'Program' || item.Type === 'Recording') {
-                    cardImageContainerClass += ' coveredImage-noScale';
-                }
             }
 
             if (!imgUrl) {

--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -1211,6 +1211,10 @@ import 'programStyles';
 
             if (coveredImage) {
                 cardImageContainerClass += ' coveredImage';
+
+                if (item.Type === 'TvChannel') {
+                    cardImageContainerClass += ' coveredImage-contain';
+                }
             }
 
             if (!imgUrl) {

--- a/src/controllers/session/login/index.js
+++ b/src/controllers/session/login/index.js
@@ -115,11 +115,11 @@ import 'emby-checkbox';
                     tag: user.PrimaryImageTag,
                     type: 'Primary'
                 });
-                html += '<div class="cardImageContainer coveredImage coveredImage-noScale" style="background-image:url(\'' + imgUrl + "');\"></div>";
+                html += '<div class="cardImageContainer coveredImage" style="background-image:url(\'' + imgUrl + "');\"></div>";
             } else {
                 const background = getMetroColor(user.Id);
                 imgUrl = 'assets/img/avatar.png';
-                html += '<div class="cardImageContainer coveredImage coveredImage-noScale" style="background-image:url(\'' + imgUrl + "');background-color:" + background + ';"></div>';
+                html += '<div class="cardImageContainer coveredImage" style="background-image:url(\'' + imgUrl + "');background-color:" + background + ';"></div>';
             }
 
             html += '</div>';


### PR DESCRIPTION
**Changes**
* Removes some unused css
* Removes the `coveredImage-noScale` class since `coveredImage` uses `background-size: cover;` by default
* Uses `background-size: contain;` for TV channel logos to avoid clipping

**Issues**
N/A
