### PR TITLE
Fix emby-scroller focus and scroll in TV layout

### DIFF
--- a/src/elements/emby-scroller/emby-scroller.js
+++ b/src/elements/emby-scroller/emby-scroller.js
@@ -20,13 +20,13 @@ import 'css!./emby-scroller';
             if (e.explicitOriginalTarget.parentNode === e.target.parentNode) {
                 const focused = focusManager.focusableParent(e.target);
                 if (focused) {
-                    scrollerInstance.toCenter(focused);
+                    scrollerInstance.scrollUntilVisible(e.explicitOriginalTarget, focused);
                 }
             } else {
                 const focused = this.querySelector('.lastFocused');
                 if (focused) {
                     focusManager.focus(focused);
-                    scrollerInstance.toCenter(focused);
+                    scrollerInstance.scrollUntilVisible(e.explicitOriginalTarget, focused);
                 }
                 e.stopPropagation();
             }

--- a/src/elements/emby-scroller/emby-scroller.js
+++ b/src/elements/emby-scroller/emby-scroller.js
@@ -17,7 +17,7 @@ import 'css!./emby-scroller';
 
     function initCenterFocus(elem, scrollerInstance) {
         dom.addEventListener(elem, 'focus', function (e) {
-            if (e.explicitOriginalTarget.parentNode === e.target.parentNode) {
+            if (e.relatedTarget.parentNode === e.target.parentNode) {
                 const focused = focusManager.focusableParent(e.target);
                 if (focused) {
                     scrollerInstance.scrollUntilVisible(e.explicitOriginalTarget, focused);

--- a/src/elements/emby-scroller/emby-scroller.js
+++ b/src/elements/emby-scroller/emby-scroller.js
@@ -17,9 +17,32 @@ import 'css!./emby-scroller';
 
     function initCenterFocus(elem, scrollerInstance) {
         dom.addEventListener(elem, 'focus', function (e) {
-            const focused = focusManager.focusableParent(e.target);
-            if (focused) {
-                scrollerInstance.toCenter(focused);
+            if (e.explicitOriginalTarget.parentNode === e.target.parentNode) {
+                const focused = focusManager.focusableParent(e.target);
+                if (focused) {
+                    scrollerInstance.toCenter(focused);
+                }
+            } else {
+                const focused = this.querySelector('.lastFocused');
+                if (focused) {
+                    focusManager.focus(focused);
+                    scrollerInstance.toCenter(focused);
+                }
+                e.stopPropagation();
+            }
+        }, {
+            capture: true,
+            passive: true
+        });
+
+        dom.addEventListener(elem, 'focusout', function (e) {
+            if (e.explicitOriginalTarget.parentNode === e.target.parentNode) {
+                const parentContainer = e.target.parentNode;
+                const previousFocus = parentContainer.querySelector('.lastFocused');
+                if (previousFocus) {
+                    previousFocus.classList.remove('lastFocused');
+                }
+                e.target.classList.add('lastFocused');
             }
         }, {
             capture: true,

--- a/src/libraries/scroller.js
+++ b/src/libraries/scroller.js
@@ -161,7 +161,17 @@ var scrollerFactory = function (frame, options) {
             requiresReflow = false;
 
             // Reset global variables
-            frameSize = o.horizontal ? (frame).offsetWidth : (frame).offsetHeight;
+            if (layoutManager.tv) {
+                // In TV layout, the width is wrong, as the item will be aligned to the end of the element, with padding.
+                // We actually want to align it without the padding, so compute the size properly.
+                const computedStyle = getComputedStyle(frame);
+                const frameHeight = frame.clientHeight - (parseFloat(computedStyle.paddingTop) + parseFloat(computedStyle.paddingBottom));  // height with padding
+                const frameWidth = frame.clientWidth - (parseFloat(computedStyle.paddingLeft) + parseFloat(computedStyle.paddingRight));
+
+                frameSize = o.horizontal ? frameWidth : frameHeight;
+            } else {
+                frameSize = o.horizontal ? (frame).offsetWidth : (frame).offsetHeight;
+            }
 
             slideeSize = o.scrollWidth || Math.max(slideeElement[o.horizontal ? 'offsetWidth' : 'offsetHeight'], slideeElement[o.horizontal ? 'scrollWidth' : 'scrollHeight']);
 
@@ -829,6 +839,10 @@ scrollerFactory.prototype.to = function (location, item, immediate) {
     if (type(item) === 'boolean') {
         immediate = item;
         item = undefined;
+    }
+
+    if (location === 'end') {
+        console.warn(this._pos[location]);
     }
 
     if (item === undefined) {

--- a/src/libraries/scroller.js
+++ b/src/libraries/scroller.js
@@ -165,7 +165,7 @@ var scrollerFactory = function (frame, options) {
                 // In TV layout, the width is wrong, as the item will be aligned to the end of the element, with padding.
                 // We actually want to align it without the padding, so compute the size properly.
                 const computedStyle = getComputedStyle(frame);
-                const frameHeight = frame.clientHeight - (parseFloat(computedStyle.paddingTop) + parseFloat(computedStyle.paddingBottom));  // height with padding
+                const frameHeight = frame.clientHeight - (parseFloat(computedStyle.paddingTop) + parseFloat(computedStyle.paddingBottom));
                 const frameWidth = frame.clientWidth - (parseFloat(computedStyle.paddingLeft) + parseFloat(computedStyle.paddingRight));
 
                 frameSize = o.horizontal ? frameWidth : frameHeight;
@@ -876,7 +876,7 @@ scrollerFactory.prototype.scrollUntilVisible = function (previousItem, item, imm
         // We're going right
         this.to('start', item, immediate);
     }
-}
+};
 
 /**
  * Animate element or the whole SLIDEE to the start of the frame.

--- a/src/libraries/scroller.js
+++ b/src/libraries/scroller.js
@@ -843,6 +843,28 @@ scrollerFactory.prototype.to = function (location, item, immediate) {
 };
 
 /**
+ * Scrolls an element into view
+ *
+ * @param  {Mixed}  previousItem
+ * @param  {Mixed}  item
+ * @param  {Bool}   immediate
+ *
+ * @return {Void}
+ */
+scrollerFactory.prototype.scrollUntilVisible = function (previousItem, item, immediate) {
+    const previousItemPos = this.getPos(previousItem);
+    const itemPos = this.getPos(item);
+
+    if (previousItemPos.start < itemPos.start && !itemPos.isVisible) {
+        // We're going left
+        this.to('end', item, immediate);
+    } else if (!itemPos.isVisible) {
+        // We're going right
+        this.to('start', item, immediate);
+    }
+}
+
+/**
  * Animate element or the whole SLIDEE to the start of the frame.
  *
  * @param {Mixed} item      Item DOM element, or index starting at 0. Omitting will animate SLIDEE.


### PR DESCRIPTION
**Changes**
When moving out of an emby-scroller, keep the last focused element, then reuse it as the focus target when entering back into that scroller.

This prevent the weird shifting and inconsistent behavior when moving between scrollers.

This also removes the weird center focus and makes the scolling follow the focus (So going right when at the right edge of the screen will scroll one item to the right, going left at the left edge of the screen will scroll one item left)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
