### PR TITLE
Fix ES6 import - browser

### DIFF
--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -203,7 +203,7 @@ function initClient() {
             createConnectionManager().then(function () {
                 console.debug('initAfterDependencies promises resolved');
 
-                require(['globalize', 'browser'], function (globalize, browser) {
+                require(['globalize', 'browser'], function (globalize, {default: browser}) {
                     window.Globalize = globalize;
                     loadCoreDictionary(globalize).then(function () {
                         onGlobalizeInit(browser, globalize);


### PR DESCRIPTION
In Tizen 3 (emulator), app crashes on injecting of page (`selectServer`, but this doesn't matter).
At first, I found out that with non-ES6 `browser` everything is fine.
Next, I found out that crash happens if `fonts.css` is used. With `fonts.sized.css`, everything is fine.
And finally, I found out that `browser` isn't imported correctly.

**Changes**
Add `default` target when import `browser`.

**Issues**
Tizen 3 app crashes.
