### PR TITLE
Fix onPosterClick for .detailImageContainer (with other UI modifications)

### DIFF
--- a/src/components/cardbuilder/card.css
+++ b/src/components/cardbuilder/card.css
@@ -316,10 +316,11 @@ button::-moz-focus-inner {
     vertical-align: middle;
     font-family: inherit;
     font-size: inherit;
+    text-decoration: none;
 }
 
 .textActionButton:hover {
-    text-decoration: underline;
+    text-decoration: underline !important;
 }
 
 .cardText > .textActionButton {

--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -845,7 +845,7 @@ import ServerConnections from '../ServerConnections';
                     Name: name,
                     Type: item.Type,
                     CollectionType: item.CollectionType,
-                    IsFolder: item.IsFolder,
+                    IsFolder: item.IsFolder
                 }, null, null, 'a'));
             }
 
@@ -1028,8 +1028,8 @@ import ServerConnections from '../ServerConnections';
             }
 
             let href = '';
-            if(tag === 'a') {
-                href = `href="${appRouter.getRouteUrl(item)}"`
+            if (tag === 'a') {
+                href = `href="${appRouter.getRouteUrl(item)}"`;
             }
 
             let html = '<' + tag + ' ' + itemShortcuts.getShortcutAttributesHtml(item, serverId) + ' ' + href + ' type="button" class="itemAction textActionButton" title="' + text + '" data-action="link">';
@@ -1314,7 +1314,7 @@ import ServerConnections from '../ServerConnections';
             }
 
             const mediaSourceCount = item.MediaSourceCount || 1;
-            if (mediaSourceCount > 1 && (options.indicators == null ||  typeof options.indicators == 'boolean' && options.indicators || typeof options.indicators?.mediaSourceCount == 'boolean' && options.indicators.mediaSourceCount)) {
+            if (mediaSourceCount > 1 && (options.indicators == null || typeof options.indicators == 'boolean' && options.indicators || typeof options.indicators?.mediaSourceCount == 'boolean' && options.indicators.mediaSourceCount)) {
                 innerCardFooter += '<div class="mediaSourceIndicator">' + mediaSourceCount + '</div>';
             }
 
@@ -1502,7 +1502,7 @@ import ServerConnections from '../ServerConnections';
             }
 
             // Only show hover menu if hoverMenu.cornerButtons is set and cornerButtons has properties set to true
