### PR TITLE
Revert "pull fonts from official repository"

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "howler": "^2.2.1",
     "intersection-observer": "^0.11.0",
     "jellyfin-apiclient": "^1.4.2",
+    "jellyfin-noto": "https://github.com/jellyfin/jellyfin-noto",
     "jquery": "^3.5.1",
     "jstree": "^3.3.10",
     "libarchive.js": "^1.3.0",

--- a/src/bundle.js
+++ b/src/bundle.js
@@ -90,6 +90,12 @@ _define('material-icons', function() {
     return materialIcons;
 });
 
+// noto font
+const noto = require('jellyfin-noto');
+_define('jellyfin-noto', function () {
+    return noto;
+});
+
 const epubjs = require('epubjs');
 _define('epubjs', function () {
     return epubjs;

--- a/src/config.json
+++ b/src/config.json
@@ -22,12 +22,6 @@
       "id": "wmc"
     }
   ],
-  "fonts": [
-    "https://repo.jellyfin.org/releases/other/jellyfin-noto/font-faces.css",
-    "https://repo.jellyfin.org/releases/other/jellyfin-noto/css/KR.css",
-    "https://repo.jellyfin.org/releases/other/jellyfin-noto/css/JP.css",
-    "https://repo.jellyfin.org/releases/other/jellyfin-noto/css/SC.css"
-  ],
   "plugins": [
     "plugins/playAccessValidation/plugin",
     "plugins/experimentalWarnings/plugin",

--- a/src/scripts/autoThemes.js
+++ b/src/scripts/autoThemes.js
@@ -1,22 +1,11 @@
 import * as userSettings from 'userSettings';
-import * as webSettings from 'webSettings';
 import skinManager from 'skinManager';
 import events from 'events';
 
-// set the default theme when loading
+// Set the default theme when loading
 skinManager.setTheme(userSettings.theme());
 
-// set the saved theme once a user authenticates
+// Set the user's prefered theme when signing in
 events.on(window.connectionManager, 'localusersignedin', function (e, user) {
     skinManager.setTheme(userSettings.theme());
-});
-
-webSettings.getFonts().then(fonts => {
-    for (const font of fonts) {
-        const link = document.createElement('link');
-        link.setAttribute('rel', 'stylesheet');
-        link.href = font;
-
-        document.getElementsByTagName('head')[0].appendChild(link);
-    }
 });

--- a/src/scripts/settings/webSettings.js
+++ b/src/scripts/settings/webSettings.js
@@ -102,12 +102,3 @@ export function getPlugins() {
         return [];
     });
 }
-
-export function getFonts() {
-    return getConfig().then(config => {
-        return config.fonts;
-    }).catch(error => {
-        console.log('cannot get web config:', error);
-        return [];
-    });
-}

--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -506,6 +506,7 @@ function initClient() {
                     'sortable',
                     'webcomponents',
                     'material-icons',
+                    'jellyfin-noto',
                     'date-fns',
                     'page',
                     'polyfill',
@@ -528,7 +529,7 @@ function initClient() {
         });
 
         promise = require(['fetch'])
-            .then(() => require(['jQuery', 'polyfill', 'fast-text-encoding', 'intersection-observer', 'classlist-polyfill', 'css!assets/css/site'], (jQuery) => {
+            .then(() => require(['jQuery', 'polyfill', 'fast-text-encoding', 'intersection-observer', 'classlist-polyfill', 'css!assets/css/site', 'jellyfin-noto'], (jQuery) => {
                 // Expose jQuery globally
                 window.$ = jQuery;
                 window.jQuery = jQuery;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6423,6 +6423,10 @@ jellyfin-apiclient@^1.4.2:
   resolved "https://registry.yarnpkg.com/jellyfin-apiclient/-/jellyfin-apiclient-1.4.2.tgz#0a7ab7b371380cfb1bc9789204439b8dfdcdbafd"
   integrity sha512-xUvt1G0cDlam6hJgC5Jr6EE5botzdEMGxeer3Vm0+zhM7nb8iFnRmQRmTpVbXtYS8NLiHsiUmK1RLlelgtWDYg==
 
+"jellyfin-noto@https://github.com/jellyfin/jellyfin-noto":
+  version "1.0.3"
+  resolved "https://github.com/jellyfin/jellyfin-noto#b784602db063734c721a46563ae5d6577ec2b35d"
+
 jest-worker@^26.6.1:
   version "26.6.1"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-26.6.1.tgz#c2ae8cde6802cc14056043f997469ec170d9c32a"


### PR DESCRIPTION
Reverts jellyfin/jellyfin-web#2010

Let's leave these in the Web app. We don't like the idea of them being pulled over the Internet constantly. Breaks the "self-hosted, no centralization" mentality.