### PR TITLE
Add server selection response handling

### DIFF
--- a/src/components/appRouter.js
+++ b/src/components/appRouter.js
@@ -503,23 +503,29 @@ class AppRouter {
         const firstResult = this.firstConnectionResult;
 
         this.firstConnectionResult = null;
-        if (firstResult && firstResult.State === 'ServerSignIn') {
-            const url = firstResult.ApiClient.serverAddress() + '/System/Info/Public';
-            fetch(url).then(response => {
-                if (!response.ok) return Promise.reject('fetch failed');
-                return response.json();
-            }).then(data => {
-                if (data !== null && data.StartupWizardCompleted === false) {
-                    ServerConnections.setLocalApiClient(firstResult.ApiClient);
-                    Dashboard.navigate('wizardstart.html');
-                } else {
-                    this.handleConnectionResult(firstResult);
-                }
-            }).catch(error => {
-                console.error(error);
-            });
+        if (firstResult) {
+            if (firstResult.State === 'ServerSelection') {
+                // FIXME: On single-server configuration (webui shipped with the server), we probably need to update server Id and re-connect. But server select also works
+                Dashboard.selectServer();
+                return;
+            } else if (firstResult.State === 'ServerSignIn') {
+                const url = firstResult.ApiClient.serverAddress() + '/System/Info/Public';
+                fetch(url).then(response => {
+                    if (!response.ok) return Promise.reject('fetch failed');
+                    return response.json();
+                }).then(data => {
+                    if (data !== null && data.StartupWizardCompleted === false) {
+                        ServerConnections.setLocalApiClient(firstResult.ApiClient);
+                        Dashboard.navigate('wizardstart.html');
+                    } else {
+                        this.handleConnectionResult(firstResult);
+                    }
+                }).catch(error => {
+                    console.error(error);
+                });
 
-            return;
+                return;
+            }
         }
 
         const apiClient = ServerConnections.currentApiClient();


### PR DESCRIPTION
If server is down or server hash has been changed, connection state is `ServerSelection`.
Redirect user to the server selection page.
This is not the best solution, but at least user won't get hung up with "Circle Of Death".

**Changes**
Add server selection response handling

**Issues**
This issue occurs on standalone and bundled web.
https://github.com/jellyfin/jellyfin-tizen/issues/75

_Review with `Hide whitespace changes`_
