### PR TITLE
Edit admin dashboard menu for plugins

### DIFF
--- a/src/scripts/libraryMenu.js
+++ b/src/scripts/libraryMenu.js
@@ -464,6 +464,7 @@ import Headroom from 'headroom.js';
             pageIds: ['liveTvSettingsPage'],
             icon: 'dvr'
         });
+        addPluginPagesToMainMenu(links, pluginItems, 'livetv');
         links.push({
             divider: true,
             name: globalize.translate('TabAdvanced')
@@ -503,6 +504,10 @@ import Headroom from 'headroom.js';
             href: '#!/scheduledtasks.html',
             pageIds: ['scheduledTasksPage', 'scheduledTaskPage'],
             icon: 'schedule'
+        });
+        links.push({
+            divider: true,
+            name: globalize.translate('TabPlugins')
         });
         addPluginPagesToMainMenu(links, pluginItems);
         return links;

--- a/src/scripts/libraryMenu.js
+++ b/src/scripts/libraryMenu.js
@@ -512,7 +512,6 @@ import Headroom from 'headroom.js';
             });
             addPluginPagesToMainMenu(links, pluginItems);
         }
-        
         return links;
     }
 

--- a/src/scripts/libraryMenu.js
+++ b/src/scripts/libraryMenu.js
@@ -516,9 +516,7 @@ import Headroom from 'headroom.js';
     }
 
     function hasUnsortedPlugins(pluginItems) {
-        for (let i = 0, length = pluginItems.length; i < length; i++) {
-            const pluginItem = pluginItems[i];
-
+        for (const pluginItem of pluginItems) {
             if (pluginItem.EnableInMainMenu && pluginItem.MenuSection === undefined) {
                 return true;
             }
@@ -527,9 +525,7 @@ import Headroom from 'headroom.js';
     }
 
     function addPluginPagesToMainMenu(links, pluginItems, section) {
-        for (let i = 0, length = pluginItems.length; i < length; i++) {
-            const pluginItem = pluginItems[i];
-
+        for (const pluginItem of pluginItems) {
             if (pluginItem.EnableInMainMenu && pluginItem.MenuSection === section) {
                 links.push({
                     name: pluginItem.DisplayName,

--- a/src/scripts/libraryMenu.js
+++ b/src/scripts/libraryMenu.js
@@ -505,12 +505,26 @@ import Headroom from 'headroom.js';
             pageIds: ['scheduledTasksPage', 'scheduledTaskPage'],
             icon: 'schedule'
         });
-        links.push({
-            divider: true,
-            name: globalize.translate('TabPlugins')
-        });
-        addPluginPagesToMainMenu(links, pluginItems);
+        if (hasUnsortedPlugins(pluginItems)) {
+            links.push({
+                divider: true,
+                name: globalize.translate('TabPlugins')
+            });
+            addPluginPagesToMainMenu(links, pluginItems);
+        }
+        
         return links;
+    }
+
+    function hasUnsortedPlugins(pluginItems) {
+        for (let i = 0, length = pluginItems.length; i < length; i++) {
+            const pluginItem = pluginItems[i];
+
+            if (pluginItem.EnableInMainMenu && pluginItem.MenuSection === undefined) {
+                return true;
+            }
+        }
+        return false;
     }
 
     function addPluginPagesToMainMenu(links, pluginItems, section) {


### PR DESCRIPTION
**Changes**
I think it would look a little more tidy in the menu if un sorted plugin menu items were under their own section. Also, would like to be able to add plugin items under Live TV(Maybe should allow this for all sections?).

Uhh sorry if its trash code and if you all don't want it thats A-OK 😅

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->