### PR TITLE
Always allow stopping via the action menu

### DIFF
--- a/src/components/nowPlayingBar/nowPlayingBar.js
+++ b/src/components/nowPlayingBar/nowPlayingBar.js
@@ -556,6 +556,7 @@ import { appRouter } from '../appRouter';
                         const options = {
                             play: false,
                             queue: false,
+                            stopPlayback: true,
                             clearQueue: true,
                             positionTo: contextButton
                         };

--- a/src/components/remotecontrol/remotecontrol.js
+++ b/src/components/remotecontrol/remotecontrol.js
@@ -209,11 +209,10 @@ function updateNowPlayingInfo(context, state, serverId) {
         if (autoFocusContextButton) {
             contextButton.focus();
         }
-        const stopPlayback = !!layoutManager.mobile;
         const options = {
             play: false,
             queue: false,
-            stopPlayback: stopPlayback,
+            stopPlayback: true,
             clearQueue: true,
             openAlbum: false,
             positionTo: contextButton


### PR DESCRIPTION
**Changes**
Always add stop playback button to the action menu. Currently this option is not displayed on the desktop layout when on small screens.

**Issues**
Fixes #2099 
