### PR TITLE
Add BR: nodejs for Fedora 33 and up

### DIFF
--- a/fedora/jellyfin-web.spec
+++ b/fedora/jellyfin-web.spec
@@ -2,7 +2,7 @@
 
 Name:           jellyfin-web
 Version:        10.7.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        The Free Software Media System web client
 License:        GPLv3
 URL:            https://jellyfin.org

--- a/fedora/jellyfin-web.spec
+++ b/fedora/jellyfin-web.spec
@@ -18,6 +18,9 @@ BuildRequires:  nodejs-yarn
 # ditto for Fedora's yarn RPM
 BuildRequires: git
 BuildArch:		noarch
+%if 0%{?fedora} >= 33
+BuildRequires: nodejs
+%endif
 
 # Disable Automatic Dependency Processing
 AutoReqProv:    no

--- a/fedora/jellyfin-web.spec
+++ b/fedora/jellyfin-web.spec
@@ -41,7 +41,8 @@ mv dist %{buildroot}%{_datadir}/jellyfin-web
 %{__install} -D -m 0644 LICENSE %{buildroot}%{_datadir}/licenses/jellyfin/LICENSE
 
 %files
-%attr(644,root,root) %{_datadir}/jellyfin-web
+%defattr(644,root,root,755)
+%{_datadir}/jellyfin-web
 %{_datadir}/licenses/jellyfin/LICENSE
 
 %changelog

--- a/fedora/jellyfin-web.spec
+++ b/fedora/jellyfin-web.spec
@@ -6,7 +6,7 @@ Release:        1%{?dist}
 Summary:        The Free Software Media System web client
 License:        GPLv3
 URL:            https://jellyfin.org
-# Jellyfin Server tarball created by `make -f .copr/Makefile srpm`, real URL ends with `v%{version}.tar.gz`
+# Jellyfin Server tarball created by `make -f .copr/Makefile srpm`, real URL ends with `v%%{version}.tar.gz`
 Source0:        jellyfin-web-%{version}.tar.gz
 
 %if 0%{?centos}

--- a/fedora/jellyfin-web.spec
+++ b/fedora/jellyfin-web.spec
@@ -41,7 +41,7 @@ mv dist %{buildroot}%{_datadir}/jellyfin-web
 %{__install} -D -m 0644 LICENSE %{buildroot}%{_datadir}/licenses/jellyfin/LICENSE
 
 %files
-%attr(755,root,root) %{_datadir}/jellyfin-web
+%attr(644,root,root) %{_datadir}/jellyfin-web
 %{_datadir}/licenses/jellyfin/LICENSE
 
 %changelog


### PR DESCRIPTION
nodejs doesn't seem to be implicitly installed as a BR: on Fedora 33, so set
an explicit BR: for it.