### PR TITLE
Disable 'Remember Me' by default [2.0]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2095,6 +2095,16 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "blurhash": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/blurhash/-/blurhash-1.1.3.tgz",
@@ -4607,6 +4617,13 @@
         }
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -5975,9 +5992,11 @@
       "dev": true
     },
     "jellyfin-apiclient": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/jellyfin-apiclient/-/jellyfin-apiclient-1.6.0.tgz",
-      "integrity": "sha512-LL8YwUQJYTFdlx6VwA5C3+KWkLEM0V56fJGruUDwCVUCFQQVJ+E6hpHIO1lMeo26ZxURtebf5VtCCG35ZHugbg=="
+      "version": "git+https://github.com/dmitrylyzo/jellyfin-apiclient-javascript.git#814acf87dd97484e83044036ea19a5e056ce7cb9",
+      "from": "git+https://github.com/dmitrylyzo/jellyfin-apiclient-javascript.git#remember-me",
+      "requires": {
+        "js-cookie": "^2.2.1"
+      }
     },
     "jest-worker": {
       "version": "26.6.2",
@@ -6017,6 +6036,11 @@
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
       "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==",
       "dev": true
+    },
+    "js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -6860,6 +6884,13 @@
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
       "dev": true
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
     },
     "nanoid": {
       "version": "3.1.22",
@@ -13207,7 +13238,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "headroom.js": "^0.12.0",
     "hls.js": "^0.14.17",
     "intersection-observer": "^0.12.0",
-    "jellyfin-apiclient": "^1.6.0",
+    "jellyfin-apiclient": "git+https://github.com/dmitrylyzo/jellyfin-apiclient-javascript.git#remember-me",
     "jquery": "^3.5.1",
     "jstree": "^3.3.11",
     "libarchive.js": "^1.3.0",

--- a/src/components/appRouter.js
+++ b/src/components/appRouter.js
@@ -1,5 +1,4 @@
 import { appHost } from './apphost';
-import appSettings from '../scripts/settings/appSettings';
 import backdrop from './backdrop/backdrop';
 import browser from '../scripts/browser';
 import { Events } from 'jellyfin-apiclient';
@@ -98,9 +97,7 @@ class AppRouter {
     beginConnectionWizard() {
         backdrop.clearBackdrop();
         loading.show();
-        ServerConnections.connect({
-            enableAutoLogin: appSettings.enableAutoLogin()
-        }).then((result) => {
+        ServerConnections.connect().then((result) => {
             this.handleConnectionResult(result);
         });
     }
@@ -162,9 +159,7 @@ class AppRouter {
         Events.on(appHost, 'beforeexit', this.onBeforeExit);
         Events.on(appHost, 'resume', this.onAppResume);
 
-        ServerConnections.connect({
-            enableAutoLogin: appSettings.enableAutoLogin()
-        }).then((result) => {
+        ServerConnections.connect().then((result) => {
             this.firstConnectionResult = result;
             options = options || {};
             page({

--- a/src/controllers/session/addServer/index.js
+++ b/src/controllers/session/addServer/index.js
@@ -1,4 +1,3 @@
-import appSettings from '../../../scripts/settings/appSettings';
 import loading from '../../../components/loading/loading';
 import globalize from '../../../scripts/globalize';
 import '../../../elements/emby-button/emby-button';
@@ -38,9 +37,7 @@ import ServerConnections from '../../../components/ServerConnections';
     function submitServer(page) {
         loading.show();
         const host = page.querySelector('#txtServerHost').value;
-        ServerConnections.connectToAddress(host, {
-            enableAutoLogin: appSettings.enableAutoLogin()
-        }).then(function(result) {
+        ServerConnections.connectToAddress(host).then(function(result) {
             handleConnectionResult(page, result);
         }, function() {
             handleConnectionResult(page, {

--- a/src/controllers/session/login/index.html
+++ b/src/controllers/session/login/index.html
@@ -13,7 +13,7 @@
             </div>
 
             <label class="checkboxContainer">
-                <input is="emby-checkbox" type="checkbox" class="chkRememberLogin" checked />
+                <input is="emby-checkbox" type="checkbox" class="chkRememberLogin" />
                 <span>${RememberMe}</span>
             </label>
 

--- a/src/controllers/session/login/index.js
+++ b/src/controllers/session/login/index.js
@@ -1,5 +1,4 @@
 import { appHost } from '../../../components/apphost';
-import appSettings from '../../../scripts/settings/appSettings';
 import dom from '../../../scripts/dom';
 import loading from '../../../components/loading/loading';
 import layoutManager from '../../../components/layoutManager';
@@ -19,9 +18,9 @@ import cardBuilder from '../../../components/cardbuilder/cardBuilder';
 
     const enableFocusTransform = !browser.slow && !browser.edge;
 
-    function authenticateUserByName(page, apiClient, username, password) {
+    function authenticateUserByName(page, apiClient, username, password, rememberMe) {
         loading.show();
-        apiClient.authenticateUserByName(username, password).then(function (result) {
+        apiClient.authenticateUserByName(username, password, rememberMe).then(function (result) {
             const user = result.User;
             loading.hide();
 
@@ -76,7 +75,8 @@ import cardBuilder from '../../../components/cardbuilder/cardBuilder';
                         dialogHelper.close(dlg);
                     }
 
-                    const result = await apiClient.quickConnect(data.Authentication);
+                    // FIXME: Save token for now. 'Remember Me' for Quick Connect?
+                    const result = await apiClient.quickConnect(data.Authentication, true);
                     onLoginSuccessful(result.User.Id, result.AccessToken, apiClient);
                 }, function (e) {
                     clearInterval(interval);
@@ -114,7 +114,6 @@ import cardBuilder from '../../../components/cardbuilder/cardBuilder';
     }
 
     function showManualForm(context, showCancel, focusPassword) {
-        context.querySelector('.chkRememberLogin').checked = appSettings.enableAutoLogin();
         context.querySelector('.manualLoginForm').classList.remove('hide');
         context.querySelector('.visualLoginForm').classList.add('hide');
         context.querySelector('.btnManual').classList.add('hide');
@@ -218,7 +217,7 @@ import cardBuilder from '../../../components/cardbuilder/cardBuilder';
                     context.querySelector('#txtManualName').value = '';
                     showManualForm(context, true);
                 } else if (haspw == 'false') {
-                    authenticateUserByName(context, getApiClient(), name, '');
+                    authenticateUserByName(context, getApiClient(), name, '', false);
                 } else {
                     context.querySelector('#txtManualName').value = name;
                     context.querySelector('#txtManualPassword').value = '';
@@ -227,9 +226,8 @@ import cardBuilder from '../../../components/cardbuilder/cardBuilder';
             }
         });
         view.querySelector('.manualLoginForm').addEventListener('submit', function (e) {
-            appSettings.enableAutoLogin(view.querySelector('.chkRememberLogin').checked);
             const apiClient = getApiClient();
-            authenticateUserByName(view, apiClient, view.querySelector('#txtManualName').value, view.querySelector('#txtManualPassword').value);
+            authenticateUserByName(view, apiClient, view.querySelector('#txtManualName').value, view.querySelector('#txtManualPassword').value, view.querySelector('.chkRememberLogin').checked);
             e.preventDefault();
             return false;
         });

--- a/src/controllers/session/selectServer/index.js
+++ b/src/controllers/session/selectServer/index.js
@@ -2,7 +2,6 @@ import loading from '../../../components/loading/loading';
 import { appRouter } from '../../../components/appRouter';
 import layoutManager from '../../../components/layoutManager';
 import libraryMenu from '../../../scripts/libraryMenu';
-import appSettings from '../../../scripts/settings/appSettings';
 import focusManager from '../../../components/focusManager';
 import globalize from '../../../scripts/globalize';
 import actionSheet from '../../../components/actionSheet/actionSheet';
@@ -114,9 +113,7 @@ import cardBuilder from '../../../components/cardbuilder/cardBuilder';
     export default function (view, params) {
         function connectToServer(server) {
             loading.show();
-            ServerConnections.connectToServer(server, {
-                enableAutoLogin: appSettings.enableAutoLogin()
-            }).then(function (result) {
+            ServerConnections.connectToServer(server).then(function (result) {
                 loading.hide();
                 const apiClient = result.ApiClient;
 

--- a/src/scripts/settings/appSettings.js
+++ b/src/scripts/settings/appSettings.js
@@ -10,14 +10,6 @@ class AppSettings {
         return name;
     }
 
-    enableAutoLogin(val) {
-        if (val !== undefined) {
-            this.set('enableAutoLogin', val.toString());
-        }
-
-        return this.get('enableAutoLogin') !== 'false';
-    }
-
     enableSystemExternalPlayers(val) {
         if (val !== undefined) {
             this.set('enableSystemExternalPlayers', val.toString());


### PR DESCRIPTION
_Better :crossed_fingers: alternative to #1952_

Requires https://github.com/jellyfin/jellyfin-apiclient-javascript/pull/154

https://github.com/jellyfin/jellyfin-tizen/issues/51 in short (and interpreted):

User has 2 accounts on the server:
- admin/parent
- child

Client is on TV (or any shared device).

When you are logging in via manual form, `Remember Me` is checked by default or restored from `localStorage` and you have to disable it for admin/parent account each time other user enabled it.

Unset `enableAutoLogin` is treated as `true`, so if you have valid `AccessToken`, app logs in.

When you are logging in via visual form, you cannot turn on/off auto login - its state is taken from previously saved `enableAutoLogin`, i.e. it may be unexpected for user.

**Changes**
- `Remember Me` is unchecked and not restored - you are presumably starting a new session. And if you want to be remembered you check `Remember Me` once (in opposite to unchecking it each time).
- For visual form, `Remember Me` is always unchecked. If you have no password, you can easily click your card. With password, you must use manual form (switched automatically). If you want to be "remembered", you can still open the manual form and enable the option.

**Differences from #1952**
- Being "unremembered", you can now normally open links in a new tab.
- Refresh doesn't close the session.
- Chrome and Firefox with `Restore previous session` enabled will retain the session cookies, and Jellyfin session will be "remembered" regardless of the user's choice.

**Issues**
Fixes https://github.com/jellyfin/jellyfin-tizen/issues/51

@varlesh also said that `Remember Me` isn't restored from previous state. So there might be a `localStorage` issue, but it works on Tizen 4 and 5 (emulator).
