### PR TITLE
Remove reference to sharing help element

### DIFF
--- a/src/controllers/dashboard/users/useredit.js
+++ b/src/controllers/dashboard/users/useredit.js
@@ -174,7 +174,6 @@ import toast from '../../../components/toast/toast';
 
     $(document).on('pageinit', '#editUserPage', function () {
         $('.editUserProfileForm').off('submit', onSubmit).on('submit', onSubmit);
-        this.querySelector('.sharingHelp').innerHTML = globalize.translate('OptionAllowLinkSharingHelp', 30);
         const page = this;
         $('#chkEnableDeleteAllFolders', this).on('change', function () {
             if (this.checked) {


### PR DESCRIPTION
**Changes**
Remove reference to removed element throwing an exception on user edit screen.

**Issues**
Fixes the missing remote connections option from https://github.com/jellyfin/jellyfin/issues/4684
