### PR TITLE
Fix Schedules Direct Listings

### DIFF
--- a/src/components/tvproviders/schedulesdirect.js
+++ b/src/components/tvproviders/schedulesdirect.js
@@ -84,9 +84,6 @@ export default function (page, providerId, options) {
     }
 
     function sha256(str) {
-        if (!self.TextEncoder) {
-            return Promise.resolve('');
-        }
 
         const buffer = new TextEncoder('utf-8').encode(str);
         return crypto.subtle.digest('SHA-256', buffer).then(function (hash) {

--- a/src/components/tvproviders/schedulesdirect.js
+++ b/src/components/tvproviders/schedulesdirect.js
@@ -83,20 +83,6 @@ export default function (page, providerId, options) {
         loading.hide();
     }
 
-    function hex(buffer) {
-        const hexCodes = [];
-        const view = new DataView(buffer);
-
-        for (let i = 0; i < view.byteLength; i += 4) {
-            const value = view.getUint32(i);
-            const stringValue = value.toString(16);
-            const paddedValue = ('00000000' + stringValue).slice(-'00000000'.length);
-            hexCodes.push(paddedValue);
-        }
-
-        return hexCodes.join('');
-    }
-
     function submitLoginForm() {
         loading.show();
         const info = {

--- a/src/components/tvproviders/schedulesdirect.js
+++ b/src/components/tvproviders/schedulesdirect.js
@@ -83,13 +83,6 @@ export default function (page, providerId, options) {
         loading.hide();
     }
 
-    function sha1(str) {
-        const buffer = new TextEncoder('utf-8').encode(str);
-        return crypto.subtle.digest('SHA-1', buffer).then(function (hash) {
-            return hex(hash);
-        });
-    }
-
     function hex(buffer) {
         const hexCodes = [];
         const view = new DataView(buffer);
@@ -106,35 +99,33 @@ export default function (page, providerId, options) {
 
     function submitLoginForm() {
         loading.show();
-        sha1(page.querySelector('.txtPass').value).then(function (passwordHash) {
-            const info = {
-                Type: 'SchedulesDirect',
-                Username: page.querySelector('.txtUser').value,
-                EnableAllTuners: true,
-                Password: passwordHash
-            };
-            const id = providerId;
+        const info = {
+            Type: 'SchedulesDirect',
+            Username: page.querySelector('.txtUser').value,
+            EnableAllTuners: true,
+            Password: page.querySelector('.txtPass').value
+        };
+        const id = providerId;
 
-            if (id) {
-                info.Id = id;
-            }
+        if (id) {
+            info.Id = id;
+        }
 
-            ApiClient.ajax({
-                type: 'POST',
-                url: ApiClient.getUrl('LiveTv/ListingProviders', {
-                    ValidateLogin: true
-                }),
-                data: JSON.stringify(info),
-                contentType: 'application/json',
-                dataType: 'json'
-            }).then(function (result) {
-                Dashboard.processServerConfigurationUpdateResult();
-                providerId = result.Id;
-                reload();
-            }, function () {
-                Dashboard.alert({ // ApiClient.ajax() error handler
-                    message: globalize.translate('ErrorSavingTvProvider')
-                });
+        ApiClient.ajax({
+            type: 'POST',
+            url: ApiClient.getUrl('LiveTv/ListingProviders', {
+                ValidateLogin: true
+            }),
+            data: JSON.stringify(info),
+            contentType: 'application/json',
+            dataType: 'json'
+        }).then(function (result) {
+            Dashboard.processServerConfigurationUpdateResult();
+            providerId = result.Id;
+            reload();
+        }, function () {
+            Dashboard.alert({ // ApiClient.ajax() error handler
+                message: globalize.translate('ErrorSavingTvProvider')
             });
         });
     }

--- a/src/components/tvproviders/schedulesdirect.js
+++ b/src/components/tvproviders/schedulesdirect.js
@@ -83,10 +83,9 @@ export default function (page, providerId, options) {
         loading.hide();
     }
 
-    function sha256(str) {
-
+    function sha1(str) {
         const buffer = new TextEncoder('utf-8').encode(str);
-        return crypto.subtle.digest('SHA-256', buffer).then(function (hash) {
+        return crypto.subtle.digest('SHA-1', buffer).then(function (hash) {
             return hex(hash);
         });
     }
@@ -107,13 +106,12 @@ export default function (page, providerId, options) {
 
     function submitLoginForm() {
         loading.show();
-        sha256(page.querySelector('.txtPass').value).then(function (passwordHash) {
+        sha1(page.querySelector('.txtPass').value).then(function (passwordHash) {
             const info = {
                 Type: 'SchedulesDirect',
                 Username: page.querySelector('.txtUser').value,
                 EnableAllTuners: true,
-                Password: passwordHash,
-                Pw: page.querySelector('.txtPass').value
+                Password: passwordHash
             };
             const id = providerId;
 


### PR DESCRIPTION
Schedules Direct not able to be added as a new Listing Provider

**Changes**
 * Changed Password Encoding to be SHA-1 as required by SchedulesDirect rather than SHA256
 * Removed check for self.TextEncoder as this is never set
 * Removed Plain Text password from API call, as not required

Relies on server PR jellyfin/jellyfin#4440