### PR TITLE
Add HEVC in TS for Tizen and webOS

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -463,6 +463,10 @@ import browser from './browser';
             if (!browser.safari) {
                 mp4VideoCodecs.push('hevc');
             }
+
+            if (browser.tizen || browser.web0s) {
+                hlsInTsVideoCodecs.push('hevc');
+            }
         }
 
         if (supportsMpeg2Video()) {


### PR DESCRIPTION
In #2064, `hevc` in `ts` for Tizen and webOS was removed.

**Changes**
Add HEVC in TS for Tizen and webOS

**Issues**
https://github.com/jellyfin/jellyfin-tizen/issues/69

But there is an issue with multiple video codecs in the transcoding profile: https://github.com/jellyfin/jellyfin/issues/5576