### PR TITLE
Fixed header tooltips not being translated to the user language

### DIFF
--- a/src/scripts/libraryMenu.js
+++ b/src/scripts/libraryMenu.js
@@ -74,6 +74,8 @@ import 'flexStyles';
     }
 
     function updateUserInHeader(user) {
+        renderHeader();
+
         let hasImage;
 
         if (user && user.name) {
@@ -954,8 +956,6 @@ import 'flexStyles';
         updateBackButton(page);
         updateLibraryNavLinks(page);
     });
-
-    renderHeader();
 
     events.on(connectionManager, 'localusersignedin', function (e, user) {
         const currentApiClient = connectionManager.getApiClient(user.ServerId);


### PR DESCRIPTION
Fixes the header's tooltips being in default browser language instead of being what the user display setting is.

**Issues**
Fixes #1682 
