### PR TITLE
SyncPlay, don't use bad ApiClient

### DIFF
--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -169,8 +169,11 @@ function initSyncPlay() {
 
     // Start SyncPlay.
     const apiClient = ServerConnections.currentApiClient();
-    SyncPlay.Manager.init(apiClient);
+    if (apiClient) SyncPlay.Manager.init(apiClient);
     SyncPlayToasts.init();
+
+    // FIXME: Multiple apiClients?
+    Events.on(ServerConnections, 'apiclientcreated', (e, newApiClient) => SyncPlay.Manager.init(newApiClient));
 }
 
 function onAppReady() {


### PR DESCRIPTION
_I think this is more a hack than a fix._

In multiserver app (Tizen), SyncPlay starts too early and undefined `apiClient` is passed to it.
SyncPlay probably requires some changes to support server switching (cc @OancaAndrei).

**Changes**
- Check `apiClient` before use.
- Watch for creation of `ApiClient`.

**Issues**
In multiserver app, undefined `apiClient` is passed to SyncPlay.

**How to check multiserver with DevServer**
- Enable [`mutliserver`](https://github.com/jellyfin/jellyfin-web/blob/ac0c0648410397b14822c94a123775d5cec82196/src/config.json#L3)
- `yarn serve`
- Open DevServer in browser.
- Clear `localStorage` for DevServer.
- Refresh.
- You should see Select Server page.
