### PR TITLE
Fix mkv direct play in chromium based browsers

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -159,7 +159,10 @@ import browser from './browser';
             return true;
         }
 
-        if (browser.edgeChromium && browser.windows) {
+        // There's no proper method to check MKV in web browsers.
+        // Chromium based browsers support MKV container.
+        // Chrome on iOS/iPad OS is regarded as safari.
+        if (browser.chrome || browser.edg || browser.edga) {
             return true;
         }
 


### PR DESCRIPTION
**Changes**
- Fix mkv direct play in chromium based browsers

**Issues**
`canPlayType('video/x-matroska')` and `canPlayType('video/mkv')` cannot check MKV support properly.
