### PR TITLE
Rework card sizes and breakpoints

### DIFF
--- a/src/components/cardbuilder/card.css
+++ b/src/components/cardbuilder/card.css
@@ -117,12 +117,12 @@ button::-moz-focus-inner {
 }
 
 .cardBox-bottompadded {
-    margin-bottom: 1.8em !important;
+    margin-bottom: 0.6em;
 }
 
 @media (max-width: 50em) {
     .cardBox-bottompadded {
-        margin-bottom: 1.2em !important;
+        margin-bottom: 0.6em;
     }
 }
 
@@ -604,134 +604,40 @@ button::-moz-focus-inner {
     width: 16.666666666666666666666666666667%;
 }
 
-.overflowBackdropCard {
-    width: 72vw;
-}
-
+/* Phone (0px+) */
+.overflowBackdropCard,
 .overflowSmallBackdropCard {
-    width: 72vw;
+    width: calc(100vw / 2 - 0.95em);
 }
 
 .overflowSquareCard,
 .overflowPortraitCard {
-    width: 40vw;
+    width: calc(100vw / 3 - 0.65em);
 }
 
-@media (min-width: 25em) {
-    .overflowPortraitCard {
-        width: 31.2vw;
-    }
-}
-
-@media (min-width: 35em) {
-    .overflowSquareCard {
-        width: 31.2vw;
-    }
-
-    .overflowBackdropCard {
-        width: 45.5vw;
-    }
-
-    .overflowSmallBackdropCard {
-        width: 30vw;
-    }
-}
-
-@media (min-width: 43.75em) {
-    .overflowSquareCard,
-    .overflowPortraitCard {
-        width: 23.1vw;
-    }
-}
-
-@media (min-width: 48.125em) {
+/* Desktop (992px+) */
+@media (min-width: 768px) {
     .overflowBackdropCard,
     .overflowSmallBackdropCard {
-        width: 30vw;
+        width: calc(100vw / 3 - 2.2vw);
+    }
+
+    .overflowSquareCard,
+    .overflowPortraitCard {
+        width: calc(100vw / 6 - 1.1vw);
     }
 }
 
-@media (orientation: landscape) {
+/* Large Desktop (1200px+) */
+@media (min-width: 1200px) {
     .overflowBackdropCard,
     .overflowSmallBackdropCard {
-        width: 30vw;
+        width: calc(100vw / 4.295);
     }
 
     .overflowSquareCard,
     .overflowPortraitCard {
-        width: 23.1vw;
-    }
-}
-
-@media (orientation: landscape) and (min-width: 48.125em) {
-    .overflowBackdropCard,
-    .overflowSmallBackdropCard {
-        width: 23.1vw;
-    }
-}
-
-@media (orientation: landscape) and (min-width: 50em) {
-    .overflowSmallBackdropCard {
-        width: 15.5vw;
-    }
-}
-
-@media (min-width: 50em) {
-    .overflowSquareCard,
-    .overflowPortraitCard {
-        width: 18.5vw;
-    }
-}
-
-@media (min-width: 75em) {
-    .overflowBackdropCard,
-    .overflowSmallBackdropCard {
-        width: 23.1vw;
-    }
-
-    .overflowSquareCard,
-    .overflowPortraitCard {
-        width: 15.5vw;
-    }
-}
-
-@media (min-width: 87.5em) {
-    .overflowSquareCard,
-    .overflowPortraitCard {
-        width: 13.3vw;
-    }
-}
-
-@media (min-width: 100em) {
-    .overflowBackdropCard,
-    .overflowSmallBackdropCard {
-        width: 18.7vw;
-    }
-
-    .overflowSquareCard,
-    .overflowPortraitCard {
-        width: 11.6vw;
-    }
-}
-
-@media (min-width: 120em) {
-    .overflowSquareCard,
-    .overflowPortraitCard {
-        width: 10.41vw;
-    }
-}
-
-@media (min-width: 131.25em) {
-    .overflowSquareCard,
-    .overflowPortraitCard {
-        width: 9.3vw;
-    }
-}
-
-@media (min-width: 156.25em) {
-    .overflowBackdropCard,
-    .overflowSmallBackdropCard {
-        width: 15.6vw;
+        width: 11.64vw;
     }
 }
 

--- a/src/components/cardbuilder/card.css
+++ b/src/components/cardbuilder/card.css
@@ -170,6 +170,7 @@ button::-moz-focus-inner {
 }
 
 .cardScalable .cardImageContainer {
+    display: flex;
     height: 100%;
     contain: strict;
 }

--- a/src/components/cardbuilder/card.css
+++ b/src/components/cardbuilder/card.css
@@ -441,226 +441,12 @@ button::-moz-focus-inner {
     transition: transform 200ms ease-out;
 }
 
-.bannerCard {
-    width: 100%;
-}
-
-.backdropCard {
-    width: 100%;
-}
-
-.smallBackdropCard {
-    width: 50%;
-}
-
-.squareCard {
-    width: 50%;
-}
-
-.portraitCard {
-    width: 33.333333333333333333333333333333%;
-}
-
-.mixedPortraitCard {
-    width: 12em;
-}
-
-.mixedSquareCard {
-    width: 18em;
-}
-
-.mixedBackdropCard {
-    width: 32em;
-}
-
-@media (min-width: 25em) {
-    .backdropCard {
-        width: 50%;
-    }
-}
-
-@media (min-width: 31.25em) {
-    .smallBackdropCard {
-        width: 33.333333333333333333333333333333%;
-    }
-
-    .squareCard,
-    .portraitCard {
-        width: 33.333333333333333333333333333333%;
-    }
-}
-
-@media (min-width: 43.75em) {
-    .squareCard,
-    .portraitCard {
-        width: 25%;
-    }
-}
-
-@media (min-width: 48.125em) {
-    .backdropCard {
-        width: 33.333333333333333333333333333333%;
-    }
-}
-
-@media (min-width: 50em) {
-    .bannerCard {
-        width: 50%;
-    }
-
-    .squareCard,
-    .portraitCard {
-        width: 20%;
-    }
-
-    .smallBackdropCard {
-        width: 25%;
-    }
-}
-
-@media (min-width: 62.5em) {
-    .smallBackdropCard {
-        width: 20%;
-    }
-}
-
-@media (min-width: 75em) {
-    .backdropCard {
-        width: 25%;
-    }
-
-    .squareCard,
-    .portraitCard {
-        width: 16.666666666666666666666666666667%;
-    }
-
-    .bannerCard {
-        width: 33.333333333333333333333333333333%;
-    }
-
-    .smallBackdropCard {
-        width: 16.666666666666666666666666666667%;
-    }
-}
-
-@media (min-width: 87.5em) {
-    .squareCard,
-    .portraitCard {
-        width: 14.285714285714285714285714285714%;
-    }
-
-    .smallBackdropCard {
-        width: 14.285714285714285714285714285714%;
-    }
-}
-
-@media (min-width: 100em) {
-    .smallBackdropCard {
-        width: 12.5%;
-    }
-
-    .backdropCard {
-        width: 20%;
-    }
-
-    .squareCard,
-    .portraitCard {
-        width: 12.5%;
-    }
-}
-
-@media (min-width: 120em) {
-    .squareCard,
-    .portraitCard {
-        width: 11.111111111111111111111111111111%;
-    }
-}
-
-@media (min-width: 131.25em) {
-    .bannerCard {
-        width: 25%;
-    }
-
-    .squareCard,
-    .portraitCard {
-        width: 10%;
-    }
-}
-
-@media (min-width: 156.25em) {
-    .backdropCard {
-        width: 16.666666666666666666666666666667%;
-    }
-}
-
-.itemsContainer-tv > .backdropCard {
-    width: 25%;
-}
-
-.itemsContainer-tv > .squareCard {
-    width: 16.666666666666666666666666666667%;
-}
-
-.itemsContainer-tv > .portraitCard {
-    width: 16.666666666666666666666666666667%;
-}
-
-/* Phone (0px+) */
-.overflowBackdropCard,
-.overflowSmallBackdropCard {
-    width: calc(100vw / 2 - 0.95em);
-}
-
-.overflowSquareCard,
-.overflowPortraitCard {
-    width: calc(100vw / 3 - 0.65em);
-}
-
-/* Desktop (992px+) */
-@media (min-width: 768px) {
-    .overflowBackdropCard,
-    .overflowSmallBackdropCard {
-        width: calc(100vw / 3 - 2.2vw);
-    }
-
-    .overflowSquareCard,
-    .overflowPortraitCard {
-        width: calc(100vw / 6 - 1.1vw);
-    }
-}
-
-/* Large Desktop (1200px+) */
-@media (min-width: 1200px) {
-    .overflowBackdropCard,
-    .overflowSmallBackdropCard {
-        width: calc(100vw / 4.295);
-    }
-
-    .overflowSquareCard,
-    .overflowPortraitCard {
-        width: 11.64vw;
-    }
-}
-
-.itemsContainer-tv > .overflowBackdropCard {
-    width: 23.5vw;
-}
-
 .overflowBackdropCard-textCard {
     width: 15.5vw !important;
 }
 
 .overflowBackdropCard-textCardPadder {
     padding-bottom: 87.75%;
-}
-
-.itemsContainer-tv > .overflowSquareCard,
-.itemsContainer-tv > .overflowPortraitCard {
-    width: 15.6vw;
-}
-
-.itemsContainer-tv > .overflowSmallBackdropCard {
-    width: 18.8vw;
 }
 
 .cardOverlayContainer {
@@ -710,4 +496,61 @@ button::-moz-focus-inner {
 .cardOverlayFab-primary:hover {
     transform: scale(1.4, 1.4);
     transition: 0.2s;
+}
+
+/* Phone (0px+) */
+.bannerCard {
+    width: 100%;
+}
+
+.backdropCard {
+    width: 100%;
+}
+
+.smallBackdropCard {
+    width: calc(50% / 2);
+}
+
+.squareCard {
+    width: calc(50% / 2);
+}
+
+.portraitCard {
+    width: calc(100% / 3);
+}
+
+.overflowBackdropCard,
+.overflowSmallBackdropCard {
+    width: calc(100% / 2);
+}
+
+.overflowSquareCard,
+.overflowPortraitCard {
+    width: calc(100% / 3);
+}
+
+/* Desktop (992px+) */
+@media (min-width: 768px) {
+    .overflowBackdropCard,
+    .overflowSmallBackdropCard {
+        width: calc(100% / 3);
+    }
+
+    .overflowSquareCard,
+    .overflowPortraitCard {
+        width: calc(100% / 6);
+    }
+}
+
+/* Large Desktop (1200px+) */
+@media (min-width: 1200px) {
+    .overflowBackdropCard,
+    .overflowSmallBackdropCard {
+        width: calc(100% / 4);
+    }
+
+    .overflowSquareCard,
+    .overflowPortraitCard {
+        width: calc(100% / 8);
+    }
 }

--- a/src/elements/emby-scroller/emby-scroller.css
+++ b/src/elements/emby-scroller/emby-scroller.css
@@ -9,8 +9,8 @@
 
 /* align first card in scroller to heading */
 .itemsContainer > .card > .cardBox {
-    margin-left: 0;
-    margin-right: 1.2em;
+    margin-left: 0.6em;
+    margin-right: 0.6em;
 }
 
 .servers > .card > .cardBox {


### PR DESCRIPTION
**Changes**

Companion to #1788 but for the cards.

This does the following:
* **Reduces the number of breakpoints for cards**
  Keeping with the "mobile-first" paradigm for CSS, this has the phone breakpoint as default. It's overridden with the following breakpoints: Desktop (992px) and Large Desktop (1200px)  
  The idea is to have a limited amount of breaks for the number of cards shown at a time, keeping them big enough to be visually striking, while not crowding the view too much.  
* **Implement a specific number of cards for resolutions where LRUD navigation happens**
  This means that every Backdrop-style card will be equal in width to two Portrait- or Square-style cards. This should prevent the left/right jumps we currently have.
* **Make the card sizing rules more readable**
  Old rules are harder to make sense of: `width: 16.666666666666666666666666666667%;`.
  New rules use the following format: `width: calc(100vw / number_of_cards - adjustment_in_vw);`

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
