### PR TITLE
Migrate from ticks to milliseconds.

### DIFF
--- a/package.json
+++ b/package.json
@@ -336,6 +336,7 @@
           "src/scripts/fileDownloader.js",
           "src/scripts/filesystem.js",
           "src/scripts/globalize.js",
+          "src/scripts/timeConversions.js",
           "src/scripts/imagehelper.js",
           "src/scripts/itembynamedetailpage.js",
           "src/scripts/inputManager.js",

--- a/src/components/htmlMediaHelper.js
+++ b/src/components/htmlMediaHelper.js
@@ -3,6 +3,11 @@
 import appSettings from 'appSettings' ;
 import browser from 'browser';
 import events from 'events';
+import {
+    ticksToMs,
+    ticksToSeconds,
+    secondsToTicks
+} from 'timeConversions';
 
     export function getSavedVolume() {
         return appSettings.get('volume') || 1;
@@ -136,7 +141,7 @@ import events from 'events';
     }
 
     export function seekOnPlaybackStart(instance, element, ticks, onMediaReady) {
-        var seconds = (ticks || 0) / 10000000;
+        var seconds = ticksToSeconds(ticks || 0);
 
         if (seconds) {
             // Appending #t=xxx to the query string doesn't seem to work with HLS
@@ -176,7 +181,7 @@ import events from 'events';
                 var playlist = new Windows.Media.Playback.MediaPlaybackList();
 
                 var source1 = Windows.Media.Core.MediaSource.createFromStorageFile(file);
-                var startTime = (options.playerStartPositionTicks || 0) / 10000;
+                var startTime = ticksToMs(options.playerStartPositionTicks || 0);
                 playlist.items.append(new Windows.Media.Playback.MediaPlaybackItem(source1, startTime));
                 elem.src = URL.createObjectURL(playlist, { oneTimeOnly: true });
                 return Promise.resolve();
@@ -392,8 +397,8 @@ import events from 'events';
             }
 
             ranges.push({
-                start: (start * 10000000) + offset,
-                end: (end * 10000000) + offset
+                start: secondsToTicks(start) + offset,
+                end: secondsToTicks(end) + offset
             });
         }
 

--- a/src/components/mediainfo/mediainfo.js
+++ b/src/components/mediainfo/mediainfo.js
@@ -7,6 +7,9 @@ import 'material-icons';
 import 'css!./mediainfo.css';
 import 'programStyles';
 import 'emby-button';
