### PR TITLE
Disable multi download option

### DIFF
--- a/src/components/multiSelect/multiSelect.js
+++ b/src/components/multiSelect/multiSelect.js
@@ -194,11 +194,14 @@ import confirm from '../confirm/confirm';
             }
 
             if (user.Policy.EnableContentDownloading && appHost.supports('filedownload')) {
+                // Disabled because there is no callback for this item
+                /*
                 menuItems.push({
                     name: globalize.translate('Download'),
                     id: 'download',
                     icon: 'file_download'
                 });
+                */
             }
 
             if (user.Policy.IsAdministrator) {


### PR DESCRIPTION
This option was enabled in #74 but no callback was added. I left it in if we decide to add a callback in 10.8, but this change is small enough to backport into 10.7.

More information in https://github.com/jellyfin/jellyfin-android/issues/162

**Changes**
- Removed multi download option due too missing callback

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
