### PR TITLE
Add api key to remote image urls

### DIFF
--- a/src/components/itemidentifier/itemidentifier.js
+++ b/src/components/itemidentifier/itemidentifier.js
@@ -261,7 +261,11 @@ import template from './itemidentifier.template.html';
     function getSearchImageDisplayUrl(url, provider) {
         const apiClient = getApiClient();
 
-        return apiClient.getUrl('Items/RemoteSearch/Image', { imageUrl: url, ProviderName: provider });
+        return apiClient.getUrl('Items/RemoteSearch/Image', {
+            imageUrl: url,
+            ProviderName: provider,
+            api_key: apiClient.accessToken()
+        });
     }
 
     function submitIdentficationResult(page) {


### PR DESCRIPTION
**Changes**
Fixes missing images when identifying media due to authentication now being required on the `/Items/RemoteSearch/Image` endpoint.

**Issues**
N/A
