### PR TITLE
Do not use AC3 for audio transcoding if AAC and MP3 are supported

### DIFF
--- a/src/components/apphost.js
+++ b/src/components/apphost.js
@@ -7,6 +7,9 @@ import * as webSettings from '../scripts/settings/webSettings';
 import globalize from '../scripts/globalize';
 import profileBuilder from '../scripts/browserDeviceProfile';
 
+const appName = 'Jellyfin Web';
+const appVersion = '10.7.0';
+
 function getBaseProfileOptions(item) {
     const disableHlsVideoAudioCodecs = [];
 
@@ -31,7 +34,7 @@ function getDeviceProfile(item, options = {}) {
         let profile;
 
         if (window.NativeShell) {
-            profile = window.NativeShell.AppHost.getDeviceProfile(profileBuilder);
+            profile = window.NativeShell.AppHost.getDeviceProfile(profileBuilder, appVersion);
         } else {
             const builderOpts = getBaseProfileOptions(item);
             profile = profileBuilder(builderOpts);
@@ -316,8 +319,6 @@ function askForExit() {
 
 let deviceId;
 let deviceName;
-const appName = 'Jellyfin Web';
-const appVersion = '10.7.0';
 
 export const appHost = {
     getWindowState: function () {

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -345,26 +345,8 @@ import browser from './browser';
         const canPlayEac3VideoAudio = supportsEac3(videoTestElement);
         const canPlayAc3VideoAudioInHls = supportsAc3InHls(videoTestElement);
 
-        if (canPlayAc3VideoAudio) {
-            videoAudioCodecs.push('ac3');
-            if (canPlayEac3VideoAudio) {
-                videoAudioCodecs.push('eac3');
-            }
-
-            // This works in edge desktop, but not mobile
-            // TODO: Retest this on mobile
-            // Transcoding codec is the first in hlsVideoAudioCodecs
-            // Put ac3/eac3 first only when the audio channels > 2 and need transcoding
-            if (canPlayAc3VideoAudioInHls && physicalAudioChannels > 2) {
-                hlsInTsVideoAudioCodecs.push('ac3');
-                hlsInFmp4VideoAudioCodecs.push('ac3');
-                if (canPlayEac3VideoAudio) {
-                    hlsInTsVideoAudioCodecs.push('eac3');
-                    hlsInFmp4VideoAudioCodecs.push('eac3');
-                }
-            }
-        }
-
+        // Transcoding codec is the first in hlsVideoAudioCodecs.
+        // Prefer AAC, MP3 to other codecs when audio transcoding.
         if (canPlayAacVideoAudio) {
             videoAudioCodecs.push('aac');
             hlsInTsVideoAudioCodecs.push('aac');
@@ -382,25 +364,21 @@ import browser from './browser';
             hlsInFmp4VideoAudioCodecs.push('mp3');
         }
 
-        // For ac3/eac3 directstream
+        // For AC3/EAC3 remuxing.
+        // Do not use AC3 for audio transcoding unless AAC and MP3 are not supported.
         if (canPlayAc3VideoAudio) {
-            if (canPlayAc3VideoAudioInHls) {
-                if (hlsInTsVideoAudioCodecs.indexOf('ac3') === -1) {
-                    hlsInTsVideoAudioCodecs.push('ac3');
-                }
+            videoAudioCodecs.push('ac3');
+            if (canPlayEac3VideoAudio) {
+                videoAudioCodecs.push('eac3');
+            }
 
-                if (hlsInFmp4VideoAudioCodecs.indexOf('ac3') === -1) {
-                    hlsInFmp4VideoAudioCodecs.push('ac3');
-                }
+            if (canPlayAc3VideoAudioInHls) {
+                hlsInTsVideoAudioCodecs.push('ac3');
+                hlsInFmp4VideoAudioCodecs.push('ac3');
 
                 if (canPlayEac3VideoAudio) {
-                    if (hlsInTsVideoAudioCodecs.indexOf('eac3') === -1) {
-                        hlsInTsVideoAudioCodecs.push('eac3');
-                    }
-
-                    if (hlsInFmp4VideoAudioCodecs.indexOf('eac3') === -1) {
-                        hlsInFmp4VideoAudioCodecs.push('eac3');
-                    }
+                    hlsInTsVideoAudioCodecs.push('eac3');
+                    hlsInFmp4VideoAudioCodecs.push('eac3');
                 }
             }
         }

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -538,17 +538,27 @@ import browser from './browser';
                 Type: 'Audio'
             });
 
-            if (audioFormat === 'webma') {
+            // https://www.webmproject.org/about/faq/
+            if (audioFormat === 'opus' || audioFormat === 'webma') {
                 profile.DirectPlayProfiles.push({
                     Container: 'webm',
+                    AudioCodec: audioFormat,
                     Type: 'Audio'
                 });
             }
 
             // aac also appears in the m4a and m4b container
+            // m4a/alac only works when using safari
             if (audioFormat === 'aac' || audioFormat === 'alac') {
                 profile.DirectPlayProfiles.push({
-                    Container: 'm4a,m4b',
+                    Container: 'm4a',
+                    AudioCodec: audioFormat,
+                    Type: 'Audio'
+                });
+
+                profile.DirectPlayProfiles.push({
+                    Container: 'm4b',
+                    AudioCodec: audioFormat,
                     Type: 'Audio'
                 });
             }


### PR DESCRIPTION
**Changes**
- Do not use AC3 for audio transcoding if AAC and MP3 are supported.
- Fix alac playback on firefox and chrome.

**Issues**
Transcoding to 2ch AC3 can cause no sound on some iOS devices.
