### PR TITLE
Replace bash prepare script with node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   "scripts": {
     "start": "yarn serve",
     "serve": "webpack serve --config webpack.dev.js",
-    "prepare": "./scripts/prepare.sh",
+    "prepare": "node ./scripts/prepare.js",
     "build:development": "webpack --config webpack.dev.js",
     "build:production": "webpack --config webpack.prod.js",
     "lint": "eslint \"src/\"",

--- a/scripts/prepare.js
+++ b/scripts/prepare.js
@@ -1,0 +1,12 @@
+const { execSync } = require('child_process');
+
+/**
+ * The npm `prepare` script needs to run a build to support installing
+ * a package from git repositories (this is dumb but a limitation of how
+ * npm behaves). We don't want to run these in CI though because
+ * building is slow so this script will skip the build when the
+ * `SKIP_PREPARE` environment variable has been set.
+ */
+if (!process.env.SKIP_PREPARE) {
+    execSync('webpack --config webpack.prod.js', { stdio: 'inherit' });
+}

--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-if [ -z "${SKIP_PREPARE}" ]; then
-    webpack --config webpack.prod.js
-fi


### PR DESCRIPTION
**Changes**
Addresses an issue caused by #2080 where the prepare script run on installs was not cross platform.

**Issues**
#2241
