### PR TITLE
Change all instances of currentTime and duration to be in ticks.

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -685,7 +685,7 @@ function getNowPlayingItemForReporting(player, item, mediaSource) {
         nowPlayingItem.MediaSources = null;
     }
 
-    nowPlayingItem.RunTimeTicks = nowPlayingItem.RunTimeTicks || player.duration() * 10000;
+    nowPlayingItem.RunTimeTicks = nowPlayingItem.RunTimeTicks || player.duration();
 
     return nowPlayingItem;
 }
@@ -1618,11 +1618,7 @@ class PlaybackManager {
 
             player = player || self._currentPlayer;
             if (player && !enableLocalPlaylistManagement(player)) {
-                if (player.isLocalPlayer) {
-                    return player.seek((ticks || 0) / 10000);
-                } else {
-                    return player.seek(ticks);
-                }
+                return player.seek(ticks);
             }
 
             changeStream(player, ticks);
@@ -1631,11 +1627,7 @@ class PlaybackManager {
         self.seekRelative = function (offsetTicks, player) {
             player = player || self._currentPlayer;
             if (player && !enableLocalPlaylistManagement(player) && player.seekRelative) {
-                if (player.isLocalPlayer) {
-                    return player.seekRelative((ticks || 0) / 10000);
-                } else {
-                    return player.seekRelative(ticks);
-                }
+                return player.seekRelative(ticks);
             }
 
             const ticks = getCurrentTicks(player) + offsetTicks;
@@ -1671,7 +1663,7 @@ class PlaybackManager {
 
         function changeStream(player, ticks, params) {
             if (canPlayerSeek(player) && params == null) {
-                player.currentTime(parseInt(ticks / 10000));
+                player.currentTime(ticks);
                 return;
             }
 
@@ -2022,10 +2014,6 @@ class PlaybackManager {
 
             let playerDuration = player.duration();
 
-            if (playerDuration) {
-                playerDuration *= 10000;
-            }
-
             return playerDuration;
         };
 
@@ -2034,7 +2022,7 @@ class PlaybackManager {
                 throw new Error('player cannot be null');
             }
 
-            let playerTime = Math.floor(10000 * (player).currentTime());
+            let playerTime = player.currentTime();
 
             const streamInfo = getPlayerData(player).streamInfo;
             if (streamInfo) {

--- a/src/plugins/htmlAudioPlayer/plugin.js
+++ b/src/plugins/htmlAudioPlayer/plugin.js
@@ -347,16 +347,16 @@ class HtmlAudioPlayer {
         const mediaElement = this._mediaElement;
         if (mediaElement) {
             if (val != null) {
-                mediaElement.currentTime = val / 1000;
+                mediaElement.currentTime = val / 10000000;
                 return;
             }
 
             const currentTime = this._currentTime;
             if (currentTime) {
-                return currentTime * 1000;
+                return currentTime * 10000000;
             }
 
-            return (mediaElement.currentTime || 0) * 1000;
+            return (mediaElement.currentTime || 0) * 10000000;
         }
     }
 
@@ -365,7 +365,7 @@ class HtmlAudioPlayer {
         if (mediaElement) {
             const duration = mediaElement.duration;
             if (htmlMediaHelper.isValidDuration(duration)) {
-                return duration * 1000;
+                return duration * 10000000;
             }
         }
 

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1428,16 +1428,16 @@ function tryRemoveElement(elem) {
         const mediaElement = this.#mediaElement;
         if (mediaElement) {
             if (val != null) {
-                mediaElement.currentTime = val / 1000;
+                mediaElement.currentTime = val / 10000000;
                 return;
             }
 
             const currentTime = this.#currentTime;
             if (currentTime) {
-                return currentTime * 1000;
+                return currentTime * 10000000;
             }
 
-            return (mediaElement.currentTime || 0) * 1000;
+            return (mediaElement.currentTime || 0) * 10000000;
         }
     }
 
@@ -1446,7 +1446,7 @@ function tryRemoveElement(elem) {
         if (mediaElement) {
             const duration = mediaElement.duration;
             if (isValidDuration(duration)) {
-                return duration * 1000;
+                return duration * 10000000;
             }
         }
 


### PR DESCRIPTION
This fixes seeking on remote players so that it will seek properly instead of skipping episodes. It also removes [sections like these](https://github.com/jellyfin/jellyfin-web/blob/master/src/components/playback/playbackmanager.js#L1621) which detect the type of player.

The following has been tested:
 - Seeking while casting to MPV Shim
 - Seeking while playing video locally
 - Seeking while playing audio locally
 - Seeking while using SyncPlay (note caveat 1)

The following has not been tested:
 - Seeking while casting to Chromecast

**Changes**
Replace all known instances of player currentTime methods to be in ticks. Duration is also changed to ticks.

**Issues**
Fix https://github.com/jellyfin/jellyfin-web/issues/1790

**Caveats**
1. Creating a SyncPlay session from the web client is currently broken, but joining one works. This PR is not the cause.
2. It could be more ideal for currentTime to be in ms instead. This PR is one possible solution to the problem.

**Alternative Versions**
https://github.com/jellyfin/jellyfin-web/pull/1810 is the alternative to this PR, which uses ms instead of ticks.