### PR TITLE
Fix the overlap in iOS music view and the hidden nowPlayingBar

### DIFF
--- a/src/components/nowPlayingBar/nowPlayingBar.js
+++ b/src/components/nowPlayingBar/nowPlayingBar.js
@@ -660,7 +660,7 @@ import { appRouter } from '../appRouter';
         console.debug('nowplaying event: ' + event.type);
         const player = this;
 
-        if (!state.NowPlayingItem || layoutManager.tv || !state.IsFullscreen) {
+        if (!state.NowPlayingItem || layoutManager.tv) {
             hideNowPlayingBar();
             return;
         }

--- a/src/components/nowPlayingBar/nowPlayingBar.js
+++ b/src/components/nowPlayingBar/nowPlayingBar.js
@@ -660,7 +660,7 @@ import { appRouter } from '../appRouter';
         console.debug('nowplaying event: ' + event.type);
         const player = this;
 
-        if (!state.NowPlayingItem || layoutManager.tv) {
+        if (!state.NowPlayingItem || layoutManager.tv || state.IsFullscreen === false) {
             hideNowPlayingBar();
             return;
         }

--- a/src/components/remotecontrol/remotecontrol.css
+++ b/src/components/remotecontrol/remotecontrol.css
@@ -10,6 +10,8 @@
     -webkit-box-direction: normal;
     -webkit-flex-direction: row;
     flex-direction: row;
+    -webkit-flex-shrink: 0;
+    flex-shrink: 0;
 }
 
 .navigationSection {
@@ -51,6 +53,12 @@
     display: flex;
 }
 
+.infoContainer,
+.sliderContainer {
+    -webkit-flex-shrink: 0;
+    flex-shrink: 0;
+}
+
 .nowPlayingInfoContainerMedia {
     text-align: left;
     margin-bottom: 1em;
@@ -75,6 +83,8 @@
     align-items: center;
     -webkit-flex-wrap: wrap;
     flex-wrap: wrap;
+    -webkit-flex-shrink: 0;
+    flex-shrink: 0;
 }
 
 .nowPlayingInfoControls,

--- a/src/controllers/playback/queue/index.html
+++ b/src/controllers/playback/queue/index.html
@@ -6,7 +6,7 @@
             <div class="nowPlayingPageImageContainer"></div>
             <div class="nowPlayingInfoControls">
 
-                <div class="flex">
+                <div class="infoContainer flex">
 
                     <div class="nowPlayingInfoContainerMedia">
                         <h2 class="nowPlayingPageTitle"></h2>


### PR DESCRIPTION
**Changes**
- Fix the overlap in iOS music view.
- Fix the issue that nowPlayingBar is still hidden after exiting the music control pannel.

Before: <img src="https://user-images.githubusercontent.com/14953024/100543245-f0652180-3289-11eb-9031-9918a8d68209.jpg" height = "500" align=center />

After: 100% <img src="https://user-images.githubusercontent.com/14953024/100543299-45a13300-328a-11eb-956f-89b8487e63c1.jpg" height = "500" align=center /> 125%: <img src="https://user-images.githubusercontent.com/14953024/100543375-bba59a00-328a-11eb-8e38-a759d2b0ba96.jpg" height = "500" align=center />






**Issues**
Fixes #1602 #1931
