### PR TITLE
Hide progress bar when playing theme media

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -41,6 +41,7 @@
  - [Cromefire_](https://github.com/cromefire)
  - [Orry Verducci](https://github.com/orryverducci)
  - [Camc314](https://github.com/camc314)
+ - [danieladov](https://github.com/danieladov)
 
 # Emby Contributors
 

--- a/src/components/nowPlayingBar/nowPlayingBar.js
+++ b/src/components/nowPlayingBar/nowPlayingBar.js
@@ -664,7 +664,7 @@ import 'emby-ratingbutton';
         console.debug('nowplaying event: ' + event.type);
         const player = this;
 
-        if (!state.NowPlayingItem || layoutManager.tv) {
+        if (!state.NowPlayingItem || layoutManager.tv || !state.IsFullscreen) {
             hideNowPlayingBar();
             return;
         }

--- a/src/components/themeMediaPlayer.js
+++ b/src/components/themeMediaPlayer.js
@@ -26,8 +26,7 @@ function playThemeMedia(items, ownerId) {
             enableRemotePlayers: false
         }).then(function () {
             currentOwnerId = ownerId;
-        })
-       
+        });
     } else {
         stopIfPlaying();
     }

--- a/src/components/themeMediaPlayer.js
+++ b/src/components/themeMediaPlayer.js
@@ -26,8 +26,8 @@ function playThemeMedia(items, ownerId) {
             enableRemotePlayers: false
         }).then(function () {
             currentOwnerId = ownerId;
-        });
-        document.getElementsByClassName("nowPlayingBarTop")[0].style.display = "none";
+        })
+       
     } else {
         stopIfPlaying();
     }

--- a/src/components/themeMediaPlayer.js
+++ b/src/components/themeMediaPlayer.js
@@ -27,6 +27,7 @@ function playThemeMedia(items, ownerId) {
         }).then(function () {
             currentOwnerId = ownerId;
         });
+        document.getElementsByClassName("nowPlayingBarTop")[0].style.display = "none";
     } else {
         stopIfPlaying();
     }


### PR DESCRIPTION

Currently, jellyfin plays the theme songs correctly but the progress bar is always present during it.  As here
![themeSongsBar](https://user-images.githubusercontent.com/29411250/97821924-6ccd0a80-1cb4-11eb-80a2-dba1be636637.png)

With these changes the progress bar is hidden.


