### PR TITLE
fix: message appearing after adding repositories

### DIFF
--- a/src/controllers/dashboard/plugins/repositories/index.js
+++ b/src/controllers/dashboard/plugins/repositories/index.js
@@ -52,6 +52,8 @@ function populateList(options) {
     html += '</div>';
     if (!options.repositories.length) {
         options.noneElement.classList.remove('hide');
+    } else {
+        options.noneElement.classList.add('hide');
     }
 
     options.listElement.innerHTML = html;


### PR DESCRIPTION
Fixes the "No repository" message appearing after adding repositories:

**Steps to reproduce**:

* Delete all the repositories. "No repository" message will appear.
* Add a new repository
* New repository will be added to the list, but the message will still be there

**Expected behaviour**:

Message doesn't appear as soon as the new repository is added