### PR TITLE
Make mediaInfo report viewing progress

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -41,6 +41,7 @@
  - [Cromefire_](https://github.com/cromefire)
  - [Orry Verducci](https://github.com/orryverducci)
  - [Camc314](https://github.com/camc314)
+ - [DanielHLewis](https://github.com/danielhlewis)
 
 # Emby Contributors
 

--- a/src/components/mediainfo/mediainfo.js
+++ b/src/components/mediainfo/mediainfo.js
@@ -257,16 +257,18 @@ import 'emby-button';
             if (item.Type === 'Audio') {
                 miscInfo.push(datetime.getDisplayRunningTime(item.RunTimeTicks));
             } else {
-                minutes = item.RunTimeTicks / 600000000;
+                // 10,000 ticks per millisecond * 60,000 milliseconds per minute = 600,000,000 ticks per minute
+                const ticksPerMinute = 10000 * 60000;
+                minutes = item.RunTimeTicks / ticksPerMinute;
 
                 minutes = minutes || 1;
 
                 if (item.UserData?.PlaybackPositionTicks) {
-                    let remainingMinutes = (item.RunTimeTicks - item.UserData.PlaybackPositionTicks) / 600000000;
+                    let remainingMinutes = (item.RunTimeTicks - item.UserData.PlaybackPositionTicks) / ticksPerMinute;
                     remainingMinutes = remainingMinutes || 1;
-                    miscInfo.push(`${Math.round(minutes)} mins (${Math.round(remainingMinutes)} remaining)`);
+                    miscInfo.push(`${globalize.translate('ValueMinutes', Math.round(minutes))} (${globalize.translate("NumberRemaining", Math.round(remainingMinutes))})`);
                 } else {
-                    miscInfo.push(`${Math.round(minutes)} mins`);
+                    miscInfo.push(`${globalize.translate('ValueMinutes', Math.round(minutes))}`);
                 }
             }
         }

--- a/src/components/mediainfo/mediainfo.js
+++ b/src/components/mediainfo/mediainfo.js
@@ -261,7 +261,13 @@ import 'emby-button';
 
                 minutes = minutes || 1;
 
-                miscInfo.push(`${Math.round(minutes)} mins`);
+                if (item.UserData?.PlaybackPositionTicks) {
+                    let remainingMinutes = (item.RunTimeTicks - item.UserData.PlaybackPositionTicks) / 600000000;
+                    remainingMinutes = remainingMinutes || 1;
+                    miscInfo.push(`${Math.round(minutes)} mins (${Math.round(remainingMinutes)} remaining)`);
+                } else {
+                    miscInfo.push(`${Math.round(minutes)} mins`);
+                }
             }
         }
 
@@ -319,7 +325,7 @@ import 'emby-button';
     export function getEndsAt(item) {
         if (item.MediaType === 'Video' && item.RunTimeTicks) {
             if (!item.StartDate) {
-                let endDate = new Date().getTime() + (item.RunTimeTicks / 10000);
+                let endDate = new Date().getTime() + ((item.RunTimeTicks - (item.UserData?.PlaybackPositionTicks || 0)) / 10000);
                 endDate = new Date(endDate);
 
                 const displayTime = datetime.getDisplayTime(endDate);

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -151,7 +151,7 @@
     "DeinterlaceMethodHelp": "Select the deinterlacing method to use when software transcoding interlaced content. When hardware acceleration supporting hardware deinterlacing is enabled the hardware deinterlacer will be used instead of this setting.",
     "Delete": "Delete",
     "DeleteAll": "Delete All",
-    "DeleteDevicesConfirmation": "Are you sure you wish to delete all devices? All other sessions will be logged out. Devices will reappear the next time a user signs in.", 
+    "DeleteDevicesConfirmation": "Are you sure you wish to delete all devices? All other sessions will be logged out. Devices will reappear the next time a user signs in.",
     "DeleteDeviceConfirmation": "Are you sure you wish to delete this device? It will reappear the next time a user signs in with it.",
     "DeleteImage": "Delete Image",
     "DeleteImageConfirmation": "Are you sure you wish to delete this image?",
@@ -1430,5 +1430,6 @@
     "SubtitleVerticalPositionHelp": "Line number where text appears. Positive numbers indicate top down. Negative numbers indicate bottom up.",
     "Preview": "Preview",
     "LabelMaxMuxingQueueSize": "Max muxing queue size:",
-    "LabelMaxMuxingQueueSizeHelp": "Maximum number of packets that can be buffered while waiting for all streams to initialize. Try to increase it if you still encounter \"Too many packets buffered for output stream\" error in ffmpeg logs. The recommended value is 2048."
+    "LabelMaxMuxingQueueSizeHelp": "Maximum number of packets that can be buffered while waiting for all streams to initialize. Try to increase it if you still encounter \"Too many packets buffered for output stream\" error in ffmpeg logs. The recommended value is 2048.",
+    "NumberRemaining": "{0} remaining"
 }


### PR DESCRIPTION
On the details page for video files, if the user has partially viewed
the video, the number of minutes remaining will be displayed along
with the total number of minutes in the file. Also, the 'Ends at'
time will be calculated from the resume point, rather than the
beginning of the video.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
