### PR TITLE
Support async plugin loading from window

### DIFF
--- a/src/components/pluginManager.js
+++ b/src/components/pluginManager.js
@@ -75,9 +75,9 @@ import { playbackManager } from './playback/playbackmanager';
                 if (pluginSpec in window) {
                     console.log(`Loading plugin (via window): ${pluginSpec}`);
                     let pluginInstance = await window[pluginSpec];
-                    
+
                     if (typeof pluginInstance === 'function') {
-                       pluginInstance = await pluginInstance(); 
+                        pluginInstance = await pluginInstance(); 
                     }
 
                     // init plugin and pass basic dependencies

--- a/src/components/pluginManager.js
+++ b/src/components/pluginManager.js
@@ -77,7 +77,7 @@ import { playbackManager } from './playback/playbackmanager';
                     let pluginInstance = await window[pluginSpec];
 
                     if (typeof pluginInstance === 'function') {
-                        pluginInstance = await pluginInstance(); 
+                        pluginInstance = await pluginInstance();
                     }
 
                     // init plugin and pass basic dependencies

--- a/src/components/pluginManager.js
+++ b/src/components/pluginManager.js
@@ -74,9 +74,14 @@ import { playbackManager } from './playback/playbackmanager';
             if (typeof pluginSpec === 'string') {
                 if (pluginSpec in window) {
                     console.log(`Loading plugin (via window): ${pluginSpec}`);
+                    let pluginInstance = await window[pluginSpec];
+                    
+                    if (typeof pluginInstance === 'function') {
+                       pluginInstance = await pluginInstance(); 
+                    }
 
                     // init plugin and pass basic dependencies
-                    plugin = new window[pluginSpec]({
+                    plugin = new pluginInstance({
                         events: Events,
                         loading,
                         appSettings,


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Support plugins defined on window to be promises by always awaiting
- Support plugins defined on window to be functions returning a promise

This way the nativeshell in jellyfin-android can asynchronously load it's own plugins.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Linked PR (not dependent): #2137