### PR TITLE
Fix OSD gradients not letting pointer events through

### DIFF
--- a/src/assets/css/videoosd.css
+++ b/src/assets/css/videoosd.css
@@ -22,6 +22,7 @@
     color: #fff;
     user-select: none;
     -webkit-touch-callout: none;
+    pointer-events: none;
 }
 
 .skinHeader-withBackground.osdHeader {
@@ -32,6 +33,7 @@
     backdrop-filter: none;
     color: #eee;
     height: 7.5em;
+    pointer-events: none;
 }
 
 .osdHeader-hidden {
@@ -39,6 +41,7 @@
 }
 
 .osdHeader .headerTop {
+    pointer-events: all;
     max-height: 3.5em;
 }
 
@@ -104,6 +107,7 @@
 }
 
 .osdControls {
+    pointer-events: all;
     flex-grow: 1;
     padding: 0 0.8em;
 }


### PR DESCRIPTION
**Changes**

This adds a few lines of CSS to make the gradients on the OSD let the pointer events through (For pausing the video, for example).

To prevent the OSD buttons from not working, it restores all pointer events on some smaller zones of the OSD.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
