### PR TITLE
Remove advanced toggle for library editor

### DIFF
--- a/src/components/libraryoptionseditor/libraryoptionseditor.js
+++ b/src/components/libraryoptionseditor/libraryoptionseditor.js
@@ -378,13 +378,6 @@ import 'emby-input';
         });
     }
 
-    export function setAdvancedVisible(parent, visible) {
-        const elems = parent.querySelectorAll('.advanced');
-        for (let i = 0; i < elems.length; i++) {
-            visible ? elems[i].classList.remove('advancedHide') : elems[i].classList.add('advancedHide');
-        }
-    }
-
     export function setContentType(parent, contentType) {
         if (contentType === 'homevideos' || contentType === 'photos') {
             parent.querySelector('.chkEnablePhotosContainer').classList.remove('hide');
@@ -593,6 +586,5 @@ export default {
     embed: embed,
     setContentType: setContentType,
     getLibraryOptions: getLibraryOptions,
-    setLibraryOptions: setLibraryOptions,
-    setAdvancedVisible: setAdvancedVisible
+    setLibraryOptions: setLibraryOptions
 };

--- a/src/components/libraryoptionseditor/libraryoptionseditor.template.html
+++ b/src/components/libraryoptionseditor/libraryoptionseditor.template.html
@@ -1,8 +1,3 @@
-<style>
-    .advancedHide {
-        display: none !important;
-    }
-</style>
 <h2>${HeaderLibrarySettings}</h2>
 <div class="selectContainer fldMetadataLanguage hide">
     <select is="emby-select" id="selectLanguage" label="${LabelMetadataDownloadLanguage}"></select>

--- a/src/components/mediaLibraryCreator/mediaLibraryCreator.js
+++ b/src/components/mediaLibraryCreator/mediaLibraryCreator.js
@@ -98,12 +98,6 @@ import 'flexStyles';
         page.querySelector('.btnAddFolder').addEventListener('click', onAddButtonClick);
         page.querySelector('.btnSubmit').addEventListener('click', onAddLibrary);
         page.querySelector('.folderList').addEventListener('click', onRemoveClick);
-        page.querySelector('.chkAdvanced').addEventListener('change', onToggleAdvancedChange);
-    }
-
-    function onToggleAdvancedChange() {
-        const dlg = dom.parentWithClass(this, 'dlg-librarycreator');
-        libraryoptionseditor.setAdvancedVisible(dlg.querySelector('.libraryOptions'), this.checked);
     }
 
     function onAddButtonClick() {
@@ -190,7 +184,6 @@ import 'flexStyles';
     function initLibraryOptions(dlg) {
         libraryoptionseditor.embed(dlg.querySelector('.libraryOptions')).then(() => {
             $('#selectCollectionType', dlg).trigger('change');
-            onToggleAdvancedChange.call(dlg.querySelector('.chkAdvanced'));
         });
     }
 

--- a/src/components/mediaLibraryCreator/mediaLibraryCreator.template.html
+++ b/src/components/mediaLibraryCreator/mediaLibraryCreator.template.html
@@ -5,12 +5,6 @@
 
 <div class="formDialogContent scrollY" style="padding-top:2em;">
     <div class="dialogContentInner dialog-content-centered">
-        <div class="inputContainer" style="text-align:right;">
-            <label style="width:auto;">
-                <input is="emby-toggle" type="checkbox" class="chkAdvanced noautofocus" />
-                <span>${ShowAdvancedSettings}</span>
-            </label>
-        </div>
 
         <div id="fldCollectionType" class="selectContainer">
             <select is="emby-select" id="selectCollectionType" data-mini="true" required="required" label="${LabelContentType}"></select>

--- a/src/components/mediaLibraryEditor/mediaLibraryEditor.js
+++ b/src/components/mediaLibraryEditor/mediaLibraryEditor.js
@@ -189,20 +189,12 @@ import 'flexStyles';
         });
     }
 
-    function onToggleAdvancedChange() {
-        const dlg = dom.parentWithClass(this, 'dlg-libraryeditor');
-        libraryoptionseditor.setAdvancedVisible(dlg.querySelector('.libraryOptions'), this.checked);
-    }
-
     function initEditor(dlg, options) {
         renderLibrary(dlg, options);
         dlg.querySelector('.btnAddFolder').addEventListener('click', onAddButtonClick);
         dlg.querySelector('.folderList').addEventListener('click', onListItemClick);
-        dlg.querySelector('.chkAdvanced').addEventListener('change', onToggleAdvancedChange);
         dlg.querySelector('.btnSubmit').addEventListener('click', onEditLibrary);
-        libraryoptionseditor.embed(dlg.querySelector('.libraryOptions'), options.library.CollectionType, options.library.LibraryOptions).then(() => {
-            onToggleAdvancedChange.call(dlg.querySelector('.chkAdvanced'));
-        });
+        libraryoptionseditor.embed(dlg.querySelector('.libraryOptions'), options.library.CollectionType, options.library.LibraryOptions);
     }
 
     function onDialogClosed() {

--- a/src/components/mediaLibraryEditor/mediaLibraryEditor.template.html
+++ b/src/components/mediaLibraryEditor/mediaLibraryEditor.template.html
@@ -9,13 +9,6 @@
             ${ChangingMetadataImageSettingsNewContent}
         </div>
 
-        <div class="inputContainer" style="text-align:right;">
-            <label style="width:auto;">
-                <input is="emby-toggle" type="checkbox" class="chkAdvanced noautofocus" />
-                <span>${ShowAdvancedSettings}</span>
-            </label>
-        </div>
-
         <div class="folders hide">
             <div style="display: flex; align-items: center;">
                 <h1 style="margin: .5em 0;">${Folders}</h1>


### PR DESCRIPTION
**Changes**
Removed the advanced toggle for library editor as none of it really constitutes "advanced use".
