### PR TITLE
Add BuildRequires: git to Fedora specfile

### DIFF
--- a/fedora/jellyfin-web.spec
+++ b/fedora/jellyfin-web.spec
@@ -2,7 +2,7 @@
 
 Name:           jellyfin-web
 Version:        10.6.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        The Free Software Media System web client
 License:        GPLv3
 URL:            https://jellyfin.org
@@ -11,6 +11,8 @@ Source0:        jellyfin-web-%{version}.tar.gz
 
 %if 0%{?centos}
 BuildRequires:  yarn
+# sadly the yarn RPM at https://dl.yarnpkg.com/rpm/ uses git but doesn't Requires: it
+BuildRequires: git
 %else
 BuildRequires:  nodejs-yarn
 %endif


### PR DESCRIPTION
**Changes**
Sadly the yarn RPM at https://dl.yarnpkg.com/rpm/ uses git but doesn't
add it as a BuildRequires:.

This really should be reported upstream at yarnpkg.com.