### PR TITLE
Hide Volume controls unless hovering

### DIFF
--- a/src/assets/css/videoosd.css
+++ b/src/assets/css/videoosd.css
@@ -128,11 +128,24 @@
     align-items: center;
 }
 
-.osdVolumeSliderContainer {
-    width: 9em;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    flex-grow: 1;
+@media (hover: hover) {
+    .osdVolumeSliderContainer {
+        width: 1em;
+        opacity: 0;
+        transition: all 0.25s ease-in-out;
+    }
+
+    .volumeButtons:hover .osdVolumeSliderContainer {
+        width: 9em;
+        opacity: 1;
+        transition: width 0.25s ease-in-out;
+    }
+}
+
+@media (hover: none) {
+    .osdVolumeSliderContainer {
+        width: 9em;
+    }
 }
 
 .osdMediaInfo,

--- a/src/components/remotecontrol/remotecontrol.css
+++ b/src/components/remotecontrol/remotecontrol.css
@@ -457,8 +457,24 @@
     display: none;
 }
 
-.nowPlayingVolumeSliderContainer {
-    width: 9em;
+@media (hover: hover) {
+    .nowPlayingVolumeSliderContainer {
+        width: 1em;
+        opacity: 0;
+        transition: all 0.25s ease-in-out;
+    }
+
+    .volumecontrol:hover .nowPlayingVolumeSliderContainer {
+        width: 9em;
+        opacity: 1;
+        transition: width 0.25s ease-in-out;
+    }
+}
+
+@media (hover: none) {
+    .nowPlayingVolumeSliderContainer {
+        width: 9em;
+    }
 }
 
 @media all and (max-width: 63em) {

--- a/src/controllers/playback/video/index.html
+++ b/src/controllers/playback/video/index.html
@@ -15,11 +15,11 @@
             <div class="osdTextContainer osdSecondaryMediaInfo"></div>
 
             <div class="flex flex-direction-row align-items-center">
-                <div class="osdTextContainer startTimeText" style="margin: 0 .25em 0 0;"></div>
-                <div class="sliderContainer flex-grow" style="margin: .5em .5em .25em;">
+                <div class="osdTextContainer startTimeText" style="margin: 0 0.25em 0 0;"></div>
+                <div class="sliderContainer flex-grow" style="margin: 0.5em 0.5em 0.25em;">
                     <input type="range" step=".01" min="0" max="100" value="0" is="emby-slider" class="osdPositionSlider" data-slider-keep-progress="true" />
                 </div>
-                <div class="osdTextContainer endTimeText" style="margin: 0 0 0 .25em;"></div>
+                <div class="osdTextContainer endTimeText" style="margin: 0 0 0 0.25em;"></div>
             </div>
 
             <div class="buttons focuscontainer-x">
@@ -74,12 +74,12 @@
                 </div>
 
                 <div class="volumeButtons hide-mouse-idle-tv">
-                    <button is="paper-icon-button-light" class="buttonMute autoSize" title="${Mute} (m)">
-                        <span class="xlargePaperIconButton material-icons volume_up"></span>
-                    </button>
                     <div class="sliderContainer osdVolumeSliderContainer">
                         <input is="emby-slider" type="range" step="1" min="0" max="100" value="0" class="osdVolumeSlider" />
                     </div>
+                    <button is="paper-icon-button-light" class="buttonMute autoSize" title="${Mute} (m)">
+                        <span class="xlargePaperIconButton material-icons volume_up"></span>
+                    </button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
**Changes**
On touch devices, the controls are unaffected

See gif Below
![2020-08-30-jellyfin-hover vol adjust demo-cropped](https://user-images.githubusercontent.com/18101008/91664695-cf552f00-eae8-11ea-9e99-4024af470706.gif)

