### PR TITLE
Allow decimal entry for bitrate on mobile

### DIFF
--- a/src/controllers/dashboard/streaming.html
+++ b/src/controllers/dashboard/streaming.html
@@ -7,7 +7,7 @@
                         <h2 class="sectionTitle">${TabStreaming}</h2>
                     </div>
                     <div class="inputContainer">
-                        <input is="emby-input" type="number" id="txtRemoteClientBitrateLimit" pattern="[0-9]*" min="0" step=".25" label="${LabelRemoteClientBitrateLimit}" />
+                        <input is="emby-input" type="number" id="txtRemoteClientBitrateLimit" inputmode="decimal" pattern="[0-9]*(\.[0-9]*)?" min="0" step=".25" label="${LabelRemoteClientBitrateLimit}" />
                         <div class="fieldDescription">${LabelRemoteClientBitrateLimitHelp}</div>
                     </div>
                 </div>

--- a/src/controllers/dashboard/streaming.html
+++ b/src/controllers/dashboard/streaming.html
@@ -7,7 +7,7 @@
                         <h2 class="sectionTitle">${TabStreaming}</h2>
                     </div>
                     <div class="inputContainer">
-                        <input is="emby-input" type="number" id="txtRemoteClientBitrateLimit" inputmode="decimal" pattern="[0-9]*(\.[0-9]*)?" min="0" step=".25" label="${LabelRemoteClientBitrateLimit}" />
+                        <input is="emby-input" type="number" id="txtRemoteClientBitrateLimit" inputmode="decimal" pattern="[0-9]*(\.[0-9]+)?" min="0" step=".25" label="${LabelRemoteClientBitrateLimit}" />
                         <div class="fieldDescription">${LabelRemoteClientBitrateLimitHelp}</div>
                     </div>
                 </div>

--- a/src/controllers/dashboard/users/useredit.html
+++ b/src/controllers/dashboard/users/useredit.html
@@ -99,7 +99,7 @@
                 <br />
                 <div class="verticalSection">
                     <div class="inputContainer">
-                        <input is="emby-input" type="number" id="txtRemoteClientBitrateLimit" pattern="[0-9]*" min="0" step=".25" label="${LabelRemoteClientBitrateLimit}" />
+                        <input is="emby-input" type="number" id="txtRemoteClientBitrateLimit" inputmode="decimal" pattern="[0-9]*(\.[0-9]*)?" min="0" step=".25" label="${LabelRemoteClientBitrateLimit}" />
                         <div class="fieldDescription">${LabelRemoteClientBitrateLimitHelp}</div>
                         <div class="fieldDescription">${LabelUserRemoteClientBitrateLimitHelp}</div>
                     </div>

--- a/src/controllers/dashboard/users/useredit.html
+++ b/src/controllers/dashboard/users/useredit.html
@@ -99,7 +99,7 @@
                 <br />
                 <div class="verticalSection">
                     <div class="inputContainer">
-                        <input is="emby-input" type="number" id="txtRemoteClientBitrateLimit" inputmode="decimal" pattern="[0-9]*(\.[0-9]*)?" min="0" step=".25" label="${LabelRemoteClientBitrateLimit}" />
+                        <input is="emby-input" type="number" id="txtRemoteClientBitrateLimit" inputmode="decimal" pattern="[0-9]*(\.[0-9]+)?" min="0" step=".25" label="${LabelRemoteClientBitrateLimit}" />
                         <div class="fieldDescription">${LabelRemoteClientBitrateLimitHelp}</div>
                         <div class="fieldDescription">${LabelUserRemoteClientBitrateLimitHelp}</div>
                     </div>


### PR DESCRIPTION
**Changes**
Changes the validation pattern and inputmode for the bitrate field to allow decimal values to be entered on mobile

**Issues**
Fixes https://github.com/jellyfin/jellyfin-expo/issues/194
