### PR TITLE
Allow logos without backdrops enabled

### DIFF
--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -745,9 +745,7 @@ function renderLogo(page, item, apiClient) {
 
     const url = logoImageUrl(item, apiClient, {});
 
-    if (!layoutManager.mobile && !userSettings.enableBackdrops()) {
-        detailLogo.classList.add('hide');
-    } else if (url) {
+    if (url) {
         detailLogo.classList.remove('hide');
         imageLoader.setLazyImage(detailLogo, url);
     } else {


### PR DESCRIPTION
**Changes**
The new item details screen has the section where the logo is displayed present when backdrops are disabled so it makes sense to show the logo in that space.

Tagging for backport as I've seen this question come up a few times.

**Issues**
N/A
