### PR TITLE
Remove withCredentials from xhrSetup in hls.js

### DIFF
--- a/src/plugins/htmlAudioPlayer/plugin.js
+++ b/src/plugins/htmlAudioPlayer/plugin.js
@@ -132,10 +132,7 @@ class HtmlAudioPlayer {
                 return new Promise(function (resolve, reject) {
                     requireHlsPlayer(function () {
                         const hls = new Hls({
-                            manifestLoadingTimeOut: 20000,
-                            xhrSetup: function (xhr, url) {
-                                xhr.withCredentials = true;
-                            }
+                            manifestLoadingTimeOut: 20000
                         });
                         hls.loadSource(val);
                         hls.attachMedia(elem);

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -393,10 +393,7 @@ function tryRemoveElement(elem) {
             return new Promise((resolve, reject) => {
                 requireHlsPlayer(() => {
                     const hls = new Hls({
-                        manifestLoadingTimeOut: 20000,
-                        xhrSetup(xhr) {
-                            xhr.withCredentials = true;
-                        }
+                        manifestLoadingTimeOut: 20000
                     });
                     hls.loadSource(url);
                     hls.attachMedia(elem);


### PR DESCRIPTION
**Changes**

This prevents playback from failing, by not sending credentials with the manifest request on playback.

The request contains an API key, so credentials are not needed.

It prevents the following error from happening:
```
The value of the 'Access-Control-Allow-Origin' header in the response must not be the wildcard '*' when the request's credentials mode is 'include'. The credentials mode of requests initiated by the XMLHttpRequest is controlled by the withCredentials attribute.
```

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
