### PR TITLE
Remove custom hover style

### DIFF
--- a/src/components/remotecontrol/remotecontrol.css
+++ b/src/components/remotecontrol/remotecontrol.css
@@ -372,8 +372,7 @@
         font-size: smaller;
     }
 
-    .paper-icon-button-light:hover {
-        color: #fff !important;
+    .paper-icon-button-light {
         background-color: transparent !important;
     }
 
@@ -381,10 +380,6 @@
         padding: 0;
         margin: 0;
         font-size: 1.7em;
-    }
-
-    .btnPlayPause:hover {
-        background-color: transparent !important;
     }
 
     .nowPlayingPageImage {


### PR DESCRIPTION
#1867 disables `hover` style on mobile. But there is one more place that is causing #1833. This is only relevant for narrow screens (`43em`).
https://github.com/jellyfin/jellyfin-web/blob/6a82956cf46135e44a2a9ad620bcac6118b110f4/src/components/remotecontrol/remotecontrol.css#L375-L378
~These lines were probably added to fix the same `hover` style issue, and became unnecessary because #1867 disabled unwanted `hover` styles.~

**Desktop**
Before
![before_desktop](https://user-images.githubusercontent.com/56478732/97785586-eaaaec00-1bb6-11eb-9ea5-3a87e0dd6c42.gif)

After
![test2](https://user-images.githubusercontent.com/56478732/98013346-538aa200-1e0b-11eb-9eef-a59887722849.gif)

**Mobile**
Before
![before_mobile](https://user-images.githubusercontent.com/56478732/97785601-fe565280-1bb6-11eb-8dfb-8230fc67a262.gif)

After
![output](https://user-images.githubusercontent.com/56478732/99887932-87622600-2c59-11eb-9ed9-e30f7642851a.gif)

**Changes**
Remove custom hover style.

**Issues**
Fixes #1833
