### PR TITLE
Fix chevron centering on home section titles

### DIFF
--- a/src/assets/css/dashboard.css
+++ b/src/assets/css/dashboard.css
@@ -231,6 +231,13 @@ div[data-role=controlgroup] a.ui-btn-active {
     margin-bottom: 0.5em;
 }
 
+.dashboardSection .sectionTitleTextButton > .material-icons.material-icons {
+    font-size: 1.17em;
+    margin-top: 0.5em;
+    margin-bottom: 0.5em;
+    padding-top: 0;
+}
+
 .activeRecordingItems > .card {
     width: 50%;
 }

--- a/src/assets/css/librarybrowser.css
+++ b/src/assets/css/librarybrowser.css
@@ -779,6 +779,17 @@ div.itemDetailGalleryLink.defaultCardBackground {
     height: 23vw;
 }
 
+.sectionTitleTextButton > .material-icons {
+    font-size: 1.5em;
+    margin-bottom: 0.35em;
+    margin-top: 0;
+}
+
+.layout-mobile .sectionTitleTextButton > .material-icons {
+    margin-bottom: 0;
+    padding-top: 0.5em;
+}
+
 .itemDetailGalleryLink.defaultCardBackground > .material-icons {
     font-size: 15vw;
     margin-top: 50%;


### PR DESCRIPTION
**Changes**
Fixes the centering issues of the chevron icons in the home section titles

**Before:**
![Screenshot_2020-12-22 Jellyfin](https://user-images.githubusercontent.com/3450688/102854279-39734600-43f0-11eb-99f7-64ed0d60c27a.png)

**After:**
![Screenshot_2020-12-22 Jellyfin(1)](https://user-images.githubusercontent.com/3450688/102854285-4001bd80-43f0-11eb-861b-3b385f3f2f69.png)

**Issues**
N/A
