### PR TITLE
Fix multiplication of event listeners on Live TV pages

### DIFF
--- a/src/controllers/livetvsettings.js
+++ b/src/controllers/livetvsettings.js
@@ -56,75 +56,73 @@ function showSaveMessage(recordingPathChanged) {
     }
 }
 
-export default function () {
-    $(document).on('pageinit', '#liveTvSettingsPage', function () {
-        const page = this;
-        $('.liveTvSettingsForm').off('submit', onSubmit).on('submit', onSubmit);
-        $('#btnSelectRecordingPath', page).on('click.selectDirectory', function () {
-            import('../components/directorybrowser/directorybrowser').then(({default: directoryBrowser}) => {
-                const picker = new directoryBrowser();
-                picker.show({
-                    callback: function (path) {
-                        if (path) {
-                            $('#txtRecordingPath', page).val(path);
-                        }
-
-                        picker.close();
-                    },
-                    validateWriteable: true
-                });
-            });
-        });
-        $('#btnSelectMovieRecordingPath', page).on('click.selectDirectory', function () {
-            import('../components/directorybrowser/directorybrowser').then(({default: directoryBrowser}) => {
-                const picker = new directoryBrowser();
-                picker.show({
-                    callback: function (path) {
-                        if (path) {
-                            $('#txtMovieRecordingPath', page).val(path);
-                        }
-
-                        picker.close();
-                    },
-                    validateWriteable: true
-                });
-            });
-        });
-        $('#btnSelectSeriesRecordingPath', page).on('click.selectDirectory', function () {
-            import('../components/directorybrowser/directorybrowser').then(({default: directoryBrowser}) => {
-                const picker = new directoryBrowser();
-                picker.show({
-                    callback: function (path) {
-                        if (path) {
-                            $('#txtSeriesRecordingPath', page).val(path);
-                        }
-
-                        picker.close();
-                    },
-                    validateWriteable: true
-                });
-            });
-        });
-        $('#btnSelectPostProcessorPath', page).on('click.selectDirectory', function () {
-            import('../components/directorybrowser/directorybrowser').then(({default: directoryBrowser}) => {
-                const picker = new directoryBrowser();
-                picker.show({
-                    includeFiles: true,
-                    callback: function (path) {
-                        if (path) {
-                            $('#txtPostProcessor', page).val(path);
-                        }
-
-                        picker.close();
+$(document).on('pageinit', '#liveTvSettingsPage', function () {
+    const page = this;
+    $('.liveTvSettingsForm').off('submit', onSubmit).on('submit', onSubmit);
+    $('#btnSelectRecordingPath', page).on('click.selectDirectory', function () {
+        import('../components/directorybrowser/directorybrowser').then(({default: directoryBrowser}) => {
+            const picker = new directoryBrowser();
+            picker.show({
+                callback: function (path) {
+                    if (path) {
+                        $('#txtRecordingPath', page).val(path);
                     }
-                });
+
+                    picker.close();
+                },
+                validateWriteable: true
             });
-        });
-    }).on('pageshow', '#liveTvSettingsPage', function () {
-        loading.show();
-        const page = this;
-        ApiClient.getNamedConfiguration('livetv').then(function (config) {
-            loadPage(page, config);
         });
     });
-}
+    $('#btnSelectMovieRecordingPath', page).on('click.selectDirectory', function () {
+        import('../components/directorybrowser/directorybrowser').then(({default: directoryBrowser}) => {
+            const picker = new directoryBrowser();
+            picker.show({
+                callback: function (path) {
+                    if (path) {
+                        $('#txtMovieRecordingPath', page).val(path);
+                    }
+
+                    picker.close();
+                },
+                validateWriteable: true
+            });
+        });
+    });
+    $('#btnSelectSeriesRecordingPath', page).on('click.selectDirectory', function () {
+        import('../components/directorybrowser/directorybrowser').then(({default: directoryBrowser}) => {
+            const picker = new directoryBrowser();
+            picker.show({
+                callback: function (path) {
+                    if (path) {
+                        $('#txtSeriesRecordingPath', page).val(path);
+                    }
+
+                    picker.close();
+                },
+                validateWriteable: true
+            });
+        });
+    });
+    $('#btnSelectPostProcessorPath', page).on('click.selectDirectory', function () {
+        import('../components/directorybrowser/directorybrowser').then(({default: directoryBrowser}) => {
+            const picker = new directoryBrowser();
+            picker.show({
+                includeFiles: true,
+                callback: function (path) {
+                    if (path) {
+                        $('#txtPostProcessor', page).val(path);
+                    }
+
+                    picker.close();
+                }
+            });
+        });
+    });
+}).on('pageshow', '#liveTvSettingsPage', function () {
+    loading.show();
+    const page = this;
+    ApiClient.getNamedConfiguration('livetv').then(function (config) {
+        loadPage(page, config);
+    });
+});

--- a/src/controllers/livetvstatus.js
+++ b/src/controllers/livetvstatus.js
@@ -293,36 +293,34 @@ function onDevicesListClick(e) {
     }
 }
 
-export default function () {
-    $(document).on('pageinit', '#liveTvStatusPage', function () {
-        const page = this;
-        $('.btnAddDevice', page).on('click', function () {
-            addDevice(this);
-        });
-        $('.formAddDevice', page).on('submit', function () {
-            submitAddDeviceForm(page);
-            return false;
-        });
-        $('.btnAddProvider', page).on('click', function () {
-            addProvider(this);
-        });
-        page.querySelector('.devicesList').addEventListener('click', onDevicesListClick);
-    }).on('pageshow', '#liveTvStatusPage', function () {
-        const page = this;
-        reload(page);
-        taskButton({
-            mode: 'on',
-            progressElem: page.querySelector('.refreshGuideProgress'),
-            taskKey: 'RefreshGuide',
-            button: page.querySelector('.btnRefresh')
-        });
-    }).on('pagehide', '#liveTvStatusPage', function () {
-        const page = this;
-        taskButton({
-            mode: 'off',
-            progressElem: page.querySelector('.refreshGuideProgress'),
-            taskKey: 'RefreshGuide',
-            button: page.querySelector('.btnRefresh')
-        });
+$(document).on('pageinit', '#liveTvStatusPage', function () {
+    const page = this;
+    $('.btnAddDevice', page).on('click', function () {
+        addDevice(this);
     });
-}
+    $('.formAddDevice', page).on('submit', function () {
+        submitAddDeviceForm(page);
+        return false;
+    });
+    $('.btnAddProvider', page).on('click', function () {
+        addProvider(this);
+    });
+    page.querySelector('.devicesList').addEventListener('click', onDevicesListClick);
+}).on('pageshow', '#liveTvStatusPage', function () {
+    const page = this;
+    reload(page);
+    taskButton({
+        mode: 'on',
+        progressElem: page.querySelector('.refreshGuideProgress'),
+        taskKey: 'RefreshGuide',
+        button: page.querySelector('.btnRefresh')
+    });
+}).on('pagehide', '#liveTvStatusPage', function () {
+    const page = this;
+    taskButton({
+        mode: 'off',
+        progressElem: page.querySelector('.refreshGuideProgress'),
+        taskKey: 'RefreshGuide',
+        button: page.querySelector('.btnRefresh')
+    });
+});


### PR DESCRIPTION
**Changes**
Remove unnecessary export.

**Issues**
- Multiple menus are displayed on adding EPG (`livetvstatus`).
- Multiple `Select Path` dialogs are displayed (`livetvsettings`).

**How to reproduce**
1. Go to `Dashboard` / `Live TV`
2. Go to `Dashboard` / `DVR`
3. Go to `Dashboard` / `Live TV`
4. Click `+` (add) next to `TV Guide Data Providers` -> 2 menus are open
5. Go to `Dashboard` / `DVR`
6. Click `Select Directory` next to `Default recording path` -> 2 dialogs are open