### PR TITLE
browser.js: Avoid misdetecting Chrome OS as OS X

### DIFF
--- a/src/scripts/browser.js
+++ b/src/scripts/browser.js
@@ -210,7 +210,7 @@ if (!browser.chrome && !browser.edgeChromium && !browser.edge && !browser.opera 
     browser.safari = true;
 }
 
-browser.osx = userAgent.toLowerCase().indexOf('os x') !== -1;
+browser.osx = userAgent.toLowerCase().indexOf('mac os x') !== -1;
 
 // This is a workaround to detect iPads on iOS 13+ that report as desktop Safari
 // This may break in the future if Apple releases a touchscreen Mac


### PR DESCRIPTION
Matching for lower-case "os x" not only finds "Mac OS X" but also
"CrOS x86_64". Mismatching Chrome OS as Apple device leads to
playback issues due to differences in supported client formats.

I checked User Agent lists on the Internet (e.g. https://developers.whatismybrowser.com/useragents/explore/) and all Apple browsers seem to report "Mac OS X $version" (mac OS) or something similar to "iPhone OS $version like Mac OS X" (iOS device family), so that extended regex should still work.

Fixes #2477 