### PR TITLE
Fix attachment delivery urls

### DIFF
--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1049,11 +1049,11 @@ function tryRemoveElement(elem) {
         renderSsaAss(videoElement, track, item) {
             const avaliableFonts = [];
             const attachments = this._currentPlayOptions.mediaSource.MediaAttachments || [];
+            const apiClient = ServerConnections.getApiClient(item);
             attachments.map(function (i) {
                 // embedded font url
-                return avaliableFonts.push(i.DeliveryUrl);
+                return avaliableFonts.push(apiClient.getUrl(i.DeliveryUrl));
             });
-            const apiClient = ServerConnections.getApiClient(item);
             const fallbackFontList = apiClient.getUrl('/FallbackFont/Fonts', {
                 api_key: apiClient.accessToken()
             });


### PR DESCRIPTION
Return missed `apiClient.getUrl` call (initially was added in d3c0bdd2422fb54690586dd2e680e36cbdec7b18).
Was accidentally (?) removed in 86c87446e343eb10f388852f1d3e049efc0b6edd

**Changes**
Return missed `apiClient.getUrl`.

**Issues**
SubtitlesOctopus fails to load attachments in case of embedded webui (Tizen app) - base URL is app URL instead of server URL.
Probably https://github.com/jellyfin/jellyfin-tizen/issues/62 and https://github.com/jellyfin/jellyfin-tizen/issues/64