### PR TITLE
Fix LiveTV group anchors

### DIFF
--- a/src/controllers/livetv/livetvsuggested.js
+++ b/src/controllers/livetv/livetvsuggested.js
@@ -338,7 +338,7 @@ export default function (view, params) {
     let initialTabIndex = currentTabIndex;
     let lastFullRender = 0;
     [].forEach.call(view.querySelectorAll('.sectionTitleTextButton-programs'), function (link) {
-        const href = link.href;
+        const href = link.getAttribute('href');
 
         if (href) {
             link.href = href + '&serverId=' + ApiClient.serverId();


### PR DESCRIPTION
This line makes an absolute URL.
https://github.com/jellyfin/jellyfin-web/blob/399226518969f6158afe725370050f34c3d923c2/src/controllers/livetv/livetvsuggested.js#L341
We get full `index.html` URL + attribute value.

**Changes**
Use unchanged `href` attribute.

**Issues**
Program group anchor navigates nowhere.

**How to reproduce**
_Assume you have LiveTV_
1. Go to LiveTV library
2. On the first tab (`Programs`), click on the group (`On Now`/`Shows`/...)
3. Browser navigates to `.../index.html#!/list.htm?...` instead of just `list.html?...`