### PR TITLE
Add controls page to the user settings

### DIFF
--- a/src/controllers/user/controls/index.html
+++ b/src/controllers/user/controls/index.html
@@ -1,0 +1,24 @@
+<div id="controlsPreferencesPage" data-role="page" class="page libraryPage userPreferencesPage noSecondaryNavPage" data-title="${Controls}" data-menubutton="true">
+    <div class="padded-left padded-right padded-bottom-page">
+        <form style="margin: 0 auto;">
+            <div class="verticalSection verticalSection-extrabottompadding">
+                <h2 class="sectionTitle">
+                    ${Controls}
+                </h2>
+
+                <div class="checkboxContainer checkboxContainer-withDescription">
+                    <label>
+                        <input type="checkbox" is="emby-checkbox" class="chkEnableGamepad" />
+                        <span>${LabelEnableGamepad}</span>
+                    </label>
+                    <div class="fieldDescription checkboxFieldDescription">${EnableGamepadHelp}</div>
+                    <div class="fieldDescription checkboxFieldDescription">${LabelPleaseRestart}</div>
+                </div>
+            </div>
+
+            <button is="emby-button" type="submit" class="raised button-submit block btnSave hide">
+                <span>${Save}</span>
+            </button>
+        </form>
+    </div>
+</div>

--- a/src/controllers/user/controls/index.js
+++ b/src/controllers/user/controls/index.js
@@ -1,0 +1,28 @@
+import { Events } from 'jellyfin-apiclient';
+import toast from '../../../components/toast/toast';
+import globalize from '../../../scripts/globalize';
+import appSettings from '../../../scripts/settings/appSettings';
+
+export default function (view, params) {
+    function submit(e) {
+        appSettings.enableGamepad(view.querySelector('.chkEnableGamepad').checked);
+
+        toast(globalize.translate('SettingsSaved'));
+
+        Events.trigger(view, 'saved');
+
+        if (e) e.preventDefault();
+
+        return false;
+    }
+
+    view.addEventListener('viewshow', function () {
+        view.querySelector('.chkEnableGamepad').checked = appSettings.enableGamepad();
+        view.querySelector('form').addEventListener('submit', submit);
+        view.querySelector('.btnSave').classList.remove('hide');
+
+        import('../../../components/autoFocuser').then(({default: autoFocuser}) => {
+            autoFocuser.autoFocus(view);
+        });
+    });
+}

--- a/src/controllers/user/controls/index.js
+++ b/src/controllers/user/controls/index.js
@@ -3,7 +3,7 @@ import toast from '../../../components/toast/toast';
 import globalize from '../../../scripts/globalize';
 import appSettings from '../../../scripts/settings/appSettings';
 
