### PR TITLE
Disable 'Remember Me' by default

### DIFF
--- a/src/controllers/session/login/index.html
+++ b/src/controllers/session/login/index.html
@@ -13,7 +13,7 @@
             </div>
 
             <label class="checkboxContainer">
-                <input is="emby-checkbox" type="checkbox" class="chkRememberLogin" checked />
+                <input is="emby-checkbox" type="checkbox" class="chkRememberLogin" />
                 <span>${RememberMe}</span>
             </label>
 

--- a/src/controllers/session/login/index.js
+++ b/src/controllers/session/login/index.js
@@ -114,7 +114,6 @@ import cardBuilder from '../../../components/cardbuilder/cardBuilder';
     }
 
     function showManualForm(context, showCancel, focusPassword) {
-        context.querySelector('.chkRememberLogin').checked = appSettings.enableAutoLogin();
         context.querySelector('.manualLoginForm').classList.remove('hide');
         context.querySelector('.visualLoginForm').classList.add('hide');
         context.querySelector('.btnManual').classList.add('hide');
@@ -205,6 +204,9 @@ import cardBuilder from '../../../components/cardbuilder/cardBuilder';
         }
 
         view.querySelector('#divUsers').addEventListener('click', function (e) {
+            // Prevent auto login if logged in via visual form
+            appSettings.enableAutoLogin(false);
+
             const card = dom.parentWithClass(e.target, 'card');
             const cardContent = card ? card.querySelector('.cardContent') : null;
 

--- a/src/scripts/settings/appSettings.js
+++ b/src/scripts/settings/appSettings.js
@@ -15,7 +15,7 @@ class AppSettings {
             this.set('enableAutoLogin', val.toString());
         }
 
-        return this.get('enableAutoLogin') !== 'false';
+        return this.get('enableAutoLogin') === 'true';
     }
 
     enableSystemExternalPlayers(val) {


### PR DESCRIPTION
https://github.com/jellyfin/jellyfin-tizen/issues/51 in short (and interpreted):

User has 2 accounts on the server:
- admin/parent
- child

Client is on TV (or any shared device).

When you are logging in via manual form, `Remember Me` is checked by default or restored from `localStorage` and you have to disable it for admin/parent account each time other user enabled it.

Unset `enableAutoLogin` is treated as `true`, so if you have valid `AccessToken`, app logs in.

When you are logging in via visual form, you cannot turn on/off auto login (that's probably why unset `enableAutoLogin` is treated as `true`). So if no one set `Remember Me` (via manual form), you will be logged in.

**Changes**
- `Remember Me` is unchecked and not restored - you are presumably starting a new session. And if you want to be remembered you check `Remember Me` once (in opposite to unchecking it each time).
- Unset `enableAutoLogin` is treated as `false`.
- Visual form turns off `enableAutoLogin`, which disables auto login via visual form. If you have no password, you can easily click your card. With password, you must use manual form (switched automatically).

**Issues**
Fixes https://github.com/jellyfin/jellyfin-tizen/issues/51

@varlesh also said that `Remember Me` isn't restored from previous state. So there might be a `localStorage` issue, but it works on Tizen 4 and 5 (emulator).