### PR TITLE
Simplify hiding menu items based on supported features

### DIFF
--- a/src/controllers/user/menu/index.js
+++ b/src/controllers/user/menu/index.js
@@ -29,17 +29,11 @@ export default function (view, params) {
         page.querySelector('.lnkSubtitlePreferences').setAttribute('href', '#!/mypreferencessubtitles.html?userId=' + userId);
         page.querySelector('.lnkQuickConnectPreferences').setAttribute('href', '#!/mypreferencesquickconnect.html');
 
-        if (window.NativeShell && window.NativeShell.AppHost.supports('clientsettings')) {
-            page.querySelector('.clientSettings').classList.remove('hide');
-        } else {
-            page.querySelector('.clientSettings').classList.add('hide');
-        }
+        const supportsClientSettings = appHost.supports('clientsettings');
+        page.querySelector('.clientSettings').classList.toggle('hide', !supportsClientSettings);
 
-        if (appHost.supports('multiserver')) {
-            page.querySelector('.selectServer').classList.remove('hide');
-        } else {
-            page.querySelector('.selectServer').classList.add('hide');
-        }
+        const supportsMultiServer = appHost.supports('multiserver');
+        page.querySelector('.selectServer').classList.toggle('hide', !supportsMultiServer);
 
         ApiClient.getUser(userId).then(function (user) {
             page.querySelector('.headerUsername').innerHTML = user.Name;


### PR DESCRIPTION
Using `toggle()` with the 'force' parameter instead of the if/else, replace the NativeShell calls with `appHost.supports()` (which calls NativeShell anyways).