### PR TITLE
Add lint rule for array callback returns

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,6 +29,7 @@ module.exports = {
         'plugin:compat/recommended'
     ],
     rules: {
+        'array-callback-return': ['error'],
         'block-spacing': ['error'],
         'brace-style': ['error', '1tbs', { 'allowSingleLine': true }],
         'comma-dangle': ['error', 'never'],

--- a/src/components/multiSelect/multiSelect.js
+++ b/src/components/multiSelect/multiSelect.js
@@ -157,9 +157,7 @@ import confirm from '../confirm/confirm';
             }
 
             confirm(msg, title).then(() => {
-                const promises = itemIds.map(itemId => {
-                    apiClient.deleteItem(itemId);
-                });
+                const promises = itemIds.map(itemId => apiClient.deleteItem(itemId));
 
                 Promise.all(promises).then(resolve, () => {
                     alertText(globalize.translate('ErrorDeletingItem')).then(reject, reject);

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -283,9 +283,9 @@ function getAudioMaxValues(deviceProfile) {
     let maxAudioBitDepth = null;
     let maxAudioBitrate = null;
 
-    deviceProfile.CodecProfiles.map(function (codecProfile) {
+    deviceProfile.CodecProfiles.forEach(codecProfile => {
         if (codecProfile.Type === 'Audio') {
-            (codecProfile.Conditions || []).map(function (condition) {
+            (codecProfile.Conditions || []).forEach(condition => {
                 if (condition.Condition === 'LessThanEqual' && condition.Property === 'AudioBitDepth') {
                     return maxAudioBitDepth = condition.Value;
                 } else if (condition.Condition === 'LessThanEqual' && condition.Property === 'AudioSampleRate') {
@@ -334,7 +334,7 @@ function getAudioStreamUrlFromDeviceProfile(item, deviceProfile, maxBitrate, api
 
     let directPlayContainers = '';
 
-    deviceProfile.DirectPlayProfiles.map(function (p) {
+    deviceProfile.DirectPlayProfiles.forEach(p => {
         if (p.Type === 'Audio') {
             if (directPlayContainers) {
                 directPlayContainers += ',' + p.Container;
@@ -360,7 +360,7 @@ function getStreamUrls(items, deviceProfile, maxBitrate, apiClient, startPositio
 
     let audioDirectPlayContainers = '';
 
-    deviceProfile.DirectPlayProfiles.map(function (p) {
+    deviceProfile.DirectPlayProfiles.forEach(p => {
         if (p.Type === 'Audio') {
             if (audioDirectPlayContainers) {
                 audioDirectPlayContainers += ',' + p.Container;

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -287,11 +287,11 @@ function getAudioMaxValues(deviceProfile) {
         if (codecProfile.Type === 'Audio') {
             (codecProfile.Conditions || []).forEach(condition => {
                 if (condition.Condition === 'LessThanEqual' && condition.Property === 'AudioBitDepth') {
-                    return maxAudioBitDepth = condition.Value;
+                    maxAudioBitDepth = condition.Value;
                 } else if (condition.Condition === 'LessThanEqual' && condition.Property === 'AudioSampleRate') {
-                    return maxAudioSampleRate = condition.Value;
+                    maxAudioSampleRate = condition.Value;
                 } else if (condition.Condition === 'LessThanEqual' && condition.Property === 'AudioBitrate') {
-                    return maxAudioBitrate = condition.Value;
+                    maxAudioBitrate = condition.Value;
                 }
             });
         }

--- a/src/plugins/sessionPlayer/plugin.js
+++ b/src/plugins/sessionPlayer/plugin.js
@@ -86,7 +86,7 @@ function unsubscribeFromPlayerUpdates(instance) {
 function processUpdatedSessions(instance, sessions, apiClient) {
     const serverId = apiClient.serverId();
 
-    sessions.map(function (s) {
+    sessions.forEach(s => {
         if (s.NowPlayingItem) {
             s.NowPlayingItem.ServerId = serverId;
         }

--- a/src/scripts/shell.js
+++ b/src/scripts/shell.js
@@ -33,9 +33,7 @@ export default {
      */
     downloadFiles(items) {
         if (window.NativeShell) {
-            items.map(function(item) {
-                window.NativeShell.downloadFile(item);
-            });
+            items.forEach(item => window.NativeShell.downloadFile(item));
             return true;
         }
         return false;


### PR DESCRIPTION
**Changes**
* Enables the [array-callback-return](https://eslint.org/docs/rules/array-callback-return) rule for eslint because SonarQube hates these
* Fixes incorrect usages of `Array.map()`

**Issues**
N/A
