### PR TITLE
Make fallback text on cards less tiny

### DIFF
--- a/src/components/cardbuilder/card.css
+++ b/src/components/cardbuilder/card.css
@@ -372,6 +372,8 @@ button::-moz-focus-inner {
 .cardDefaultText {
     white-space: normal;
     text-align: center;
+    font-size: 2em;
+    font-weight: bold;
 }
 
 .cardImageContainer .cardImageIcon {


### PR DESCRIPTION
**Changes**
Increases the font size and makes it bold for display inside cards when not using an image or icon.

![Screenshot_2020-08-20 Jellyfin(1)](https://user-images.githubusercontent.com/3450688/90808538-2dfef980-e2ee-11ea-8385-4d8af8af612a.png)

**Issues**
N/A
