### PR TITLE
Fix Enter key in Edit Metadata dialog

### DIFF
--- a/src/components/metadataEditor/metadataEditor.template.html
+++ b/src/components/metadataEditor/metadataEditor.template.html
@@ -251,7 +251,7 @@
             </div>
             <br />
             <div class="formDialogFooter">
-                <button is="emby-button" class="raised button-cancel block btnCancel formDialogFooterItem">
+                <button is="emby-button" type="button" class="raised button-cancel block btnCancel formDialogFooterItem">
                     <span>${Cancel}</span>
                 </button>
                 <button is="emby-button" type="submit" class="raised button-submit block btnSave formDialogFooterItem">


### PR DESCRIPTION
**Changes**
The Cancel button in the Edit Metadata dialog was missing a `type="button"` attribute. Since it's inside a `form` element, it defaults to `type="submit"`, and since pressing the Enter key inside a form "clicks" the first submit button, pressing Enter was "clicking" the Cancel button instead of the Save Changes button, and changes were lost instead of saved.

This PR adds the missing attribute, so the Enter key "clicks" the right button, and changes are saved as expected.

**Issues**
Fixes #1922 
