### PR TITLE
Fix anchor click action and plugin configuration page URL

### DIFF
--- a/src/elements/emby-button/emby-button.js
+++ b/src/elements/emby-button/emby-button.js
@@ -18,6 +18,7 @@ function onAnchorClick(e) {
                 shell.openUrl(href);
             }
         } else {
+            e.preventDefault();
             appRouter.show(href);
         }
     } else {

--- a/src/scripts/clientUtils.js
+++ b/src/scripts/clientUtils.js
@@ -95,7 +95,7 @@ export function logout() {
 }
 
 export function getPluginUrl(name) {
-    return '#!/configurationpage?name=' + encodeURIComponent(name);
+    return 'configurationpage?name=' + encodeURIComponent(name);
 }
 
 export function navigate(url, preserveQueryString) {


### PR DESCRIPTION
Introduced by 915589986001f28de69b64f7a7ad4213dbf4b134
`page.clickHandler` has `preventDefault` [here](https://github.com/visionmedia/page.js/blob/4f9991658f9b9e3de9b6059bade93693af24d6bd/page.js#L824). But it handles other [things](https://github.com/visionmedia/page.js/blob/4f9991658f9b9e3de9b6059bade93693af24d6bd/page.js#L777-L796). We probably don't need them.

**Changes**
- Prevent native navigation from anchor.
- Fix plugin configuration page url.

**Issues**
- `Back` action doesn't work.
- Fixes https://github.com/jellyfin/jellyfin-plugin-playbackreporting/issues/29.
- Fixes https://github.com/jellyfin/jellyfin-plugin-reports/issues/38

**How to reproduce**
- Open fresh JF home page
- Go to Preferences
- Go to Dashboard
At this point, the anchor pushes its `href` and breaks history of `page` (by calling `page.stop`).
- Back doesn't work.
