### PR TITLE
Fix Airplay in Safari

### DIFF
--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1539,7 +1539,7 @@ function tryRemoveElement(elem) {
         return false;
     }
 
-    static isAirPlayEnabled() {
+    isAirPlayEnabled() {
         if (document.AirPlayEnabled) {
             return !!document.AirplayElement;
         }


### PR DESCRIPTION
**Issues**
`TypeError: this.isAirPlayEnabled is not a function. (In 'this.isAirPlayEnabled()', 'this.isAirPlayEnabled' is undefined)`

Fixes: #2066
