### PR TITLE
Removed excess quality options to make menu more manageable

### DIFF
--- a/src/components/qualityOptions.js
+++ b/src/components/qualityOptions.js
@@ -15,56 +15,6 @@ export function getVideoQualityOptions(options) {
 
     const qualityOptions = [];
 
-    if (maxAllowedWidth >= 3800) {
-        qualityOptions.push({ name: '4K - 120 Mbps', maxHeight: 2160, bitrate: 120000000 });
-        qualityOptions.push({ name: '4K - 100 Mbps', maxHeight: 2160, bitrate: 100000000 });
-        qualityOptions.push({ name: '4K - 80 Mbps', maxHeight: 2160, bitrate: 80000000 });
-    }
-
-    // Some 1080- videos are reported as 1912?
-    if (maxAllowedWidth >= 1900) {
-        qualityOptions.push({ name: '1080p - 60 Mbps', maxHeight: 1080, bitrate: 60000000 });
-        qualityOptions.push({ name: '1080p - 50 Mbps', maxHeight: 1080, bitrate: 50000000 });
-        qualityOptions.push({ name: '1080p - 40 Mbps', maxHeight: 1080, bitrate: 40000000 });
-        qualityOptions.push({ name: '1080p - 30 Mbps', maxHeight: 1080, bitrate: 30000000 });
-        qualityOptions.push({ name: '1080p - 25 Mbps', maxHeight: 1080, bitrate: 25000000 });
-        qualityOptions.push({ name: '1080p - 20 Mbps', maxHeight: 1080, bitrate: 20000000 });
-        qualityOptions.push({ name: '1080p - 15 Mbps', maxHeight: 1080, bitrate: 15000000 });
-        qualityOptions.push({ name: '1080p - 10 Mbps', maxHeight: 1080, bitrate: 10000001 });
-        qualityOptions.push({ name: '1080p - 8 Mbps', maxHeight: 1080, bitrate: 8000001 });
-        qualityOptions.push({ name: '1080p - 6 Mbps', maxHeight: 1080, bitrate: 6000001 });
-        qualityOptions.push({ name: '1080p - 5 Mbps', maxHeight: 1080, bitrate: 5000001 });
-        qualityOptions.push({ name: '1080p - 4 Mbps', maxHeight: 1080, bitrate: 4000002 });
-    } else if (maxAllowedWidth >= 1260) {
-        qualityOptions.push({ name: '720p - 10 Mbps', maxHeight: 720, bitrate: 10000000 });
-        qualityOptions.push({ name: '720p - 8 Mbps', maxHeight: 720, bitrate: 8000000 });
-        qualityOptions.push({ name: '720p - 6 Mbps', maxHeight: 720, bitrate: 6000000 });
-        qualityOptions.push({ name: '720p - 5 Mbps', maxHeight: 720, bitrate: 5000000 });
-    } else if (maxAllowedWidth >= 620) {
-        qualityOptions.push({ name: '480p - 4 Mbps', maxHeight: 480, bitrate: 4000001 });
-        qualityOptions.push({ name: '480p - 3 Mbps', maxHeight: 480, bitrate: 3000001 });
-        qualityOptions.push({ name: '480p - 2.5 Mbps', maxHeight: 480, bitrate: 2500000 });
-        qualityOptions.push({ name: '480p - 2 Mbps', maxHeight: 480, bitrate: 2000001 });
-        qualityOptions.push({ name: '480p - 1.5 Mbps', maxHeight: 480, bitrate: 1500001 });
-    }
-
-    if (maxAllowedWidth >= 1260) {
-        qualityOptions.push({ name: '720p - 4 Mbps', maxHeight: 720, bitrate: 4000000 });
-        qualityOptions.push({ name: '720p - 3 Mbps', maxHeight: 720, bitrate: 3000000 });
-        qualityOptions.push({ name: '720p - 2 Mbps', maxHeight: 720, bitrate: 2000000 });
-
-        // The extra 1 is because they're keyed off the bitrate value
-        qualityOptions.push({ name: '720p - 1.5 Mbps', maxHeight: 720, bitrate: 1500000 });
-        qualityOptions.push({ name: '720p - 1 Mbps', maxHeight: 720, bitrate: 1000001 });
-    }
-
-    qualityOptions.push({ name: '480p - 1 Mbps', maxHeight: 480, bitrate: 1000000 });
-    qualityOptions.push({ name: '480p - 720 kbps', maxHeight: 480, bitrate: 720000 });
-    qualityOptions.push({ name: '480p - 420 kbps', maxHeight: 480, bitrate: 420000 });
-    qualityOptions.push({ name: '360p', maxHeight: 360, bitrate: 400000 });
-    qualityOptions.push({ name: '240p', maxHeight: 240, bitrate: 320000 });
-    qualityOptions.push({ name: '144p', maxHeight: 144, bitrate: 192000 });
-
     const autoQualityOption = {
         name: globalize.translate('Auto'),
         bitrate: 0,
@@ -74,6 +24,31 @@ export function getVideoQualityOptions(options) {
     if (options.enableAuto) {
         qualityOptions.push(autoQualityOption);
     }
+
+    // Quality options are indexed by bitrate. If you must duplicate them, make sure each of them are unique (by making the last digit a 1)
+    if (maxAllowedWidth >= 3800) {
+        qualityOptions.push({ name: '4K - 120 Mbps', maxHeight: 2160, bitrate: 120000000 });
+        qualityOptions.push({ name: '4K - 80 Mbps', maxHeight: 2160, bitrate: 80000000 });
+    }
+    if (maxAllowedWidth >= 1900) { // Some 1080- videos are reported as 1912?
+        qualityOptions.push({ name: '1080p - 60 Mbps', maxHeight: 1080, bitrate: 60000000 });
+        qualityOptions.push({ name: '1080p - 40 Mbps', maxHeight: 1080, bitrate: 40000000 });
+        qualityOptions.push({ name: '1080p - 20 Mbps', maxHeight: 1080, bitrate: 20000000 });
+        qualityOptions.push({ name: '1080p - 15 Mbps', maxHeight: 1080, bitrate: 15000000 });
+        qualityOptions.push({ name: '1080p - 10 Mbps', maxHeight: 1080, bitrate: 10000000 });
+    } 
+    if (maxAllowedWidth >= 1260) {
+        qualityOptions.push({ name: '720p - 8 Mbps', maxHeight: 720, bitrate: 8000000 });
+        qualityOptions.push({ name: '720p - 6 Mbps', maxHeight: 720, bitrate: 6000000 });
+        qualityOptions.push({ name: '720p - 3 Mbps', maxHeight: 720, bitrate: 3000000 });
+    } 
+    if (maxAllowedWidth >= 620) {
+        qualityOptions.push({ name: '480p - 1.5 Mbps', maxHeight: 480, bitrate: 1500000 });
+        qualityOptions.push({ name: '480p - 720 kbps', maxHeight: 480, bitrate: 720000 });
+        qualityOptions.push({ name: '480p - 420 kbps', maxHeight: 480, bitrate: 420000 });
+    }
+
+    qualityOptions.push({ name: '360p - 360 kbps', maxHeight: 360, bitrate: 360000 });
 
     if (maxStreamingBitrate) {
         let selectedIndex = -1;
@@ -106,16 +81,6 @@ export function getAudioQualityOptions(options) {
 
     const qualityOptions = [];
 
-    qualityOptions.push({ name: '2 Mbps', bitrate: 2000000 });
-    qualityOptions.push({ name: '1.5 Mbps', bitrate: 1500000 });
-    qualityOptions.push({ name: '1 Mbps', bitrate: 1000000 });
-    qualityOptions.push({ name: '320 kbps', bitrate: 320000 });
-    qualityOptions.push({ name: '256 kbps', bitrate: 256000 });
-    qualityOptions.push({ name: '192 kbps', bitrate: 192000 });
-    qualityOptions.push({ name: '128 kbps', bitrate: 128000 });
-    qualityOptions.push({ name: '96 kbps', bitrate: 96000 });
-    qualityOptions.push({ name: '64 kbps', bitrate: 64000 });
-
     const autoQualityOption = {
         name: globalize.translate('Auto'),
         bitrate: 0,
@@ -125,6 +90,16 @@ export function getAudioQualityOptions(options) {
     if (options.enableAuto) {
         qualityOptions.push(autoQualityOption);
     }
+
+    qualityOptions.push({ name: '2 Mbps', bitrate: 2000000 });
+    qualityOptions.push({ name: '1.5 Mbps', bitrate: 1500000 });
+    qualityOptions.push({ name: '1 Mbps', bitrate: 1000000 });
+    qualityOptions.push({ name: '320 kbps', bitrate: 320000 });
+    qualityOptions.push({ name: '256 kbps', bitrate: 256000 });
+    qualityOptions.push({ name: '192 kbps', bitrate: 192000 });
+    qualityOptions.push({ name: '128 kbps', bitrate: 128000 });
+    qualityOptions.push({ name: '96 kbps', bitrate: 96000 });
+    qualityOptions.push({ name: '64 kbps', bitrate: 64000 });
 
     if (maxStreamingBitrate) {
         let selectedIndex = -1;

--- a/src/components/qualityOptions.js
+++ b/src/components/qualityOptions.js
@@ -41,7 +41,7 @@ export function getVideoQualityOptions(options) {
     if (maxAllowedWidth >= 1260) {
         qualityOptions.push({ name: '720p - 8 Mbps', maxHeight: 720, bitrate: 8000000 });
         qualityOptions.push({ name: '720p - 6 Mbps', maxHeight: 720, bitrate: 6000000 });
-        qualityOptions.push({ name: '720p - 4 Mbps', maxHeight: 720, bitrate: 3000000 });
+        qualityOptions.push({ name: '720p - 4 Mbps', maxHeight: 720, bitrate: 4000000 });
     }
     if (maxAllowedWidth >= 620) {
         qualityOptions.push({ name: '480p - 3 Mbps', maxHeight: 480, bitrate: 3000000 });

--- a/src/components/qualityOptions.js
+++ b/src/components/qualityOptions.js
@@ -41,15 +41,15 @@ export function getVideoQualityOptions(options) {
     if (maxAllowedWidth >= 1260) {
         qualityOptions.push({ name: '720p - 8 Mbps', maxHeight: 720, bitrate: 8000000 });
         qualityOptions.push({ name: '720p - 6 Mbps', maxHeight: 720, bitrate: 6000000 });
-        qualityOptions.push({ name: '720p - 3 Mbps', maxHeight: 720, bitrate: 3000000 });
+        qualityOptions.push({ name: '720p - 4 Mbps', maxHeight: 720, bitrate: 3000000 });
     }
     if (maxAllowedWidth >= 620) {
+        qualityOptions.push({ name: '480p - 3 Mbps', maxHeight: 480, bitrate: 3000000 });
         qualityOptions.push({ name: '480p - 1.5 Mbps', maxHeight: 480, bitrate: 1500000 });
         qualityOptions.push({ name: '480p - 720 kbps', maxHeight: 480, bitrate: 720000 });
-        qualityOptions.push({ name: '480p - 420 kbps', maxHeight: 480, bitrate: 420000 });
     }
 
-    qualityOptions.push({ name: '360p - 360 kbps', maxHeight: 360, bitrate: 360000 });
+    qualityOptions.push({ name: '360p - 420 kbps', maxHeight: 360, bitrate: 420000 });
 
     if (maxStreamingBitrate) {
         let selectedIndex = -1;

--- a/src/components/qualityOptions.js
+++ b/src/components/qualityOptions.js
@@ -30,18 +30,19 @@ export function getVideoQualityOptions(options) {
         qualityOptions.push({ name: '4K - 120 Mbps', maxHeight: 2160, bitrate: 120000000 });
         qualityOptions.push({ name: '4K - 80 Mbps', maxHeight: 2160, bitrate: 80000000 });
     }
-    if (maxAllowedWidth >= 1900) { // Some 1080- videos are reported as 1912?
+    // Some 1080- videos are reported as 1912?
+    if (maxAllowedWidth >= 1900) {
         qualityOptions.push({ name: '1080p - 60 Mbps', maxHeight: 1080, bitrate: 60000000 });
         qualityOptions.push({ name: '1080p - 40 Mbps', maxHeight: 1080, bitrate: 40000000 });
         qualityOptions.push({ name: '1080p - 20 Mbps', maxHeight: 1080, bitrate: 20000000 });
         qualityOptions.push({ name: '1080p - 15 Mbps', maxHeight: 1080, bitrate: 15000000 });
         qualityOptions.push({ name: '1080p - 10 Mbps', maxHeight: 1080, bitrate: 10000000 });
-    } 
+    }
     if (maxAllowedWidth >= 1260) {
         qualityOptions.push({ name: '720p - 8 Mbps', maxHeight: 720, bitrate: 8000000 });
         qualityOptions.push({ name: '720p - 6 Mbps', maxHeight: 720, bitrate: 6000000 });
         qualityOptions.push({ name: '720p - 3 Mbps', maxHeight: 720, bitrate: 3000000 });
-    } 
+    }
     if (maxAllowedWidth >= 620) {
         qualityOptions.push({ name: '480p - 1.5 Mbps', maxHeight: 480, bitrate: 1500000 });
         qualityOptions.push({ name: '480p - 720 kbps', maxHeight: 480, bitrate: 720000 });


### PR DESCRIPTION
**Changes**
Just removed all kinds of excess quality options to make the quality selector menu not require scrolling on a 1080 screen.

Removed some duplicate bitrates as well, favoring the lower bitrate being in the lower resolution (as high res + low bitrate typically looks worse in my experience).

Also, moved Auto to the top of the list (vs the bottom) and dropped 240 and 144 resolutions outright. Smallest is now 360 and I dropped the bitrate on that slightly to make it stand out among the low end of 480 bitrates.


Previous look on desktop:

![Screenshot_20201017_191358](https://user-images.githubusercontent.com/1992688/96355863-ebbb2400-10b4-11eb-9f0c-7ae5af6de498.png)

Current look on desktop:
![Screenshot_20201017_200530](https://user-images.githubusercontent.com/1992688/96355867-f5dd2280-10b4-11eb-888e-82f63b1937e1.png)
