### PR TITLE
[2529] [RegressionFix] [Dlna] Album shuffle button does not shuffle any more since 10.6.4.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -44,6 +44,7 @@
  - [Orry Verducci](https://github.com/orryverducci)
  - [Camc314](https://github.com/camc314)
  - [danieladov](https://github.com/danieladov)
+ - [Stephane Senart](https://github.com/ssenart)
 
 # Emby Contributors
 

--- a/src/controllers/music/musicalbums.js
+++ b/src/controllers/music/musicalbums.js
@@ -24,7 +24,7 @@ import '../../elements/emby-itemscontainer/emby-itemscontainer';
         function shuffle() {
             ApiClient.getItem(ApiClient.getCurrentUserId(), params.topParentId).then(function (item) {
                 getQuery();
-                playbackManager.shuffle(item, null);
+                playbackManager.shuffle(item);
             });
         }
 


### PR DESCRIPTION
Fix 2529

**Changes**
Remove a null reference passed as shuffle method parameter. It caused always playing all instead shuffle all.

**Issues**
Fixes #2529.
