### PR TITLE
KnownProxies now supports hostnames too

### DIFF
--- a/src/strings/en-gb.json
+++ b/src/strings/en-gb.json
@@ -1412,7 +1412,7 @@
     "LabelIconMaxResHelp": "Maximum resolution of icons exposed via the upnp:icon property.",
     "LabelCurrentStatus": "Current status:",
     "LabelAlbumArtMaxResHelp": "Maximum resolution of album art exposed via the upnp:albumArtURI property.",
-    "KnownProxiesHelp": "Comma separated list of IP addresses/hostnames of known proxies used when connecting to your Jellyfin instance. This is required to make proper use of X-Forwarded-For headers. Requires a reboot after saving.",
+    "KnownProxiesHelp": "Comma separated list of IP addresses of known proxies used when connecting to your Jellyfin instance. This is required to make proper use of X-Forwarded-For headers. Requires a reboot after saving.",
     "Other": "Other",
     "EnableQuickConnect": "Enable quick connect on this server",
     "ButtonUseQuickConnect": "Use Quick Connect",

--- a/src/strings/en-gb.json
+++ b/src/strings/en-gb.json
@@ -1412,7 +1412,7 @@
     "LabelIconMaxResHelp": "Maximum resolution of icons exposed via the upnp:icon property.",
     "LabelCurrentStatus": "Current status:",
     "LabelAlbumArtMaxResHelp": "Maximum resolution of album art exposed via the upnp:albumArtURI property.",
-    "KnownProxiesHelp": "Comma separated list of IP addresses of known proxies used when connecting to your Jellyfin instance. This is required to make proper use of X-Forwarded-For headers. Requires a reboot after saving.",
+    "KnownProxiesHelp": "Comma separated list of IP addresses/hostnames of known proxies used when connecting to your Jellyfin instance. This is required to make proper use of X-Forwarded-For headers. Requires a reboot after saving.",
     "Other": "Other",
     "EnableQuickConnect": "Enable quick connect on this server",
     "ButtonUseQuickConnect": "Use Quick Connect",

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -489,7 +489,7 @@
     "ItemCount": "{0} items",
     "Items": "Items",
     "Kids": "Kids",
-    "KnownProxiesHelp": "Comma separated list of IP addresses/hostnames of known proxies used when connecting to your Jellyfin instance. This is required to make proper use of X-Forwarded-For headers. Requires a reboot after saving.",
+    "KnownProxiesHelp": "Comma separated list of IP addresses or hostnames of known proxies used when connecting to your Jellyfin instance. This is required to make proper use of X-Forwarded-For headers. Requires a reboot after saving.",
     "Label3DFormat": "3D format:",
     "LabelAbortedByServerShutdown": "(Aborted by server shutdown)",
     "LabelAccessDay": "Day of week:",

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -489,7 +489,7 @@
     "ItemCount": "{0} items",
     "Items": "Items",
     "Kids": "Kids",
-    "KnownProxiesHelp": "Comma separated list of IP addresses of known proxies used when connecting to your Jellyfin instance. This is required to make proper use of X-Forwarded-For headers. Requires a reboot after saving.",
+    "KnownProxiesHelp": "Comma separated list of IP addresses/hostnames of known proxies used when connecting to your Jellyfin instance. This is required to make proper use of X-Forwarded-For headers. Requires a reboot after saving.",
     "Label3DFormat": "3D format:",
     "LabelAbortedByServerShutdown": "(Aborted by server shutdown)",
     "LabelAccessDay": "Day of week:",


### PR DESCRIPTION
Per https://github.com/jellyfin/jellyfin/pull/4675 hostnames are supported in the KnownProxies field.
