### PR TITLE
Fix webpack globbing in hidden folder

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -48,7 +48,7 @@ module.exports = {
                     }
                 },
                 {
-                    from: __dirname + '/*.*',
+                    from: '*.*',
                     globOptions: {
                         ignore: ['**.js', '**.html']
                     }

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -44,12 +44,14 @@ module.exports = {
                 {
                     from: 'assets/**',
                     globOptions: {
+                        dot: true,
                         ignore: ['**/css/*']
                     }
                 },
                 {
                     from: '*.*',
                     globOptions: {
+                        dot: true,
                         ignore: ['**.js', '**.html']
                     }
                 }


### PR DESCRIPTION
With #2466 we lost some files: https://github.com/jellyfin/jellyfin-web/pull/2466#issuecomment-791339127
Looks like `globOptions.ignore` option just stops working if `jellyfin-web` working copy is in dot folder.

**Changes**
- Revert #2466
- Add `dot` option to `CopyPlugin`

**Issues**
Fixes #2465
Fixes #2488
