### PR TITLE
fix login autocomplete

### DIFF
--- a/src/controllers/session/login/index.html
+++ b/src/controllers/session/login/index.html
@@ -4,11 +4,6 @@
             <div class="padded-left padded-right flex align-items-center justify-content-center">
                 <h1 class="sectionTitle">${HeaderPleaseSignIn}</h1>
             </div>
-            <div style="height:0; overflow: hidden;">
-                <input type="text" name="fakeusernameremembered" tabindex="-1" />
-                <input type="password" name="fakepasswordremembered" tabindex="-1" />
-            </div>
-
             <div class="inputContainer">
                 <input is="emby-input" type="text" id="txtManualName" required="required" label="${LabelUser}" autocomplete="username" autocapitalize="off" />
             </div>


### PR DESCRIPTION
I want the jellyfin login page to work like any other login page. Today, autocomplete does not work and the fields need to be filled manually.

I've traced the "fakeusernameremembered" back the git history with `git log -p -- dashboard-ui/login.html` and they were introduced in 9abecac88bab6f0e3ca11027aa09a2231ae37aa2 by Luke in May 2016. At this time, the input fields were set to `autocomplete="off"` so it's clear that this HTML is intended to disable autocomplete from happening.

Removing this, the autocomplete does work. However, both firefox and chrome have decided to disable autocomplete for unencrypted connections.

**Changes**
Removed "fakeusernameremembered" and "fakepasswordremembered" fields.

**Issues**
Fixes #1964