### PR TITLE
Pass plugin name to pluginManager.loadPlugin

### DIFF
--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -137,7 +137,7 @@ function loadPlugins() {
         }
 
         Promise.all(list.map((plugin) => {
-            return pluginManager.loadPlugin(import(/* webpackChunkName: "[request]" */ `../plugins/${plugin}`));
+            return pluginManager.loadPlugin(plugin);
         }))
             .then(function () {
                 console.debug('finished loading plugins');


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**

The pluginManager will use the import when necessary. By passing just the name we can use other ways to load plugins in the nativeshell.

This is required for jellyfin-android and possibly the MPV shim.

Relevant code:
see https://github.com/jellyfin/jellyfin-web/blob/fb4ac021e40d52dc25a25dd03ade18c72de6ed6c/src/components/pluginManager.js#L71-L101

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Linked PR (not dependent): #2139