### PR TITLE
Fix wizard in multi-server app

### DIFF
--- a/src/components/appRouter.js
+++ b/src/components/appRouter.js
@@ -510,6 +510,7 @@ class AppRouter {
                 return response.json();
             }).then(data => {
                 if (data !== null && data.StartupWizardCompleted === false) {
+                    ServerConnections.setLocalApiClient(firstResult.ApiClient);
                     Dashboard.navigate('wizardstart.html');
                 } else {
                     this.handleConnectionResult(firstResult);


### PR DESCRIPTION
**Changes**
Set ApiClient of non-configured server as current.

**Issues**
Wizard doesn't work in multi-server app.

**Steps to reproduce**
1. Make server non-configured (`IsStartupWizardCompleted: false`).
2. Open app with `multiserver: true`. `yarn serve` fits for this.
3. Add server. It opens login page on server add.
4. Go to app root URL again. It should open `wizardstart` page (with endless loading).
5. Error [here](https://github.com/jellyfin/jellyfin-web/blob/30e8605b453337430e67f8fa031aaa5534b9259b/src/controllers/wizard/start/index.js#L42) because `ApiClient` is `undefined`.