-            if(hoverMenu?.cornerButtons == null || typeof hoverMenu?.cornerButtons == 'boolean' && hoverMenu.cornerButtons || typeof hoverMenu?.cornerButtons == 'object' && Object.entries(hoverMenu.cornerButtons).length && Object.entries(hoverMenu.cornerButtons).some(([, optVal]) => optVal == true)) {
+            if (hoverMenu?.cornerButtons == null || typeof hoverMenu?.cornerButtons == 'boolean' && hoverMenu.cornerButtons || typeof hoverMenu?.cornerButtons == 'object' && Object.entries(hoverMenu.cornerButtons).length && Object.entries(hoverMenu.cornerButtons).some(([, optVal]) => optVal == true)) {
                 html += '<div class="cardOverlayButton-br flex">';
 
                 const userData = item.UserData || {};

--- a/src/components/itemContextMenu.js
+++ b/src/components/itemContextMenu.js
@@ -450,7 +450,7 @@ import toast from './toast/toast';
                     getResolveFunction(resolve, id)();
                     break;
                 case 'openInNewTab':
-                    window.open(appRouter.getRouteUrl(item),'_blank','noopener');
+                    window.open(appRouter.getRouteUrl(item), '_blank', 'noopener');
                     getResolveFunction(resolve, id)();
                     break;
                 case 'open':

--- a/src/components/itemContextMenu.js
+++ b/src/components/itemContextMenu.js
@@ -18,6 +18,29 @@ import toast from './toast/toast';
 
         const commands = [];
 
+        // Commands for open/open in new tab, can disable by setting options.open != null or options.openInNewTab != null
+        if (options.open == null || typeof options.open == 'boolean' && options.open) {
+            commands.push({
+                name: globalize.translate('Open'),
+                id: 'open',
+                icon: 'tab'
+            });
+        }
+        if (options.openInNewTab == null || typeof options.openInNewTab == 'boolean' && options.openInNewTab) {
+            commands.push({
+                name: globalize.translate('OpenInNewTab'),
+                id: 'openInNewTab',
+                icon: 'tab'
+            });
+        }
+
+        // Add divider if we have commands and previous command isn't a divider
+        if (commands.length && commands[commands.length - 1].divider == null) {
+            commands.push({
+                divider: true
+            });
+        }
+
         if (canPlay && item.MediaType !== 'Photo') {
             if (options.play !== false) {
                 commands.push({
@@ -93,7 +116,8 @@ import toast from './toast/toast';
             }
         }
 
-        if (commands.length) {
+        // Add divider if we have added commands and previous command isn't a divider
+        if (commands.length && commands[commands.length - 1].divider == null) {
             commands.push({
                 divider: true
             });
@@ -423,6 +447,10 @@ import toast from './toast/toast';
                     break;
                 case 'refresh':
                     refresh(apiClient, item);
+                    getResolveFunction(resolve, id)();
+                    break;
+                case 'openInNewTab':
+                    window.open(appRouter.getRouteUrl(item),'_blank','noopener');
                     getResolveFunction(resolve, id)();
                     break;
                 case 'open':

--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -71,6 +71,7 @@ function hideAll(page, className, show) {
 function getContextMenuOptions(item, user, button) {
     return {
         item: item,
+        openInNewTab: false,
         open: false,
         play: false,
         playAllFromHere: false,
@@ -813,8 +814,11 @@ function renderDetailImage(elem, item, imageLoader) {
         centerText: true,
         overlayText: false,
         transition: false,
-        disableIndicators: true,
+        indicators: false,
         overlayPlayButton: true,
+        hoverMenu: {
+            cornerButtons: false
+        },
         action: 'play',
         width: dom.getWindowSize().innerWidth * 0.25
     });
@@ -1974,8 +1978,8 @@ export default function (view, params) {
         playCurrentItem(this, this.getAttribute('data-mode'));
     }
 
-    function onPosterClick(e) {
-        itemShortcuts.onClick.call(view.querySelector('.detailImageContainer'), e);
+    function onPosterClick() {
+        playCurrentItem(this, this.getAttribute('data-mode'));
     }
 
     function onInstantMixClick() {

--- a/src/elements/emby-itemscontainer/emby-itemscontainer.js
+++ b/src/elements/emby-itemscontainer/emby-itemscontainer.js
@@ -40,6 +40,12 @@ import Sortable from 'sortablejs';
         const target = e.target;
         const card = dom.parentWithAttribute(target, 'data-id');
 
+        // handle links
+        if(target.getAttribute('data-id') != null && target.getAttribute('data-action') == 'link' && target.classList.toString() === 'itemAction textActionButton' && target.tagName === 'A') {
+            // allow A tag to open regular menu
+            return false;
+        }
+
         // check for serverId, it won't be present on selectserver
         if (card && card.getAttribute('data-serverid')) {
             inputManager.handleCommand('menu', {

--- a/src/elements/emby-itemscontainer/emby-itemscontainer.js
+++ b/src/elements/emby-itemscontainer/emby-itemscontainer.js
@@ -41,7 +41,7 @@ import Sortable from 'sortablejs';
         const card = dom.parentWithAttribute(target, 'data-id');
 
         // handle links
-        if(target.getAttribute('data-id') != null && target.getAttribute('data-action') == 'link' && target.classList.toString() === 'itemAction textActionButton' && target.tagName === 'A') {
+        if (target.getAttribute('data-id') != null && target.getAttribute('data-action') == 'link' && target.classList.toString() === 'itemAction textActionButton' && target.tagName === 'A') {
             // allow A tag to open regular menu
             return false;
         }

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1083,6 +1083,8 @@
     "NoSubtitleSearchResultsFound": "No results found.",
     "NoSubtitlesHelp": "Subtitles will not be loaded by default. They can still be turned on manually during playback.",
     "NumLocationsValue": "{0} folders",
+    "OpenInNewTab": "Open in new tab",
+    "Open": "Open",
     "Off": "Off",
     "OnApplicationStartup": "On application startup",
     "OneChannel": "One channel",


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**

#### Fix onPosterClick for .detailImageContainer (with other UI improvements)
 - Now plays selected version (using same function from onPlayClick)

#### Add Open & Open in new tab to itemContextMenu
 - Top two commands are Open/Open in new tab

![context_menu_open_options](https://user-images.githubusercontent.com/4148911/106707566-af9dc780-65ae-11eb-845a-a0d947097aa2.png)


#### Update cardBuilder.js to allow show/hide via options for all indicators & hover menu
 - Added Options reference for buildCard()

#### Turned off hoverMenu & indicators for poster card on itemDetails page
 - Only shows play button on hover now (Suggested here: https://github.com/jellyfin/jellyfin-web/pull/1737)

![poster_with_no_hover_menu](https://user-images.githubusercontent.com/4148911/106707583-b4fb1200-65ae-11eb-8fb2-1ec7e9021d2b.png)

#### Updated onContextMenu to support A tag for titles below poster
 - Right click on titles below poster will show default menu
 - Allows open in new tab without losing focus

![a_tag_contextmenu_00](https://user-images.githubusercontent.com/4148911/106707598-b9272f80-65ae-11eb-86c4-c9806ba97e40.png)
![a_tag_contextmenu_01](https://user-images.githubusercontent.com/4148911/106707607-bb898980-65ae-11eb-8569-4a4fbf87efc0.png)


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes: https://github.com/jellyfin/jellyfin-web/issues/2370