### PR TITLE
Set the step of subtitle offset slider to 0.1

### DIFF
--- a/src/components/subtitlesync/subtitlesync.js
+++ b/src/components/subtitlesync/subtitlesync.js
@@ -45,11 +45,11 @@ function init(instance) {
             let inputOffset = /[-+]?\d+\.?\d*/g.exec(this.textContent);
             if (inputOffset) {
                 inputOffset = inputOffset[0];
+                inputOffset = parseFloat(inputOffset);
+                inputOffset = Math.min(30, Math.max(-30, inputOffset));
 
                 // replace current text by considered offset
                 this.textContent = inputOffset + 's';
-
-                inputOffset = parseFloat(inputOffset);
                 // set new offset
                 playbackManager.setSubtitleOffset(inputOffset, player);
                 // synchronize with slider value
@@ -121,7 +121,7 @@ function getPercentageFromOffset(value) {
     // convert fraction to percent
     percentValue *= 50;
     percentValue += 50;
-    return Math.min(100, Math.max(0, percentValue.toFixed()));
+    return Math.min(100, Math.max(0, percentValue.toFixed(1)));
 }
 
 class SubtitleSync {

--- a/src/components/subtitlesync/subtitlesync.template.html
+++ b/src/components/subtitlesync/subtitlesync.template.html
@@ -3,7 +3,7 @@
         <button type="button" is="paper-icon-button-light" class="subtitleSync-closeButton"><span class="material-icons close"></span></button>
         <div class="subtitleSyncTextField" contenteditable="true" spellcheck="false">0s</div>
         <div class="sliderContainer subtitleSyncSliderContainer">
-            <input is="emby-slider" type="range" step="1" min="0" max="100" value="50" class="subtitleSyncSlider" data-slider-keep-progress="true" />
+            <input is="emby-slider" type="range" step=".1" min="0" max="100" value="50" class="subtitleSyncSlider" data-slider-keep-progress="true" />
         </div>
     </div>
 </div>


### PR DESCRIPTION
**Changes**
- Set the step of subtitle offset slider to 0.1

Browsers such as Safari that often have problems with subtitle synchronization need this to make more precise adjustments.