+import {
+    ticksToMs
+} from 'timeConversions';
 
 /* eslint-disable indent */
     function getTimerIndicator(item) {
@@ -318,7 +321,7 @@ import 'emby-button';
     export function getEndsAt(item) {
         if (item.MediaType === 'Video' && item.RunTimeTicks) {
             if (!item.StartDate) {
-                let endDate = new Date().getTime() + (item.RunTimeTicks / 10000);
+                let endDate = new Date().getTime() + (ticksToMs(item.RunTimeTicks));
                 endDate = new Date(endDate);
 
                 const displayTime = datetime.getDisplayTime(endDate);
@@ -330,7 +333,7 @@ import 'emby-button';
     }
 
     export function getEndsAtFromPosition(runtimeTicks, positionTicks, includeText) {
-        let endDate = new Date().getTime() + ((runtimeTicks - (positionTicks || 0)) / 10000);
+        let endDate = new Date().getTime() + ticksToMs(runtimeTicks - (positionTicks || 0));
         endDate = new Date(endDate);
 
         const displayTime = datetime.getDisplayTime(endDate);

--- a/src/components/nowPlayingBar/nowPlayingBar.js
+++ b/src/components/nowPlayingBar/nowPlayingBar.js
@@ -11,6 +11,9 @@ import connectionManager from 'connectionManager';
 import itemContextMenu from 'itemContextMenu';
 import 'paper-icon-button-light';
 import 'emby-ratingbutton';
+import {
+    msToTicks
+} from 'timeConversions';
 
 /* eslint-disable indent */
 
@@ -701,7 +704,7 @@ import 'emby-ratingbutton';
 
         const player = this;
         currentRuntimeTicks = playbackManager.duration(player);
-        updateTimeDisplay(playbackManager.currentTime(player) * 10000, currentRuntimeTicks, playbackManager.getBufferedRanges(player));
+        updateTimeDisplay(msToTicks(playbackManager.currentTime(player)), currentRuntimeTicks, playbackManager.getBufferedRanges(player));
     }
 
     function releaseCurrentPlayer() {

--- a/src/components/playback/mediasession.js
+++ b/src/components/playback/mediasession.js
@@ -2,6 +2,11 @@ import playbackManager from 'playbackManager';
 import nowPlayingHelper from 'nowPlayingHelper';
 import events from 'events';
 import connectionManager from 'connectionManager';
+import {
+    ticksToMs,
+    secondsToMs
+} from 'timeConversions';
+
 /* eslint-disable indent */
 
     // Reports media playback to the device for lock screen control
@@ -112,8 +117,8 @@ import connectionManager from 'connectionManager';
         const itemId = item.Id;
 
         // Convert to ms
-        const duration = parseInt(item.RunTimeTicks ? (item.RunTimeTicks / 10000) : 0);
-        const currentTime = parseInt(playState.PositionTicks ? (playState.PositionTicks / 10000) : 0);
+        const duration = parseInt(item.RunTimeTicks ? ticksToMs(item.RunTimeTicks) : 0);
+        const currentTime = parseInt(playState.PositionTicks ? ticksToMs(playState.PositionTicks) : 0);
 
         const isPaused = playState.IsPaused || false;
         const canSeek = playState.CanSeek || false;
@@ -246,8 +251,8 @@ import connectionManager from 'connectionManager';
         navigator.mediaSession.setActionHandler('seekto', function (object) {
             const item = playbackManager.getPlayerState(currentPlayer).NowPlayingItem;
             // Convert to ms
-            const duration = parseInt(item.RunTimeTicks ? (item.RunTimeTicks / 10000) : 0);
-            const wantedTime = object.seekTime * 1000;
+            const duration = parseInt(item.RunTimeTicks ? ticksToMs(item.RunTimeTicks) : 0);
+            const wantedTime = secondsToMs(object.seekTime);
             playbackManager.seekPercent(wantedTime / duration * 100, currentPlayer);
         });
     }

--- a/src/components/remotecontrol/remotecontrol.js
+++ b/src/components/remotecontrol/remotecontrol.js
@@ -16,6 +16,10 @@ import 'cardStyle';
 import 'emby-itemscontainer';
 import 'css!./remotecontrol.css';
 import 'emby-ratingbutton';
+import {
+    msToTicks,
+    secondsToTicks
+} from 'timeConversions';
 
 /*eslint prefer-const: "error"*/
 
@@ -345,8 +349,8 @@ export default function () {
         const positionSlider = context.querySelector('.nowPlayingPositionSlider');
 
         if (positionSlider && item && item.RunTimeTicks) {
-            positionSlider.setKeyboardSteps(userSettings.skipBackLength() * 1000000 / item.RunTimeTicks,
-                userSettings.skipForwardLength() * 1000000 / item.RunTimeTicks);
+            positionSlider.setKeyboardSteps(secondsToTicks(userSettings.skipBackLength()) / 10 / item.RunTimeTicks,
+                secondsToTicks(userSettings.skipForwardLength()) / 10 / item.RunTimeTicks);
         }
 
         if (positionSlider && !positionSlider.dragging) {
@@ -619,7 +623,7 @@ export default function () {
             lastUpdateTime = now;
             const player = this;
             currentRuntimeTicks = playbackManager.duration(player);
-            updateTimeDisplay(playbackManager.currentTime(player) * 10000, currentRuntimeTicks);
+            updateTimeDisplay(msToTicks(playbackManager.currentTime(player)), currentRuntimeTicks);
         }
     }
 

--- a/src/components/syncPlay/syncPlayManager.js
+++ b/src/components/syncPlay/syncPlayManager.js
@@ -9,6 +9,11 @@ import playbackManager from 'playbackManager';
 import timeSyncManager from 'timeSyncManager';
 import toast from 'toast';
 import globalize from 'globalize';
+import {
+    msToTicks,
+    msToSeconds,
+    ticksToMs
+} from 'timeConversions';
 
 /**
  * Waits for an event to be triggered on an object. An optional timeout can specified after which the promise is rejected.
@@ -556,10 +561,10 @@ class SyncPlayManager {
                 }, SyncMethodThreshold / 2);
             }, playTimeout);
 
-            console.debug('Scheduled play in', playTimeout / 1000.0, 'seconds.');
+            console.debug('Scheduled play in', msToSeconds(playTimeout), 'seconds.');
         } else {
             // Group playback already started
-            const serverPositionTicks = positionTicks + (currentTime - playAtTimeLocal) * 10000;
+            const serverPositionTicks = positionTicks + msToTicks(currentTime - playAtTimeLocal);
             waitForEventOnce(this, 'unpause').then(() => {
                 this.localSeek(serverPositionTicks);
             });
@@ -595,7 +600,7 @@ class SyncPlayManager {
             const pauseTimeout = pauseAtTimeLocal - currentTime;
             this.scheduledCommand = setTimeout(callback, pauseTimeout);
 
-            console.debug('Scheduled pause in', pauseTimeout / 1000.0, 'seconds.');
+            console.debug('Scheduled pause in', msToSeconds(pauseTimeout), 'seconds.');
         } else {
             callback();
         }
@@ -741,12 +746,12 @@ class SyncPlayManager {
 
         const playAtTime = this.lastCommand.When;
 
-        const currentPositionTicks = playbackManager.currentTime() * 10000;
+        const currentPositionTicks = msToTicks(playbackManager.currentTime());
         // Estimate PositionTicks on server
-        const serverPositionTicks = this.lastCommand.PositionTicks + ((currentTime - playAtTime) + this.timeOffsetWithServer) * 10000;
+        const serverPositionTicks = this.lastCommand.PositionTicks + msToTicks((currentTime - playAtTime) + this.timeOffsetWithServer);
         // Measure delay that needs to be recovered
         // diff might be caused by the player internally starting the playback
-        const diffMillis = (serverPositionTicks - currentPositionTicks) / 10000.0;
+        const diffMillis = ticksToMs(serverPositionTicks - currentPositionTicks);
 
         this.playbackDiffMillis = diffMillis;
 

--- a/src/components/upnextdialog/upnextdialog.js
+++ b/src/components/upnextdialog/upnextdialog.js
@@ -10,6 +10,11 @@ import itemHelper from 'itemHelper';
 import 'css!./upnextdialog';
 import 'emby-button';
 import 'flexStyles';
+import {
+    msToTicks,
+    msToSeconds,
+    ticksToMs
+} from 'timeConversions';
 
 /* eslint-disable indent */
 
@@ -128,7 +133,7 @@ import 'flexStyles';
 
         const elem = instance.options.parent;
 
-        const secondsRemaining = Math.max(Math.round(getTimeRemainingMs(instance) / 1000), 0);
+        const secondsRemaining = Math.max(Math.round(msToSeconds(getTimeRemainingMs(instance))), 0);
 
         console.debug('up next seconds remaining: ' + secondsRemaining);
 
@@ -256,9 +261,9 @@ import 'flexStyles';
             const runtimeTicks = playbackManager.duration(options.player);
 
             if (runtimeTicks) {
-                const timeRemainingTicks = runtimeTicks - playbackManager.currentTime(options.player) * 10000;
+                const timeRemainingTicks = runtimeTicks - msToTicks(playbackManager.currentTime(options.player));
 
-                return Math.round(timeRemainingTicks / 10000);
+                return Math.round(ticksToMs(timeRemainingTicks));
             }
         }
 

--- a/src/controllers/dashboard/scheduledtasks/scheduledtask.js
+++ b/src/controllers/dashboard/scheduledtasks/scheduledtask.js
@@ -6,16 +6,20 @@ import globalize from 'globalize';
 import 'emby-input';
 import 'emby-button';
 import 'emby-select';
+import {
+    msToTicks
+} from 'timeConversions';
 
 /* eslint-disable indent */
 
     function fillTimeOfDay(select) {
         const options = [];
 
+        // TODO: Figure out what these magic number mean.
         for (let i = 0; i < 86400000; i += 900000) {
             options.push({
-                name: ScheduledTaskPage.getDisplayTime(i * 10000),
-                value: i * 10000
+                name: ScheduledTaskPage.getDisplayTime(msToTicks(i)),
+                value: msToTicks(i)
             });
         }
 

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -18,6 +18,10 @@ import 'scrollStyles';
 import 'emby-slider';
 import 'paper-icon-button-light';
 import 'css!assets/css/videoosd';
+import {
+    msToTicks,
+    secondsToTicks
+} from 'timeConversions';
 
 /* eslint-disable indent */
 
@@ -693,7 +697,7 @@ import 'css!assets/css/videoosd';
                     lastUpdateTime = now;
                     const player = this;
                     currentRuntimeTicks = playbackManager.duration(player);
-                    const currentTime = playbackManager.currentTime(player) * 10000;
+                    const currentTime = msToTicks(playbackManager.currentTime(player));
                     updateTimeDisplay(currentTime, currentRuntimeTicks, playbackManager.playbackStartTime(player), playbackManager.getBufferedRanges(player));
                     const item = currentItem;
                     refreshProgramInfoIfNeeded(player, item);
@@ -803,8 +807,8 @@ import 'css!assets/css/videoosd';
             nowPlayingPositionSlider.setIsClear(isProgressClear);
 
             if (nowPlayingItem.RunTimeTicks) {
-                nowPlayingPositionSlider.setKeyboardSteps(userSettings.skipBackLength() * 1000000 / nowPlayingItem.RunTimeTicks,
-                    userSettings.skipForwardLength() * 1000000 / nowPlayingItem.RunTimeTicks);
+                nowPlayingPositionSlider.setKeyboardSteps(secondsToTicks(userSettings.skipBackLength()) / 10 / nowPlayingItem.RunTimeTicks,
+                    secondsToTicks(userSettings.skipForwardLength()) / 10 / nowPlayingItem.RunTimeTicks);
             }
 
             if (supportedCommands.indexOf('ToggleFullscreen') === -1 || player.isLocalPlayer && layoutManager.tv && playbackManager.isFullscreen(player)) {

--- a/src/plugins/bookPlayer/plugin.js
+++ b/src/plugins/bookPlayer/plugin.js
@@ -7,6 +7,10 @@ import events from 'events';
 import 'css!./style';
 import 'material-icons';
 import 'paper-icon-button-light';
+import {
+    ticksToSeconds,
+    secondsToMs
+} from 'timeConversions';
 
 import TableOfContents from './tableOfContents';
 
@@ -62,17 +66,17 @@ export class BookPlayer {
     }
 
     currentTime() {
-        return this._progress * 1000;
+        return secondsToMs(this._progress);
     }
 
     duration() {
-        return 1000;
+        return 1000; // 1 second in Ms
     }
 
     getBufferedRanges() {
         return [{
             start: 0,
-            end: 10000000
+            end: 10000000 // 1 second in Ticks
         }];
     }
 
@@ -270,7 +274,7 @@ export class BookPlayer {
                             return reject();
                         }
 
-                        const percentageTicks = options.startPositionTicks / 10000000;
+                        const percentageTicks = ticksToSeconds(options.startPositionTicks);
                         if (percentageTicks !== 0.0) {
                             const resumeLocation = book.locations.cfiFromPercentage(percentageTicks);
                             await rendition.display(resumeLocation);

--- a/src/plugins/chromecastPlayer/plugin.js
+++ b/src/plugins/chromecastPlayer/plugin.js
@@ -5,6 +5,11 @@ import connectionManager from 'connectionManager';
 import globalize from 'globalize';
 import events from 'events';
 import castSenderApiLoader from 'castSenderApiLoader';
+import {
+    msToTicks,
+    ticksToMs,
+    ticksToSeconds
+} from 'timeConversions';
 
 // Based on https://github.com/googlecast/CastVideos-chrome/blob/master/CastVideos.js
 
@@ -695,7 +700,7 @@ class ChromecastPlayer {
     seek(position) {
         position = parseInt(position);
 
-        position = position / 10000000;
+        position = ticksToSeconds(position);
 
         this._castPlayer.sendMessage({
             options: {
@@ -950,14 +955,15 @@ class ChromecastPlayer {
 
     currentTime(val) {
         if (val != null) {
-            return this.seek(val * 10000);
+            return this.seek(msToTicks(val));
         }
 
         let state = this.lastPlayerData || {};
         state = state.PlayState || {};
-        return state.PositionTicks / 10000;
+        return ticksToMs(state.PositionTicks);
     }
 
+    // TODO: Make this return milliseconds.
     duration() {
         let state = this.lastPlayerData || {};
         state = state.NowPlayingItem || {};

--- a/src/plugins/htmlAudioPlayer/plugin.js
+++ b/src/plugins/htmlAudioPlayer/plugin.js
@@ -2,6 +2,11 @@ import events from 'events';
 import browser from 'browser';
 import appHost from 'apphost';
 import * as htmlMediaHelper from 'htmlMediaHelper';
+import {
+    msToSeconds,
+    ticksToSeconds,
+    secondsToMs
+} from 'timeConversions';
 
 function getDefaultProfile() {
     return import('browserdeviceprofile').then(({ default: profileBuilder }) => {
@@ -114,7 +119,7 @@ class HtmlAudioPlayer {
             console.debug('playing url: ' + val);
 
             // Convert to seconds
-            const seconds = (options.playerStartPositionTicks || 0) / 10000000;
+            const seconds = ticksToSeconds(options.playerStartPositionTicks || 0);
             if (seconds) {
                 val += '#t=' + seconds;
             }
@@ -344,16 +349,16 @@ class HtmlAudioPlayer {
         const mediaElement = this._mediaElement;
         if (mediaElement) {
             if (val != null) {
-                mediaElement.currentTime = val / 1000;
+                mediaElement.currentTime = msToSeconds(val);
                 return;
             }
 
             const currentTime = this._currentTime;
             if (currentTime) {
-                return currentTime * 1000;
+                return secondsToMs(currentTime);
             }
 
-            return (mediaElement.currentTime || 0) * 1000;
+            return secondsToMs(mediaElement.currentTime || 0);
         }
     }
 
@@ -362,7 +367,7 @@ class HtmlAudioPlayer {
         if (mediaElement) {
             const duration = mediaElement.duration;
             if (htmlMediaHelper.isValidDuration(duration)) {
-                return duration * 1000;
+                return secondsToMs(duration);
             }
         }
 

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -35,7 +35,6 @@ import {
     secondsToMs
 } from 'timeConversions';
 
-
 /* eslint-disable indent */
 
 function tryRemoveElement(elem) {

--- a/src/plugins/sessionPlayer/plugin.js
+++ b/src/plugins/sessionPlayer/plugin.js
@@ -2,6 +2,7 @@ import playbackManager from 'playbackManager';
 import events from 'events';
 import serverNotifications from 'serverNotifications';
 import connectionManager from 'connectionManager';
+import { ticksToMs, msToTicks } from 'timeConversions';
 
 function getActivePlayerId() {
     const info = playbackManager.getPlayerInfo();
@@ -322,14 +323,15 @@ class SessionPlayer {
 
     currentTime(val) {
         if (val != null) {
-            return this.seek(val * 10000);
+            return this.seek(msToTicks(val));
         }
 
         let state = this.lastPlayerData || {};
         state = state.PlayState || {};
-        return state.PositionTicks / 10000;
+        return ticksToMs(state.PositionTicks);
     }
 
+    // TODO: Make this return milliseconds.
     duration() {
         let state = this.lastPlayerData || {};
         state = state.NowPlayingItem || {};

--- a/src/plugins/youtubePlayer/plugin.js
+++ b/src/plugins/youtubePlayer/plugin.js
@@ -2,6 +2,7 @@ import events from 'events';
 import browser from 'browser';
 import appRouter from 'appRouter';
 import loading from 'loading';
+import { secondsToMs, msToSeconds } from 'timeConversions';
 
 /* globals YT */
 
@@ -253,18 +254,18 @@ class YoutubePlayer {
 
         if (currentYoutubePlayer) {
             if (val != null) {
-                currentYoutubePlayer.seekTo(val / 1000, true);
+                currentYoutubePlayer.seekTo(msToSeconds(val), true);
                 return;
             }
 
-            return currentYoutubePlayer.getCurrentTime() * 1000;
+            return secondsToMs(currentYoutubePlayer.getCurrentTime());
         }
     }
     duration(val) {
         const currentYoutubePlayer = this.currentYoutubePlayer;
 
         if (currentYoutubePlayer) {
-            return currentYoutubePlayer.getDuration() * 1000;
+            return secondsToMs(currentYoutubePlayer.getDuration());
         }
         return null;
     }

--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -589,6 +589,7 @@ function initClient() {
         define('appSettings', [scriptsPath + '/settings/appSettings'], returnFirstDependency);
         define('userSettings', [scriptsPath + '/settings/userSettings'], returnFirstDependency);
 
+        define('timeConversions', [scriptsPath + '/timeConversions'], returnFirstDependency);
         define('mediaSession', [componentsPath + '/playback/mediasession'], returnFirstDependency);
         define('actionsheet', [componentsPath + '/actionSheet/actionSheet'], returnFirstDependency);
         define('tunerPicker', [componentsPath + '/tunerPicker'], returnFirstDependency);

--- a/src/scripts/timeConversions.js
+++ b/src/scripts/timeConversions.js
@@ -2,7 +2,7 @@ export function ticksToMs(ticks) {
     if (typeof ticks === 'number') {
         return ticks / 10000;
     } else {
-        return ticks;  // Undefined or not a number.
+        return ticks; // Undefined or not a number.
     }
 }
 
@@ -10,7 +10,7 @@ export function msToTicks(milliseconds) {
     if (typeof milliseconds === 'number') {
         return milliseconds * 10000;
     } else {
-        return milliseconds;  // Undefined or not a number.
+        return milliseconds; // Undefined or not a number.
     }
 }
 
@@ -18,7 +18,7 @@ export function ticksToSeconds(ticks) {
     if (typeof ticks === 'number') {
         return ticks / 10000000;
     } else {
-        return ticks;  // Undefined or not a number.
+        return ticks; // Undefined or not a number.
     }
 }
 
@@ -26,7 +26,7 @@ export function msToSeconds(milliseconds) {
     if (typeof milliseconds === 'number') {
         return milliseconds / 1000;
     } else {
-        return milliseconds;  // Undefined or not a number.
+        return milliseconds; // Undefined or not a number.
     }
 }
 
@@ -34,7 +34,7 @@ export function secondsToMs(seconds) {
     if (typeof seconds === 'number') {
         return seconds * 1000;
     } else {
-        return seconds;  // Undefined or not a number.
+        return seconds; // Undefined or not a number.
     }
 }
 
@@ -42,7 +42,6 @@ export function secondsToTicks(seconds) {
     if (typeof seconds === 'number') {
         return seconds * 10000000;
     } else {
-        return seconds;  // Undefined or not a number.
+        return seconds; // Undefined or not a number.
     }
 }
-

--- a/src/scripts/timeConversions.js
+++ b/src/scripts/timeConversions.js
@@ -1,0 +1,48 @@
+export function ticksToMs(ticks) {
+    if (typeof ticks === 'number') {
+        return ticks / 10000;
+    } else {
+        return ticks;  // Undefined or not a number.
+    }
+}
+
+export function msToTicks(milliseconds) {
+    if (typeof milliseconds === 'number') {
+        return milliseconds * 10000;
+    } else {
+        return milliseconds;  // Undefined or not a number.
+    }
+}
+
+export function ticksToSeconds(ticks) {
+    if (typeof ticks === 'number') {
+        return ticks / 10000000;
+    } else {
+        return ticks;  // Undefined or not a number.
+    }
+}
+
+export function msToSeconds(milliseconds) {
+    if (typeof milliseconds === 'number') {
+        return milliseconds / 1000;
+    } else {
+        return milliseconds;  // Undefined or not a number.
+    }
+}
+
+export function secondsToMs(seconds) {
+    if (typeof seconds === 'number') {
+        return seconds * 1000;
+    } else {
+        return seconds;  // Undefined or not a number.
+    }
+}
+
+export function secondsToTicks(seconds) {
+    if (typeof seconds === 'number') {
+        return seconds * 10000000;
+    } else {
+        return seconds;  // Undefined or not a number.
+    }
+}
+


### PR DESCRIPTION
Per the decision on https://github.com/jellyfin/jellyfin-web/issues/1790, this PR is the work in progress to use milliseconds instead of ticks natively in the web client, wherever possible.

**Changes**
 - Make time conversions explicit.

