### PR TITLE
Remove standalone.js and broken navigation

### DIFF
--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -26,7 +26,7 @@ import './libraryMenu';
 import './routes';
 import '../components/themeMediaPlayer';
 import './autoBackdrops';
-import { navigate, pageClassOn, serverAddress } from './clientUtils';
+import { pageClassOn, serverAddress } from './clientUtils';
 import '../libraries/screensavermanager';
 import './serverNotifications';
 import '../components/playback/playerSelectionMenu';

--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -77,12 +77,9 @@ function loadCoreDictionary() {
 
 function init() {
     serverAddress().then(server => {
-        if (!server) {
-            navigate('selectserver.html');
-            return;
+        if (server) {
+            ServerConnections.initApiClient(server);
         }
-
-        ServerConnections.initApiClient(server);
     }).then(() => {
         console.debug('initAfterDependencies promises resolved');
 

--- a/src/scripts/standalone.js
+++ b/src/scripts/standalone.js
@@ -1,3 +1,0 @@
-window.appMode = 'standalone';
-
-import('./site');

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -4,7 +4,7 @@ const merge = require('webpack-merge');
 
 module.exports = merge(common, {
     mode: 'development',
-    entry: './scripts/standalone.js',
+    entry: './scripts/site.js',
     devtool: 'source-map',
     module: {
         rules: [


### PR DESCRIPTION
**Changes**
* Removes standalone.js which no longer serves any purpose
* Removes the call to navigate prior to the router being initialized. This redirect seems to be handled during the router initialization, but I'm not sure if there are some cases that this could still fail?

**Issues**
N/A
