### PR TITLE
Fix scaling in comics player

### DIFF
--- a/src/plugins/comicsPlayer/plugin.js
+++ b/src/plugins/comicsPlayer/plugin.js
@@ -9,6 +9,8 @@ import ServerConnections from '../../components/ServerConnections';
 import { Swiper } from 'swiper/swiper-bundle.esm';
 import 'swiper/swiper-bundle.css';
 
+import './style.scss';
+
 export class ComicsPlayer {
     constructor() {
         this.name = 'Comics Player';

--- a/src/plugins/comicsPlayer/style.scss
+++ b/src/plugins/comicsPlayer/style.scss
@@ -1,0 +1,14 @@
+#comicsPlayer {
+    .slideshowSwiperContainer {
+        height: 100%;
+    }
+
+    .slider-zoom-container {
+        text-align: center;
+        height: 100%;
+    }
+
+    .swiper-slide-img {
+        max-height: 100%;
+    }
+}


### PR DESCRIPTION
**Changes**
* Limits the slide height in the comics player so it is not greater than the screen height
* Centers slides for the comics player

**Issues**
Fixes https://github.com/jellyfin/jellyfin/issues/4808
