### PR TITLE
Fix style issues on dashboard page

### DIFF
--- a/src/assets/css/dashboard.css
+++ b/src/assets/css/dashboard.css
@@ -287,7 +287,7 @@ div[data-role=controlgroup] a.ui-btn-active {
 }
 
 .activeSession {
-    min-width: 15rem;
+    min-width: 20rem;
     width: 100% !important;
 }
 

--- a/src/assets/css/dashboard.css
+++ b/src/assets/css/dashboard.css
@@ -127,8 +127,8 @@ div[data-role=controlgroup] a.ui-btn-active {
 }
 
 .sessionAppInfo img {
-    max-width: 2.25rem;
-    max-height: 2.25rem;
+    max-width: 40px;
+    max-height: 40px;
     margin-right: 8px;
 }
 
@@ -202,6 +202,10 @@ div[data-role=controlgroup] a.ui-btn-active {
     -webkit-box-flex: 1;
     -webkit-flex-grow: 1;
     flex-grow: 1;
+}
+
+.dashboardActionsContainer {
+    margin: 1em -0.3em 0;
 }
 
 .sessionNowPlayingContent {
@@ -283,12 +287,8 @@ div[data-role=controlgroup] a.ui-btn-active {
 }
 
 .activeSession {
-    min-width: 10rem;
+    min-width: 15rem;
     width: 100% !important;
-}
-
-.activeSession .cardBox {
-    margin: 0;
 }
 
 .activitylogUserPhoto {
@@ -303,7 +303,9 @@ div[data-role=controlgroup] a.ui-btn-active {
 
 @media all and (min-width: 50em) {
     .activeSession {
-        flex: 1;
+        flex-grow: 0;
+        flex-shrink: 0;
+        flex-basis: 50%;
     }
 }
 
@@ -352,7 +354,6 @@ div[data-role=controlgroup] a.ui-btn-active {
 
 .sessionNowPlayingDetails {
     display: flex;
-    white-space: nowrap;
 }
 
 .sessionNowPlayingInfo {
@@ -379,8 +380,9 @@ div[data-role=controlgroup] a.ui-btn-active {
     background: transparent !important;
 }
 
-.activeDevices {
-    gap: 1rem;
+.activeDevices.itemsContainer {
+    /* offset for cardBox margin */
+    margin: -0.6em;
 }
 
 .activeSession .playbackProgress,

--- a/src/assets/css/dashboard.css
+++ b/src/assets/css/dashboard.css
@@ -246,20 +246,12 @@ div[data-role=controlgroup] a.ui-btn-active {
 
 @media all and (min-width: 70em) {
     .dashboardSections {
-        -webkit-flex-wrap: wrap;
         flex-wrap: wrap;
-        -webkit-box-orient: horizontal;
-        -webkit-box-direction: normal;
-        -webkit-flex-direction: row;
         flex-direction: row;
     }
 
     .dashboardColumn-2-60 {
-        width: 46%;
-    }
-
-    .dashboardColumn-2-40 {
-        width: 27%;
+        flex-grow: 2;
     }
 
     .dashboardSection {
@@ -291,6 +283,7 @@ div[data-role=controlgroup] a.ui-btn-active {
 }
 
 .activeSession {
+    min-width: 10rem;
     width: 100% !important;
 }
 

--- a/src/assets/css/dashboard.css
+++ b/src/assets/css/dashboard.css
@@ -127,8 +127,8 @@ div[data-role=controlgroup] a.ui-btn-active {
 }
 
 .sessionAppInfo img {
-    max-width: 40px;
-    max-height: 40px;
+    max-width: 2.5em;
+    max-height: 2.5em;
     margin-right: 8px;
 }
 
@@ -303,6 +303,7 @@ div[data-role=controlgroup] a.ui-btn-active {
 
 @media all and (min-width: 50em) {
     .activeSession {
+        max-width: 25rem;
         flex-grow: 0;
         flex-shrink: 0;
         flex-basis: 50%;

--- a/src/assets/css/dashboard.css
+++ b/src/assets/css/dashboard.css
@@ -127,8 +127,8 @@ div[data-role=controlgroup] a.ui-btn-active {
 }
 
 .sessionAppInfo img {
-    max-width: 40px;
-    max-height: 40px;
+    max-width: 2.25rem;
+    max-height: 2.25rem;
     margin-right: 8px;
 }
 
@@ -287,6 +287,10 @@ div[data-role=controlgroup] a.ui-btn-active {
     width: 100% !important;
 }
 
+.activeSession .cardBox {
+    margin: 0;
+}
+
 .activitylogUserPhoto {
     height: 1.71em;
     width: 1.71em;
@@ -297,15 +301,9 @@ div[data-role=controlgroup] a.ui-btn-active {
     background-position: center;
 }
 
-@media all and (min-width: 40em) {
-    .activeSession {
-        width: 100% !important;
-    }
-}
-
 @media all and (min-width: 50em) {
     .activeSession {
-        width: 50% !important;
+        flex: 1;
     }
 }
 
@@ -318,6 +316,7 @@ div[data-role=controlgroup] a.ui-btn-active {
 }
 
 .sessionAppInfo {
+    flex-grow: 1;
     padding: 0.5em;
     overflow: hidden;
 }
@@ -337,6 +336,8 @@ div[data-role=controlgroup] a.ui-btn-active {
     right: 0;
     bottom: 0;
     font-weight: 400;
+    display: flex;
+    flex-direction: column;
 }
 
 .sessionNowPlayingContent-withbackground + .sessionNowPlayingInnerContent {
@@ -351,9 +352,7 @@ div[data-role=controlgroup] a.ui-btn-active {
 
 .sessionNowPlayingDetails {
     display: flex;
-    position: absolute;
-    bottom: 0;
-    width: 100%;
+    white-space: nowrap;
 }
 
 .sessionNowPlayingInfo {
@@ -378,6 +377,10 @@ div[data-role=controlgroup] a.ui-btn-active {
     margin: 0;
     width: 100%;
     background: transparent !important;
+}
+
+.activeDevices {
+    gap: 1rem;
 }
 
 .activeSession .playbackProgress,

--- a/src/controllers/dashboard/dashboard.html
+++ b/src/controllers/dashboard/dashboard.html
@@ -16,10 +16,10 @@
                     </div>
 
                     <div style="margin-top:1em;">
-                        <button is="emby-button" type="button" class="raised btnRefresh">
+                        <button is="emby-button" type="button" class="raised btnRefresh" style="margin-left: 0;">
                             <span>${ButtonScanAllLibraries}</span>
                         </button>
-                        <button is="emby-button" type="button" id="btnRestartServer" class="raised hide" onclick="DashboardPage.restart(this);" style="margin-left:0;">
+                        <button is="emby-button" type="button" id="btnRestartServer" class="raised hide" onclick="DashboardPage.restart(this);">
                             <span>${Restart}</span>
                         </button>
                         <button is="emby-button" type="button" id="btnShutdown" class="raised" onclick="DashboardPage.shutdown(this);">

--- a/src/controllers/dashboard/dashboard.html
+++ b/src/controllers/dashboard/dashboard.html
@@ -15,8 +15,8 @@
                         <p id="architecture"></p>
                     </div>
 
-                    <div style="margin-top:1em;">
-                        <button is="emby-button" type="button" class="raised btnRefresh" style="margin-left: 0;">
+                    <div class="dashboardActionsContainer">
+                        <button is="emby-button" type="button" class="raised btnRefresh">
                             <span>${ButtonScanAllLibraries}</span>
                         </button>
                         <button is="emby-button" type="button" id="btnRestartServer" class="raised hide" onclick="DashboardPage.restart(this);">

--- a/src/elements/emby-button/emby-button.css
+++ b/src/elements/emby-button/emby-button.css
@@ -3,7 +3,7 @@
     display: inline-flex;
     align-items: center;
     box-sizing: border-box;
-    margin: 0 0.3em;
+    margin: 0.3em;
     text-align: center;
     font-size: inherit;
     font-family: inherit;


### PR DESCRIPTION
**Changes**
* Adjusts the column layout on the dashboard page to avoid tiny columns on small screens
* Adds a min-width to the session cards to avoid tiny cards on small screens
* Adds top/bottom margins for stacked emby-buttons

**Before:**
![Screenshot_2020-12-10 Jellyfin](https://user-images.githubusercontent.com/3450688/101794973-6c0a6e00-3ad5-11eb-97d4-87508356c11c.png)

**After:**
![Screenshot_2020-12-10 Jellyfin(1)](https://user-images.githubusercontent.com/3450688/101795032-775d9980-3ad5-11eb-9648-21e5f40229af.png)

**Issues**
Fixes: #2088 
