### PR TITLE
Fix tiny card icons

### DIFF
--- a/src/components/cardbuilder/card.css
+++ b/src/components/cardbuilder/card.css
@@ -363,7 +363,7 @@ button::-moz-focus-inner {
     font-weight: bold;
 }
 
-.cardImageContainer .cardImageIcon {
+.cardImageIcon {
     font-size: 5em;
     color: inherit;
 }


### PR DESCRIPTION
**Changes**
* Reverts a change from https://github.com/jellyfin/jellyfin-web/pull/813. It seems like that change was intended to fix an issue on the item details screen where the placeholder icons were the incorrect size. It appears to no longer be an issue since the item details screen now uses cards. Reverting it fixes an issue where some icons on cards are the wrong size.

**Before:**
![Screenshot_2021-01-04 Jellyfin](https://user-images.githubusercontent.com/3450688/103505716-ec986200-4e28-11eb-942b-8c93ae9d2cce.png)

**After:**
![Screenshot_2021-01-04 Jellyfin(1)](https://user-images.githubusercontent.com/3450688/103505729-f4f09d00-4e28-11eb-9dd6-ee4141c3b0a2.png)

(For reference this is the Users screen in the Admin Dashboard.)

**Issues**
N/A
