### PR TITLE
Revert change to base font size

### DIFF
--- a/src/assets/css/fonts.scss
+++ b/src/assets/css/fonts.scss
@@ -5,7 +5,7 @@
 }
 
 html {
-    @include font;
+    @include font($size: 93%);
     text-size-adjust: 100%;
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;


### PR DESCRIPTION
**Changes**
Restores the base font size from 10.6 to fix some layout and font size issues especially noticeable in the admin dashboard.

**Before:**
![Screenshot_2020-11-24 Jellyfin(1)](https://user-images.githubusercontent.com/3450688/100177869-df3e9e00-2ea0-11eb-81f6-abba09a1223a.png)

**After:**
![Screenshot_2020-11-24 Jellyfin(2)](https://user-images.githubusercontent.com/3450688/100177883-e49be880-2ea0-11eb-86ed-8356ff08134a.png)

**Issues**
N/A
