### PR TITLE
Prevent doubleclick on buttons from bubbling to video for fullscreen (alternative)

### DIFF
--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1469,7 +1469,8 @@ import { appRouter } from '../../../components/appRouter';
             dom.addEventListener(view, 'dblclick', onDoubleClick, {});
         } else {
             const options = { passive: true };
-            dom.addEventListener(view, 'dblclick', function () {
+            dom.addEventListener(view, 'dblclick', (e) => {
+                if (e.target !== view) return;
                 playbackManager.toggleFullscreen(currentPlayer);
             }, options);
         }


### PR DESCRIPTION
Alternative to #2007

**Changes**
Skip bubbled `dblclick` event.

**Issues**
Fixes #2006
