### PR TITLE
WIP: restore base-url compatible approach

### DIFF
--- a/src/scripts/clientUtils.js
+++ b/src/scripts/clientUtils.js
@@ -29,9 +29,13 @@ export async function serverAddress() {
     // if (current) return Promise.resolve(current);
 
     const urls = [];
-    urls.push(window.location.origin);
-    urls.push(`https://${window.location.hostname}:8920`);
-    urls.push(`http://${window.location.hostname}:8096`);
+
+    const urlLower = window.location.href.toLowerCase();
+    const index = urlLower.lastIndexOf('/web');
+    if (index != -1) {
+        urls.push(urlLower.substring(0, index));
+    }
+
     urls.push(...await webSettings.getServers());
 
     const promises = urls.map(url => {


### PR DESCRIPTION
Initially I just wanted to add this to the top of the list. But the issue is that I think there was nothing wrong with the way it was done before. The guesses cause CORS issues, and it's harder to remove them with time because the assumption sets in that they need to be there.

**Changes**
in src/scripts/clientUtils, function serverAddress, the list of URLs now only contain the relative to /web one and the ones from webSettings.getServers().

**Issues**
base-url probably not working anymore.

**WIP**
I did not test this yet, and you should probably test it too. We can also have a discussion about what items should be in the list of URLs to try.
