### PR TITLE
Prevent doubleclick on buttons from bubbling to video for fullscreen

### DIFF
--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1528,23 +1528,44 @@ import 'css!assets/css/videoosd';
         view.querySelector('.btnPreviousTrack').addEventListener('click', function () {
             playbackManager.previousTrack(currentPlayer);
         });
+        view.querySelector('.btnPreviousTrack').addEventListener('dblclick', function (event) {
+            event.stopPropagation();
+        });
         view.querySelector('.btnPause').addEventListener('click', function () {
             // Ignore 'click' if another element was originally clicked (Firefox/Edge issue)
             if (this.contains(clickedElement)) {
                 playbackManager.playPause(currentPlayer);
             }
         });
+        view.querySelector('.btnPause').addEventListener('dblclick', function (event) {
+            event.stopPropagation();
+        });
         view.querySelector('.btnNextTrack').addEventListener('click', function () {
             playbackManager.nextTrack(currentPlayer);
+        });
+        view.querySelector('.btnNextTrack').addEventListener('dblclick', function (event) {
+            event.stopPropagation();
         });
         btnRewind.addEventListener('click', function () {
             playbackManager.rewind(currentPlayer);
         });
+        btnRewind.addEventListener('dblclick', function (event) {
+            event.stopPropagation();
+        });
         btnFastForward.addEventListener('click', function () {
             playbackManager.fastForward(currentPlayer);
         });
+        btnFastForward.addEventListener('dblclick', function (event) {
+            event.stopPropagation();
+        });
         view.querySelector('.btnAudio').addEventListener('click', showAudioTrackSelection);
+        view.querySelector('.btnAudio').addEventListener('dblclick', function (event) {
+            event.stopPropagation();
+        });
         view.querySelector('.btnSubtitles').addEventListener('click', showSubtitleTrackSelection);
+        view.querySelector('.btnSubtitles').addEventListener('dblclick', function (event) {
+            event.stopPropagation();
+        });
 
         if (browser.touch) {
             (function () {


### PR DESCRIPTION
**Changes**
Fairly naive way of preventing the double click propagation - let me know if this is workable


**Issues**
Fixes #2006
