### PR TITLE
Disable browser hack rule for sass files

### DIFF
--- a/.stylelintrc.scss.json
+++ b/.stylelintrc.scss.json
@@ -3,6 +3,7 @@
   "plugins": [ "stylelint-scss" ],
   "rules": {
     "at-rule-no-unknown": null,
-    "scss/at-rule-no-unknown": true
+    "scss/at-rule-no-unknown": true,
+    "plugin/no-browser-hacks": null
   }
 }


### PR DESCRIPTION
**Changes**
Disables the no-browser-hacks stylelint plugin for sass files. This fixes an issue discovered in #2234 where it flags sass variable declarations as browser hacks.

**Issues**
N/A
