### PR TITLE
Sort items by premiere date on the details page

### DIFF
--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -1209,7 +1209,7 @@ function renderMoreFromArtist(view, item, apiClient) {
             IncludeItemTypes: 'MusicAlbum',
             Recursive: true,
             ExcludeItemIds: item.Id,
-            SortBy: 'ProductionYear,SortName',
+            SortBy: 'PremiereDate,ProductionYear,SortName',
             SortOrder: 'Descending'
         };
 
@@ -1391,7 +1391,7 @@ function renderChildren(page, item) {
             Fields: fields
         });
     } else if (item.Type == 'MusicArtist') {
-        query.SortBy = 'ProductionYear,SortName';
+        query.SortBy = 'PremiereDate,ProductionYear,SortName';
     }
 
     promise = promise || apiClient.getItems(apiClient.getCurrentUserId(), query);

--- a/src/scripts/itembynamedetailpage.js
+++ b/src/scripts/itembynamedetailpage.js
@@ -195,7 +195,7 @@ function renderSection(page, item, element, type) {
                 ArtistIds: '',
                 AlbumArtistIds: '',
                 SortOrder: 'Descending',
-                SortBy: 'ProductionYear,Sortname'
+                SortBy: 'PremiereDate,ProductionYear,Sortname'
             }, {
                 shape: 'overflowSquare',
                 playFromHere: true,


### PR DESCRIPTION
**Changes**

Currently, the details page sorts items by production year. This can cause weirdness when, for example, two albums are released the same year, in which case they may sort in the wrong order.

This adds PremiereDate as the first sorting field for everything filtered by dates on the details page, with a fallback to ProductionYear, then SortName to keep the current behavior as a fallback in case there is no PremiereDate.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
