### PR TITLE
Fix plugin loader for function definitions in window

### DIFF
--- a/src/components/pluginManager.js
+++ b/src/components/pluginManager.js
@@ -77,7 +77,7 @@ import { playbackManager } from './playback/playbackmanager';
                     let pluginInstance = await window[pluginSpec];
 
                     if (typeof pluginInstance === 'function') {
-                        pluginInstance = await new pluginInstance();
+                        pluginInstance = await pluginInstance();
                     }
 
                     // init plugin and pass basic dependencies

--- a/src/components/pluginManager.js
+++ b/src/components/pluginManager.js
@@ -74,14 +74,23 @@ import { playbackManager } from './playback/playbackmanager';
             if (typeof pluginSpec === 'string') {
                 if (pluginSpec in window) {
                     console.log(`Loading plugin (via window): ${pluginSpec}`);
-                    let pluginInstance = await window[pluginSpec];
 
-                    if (typeof pluginInstance === 'function') {
-                        pluginInstance = await pluginInstance();
+                    const pluginDefinition = await window[pluginSpec];
+                    if (typeof pluginDefinition !== 'function') {
+                        const err = new TypeError('Plugin definitions in window have to be an (async) function returning the plugin class');
+                        console.error(err);
+                        throw err;
+                    }
+
+                    const pluginClass = await pluginDefinition();
+                    if (typeof pluginClass !== 'function') {
+                        const err = new TypeError(`Plugin definition doesn't return a class for '${pluginSpec}'`);
+                        console.error(err);
+                        throw err;
                     }
 
                     // init plugin and pass basic dependencies
-                    plugin = new pluginInstance({
+                    plugin = new pluginClass({
                         events: Events,
                         loading,
                         appSettings,

--- a/src/components/pluginManager.js
+++ b/src/components/pluginManager.js
@@ -77,16 +77,12 @@ import { playbackManager } from './playback/playbackmanager';
 
                     const pluginDefinition = await window[pluginSpec];
                     if (typeof pluginDefinition !== 'function') {
-                        const err = new TypeError('Plugin definitions in window have to be an (async) function returning the plugin class');
-                        console.error(err);
-                        throw err;
+                        throw new TypeError('Plugin definitions in window have to be an (async) function returning the plugin class');
                     }
 
                     const pluginClass = await pluginDefinition();
                     if (typeof pluginClass !== 'function') {
-                        const err = new TypeError(`Plugin definition doesn't return a class for '${pluginSpec}'`);
-                        console.error(err);
-                        throw err;
+                        throw new TypeError(`Plugin definition doesn't return a class for '${pluginSpec}'`);
                     }
 
                     // init plugin and pass basic dependencies
@@ -107,9 +103,7 @@ import { playbackManager } from './playback/playbackmanager';
                 const pluginResult = await pluginSpec;
                 plugin = new pluginResult.default;
             } else {
-                const err = new TypeError('Plugins have to be a Promise that resolves to a plugin builder function');
-                console.error(err);
-                throw err;
+                throw new TypeError('Plugins have to be a Promise that resolves to a plugin builder function');
             }
 
             return this.#preparePlugin(pluginSpec, plugin);


### PR DESCRIPTION
This reverts commit 2dede415df2558c9be4baa48260a69cc10dea8e5 and fixes supporting functions as well as classes as plugin definitions in window.

The previous change breaks plugin loading on Android, as plugin definitions with a function return a Promise to the class (async function), which cannot be instantiated. The Promise needs to be awaited on first; and the instantiation requires the default dependencies as constructor arguments.