### PR TITLE
Fix multiple hashes added to route

### DIFF
--- a/src/components/appRouter.js
+++ b/src/components/appRouter.js
@@ -124,6 +124,11 @@ class AppRouter {
     }
 
     show(path, options) {
+        // ensure the path does not start with '#!' since the router adds this
+        if (path.startsWith('#!')) {
+            path = path.substring(2);
+        }
+
         if (path.indexOf('/') !== 0 && path.indexOf('://') === -1) {
             path = '/' + path;
         }


### PR DESCRIPTION
**Changes**
Fixes an issue introduced by #2158 where calling `appRouter.show` with a url starting with `#!` would cause an invalid url to be navigated to by page.js. (i.e. `/web#!/#!/details`)

**Issues**
N/A
