### PR TITLE
Improve behaviour of space bar pausing/playing video

### DIFF
--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -992,9 +992,13 @@ import { appRouter } from '../../../components/appRouter';
 
             const key = keyboardnavigation.getKeyName(e);
             const isKeyModified = e.ctrlKey || e.altKey || e.metaKey;
+            const currentElement = document.activeElement;
 
-            if (!currentVisibleMenu && e.keyCode === 32) {
-                playbackManager.playPause(currentPlayer);
+            if (e.keyCode === 32) {
+                if (!currentElement.className.split(' ').includes('btnPause')) {
+                    // If the focused button is the pause button it will already play/pause it
+                    playbackManager.playPause(currentPlayer);
+                }
                 showOsd();
                 return;
             }

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1,5 +1,6 @@
 import { playbackManager } from '../../../components/playback/playbackmanager';
 import SyncPlay from '../../../components/syncPlay/core';
+import browser from '../../../scripts/browser';
 import dom from '../../../scripts/dom';
 import inputManager from '../../../scripts/inputManager';
 import mouseManager from '../../../scripts/mouseManager';
@@ -987,17 +988,29 @@ import { appRouter } from '../../../components/appRouter';
          */
         let clickedElement;
 
+        function onClickCapture(e) {
+            // Firefox/Edge emits `click` even if `preventDefault` was used on `keydown`
+            // Ignore 'click' if another element was originally clicked
+            if (!e.target.contains(clickedElement)) {
+                e.preventDefault();
+                e.stopPropagation();
+                return false;
+            }
+        }
+
         function onKeyDown(e) {
             clickedElement = e.target;
 
             const key = keyboardnavigation.getKeyName(e);
             const isKeyModified = e.ctrlKey || e.altKey || e.metaKey;
-            const currentElement = document.activeElement;
 
             if (e.keyCode === 32) {
-                if (!currentElement.className.split(' ').includes('btnPause')) {
-                    // If the focused button is the pause button it will already play/pause it
+                if (e.target.tagName !== 'BUTTON' || !layoutManager.tv) {
                     playbackManager.playPause(currentPlayer);
+                    e.preventDefault();
+                    e.stopPropagation();
+                    // Trick Firefox with a null element to skip next click
+                    clickedElement = null;
                 }
                 showOsd();
                 return;
@@ -1308,6 +1321,9 @@ import { appRouter } from '../../../components/appRouter';
                     capture: true,
                     passive: true
                 });
+                if (browser.firefox || browser.edge) {
+                    dom.addEventListener(document, 'click', onClickCapture, { capture: true });
+                }
             } catch (e) {
                 appRouter.goHome();
             }
@@ -1346,6 +1362,9 @@ import { appRouter } from '../../../components/appRouter';
                 capture: true,
                 passive: true
             });
+            if (browser.firefox || browser.edge) {
+                dom.removeEventListener(document, 'click', onClickCapture, { capture: true });
+            }
             stopOsdHideTimer();
             headerElement.classList.remove('osdHeader');
             headerElement.classList.remove('osdHeader-hidden');
@@ -1495,10 +1514,7 @@ import { appRouter } from '../../../components/appRouter';
             playbackManager.previousTrack(currentPlayer);
         });
         view.querySelector('.btnPause').addEventListener('click', function () {
-            // Ignore 'click' if another element was originally clicked (Firefox/Edge issue)
-            if (this.contains(clickedElement)) {
-                playbackManager.playPause(currentPlayer);
-            }
+            playbackManager.playPause(currentPlayer);
         });
         view.querySelector('.btnNextTrack').addEventListener('click', function () {
             playbackManager.nextTrack(currentPlayer);


### PR DESCRIPTION
**Changes**
The issue seemed to stem from us not pausing if the playbackManager is set. This would work if the focused element was the pause button since that is handled differently. I modified the code to get the current focused element. If the element is the pause button then we do nothing since the space bar will behave the same as if we hit the button with the mouse. If that is not the case then we call playPause() to manually play/pause the video.

**Issues**
Fixes #2376 
