### PR TITLE
Add stylelint for sass files

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,14 +1,14 @@
 {
   "plugins": [
-		"stylelint-no-browser-hacks/lib",
+		"stylelint-no-browser-hacks/lib"
 	],
   "rules": {
     "at-rule-empty-line-before": [ "always", {
-      except: [
+      "except": [
         "blockless-after-same-name-blockless",
-        "first-nested",
+        "first-nested"
       ],
-      ignore: ["after-comment"],
+      "ignore": ["after-comment"]
     } ],
     "at-rule-name-case": "lower",
     "at-rule-name-space-after": "always-single-line",
@@ -26,27 +26,27 @@
     "color-hex-length": "short",
     "color-no-invalid-hex": true,
     "comment-empty-line-before": [ "always", {
-      except: ["first-nested"],
-      ignore: ["stylelint-commands"],
+      "except": ["first-nested"],
+      "ignore": ["stylelint-commands"]
     } ],
     "comment-no-empty": true,
     "comment-whitespace-inside": "always",
     "custom-property-empty-line-before": [ "always", {
-      except: [
+      "except": [
         "after-custom-property",
-        "first-nested",
+        "first-nested"
       ],
-      ignore: [
+      "ignore": [
         "after-comment",
-        "inside-single-line-block",
-      ],
+        "inside-single-line-block"
+      ]
     } ],
     "declaration-bang-space-after": "never",
     "declaration-bang-space-before": "always",
     "declaration-block-no-duplicate-properties": [
       true,
       {
-        ignore: ["consecutive-duplicates-with-different-values"]
+        "ignore": ["consecutive-duplicates-with-different-values"]
       }
     ],
     "declaration-block-no-shorthand-property-overrides": true,
@@ -105,8 +105,8 @@
       }
     ],
     "rule-empty-line-before": [ "always-multi-line", {
-      except: ["first-nested"],
-      ignore: ["after-comment"],
+      "except": ["first-nested"],
+      "ignore": ["after-comment"]
     } ],
     "selector-attribute-brackets-space-inside": "never",
     "selector-attribute-operator-space-after": "never",
@@ -138,6 +138,6 @@
     "value-list-comma-newline-after": "always-multi-line",
     "value-list-comma-space-after": "always-single-line",
     "value-list-comma-space-before": "never",
-    "value-list-max-empty-lines": 0,
+    "value-list-max-empty-lines": 0
   }
 }

--- a/.stylelintrc.scss.json
+++ b/.stylelintrc.scss.json
@@ -1,0 +1,8 @@
+{
+  "extends": [ "./.stylelintrc.json" ],
+  "plugins": [ "stylelint-scss" ],
+  "rules": {
+    "at-rule-no-unknown": null,
+    "scss/at-rule-no-unknown": true
+  }
+}

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "stylelint-config-rational-order": "^0.1.2",
     "stylelint-no-browser-hacks": "^1.2.1",
     "stylelint-order": "^4.1.0",
+    "stylelint-scss": "^3.18.0",
     "webpack": "^5.4.0",
     "webpack-cli": "^4.0.0",
     "webpack-dev-server": "^3.11.0",
@@ -112,6 +113,8 @@
     "build:development": "webpack --config webpack.dev.js",
     "build:production": "webpack --config webpack.prod.js",
     "lint": "eslint \".\"",
-    "stylelint": "stylelint \"src/**/*.css\""
+    "stylelint": "yarn stylelint:css && yarn stylelint:scss",
+    "stylelint:css": "stylelint \"src/**/*.css\"",
+    "stylelint:scss": "stylelint --config=\".stylelintrc.scss.json\" \"src/**/*.scss\""
   }
 }

--- a/src/plugins/bookPlayer/style.scss
+++ b/src/plugins/bookPlayer/style.scss
@@ -15,7 +15,7 @@
         top: 0;
         width: 100%;
         color: #000;
-        opacity: .7;
+        opacity: 0.7;
     }
 
     .bookPlayerContainer {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8086,6 +8086,17 @@ stylelint-order@^4.1.0:
     postcss "^7.0.31"
     postcss-sorting "^5.0.1"
 
+stylelint-scss@^3.18.0:
+  version "3.18.0"
+  resolved "https://registry.yarnpkg.com/stylelint-scss/-/stylelint-scss-3.18.0.tgz#8f06371c223909bf3f62e839548af1badeed31e9"
+  integrity sha512-LD7+hv/6/ApNGt7+nR/50ft7cezKP2HM5rI8avIdGaUWre3xlHfV4jKO/DRZhscfuN+Ewy9FMhcTq0CcS0C/SA==
+  dependencies:
+    lodash "^4.17.15"
+    postcss-media-query-parser "^0.2.3"
+    postcss-resolve-nested-selector "^0.1.1"
+    postcss-selector-parser "^6.0.2"
+    postcss-value-parser "^4.1.0"
+
 stylelint@^13.8.0:
   version "13.8.0"
   resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-13.8.0.tgz#446765dbe25e3617f819a0165956faf2563ddc23"


### PR DESCRIPTION
**Changes**
Our stylelint config was only running against css files not sass files. The rules needed extended to support sass builtin functions.

Also there were some formatting issues with the css stylelint config.

**Issues**
N/A