### PR TITLE
Add Debian conffiles with config.json

### DIFF
--- a/debian/conffiles
+++ b/debian/conffiles
@@ -1,0 +1,1 @@
+/usr/share/jellyfin/web/config.json


### PR DESCRIPTION
**Changes**
Adds a `debian/conffiles` entry with the web `config.json` in it, so that this file will not be blindly overwritten on future upgrades. Allows the administrator to edit it in-place.

Only works for Debian right now. Docker will need its own (mount-based) solution, to be documented. Fedora/Windows/MacOS IDK.

**Issues**
N/A
