### PR TITLE
Fix browser detection: Safari vs Tizen

### DIFF
--- a/src/scripts/browser.js
+++ b/src/scripts/browser.js
@@ -240,6 +240,9 @@ browser.edgeUwp = browser.edge && (userAgent.toLowerCase().indexOf('msapphost') 
 if (!browser.tizen) {
     browser.orsay = userAgent.toLowerCase().indexOf('smarthub') !== -1;
 } else {
+    // UserAgent string contains 'Safari' and 'safari' is set by matched browser, but we only want 'tizen' to be true
+    delete browser.safari;
+
     const v = (navigator.appVersion).match(/Tizen (\d+).(\d+)/);
     browser.tizenVersion = parseInt(v[1]);
 }


### PR DESCRIPTION
Tizen is also detected as Safari.
According to [this](https://developer.samsung.com/smarttv/develop/guides/fundamentals/retrieving-platform-information.html), `Mozilla/5.0 (SMART-TV; LINUX; Tizen 4.0) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 TV Safari/537.36` - contains `Safari` and `browser.safari` is set by matched browser: https://github.com/jellyfin/jellyfin-web/blob/4e5c8cd918ee38facdd508863477c36ae36f9386/src/scripts/browser.js#L148
This breaks MKV+HEVC direct playback: https://github.com/jellyfin/jellyfin-web/blob/331295e62eddeaab1f17608cd508a599fe1c4ce6/src/scripts/browserDeviceProfile.js#L462-L465

**Changes**
Remove `browser.safari` property if Tizen is detected.

**Issues**
MKV+HEVC direct playback is broken.

**Some notes**
`AirPlay` feature depends on `safari` and now it is gone. _Did it work from Samsung TV? Probably not._
https://github.com/jellyfin/jellyfin-web/blob/331295e62eddeaab1f17608cd508a599fe1c4ce6/src/plugins/htmlVideoPlayer/plugin.js#L1450-L1452
