### PR TITLE
Fix arabic import from date-fns

### DIFF
--- a/src/scripts/dfnshelper.js
+++ b/src/scripts/dfnshelper.js
@@ -1,9 +1,9 @@
-import { ar, be, bg, ca, cs, da, de, el, enGB, enUS, es, faIR, fi, fr, frCA, he, hi, hr, hu, id, it, ja, kk, ko, lt, ms, nb,
+import { arDZ, be, bg, ca, cs, da, de, el, enGB, enUS, es, faIR, fi, fr, frCA, he, hi, hr, hu, id, it, ja, kk, ko, lt, ms, nb,
     nl, pl, ptBR, pt, ro, ru, sk, sl, sv, tr, uk, vi, zhCN, zhTW } from 'date-fns/locale';
 import globalize from './globalize';
 
 const dateLocales = (locale) => ({
-    'ar': ar,
+    'ar': arDZ,
     'be-by': be,
     'bg-bg': bg,
     'ca': ca,


### PR DESCRIPTION
**Changes**
Fixes a bad import for the Arabic locale in date-fns. The generic `ar` locale is a legacy holdover and is not included in the current built files for date-fns.

**Issues**
N/A