### PR TITLE
Fix: prevent some backdrops from showing on homepage

### DIFF
--- a/src/scripts/autoBackdrops.js
+++ b/src/scripts/autoBackdrops.js
@@ -27,7 +27,7 @@ function getBackdropItemIds(apiClient, userId, types, parentId) {
         ImageTypes: 'Backdrop',
         ParentId: parentId,
         EnableTotalRecordCount: false,
-        MaxOfficialRating: parentId ? '' : 'TV-MA'
+        MaxOfficialRating: parentId ? '' : 'PG-13'
     };
     return apiClient.getItems(apiClient.getCurrentUserId(), options).then(function (result) {
         const images = result.Items.map(function (i) {

--- a/src/scripts/autoBackdrops.js
+++ b/src/scripts/autoBackdrops.js
@@ -27,7 +27,7 @@ function getBackdropItemIds(apiClient, userId, types, parentId) {
         ImageTypes: 'Backdrop',
         ParentId: parentId,
         EnableTotalRecordCount: false,
-        MaxOfficialRating: parentId === '' ? 'TV-MA' : ''
+        MaxOfficialRating: parentId ? '' : 'TV-MA'
     };
     return apiClient.getItems(apiClient.getCurrentUserId(), options).then(function (result) {
         const images = result.Items.map(function (i) {

--- a/src/scripts/autoBackdrops.js
+++ b/src/scripts/autoBackdrops.js
@@ -26,7 +26,8 @@ function getBackdropItemIds(apiClient, userId, types, parentId) {
         IncludeItemTypes: types,
         ImageTypes: 'Backdrop',
         ParentId: parentId,
-        EnableTotalRecordCount: false
+        EnableTotalRecordCount: false,
+        MaxOfficialRating: parentId === '' ? 'TV-MA' : ''
     };
     return apiClient.getItems(apiClient.getCurrentUserId(), options).then(function (result) {
         const images = result.Items.map(function (i) {


### PR DESCRIPTION
**Changes**
prevents backdrops from items with an OfficialRating > TV-MA from showing when no ParentId given

**Issues**
None