### PR TITLE
Fix layout of plugin cards

### DIFF
--- a/src/components/cardbuilder/card.css
+++ b/src/components/cardbuilder/card.css
@@ -160,13 +160,16 @@ button::-moz-focus-inner {
     background-size: cover;
     background-repeat: no-repeat;
     background-position: center center;
-    display: -webkit-flex;
     display: flex;
     align-items: center;
     justify-content: center;
     position: relative;
     background-clip: content-box !important;
     color: inherit;
+}
+
+.cardContent.cardImageContainer {
+    display: flex;
 }
 
 .cardScalable .cardImageContainer {


### PR DESCRIPTION
**Changes**
Fixes the icons in plugin cards not being vertically aligned. This was due to the `cardContent` styling overriding the `cardImageContainer` styling. Typically the `cardContent` class is applied to a different element not the same element, so this rule forces `display: flex` in the few cases where both are applied on the same element.

**Issues**
N/A
