### PR TITLE
Fix missing jellyfin-noto resources

### DIFF
--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -6,6 +6,7 @@ import 'intersection-observer';
 import 'classlist.js';
 import 'whatwg-fetch';
 import 'resize-observer-polyfill';
+import 'jellyfin-noto/font-faces.css';
 import '../assets/css/site.scss';
 import { Events } from 'jellyfin-apiclient';
 import ServerConnections from '../components/ServerConnections';


### PR DESCRIPTION
**Changes**
We were missing an import for jellyfin-noto, so the files weren't actually being included... this fixes that :smile: 

**Issues**
N/A
