### PR TITLE
Add config option to include cookies in playback requests

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1,4 +1,5 @@
 {
+  "includeCorsCredentials": false,
   "multiserver": false,
   "themes": [
     {

--- a/src/plugins/htmlAudioPlayer/plugin.js
+++ b/src/plugins/htmlAudioPlayer/plugin.js
@@ -131,7 +131,10 @@ class HtmlAudioPlayer {
                 return new Promise(function (resolve, reject) {
                     requireHlsPlayer(function () {
                         const hls = new Hls({
-                            manifestLoadingTimeOut: 20000
+                            manifestLoadingTimeOut: 20000,
+                            xhrSetup: function (xhr, url) {
+                                xhr.withCredentials = true;
+                            }
                         });
                         hls.loadSource(val);
                         hls.attachMedia(elem);

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -28,6 +28,7 @@ import Screenfull from 'screenfull';
 import globalize from '../../scripts/globalize';
 import ServerConnections from '../../components/ServerConnections';
 import profileBuilder from '../../scripts/browserDeviceProfile';
+import { getIncludeCorsCredentials } from '../../scripts/settings/webSettings';
 
 /* eslint-disable indent */
 
@@ -382,7 +383,7 @@ function tryRemoveElement(elem) {
          */
         setSrcWithHlsJs(elem, options, url) {
             return new Promise((resolve, reject) => {
-                requireHlsPlayer(() => {
+                requireHlsPlayer(async () => {
                     let maxBufferLength = 30;
                     let maxMaxBufferLength = 600;
 
@@ -395,12 +396,14 @@ function tryRemoveElement(elem) {
                         maxMaxBufferLength = 6;
                     }
 
+                    const includeCorsCredentials = await getIncludeCorsCredentials();
+
                     const hls = new Hls({
                         manifestLoadingTimeOut: 20000,
                         maxBufferLength: maxBufferLength,
                         maxMaxBufferLength: maxMaxBufferLength,
                         xhrSetup(xhr) {
-                            xhr.withCredentials = true;
+                            xhr.withCredentials = includeCorsCredentials;
                         }
                     });
                     hls.loadSource(url);
@@ -419,7 +422,7 @@ function tryRemoveElement(elem) {
         /**
          * @private
          */
-        setCurrentSrc(elem, options) {
+        async setCurrentSrc(elem, options) {
             elem.removeEventListener('error', this.onError);
 
             let val = options.url;
@@ -459,8 +462,11 @@ function tryRemoveElement(elem) {
             } else {
                 elem.autoplay = true;
 
-                // Safari will not send cookies without this
-                elem.crossOrigin = 'use-credentials';
+                const includeCorsCredentials = await getIncludeCorsCredentials();
+                if (includeCorsCredentials) {
+                    // Safari will not send cookies without this
+                    elem.crossOrigin = 'use-credentials';
+                }
 
                 return applySrc(elem, val, options).then(() => {
                     this.#currentSrc = val;

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -398,7 +398,10 @@ function tryRemoveElement(elem) {
                     const hls = new Hls({
                         manifestLoadingTimeOut: 20000,
                         maxBufferLength: maxBufferLength,
-                        maxMaxBufferLength: maxMaxBufferLength
+                        maxMaxBufferLength: maxMaxBufferLength,
+                        xhrSetup(xhr) {
+                            xhr.withCredentials = true;
+                        }
                     });
                     hls.loadSource(url);
                     hls.attachMedia(elem);

--- a/src/scripts/settings/webSettings.js
+++ b/src/scripts/settings/webSettings.js
@@ -76,6 +76,15 @@ async function getDefaultConfig() {
     }
 }
 
+export function getIncludeCorsCredentials() {
+    return getConfig()
+        .then(config => config.includeCorsCredentials)
+        .catch(error => {
+            console.log('cannot get web config:', error);
+            return false;
+        });
+}
+
 export function getMultiServer() {
     return getConfig().then(config => {
         return config.multiserver;


### PR DESCRIPTION
**Changes**
* Reverts the partial revert of #1211 in #1856
* Adds a config option to allow for sending cookies in playback requests

This allows us to support standalone mode (and development environments) by default, while still supporting external auth services that require cookies via a config option.

Replaces: https://github.com/jellyfin/jellyfin-web/pull/2151

**Issues**
N/A