-export default function (view, params) {
+export default function (view) {
     function submit(e) {
         appSettings.enableGamepad(view.querySelector('.chkEnableGamepad').checked);
 

--- a/src/controllers/user/controls/index.js
+++ b/src/controllers/user/controls/index.js
@@ -11,7 +11,7 @@ export default function (view, params) {
 
         Events.trigger(view, 'saved');
 
-        if (e) e.preventDefault();
+        e?.preventDefault();
 
         return false;
     }

--- a/src/controllers/user/menu/index.html
+++ b/src/controllers/user/menu/index.html
@@ -66,6 +66,15 @@
                         </div>
                     </div>
                 </a>
+
+                <a is="emby-linkbutton" data-ripple="false" href="#" style="display:block;padding:0;margin:0;" class="lnkControlsPreferences listItem-border">
+                    <div class="listItem">
+                        <span class="material-icons listItemIcon listItemIcon-transparent keyboard"></span>
+                        <div class="listItemBody">
+                            <div class="listItemBodyText">${Controls}</div>
+                        </div>
+                    </div>
+                </a>
             </div>
             <div class="adminSection verticalSection verticalSection-extrabottompadding hide">
                 <h2 class="sectionTitle" style="padding-left:.25em;">${HeaderAdmin}</h2>

--- a/src/controllers/user/menu/index.js
+++ b/src/controllers/user/menu/index.js
@@ -59,6 +59,7 @@ export default function (view, params) {
         if (params.userId && params.userId !== Dashboard.getCurrentUserId) {
             page.querySelector('.userSection').classList.add('hide');
             page.querySelector('.adminSection').classList.add('hide');
+            page.querySelector('.lnkControlsPreferences').classList.add('hide');
         }
 
         import('../../../components/autoFocuser').then(({default: autoFocuser}) => {

--- a/src/controllers/user/menu/index.js
+++ b/src/controllers/user/menu/index.js
@@ -28,12 +28,15 @@ export default function (view, params) {
         page.querySelector('.lnkPlaybackPreferences').setAttribute('href', '#!/mypreferencesplayback.html?userId=' + userId);
         page.querySelector('.lnkSubtitlePreferences').setAttribute('href', '#!/mypreferencessubtitles.html?userId=' + userId);
         page.querySelector('.lnkQuickConnectPreferences').setAttribute('href', '#!/mypreferencesquickconnect.html');
+        page.querySelector('.lnkControlsPreferences').setAttribute('href', '#!/mypreferencescontrols.html?userId=' + userId);
 
         const supportsClientSettings = appHost.supports('clientsettings');
         page.querySelector('.clientSettings').classList.toggle('hide', !supportsClientSettings);
 
         const supportsMultiServer = appHost.supports('multiserver');
         page.querySelector('.selectServer').classList.toggle('hide', !supportsMultiServer);
+
+        page.querySelector('.lnkControlsPreferences').classList.toggle('hide', layoutManager.mobile);
 
         ApiClient.getQuickConnect('Status')
             .then(status => {

--- a/src/scripts/keyboardNavigation.js
+++ b/src/scripts/keyboardNavigation.js
@@ -5,6 +5,7 @@
 
 import inputManager from './inputManager';
 import layoutManager from '../components/layoutManager';
+import appSettings from './settings/appSettings';
 
 /**
  * Key name mapping.
@@ -160,7 +161,7 @@ function attachGamepadScript() {
 }
 
 // No need to check for gamepads manually at load time, the eventhandler will be fired for that
-if (navigator.getGamepads) { /* eslint-disable-line compat/compat */
+if (navigator.getGamepads && appSettings.enableGamepad()) { /* eslint-disable-line compat/compat */
     window.addEventListener('gamepadconnected', attachGamepadScript);
 }
 

--- a/src/scripts/routes.js
+++ b/src/scripts/routes.js
@@ -85,6 +85,13 @@ import { appRouter } from '../components/appRouter';
     });
 
     defineRoute({
+        alias: '/mypreferencescontrols.html',
+        path: 'user/controls/index.html',
+        autoFocus: false,
+        controller: 'user/controls/index'
+    });
+
+    defineRoute({
         alias: '/mypreferencesdisplay.html',
         path: 'user/display/index.html',
         autoFocus: false,

--- a/src/scripts/settings/appSettings.js
+++ b/src/scripts/settings/appSettings.js
@@ -18,6 +18,19 @@ class AppSettings {
         return this.get('enableAutoLogin') !== 'false';
     }
 
+    /**
+     * Get or set 'Enable Gamepad' state.
+     * @param {boolean|undefined} val - Flag to enable 'Enable Gamepad' or undefined.
+     * @return {boolean} 'Enable Gamepad' state.
+     */
+    enableGamepad(val) {
+        if (val !== undefined) {
+            return this.set('enableGamepad', val.toString());
+        }
+
+        return this.get('enableGamepad') === 'true';
+    }
+
     enableSystemExternalPlayers(val) {
         if (val !== undefined) {
             this.set('enableSystemExternalPlayers', val.toString());

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1507,5 +1507,8 @@
     "MessagePlaybackError": "There was an error playing this file on your Google Cast receiver.",
     "EnableEnhancedNvdecDecoder": "Enable enhanced NVDEC decoder",
     "EnableVppTonemapping": "Enable VPP Tone mapping",
-    "AllowVppTonemappingHelp": "Full hardware based tone mapping without using OpenCL filter. Currently works only when transcoding videos with embedded HDR10 metadata."
+    "AllowVppTonemappingHelp": "Full hardware based tone mapping without using OpenCL filter. Currently works only when transcoding videos with embedded HDR10 metadata.",
+    "Controls": "Controls",
+    "LabelEnableGamepad": "Enable Gamepad",
+    "EnableGamepadHelp": "Listen for input from any connected controllers."
 }


### PR DESCRIPTION
This PR adds a new page (`Controls`) to the user settings.
It is hidden for `Mobile` layout (we could hide for `Desktop` as well, but we could add keybindings there later).

![menu](https://user-images.githubusercontent.com/56478732/112756250-06db7980-8fed-11eb-8839-4051c2c482c2.png)

The page contains only one `Enable Gamepad` option.
- It is app wide and requires a page refresh.
- Disabled by default.

![controls](https://user-images.githubusercontent.com/56478732/112756252-0a6f0080-8fed-11eb-8fb6-d209ab012fcc.png)

**Changes**
Add gamepad enabling/disabling

**Issues**
Fixes #2531 
