### PR TITLE
Fix webOS 1.2

### DIFF
--- a/src/components/viewContainer.js
+++ b/src/components/viewContainer.js
@@ -36,54 +36,56 @@ import 'css!components/viewManager/viewContainer';
             const newViewInfo = normalizeNewView(options, isPluginpage);
             const newView = newViewInfo.elem;
 
-            return new Promise((resolve) => {
-                const currentPage = allPages[pageIndex];
+            const currentPage = allPages[pageIndex];
 
-                if (currentPage) {
-                    triggerDestroy(currentPage);
-                }
+            if (currentPage) {
+                triggerDestroy(currentPage);
+            }
 
-                let view = newView;
+            let view = newView;
 
-                if (typeof view == 'string') {
-                    view = document.createElement('div');
-                    view.innerHTML = newView;
-                }
+            if (typeof view == 'string') {
+                view = document.createElement('div');
+                view.innerHTML = newView;
+            }
 
-                view.classList.add('mainAnimatedPage');
+            view.classList.add('mainAnimatedPage');
 
-                if (currentPage) {
-                    if (newViewInfo.hasScript && window.$) {
-                        mainAnimatedPages.removeChild(currentPage);
-                        view = $(view).appendTo(mainAnimatedPages)[0];
-                    } else {
-                        mainAnimatedPages.replaceChild(view, currentPage);
-                    }
+            if (currentPage) {
+                if (newViewInfo.hasScript && window.$) {
+                    mainAnimatedPages.removeChild(currentPage);
+                    view = $(view).appendTo(mainAnimatedPages)[0];
                 } else {
-                    if (newViewInfo.hasScript && window.$) {
-                        view = $(view).appendTo(mainAnimatedPages)[0];
-                    } else {
-                        mainAnimatedPages.appendChild(view);
-                    }
+                    mainAnimatedPages.replaceChild(view, currentPage);
                 }
-
-                if (options.type) {
-                    view.setAttribute('data-type', options.type);
+            } else {
+                if (newViewInfo.hasScript && window.$) {
+                    view = $(view).appendTo(mainAnimatedPages)[0];
+                } else {
+                    mainAnimatedPages.appendChild(view);
                 }
+            }
 
-                const properties = [];
+            if (options.type) {
+                view.setAttribute('data-type', options.type);
+            }
 
-                if (options.fullscreen) {
-                    properties.push('fullscreen');
-                }
+            const properties = [];
 
-                if (properties.length) {
-                    view.setAttribute('data-properties', properties.join(','));
-                }
+            if (options.fullscreen) {
+                properties.push('fullscreen');
+            }
 
-                allPages[pageIndex] = view;
+            if (properties.length) {
+                view.setAttribute('data-properties', properties.join(','));
+            }
+
+            allPages[pageIndex] = view;
+
+            return setControllerClass(view, options)
                 // Timeout for polyfilled CustomElements (webOS 1.2)
-                setControllerClass(view, options).then(() => new Promise((resolve) => setTimeout(resolve, 0))).then(() => {
+                .then(() => new Promise((resolve) => setTimeout(resolve, 0)))
+                .then(() => {
                     if (onBeforeChange) {
                         onBeforeChange(view, false, options);
                     }
@@ -101,9 +103,8 @@ import 'css!components/viewManager/viewContainer';
                         $.mobile.activePage = view;
                     }
 
-                    resolve(view);
+                    return view;
                 });
-            });
         }
     }
 

--- a/src/components/viewContainer.js
+++ b/src/components/viewContainer.js
@@ -82,7 +82,8 @@ import 'css!components/viewManager/viewContainer';
                 }
 
                 allPages[pageIndex] = view;
-                setControllerClass(view, options).then(() => {
+                // Timeout for polyfilled CustomElements (webOS 1.2)
+                setControllerClass(view, options).then(() => new Promise((resolve) => setTimeout(resolve, 0))).then(() => {
                     if (onBeforeChange) {
                         onBeforeChange(view, false, options);
                     }

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -15,7 +15,7 @@ module.exports = merge(common, {
         rules: [
             {
                 test: /\.js$/,
-                exclude: /node_modules[\\/](?!date-fns|epubjs|jellyfin-apiclient|query-string|split-on-first|strict-uri-encode|xmldom)/,
+                exclude: /node_modules[\\/](?!date-fns|epubjs|libarchive|jellyfin-apiclient|query-string|split-on-first|strict-uri-encode|xmldom)/,
                 use: {
                     loader: 'babel-loader',
                     options: {

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -8,7 +8,7 @@ module.exports = merge(common, {
         rules: [
             {
                 test: /\.js$/,
-                exclude: /node_modules[\\/](?!date-fns|epubjs|jellyfin-apiclient|query-string|split-on-first|strict-uri-encode|xmldom)/,
+                exclude: /node_modules[\\/](?!date-fns|epubjs|libarchive|jellyfin-apiclient|query-string|split-on-first|strict-uri-encode|xmldom)/,
                 use: {
                     loader: 'babel-loader',
                     options: {


### PR DESCRIPTION
**Changes**
- Exclude `libarchive` from Babel exclude list.
- Add timeout for polyfilled CustomElements.

**Issues**
- `bundle.js` contains `class` (from `libarchive`).
- Runtime errors on video OSD and remotecontrol pages. `CustomElements` is async polyfilled (`MutationObserver`?).

Alternatively, we could call `window.CustomElements.upgradeSubtree(view)` on each page.