### PR TITLE
Create 1 lazyloader observer per collection type

### DIFF
--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -1727,7 +1727,7 @@ function renderCollectionItemType(page, parentItem, type, items) {
     html += '</div>';
     const collectionItems = page.querySelector('.collectionItems');
     collectionItems.insertAdjacentHTML('beforeend', html);
-    imageLoader.lazyChildren(collectionItems);
+    imageLoader.lazyChildren(collectionItems.lastChild);
 }
 
 function renderMusicVideos(page, item, user) {


### PR DESCRIPTION
It was creating 1 observer for the collectionItems container per collection type, which could lead to multiple observers for one item.

Fixes #1741