### PR TITLE
fix: redirect to login if stored credentials are invalid

### DIFF
--- a/src/components/appRouter.js
+++ b/src/components/appRouter.js
@@ -431,7 +431,7 @@ class AppRouter {
             appRouter.showLocalLogin(apiClient.serverId());
         } else if (data.status === 403) {
             if (data.errorCode === 'ParentalControl') {
-                const isCurrentAllowed = this.currentRouteInfo ? (this.currentRouteInfo.route.anonymous || this.currentRouteInfo.route.startup) : true;
+                const isCurrentAllowed = appRouter.currentRouteInfo ? (appRouter.currentRouteInfo.route.anonymous || appRouter.currentRouteInfo.route.startup) : true;
 
                 // Bounce to the login screen, but not if a password entry fails, obviously
                 if (!isCurrentAllowed) {

--- a/src/components/appRouter.js
+++ b/src/components/appRouter.js
@@ -424,13 +424,12 @@ class AppRouter {
 
     onRequestFail(e, data) {
         const apiClient = this;
-        
+
         // 401 means the credentials are broken
         if (data.status === 401) {
             console.debug('Invalid stored credentials, redirecting to login');
             appRouter.showLocalLogin(apiClient.serverId());
-        }
-        else if (data.status === 403) {
+        } else if (data.status === 403) {
             if (data.errorCode === 'ParentalControl') {
                 const isCurrentAllowed = this.currentRouteInfo ? (this.currentRouteInfo.route.anonymous || this.currentRouteInfo.route.startup) : true;
 

--- a/src/components/appRouter.js
+++ b/src/components/appRouter.js
@@ -424,15 +424,20 @@ class AppRouter {
 
     onRequestFail(e, data) {
         const apiClient = this;
-
-        if (data.status === 403) {
+        
+        // 401 means the credentials are broken
+        if (data.status === 401) {
+            console.debug('Invalid stored credentials, redirecting to login');
+            appRouter.showLocalLogin(apiClient.serverId());
+        }
+        else if (data.status === 403) {
             if (data.errorCode === 'ParentalControl') {
                 const isCurrentAllowed = this.currentRouteInfo ? (this.currentRouteInfo.route.anonymous || this.currentRouteInfo.route.startup) : true;
 
                 // Bounce to the login screen, but not if a password entry fails, obviously
                 if (!isCurrentAllowed) {
-                    this.showForcedLogoutMessage(globalize.translate('AccessRestrictedTryAgainLater'));
-                    this.showLocalLogin(apiClient.serverId());
+                    appRouter.showForcedLogoutMessage(globalize.translate('AccessRestrictedTryAgainLater'));
+                    appRouter.showLocalLogin(apiClient.serverId());
                 }
             }
         }


### PR DESCRIPTION
**Changes**
redirect to login screen if API returns 401

also fixes an es6 migration bug

**Issues**
Too many. This might fix the "black screen" after a server upgrade or any other time that the access token is invalidated on the server and not updated in localStorage.
