### PR TITLE
Add Webpack publicPath

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -78,7 +78,8 @@ module.exports = {
     ],
     output: {
         filename: '[name].bundle.js',
-        path: path.resolve(__dirname, 'dist')
+        path: path.resolve(__dirname, 'dist'),
+        publicPath: ''
     },
     module: {
         rules: [


### PR DESCRIPTION
Error on webOS 1.2 (probably any old WebKit browser):
```
Automatic publicPath is not supported in this browser
```

The comment beside:
```js
// When supporting browsers where an automatic publicPath is not supported you must specify an output.publicPath manually via configuration
// or pass an empty string ("") and set the __webpack_public_path__ variable from your code to use your own logic.
```

**Changes**
Add empty `publicPath`.

**Issues**
webOS 1.2 fails.

No need to backport because 10.7 branch has an older webpack.
But no harm.