### PR TITLE
Fix old iOS devices that do not support AC-3

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -70,12 +70,24 @@ define(['browser'], function (browser) {
             return true;
         }
 
+        // iPhones 5c and older and old model iPads do not support AC-3/E-AC-3
+        // These models can only run iOS 10.x or lower
+        if (browser.iOS && browser.iOSVersion < 11) {
+            return false;
+        }
+
         return videoTestElement.canPlayType('audio/mp4; codecs="ac-3"').replace(/no/, '');
     }
 
     function supportsEac3(videoTestElement) {
         if (browser.tizen || browser.web0s) {
             return true;
+        }
+
+        // iPhones 5c and older and old model iPads do not support AC-3/E-AC-3
+        // These models can only run iOS 10.x or lower
+        if (browser.iOS && browser.iOSVersion < 11) {
+            return false;
         }
 
         return videoTestElement.canPlayType('audio/mp4; codecs="ec-3"').replace(/no/, '');


### PR DESCRIPTION
**Changes**
Old iPhone and iPad devices do not support AC-3 and E-AC-3. See this [support matrix](https://developer.dolby.com/platforms/apple/ios/device-support/). Testing with `canPlayType` reports "probably"/"maybe" for support of these codecs. Which is not a good indicator of if the device actually supports playback since devices that do support it only report as "probably". Based on this [max iOS support matrix](https://iosref.com/ios), it looks like we can just check for iOS versions < 11.

**Issues**
N/A
