### PR TITLE
simplify server address candidates

### DIFF
--- a/src/scripts/clientUtils.js
+++ b/src/scripts/clientUtils.js
@@ -31,13 +31,13 @@ export async function serverAddress() {
     // Use servers specified in config.json
     const urls = await webSettings.getServers();
 
-    // Otherwise, use computed base-url
+    // Otherwise use computed base URL
     if (urls.length == 0) {
         const index = window.location.href.toLowerCase().lastIndexOf('/web');
         if (index != -1) {
             urls.push(window.location.href.substring(0, index));
         } else {
-            // fall back to location without path
+            // fallback to location without path
             urls.push(window.location.origin);
         }
     }

--- a/src/scripts/clientUtils.js
+++ b/src/scripts/clientUtils.js
@@ -28,22 +28,19 @@ export async function serverAddress() {
     // TODO this makes things faster but it also blocks the wizard in some scenarios
     // if (current) return Promise.resolve(current);
 
-    const urls = [];
-    if (window.location.href.indexOf('/web/') !== -1) {
-        const split = window.location.href.split('/web/');
+    // Use servers specified in config.json
+    const urls = await webSettings.getServers();
 
-        for (let i = split.length - 1; i > 0; i--) {
-            urls.push(split.slice(0, i).join('/web/'));
+    // Otherwise, use computed base-url
+    if (urls.length == 0) {
+        const index = window.location.href.toLowerCase().lastIndexOf('/web');
+        if (index != -1) {
+            urls.push(window.location.href.substring(0, index));
+        } else {
+            // fall back to location without path
+            urls.push(window.location.origin);
         }
     }
-    urls.push(window.location.origin);
-    urls.push(`https://${window.location.hostname}:8920`);
-
-    if (window.location.protocol === 'http') {
-        urls.push(`http://${window.location.hostname}:8096`);
-    }
-
-    urls.push(...await webSettings.getServers());
 
     console.debug('URL candidates:', urls);
 


### PR DESCRIPTION
I think the most intuitive expectation, is that the web frontend should:
a) Pick only the servers in the config.json
b) pick the URL leading up to /web, but only if a) provided no candidates.

b) is stable because we know that the current URL is reachable, therefore a modification to this URL should be a pretty good bet. Essentially this is a shortcut to constructing a relative URL to the parent directory.

This will help you to get config.json right as well, because the web frontend will only consider the URLs in there if specified. So you don't get lucky and proceed to use an incorrect config.json.

In 10.6.4 this function was in src/scripts/site.js and looked (mostly) like this:

```js
    //TODO: investigate url prefix support for serverAddress function
    serverAddress: function () { 
        /// ... snip ... ///
        var urlLower = window.location.href.toLowerCase();
        var index = urlLower.lastIndexOf('/web');
        if (-1 != index) {
            return urlLower.substring(0, index);
        }
        // shitty version of window.location.origin
        var loc = window.location;
        var address = loc.protocol + '//' + loc.hostname;
        if (loc.port) {
            address += ':' + loc.port;
        }
        return address;
    }
```
It (seems to have) had a bug where case sensitive paths with uppercase could break, but other than that it has been a very stable approach. 

**Changes**
changed the function serverAddress() in src/scripts/clientUtils.js to a more strict approach.