### PR TITLE
Handle no matches on iOS version regex

### DIFF
--- a/src/scripts/browser.js
+++ b/src/scripts/browser.js
@@ -77,7 +77,9 @@ function iOSversion() {
     if (/iP(hone|od|ad)|MacIntel/.test(navigator.platform)) {
         // supports iOS 2.0 and later: <http://bit.ly/TJjs1V>
         const v = (navigator.appVersion).match(/OS (\d+)_(\d+)_?(\d+)?/);
-        return [parseInt(v[1], 10), parseInt(v[2], 10), parseInt(v[3] || 0, 10)];
+        if (v) {
+            return [parseInt(v[1], 10), parseInt(v[2], 10), parseInt(v[3] || 0, 10)];
+        }
     }
 }
 


### PR DESCRIPTION
**Changes**
This is a quick fix to avoid a crash if this method is called on iPads running new versions of iOS that match on "MacIntel" but do not report the version in the expected way. This _probably_ won't happen currently since we don't detect them as running iOS, but it's probably best to just add a safety check here regardless.

**Issues**
N/A
