### PR TITLE
Prevent merge conflicts action from running on forks

### DIFF
--- a/.github/workflows/merge-conflicts.yml
+++ b/.github/workflows/merge-conflicts.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   triage:
     runs-on: ubuntu-latest
+    if: github.repository == 'jellyfin/jellyfin-web'
     steps:
       - uses: mschilde/auto-label-merge-conflicts@master
         with:


### PR DESCRIPTION
**Changes**
* Adds a check so the merge conflicts action does not run on forks. This should prevent build failures in forks when the "merge conflict" label does not exist on the fork. https://github.com/thornbill/jellyfin-web/runs/1487614413?check_suite_focus=true

Refs: https://github.community/t/stop-github-actions-running-on-a-fork/17965/2

**Issues**
N/A
