### PR TITLE
Prevent default submit event on add plugin repo form

### DIFF
--- a/src/controllers/dashboard/plugins/repositories/index.js
+++ b/src/controllers/dashboard/plugins/repositories/index.js
@@ -136,7 +136,9 @@ export default function(view, params) {
             dialogHelper.close(dialog);
         });
 
-        dialog.querySelector('.newPluginForm').addEventListener('submit', () => {
+        dialog.querySelector('.newPluginForm').addEventListener('submit', e => {
+            e.preventDefault();
+
             repositories.push({
                 Name: dialog.querySelector('#txtRepositoryName').value,
                 Url: dialog.querySelector('#txtRepositoryUrl').value,


### PR DESCRIPTION
**Changes**
Fixes an issue where the first attempt to add a new plugin repository just reloads the page

**Issues**
N/A
