### PR TITLE
Set Content-Type header when creating a playlist

### DIFF
--- a/src/components/playlisteditor/playlisteditor.js
+++ b/src/components/playlisteditor/playlisteditor.js
@@ -49,7 +49,8 @@ import ServerConnections from '../ServerConnections';
         apiClient.ajax({
             type: 'POST',
             url: url,
-            dataType: 'json'
+            dataType: 'json',
+            contentType: 'application/json'
         }).then(result => {
             loading.hide();
 


### PR DESCRIPTION
Creating a playlist needs a `ContentType: application/json` header, even when not sending a body.
https://github.com/jellyfin/jellyfin/pull/4761

This should be backported but I don't have permission to set tags