### PR TITLE
Tune some styles on now playing page

### DIFF
--- a/src/components/remotecontrol/remotecontrol.scss
+++ b/src/components/remotecontrol/remotecontrol.scss
@@ -120,7 +120,6 @@
 .btnPlayPause {
     font-size: 2em;
     padding: 0;
-    margin: 0;
 }
 
 .nowPlayingInfoControls {

--- a/src/components/remotecontrol/remotecontrol.scss
+++ b/src/components/remotecontrol/remotecontrol.scss
@@ -118,7 +118,7 @@
 }
 
 .btnPlayPause {
-    font-size: xx-large;
+    font-size: 2em;
     padding: 0;
     margin: 0;
 }
@@ -322,7 +322,7 @@
         -webkit-box-pack: center;
         -webkit-justify-content: center;
         justify-content: center;
-        font-size: x-large;
+        font-size: 1.5em;
         height: 100%;
     }
 


### PR DESCRIPTION
`x-large` and `xx-large` are absolute sizes. We have some font size adjustments for the root element that don't apply to buttons with mentioned font sizes.

**Desktop**
_We use 93% for `font-size` of root element. Now play button is 2x from 93%. Spacing changed._
Before:
![old-desktop](https://user-images.githubusercontent.com/56478732/109418655-b0bdeb00-79da-11eb-8fd5-2544ebf437b9.png)
After:
![new-desktop](https://user-images.githubusercontent.com/56478732/109418660-b5829f00-79da-11eb-8226-246d09ba0903.png)

**iPhone5 (small screen)**
_On mobile, we use 90% for `font-size` of root element. But for iOS we use 82%. Now playback buttons are 1.5x from 90% (82% on iOS)._
Before:
![old-iphone5](https://user-images.githubusercontent.com/56478732/109418683-d3e89a80-79da-11eb-8735-e753ed88c0aa.png)
After:
![new-iphone5](https://user-images.githubusercontent.com/56478732/109418690-d8ad4e80-79da-11eb-93ff-404ee5940a96.png)

**TV**
_We use 27px for `font-size` of root element (for FHD). Now play button is 2x from 27px. Spacing changed._
Before:
![old-tv](https://user-images.githubusercontent.com/56478732/109418696-e19e2000-79da-11eb-9420-304dcc3ef4b7.png)
After:
![new-tv](https://user-images.githubusercontent.com/56478732/109418702-e4007a00-79da-11eb-8ab3-11c155928644.png)

**Changes**
- Make font size relative
- Make spacing between buttons more even

**Issues**
:eyes: 
