### PR TITLE
Fix subtitles display on Tizen 2.x

### DIFF
--- a/src/plugins/htmlVideoPlayer/style.css
+++ b/src/plugins/htmlVideoPlayer/style.css
@@ -17,7 +17,11 @@
     order: -1;
 }
 
-video::-webkit-media-controls {
+/* Controls are enabled for devices that don't support autoplay. They will be hidden when playback starts.
+   In Tizen 2.3 (and probably other old web engines), subtitles are located under '-webkit-media-controls' tree.
+   Therefore, we hide controls only if they are enabled.
+ */
+video[controls]::-webkit-media-controls {
     display: none !important;
 }
 


### PR DESCRIPTION
Thanks to @HimbeersaftLP (https://github.com/jellyfin/jellyfin-web/issues/1872#issuecomment-683810826).

I did some testing: added `controls` despite `htmlvideoautoplay`.
Without CSS, I had a native loading indicator in Firefox and Chrome.
With CSS, Chrome's indicator has been hidden. Firefox requires to omit `controls` attribute.

**Changes**
Hide controls only if they are enabled.

**Issues**
Fixes #1872
