### PR TITLE
Remove use-credentials flag that breaks cross-origin playback

### DIFF
--- a/src/plugins/htmlAudioPlayer/plugin.js
+++ b/src/plugins/htmlAudioPlayer/plugin.js
@@ -146,9 +146,6 @@ class HtmlAudioPlayer {
             }, function () {
                 elem.autoplay = true;
 
-                // Safari will not send cookies without this
-                elem.crossOrigin = 'use-credentials';
-
                 return htmlMediaHelper.applySrc(elem, val, options).then(function () {
                     self._currentSrc = val;
 

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -456,9 +456,6 @@ function tryRemoveElement(elem) {
             } else {
                 elem.autoplay = true;
 
-                // Safari will not send cookies without this
-                elem.crossOrigin = 'use-credentials';
-
                 return applySrc(elem, val, options).then(() => {
                     this.#currentSrc = val;
 


### PR DESCRIPTION
**Changes**
Fixes a playback issue where a CORS error would be triggered when playing media in standalone web

**Relevant changes**
Partial revert https://github.com/jellyfin/jellyfin-web/pull/1856
Initial change https://github.com/jellyfin/jellyfin-web/pull/1211

**Issues**
N/A
