### PR TITLE
Update config.json

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -23,10 +23,11 @@
     }
   ],
   "fonts": [
-    "https://repo.jellyfin.org/releases/other/jellyfin-noto/font-faces.css",
-    "https://repo.jellyfin.org/releases/other/jellyfin-noto/css/KR.css",
-    "https://repo.jellyfin.org/releases/other/jellyfin-noto/css/JP.css",
-    "https://repo.jellyfin.org/releases/other/jellyfin-noto/css/SC.css"
+    // Uncomment these entries to enable the jellyfin-noto font family. This will download files from the Jellyfin repo at runtime. You must adjust your CORS settings accordingly.
+    // "https://repo.jellyfin.org/releases/other/jellyfin-noto/font-faces.css",
+    // "https://repo.jellyfin.org/releases/other/jellyfin-noto/css/KR.css",
+    // "https://repo.jellyfin.org/releases/other/jellyfin-noto/css/JP.css",
+    // "https://repo.jellyfin.org/releases/other/jellyfin-noto/css/SC.css"
   ],
   "plugins": [
     "plugins/playAccessValidation/plugin",


### PR DESCRIPTION
**Changes**
Disable default downloading of jellyfin-noto fonts. Pending a better solution if one is possible.

**Issues**
Resolves #2048 
