### PR TITLE
Clear playlist in SyncPlay group

### DIFF
--- a/src/components/syncPlay/core/Controller.js
+++ b/src/components/syncPlay/core/Controller.js
@@ -101,6 +101,18 @@ class Controller {
     }
 
     /**
+     * Clears the playlist of a SyncPlay group.
+     * @param {Array} clearPlayingItem Whether to remove the playing item as well.
+     */
+    clearPlaylist(clearPlayingItem = false) {
+        const apiClient = this.manager.getApiClient();
+        apiClient.requestSyncPlayRemoveFromPlaylist({
+            ClearPlaylist: true,
+            ClearPlayingItem: clearPlayingItem
+        });
+    }
+
+    /**
      * Removes items from SyncPlay group playlist.
      * @param {Array} playlistItemIds The items to remove.
      */

--- a/src/components/syncPlay/core/Helper.js
+++ b/src/components/syncPlay/core/Helper.js
@@ -91,8 +91,7 @@ export function getItemsForPlayback(apiClient, query) {
 
         return apiClient.getItem(apiClient.getCurrentUserId(), itemId).then(function (item) {
             return {
-                Items: [item],
-                TotalRecordCount: 1
+                Items: [item]
             };
         });
     } else {

--- a/src/components/syncPlay/ui/players/NoActivePlayer.js
+++ b/src/components/syncPlay/ui/players/NoActivePlayer.js
@@ -253,7 +253,7 @@ class NoActivePlayer extends SyncPlay.Players.GenericPlayer {
     /**
      * Overrides PlaybackManager's clearQueue method.
      */
-    clearQueueRequest(clearPlayingItem, player) {
+    clearQueueRequest(clearPlayingItem) {
         const controller = syncPlayManager.getController();
         controller.clearPlaylist(clearPlayingItem);
     }

--- a/src/components/syncPlay/ui/players/NoActivePlayer.js
+++ b/src/components/syncPlay/ui/players/NoActivePlayer.js
@@ -45,6 +45,7 @@ class NoActivePlayer extends SyncPlay.Players.GenericPlayer {
 
         playbackManager._localPlay = playbackManager.play;
         playbackManager._localSetCurrentPlaylistItem = playbackManager.setCurrentPlaylistItem;
+        playbackManager._localClearQueue = playbackManager.clearQueue;
         playbackManager._localRemoveFromPlaylist = playbackManager.removeFromPlaylist;
         playbackManager._localMovePlaylistItem = playbackManager.movePlaylistItem;
         playbackManager._localQueue = playbackManager.queue;
@@ -62,6 +63,7 @@ class NoActivePlayer extends SyncPlay.Players.GenericPlayer {
 
         playbackManager.play = this.playRequest;
         playbackManager.setCurrentPlaylistItem = this.setCurrentPlaylistItemRequest;
+        playbackManager.clearQueue = this.clearQueueRequest;
         playbackManager.removeFromPlaylist = this.removeFromPlaylistRequest;
         playbackManager.movePlaylistItem = this.movePlaylistItemRequest;
         playbackManager.queue = this.queueRequest;
@@ -93,6 +95,7 @@ class NoActivePlayer extends SyncPlay.Players.GenericPlayer {
 
         playbackManager.play = playbackManager._localPlay;
         playbackManager.setCurrentPlaylistItem = playbackManager._localSetCurrentPlaylistItem;
+        playbackManager.clearQueue = this._localClearQueue;
         playbackManager.removeFromPlaylist = playbackManager._localRemoveFromPlaylist;
         playbackManager.movePlaylistItem = playbackManager._localMovePlaylistItem;
         playbackManager.queue = playbackManager._localQueue;
@@ -245,6 +248,14 @@ class NoActivePlayer extends SyncPlay.Players.GenericPlayer {
     setCurrentPlaylistItemRequest(playlistItemId, player) {
         const controller = syncPlayManager.getController();
         controller.setCurrentPlaylistItem(playlistItemId);
+    }
+
+    /**
+     * Overrides PlaybackManager's clearQueue method.
+     */
+    clearQueueRequest(clearPlayingItem, player) {
+        const controller = syncPlayManager.getController();
+        controller.clearPlaylist(clearPlayingItem);
     }
 
     /**


### PR DESCRIPTION
**Changes**
Call updated server endpoint to clear the playlist when `Clear queue` button is clicked.
Also, fix play queue breaking on duplicate items.

Server side PR [here](https://github.com/jellyfin/jellyfin/pull/5092).
