### PR TITLE
Disable first episodes in Next Up home section

### DIFF
--- a/src/components/homesections/homesections.js
+++ b/src/components/homesections/homesections.js
@@ -665,7 +665,8 @@ import ServerConnections from '../ServerConnections';
                 UserId: apiClient.getCurrentUserId(),
                 ImageTypeLimit: 1,
                 EnableImageTypes: 'Primary,Backdrop,Banner,Thumb',
-                EnableTotalRecordCount: false
+                EnableTotalRecordCount: false,
+                DisableFirstEpisode: true
             });
         };
     }


### PR DESCRIPTION
**Changes**
This makes use of the new API parameter to remove the first episodes which show up by default when the user hasn't watched anything yet.

Pretty much all the streaming services behave this way, and so do other media servers.

**Issues**

Fix #2430