### PR TITLE
Change babel.config.js sourceType to unamiguous

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -3,6 +3,7 @@ module.exports = {
         // Keep the root as a root
         '.'
     ],
+    sourceType: 'unambiguous',
     presets: [
         [
             '@babel/preset-env',


### PR DESCRIPTION
**Changes**
This should tell Babel to look into each file and treat it as a module or a script This is helpful as some dependencies are moving to TypeScript 2.7 and causing issues in the client.

Letting babel decide on what polyfills to use has had no impact on the client from my limited testing and fixes the below issue.

**Issues**
Fixes #2405 
