### PR TITLE
Unclutter listview for small screens

### DIFF
--- a/src/components/listview/listview.css
+++ b/src/components/listview/listview.css
@@ -191,6 +191,13 @@
     }
 }
 
+@media all and (max-width: 40em) {
+    [data-type='Movie'] .listItemImage,
+    [data-type='Series'] .listItemImage {
+        display: none;
+    }
+}
+
 .listItemImage-large-tv {
     width: 30vw !important;
     height: 20vw !important;

--- a/src/components/listview/listview.css
+++ b/src/components/listview/listview.css
@@ -185,6 +185,10 @@
     .listItemBody {
         padding-right: 0.5em;
     }
+
+    .listItemMediaInfo {
+        display: none;
+    }
 }
 
 .listItemImage-large-tv {


### PR DESCRIPTION
Hides Secondary item info in list view on smaller screens

**Changes**
See Below Images:

Before:
![2020-08-31-fix-list-view-small-devices-before](https://user-images.githubusercontent.com/18101008/91737707-55d04600-eba7-11ea-9932-c9366727af44.png)
After:
![2020-08-31-fix-list-view-small-devices-after](https://user-images.githubusercontent.com/18101008/91737715-59fc6380-eba7-11ea-86ab-f29c35c4419b.png)

Ignore whitespace