### PR TITLE
chore(npm): fix CI after switch to npm

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -11,7 +11,7 @@ override_dh_auto_test:
 override_dh_clistrip:
 
 override_dh_auto_build:
-	npm ci --no-audit
+	npm ci --no-audit --unsafe-perm
 	mv $(CURDIR)/dist $(CURDIR)/web
 
 override_dh_auto_clean:

--- a/deployment/Dockerfile.centos
+++ b/deployment/Dockerfile.centos
@@ -12,10 +12,9 @@ ENV IS_DOCKER=YES
 # Prepare CentOS environment
 RUN yum update -y \
   && yum install -y epel-release \
-  && yum install -y @buildsys-build rpmdevtools git yum-plugins-core autoconf automake glibc-devel
-
-# Install recent NodeJS
-RUN rpm -i https://rpm.nodesource.com/pub_10.x/el/7/x86_64/nodesource-release-el7-1.noarch.rpm
+  && yum install -y @buildsys-build rpmdevtools git yum-plugins-core autoconf automake glibc-devel gcc-c++ make \
+  && curl -fsSL https://rpm.nodesource.com/setup_12.x | bash - \
+  && yum install -y nodejs
 
 # Link to build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.centos /build.sh

--- a/deployment/Dockerfile.debian
+++ b/deployment/Dockerfile.debian
@@ -12,7 +12,9 @@ ENV IS_DOCKER=YES
 
 # Prepare Debian build environment
 RUN apt-get update \
-  && apt-get install -y debhelper mmv npm git
+  && apt-get install -y debhelper mmv git curl \
+  && curl -fsSL https://deb.nodesource.com/setup_12.x | bash - \
+  && apt-get install -y nodejs
 
 
 # Link to build script

--- a/deployment/Dockerfile.docker
+++ b/deployment/Dockerfile.docker
@@ -8,4 +8,4 @@ RUN apk add autoconf g++ make libpng-dev gifsicle alpine-sdk automake libtool ma
 WORKDIR ${SOURCE_DIR}
 COPY . .
 
-RUN npm ci --no-audit && mv dist ${ARTIFACT_DIR}
+RUN npm ci --no-audit --unsafe-perm && mv dist ${ARTIFACT_DIR}

--- a/deployment/Dockerfile.portable
+++ b/deployment/Dockerfile.portable
@@ -11,7 +11,9 @@ ENV IS_DOCKER=YES
 
 # Prepare Debian build environment
 RUN apt-get update \
-  && apt-get install -y mmv npm git
+  && apt-get install -y mmv curl git \
+  && curl -fsSL https://deb.nodesource.com/setup_12.x | bash - \
+  && apt-get install -y nodejs
 
 # Link to build script
 RUN ln -sf ${SOURCE_DIR}/deployment/build.portable /build.sh

--- a/deployment/build.portable
+++ b/deployment/build.portable
@@ -14,7 +14,7 @@ else
 fi
 
 # build archives
-npm ci --no-audit
+npm ci --no-audit --unsafe-perm
 mv dist jellyfin-web_${version}
 tar -czf jellyfin-web_${version}_portable.tar.gz jellyfin-web_${version}
 rm -rf dist

--- a/fedora/jellyfin-web.spec
+++ b/fedora/jellyfin-web.spec
@@ -27,7 +27,8 @@ Jellyfin is a free software media system that puts you in control of managing an
 %build
 
 %install
-npm ci --no-audit
+chown root:root -R .
+npm ci --no-audit --unsafe-perm
 %{__mkdir} -p %{buildroot}%{_datadir}
 mv dist %{buildroot}%{_datadir}/jellyfin-web
 %{__install} -D -m 0644 LICENSE %{buildroot}%{_datadir}/licenses/jellyfin/LICENSE


### PR DESCRIPTION
After the switch to npm, builds got broken. After a investigation and testing all the OSs (this time running ``git clean -fxd`` and ``docker system prune --all -f`` between each test, as some builds happens with a mountpoint to host), I determined the following causes:

* npm [doesn't like root environments and tries to downgrade the permissions, failing at doing that in some environments](https://github.com/npm/npm/issues/3497). Adding the flag ``unsafe-perm`` solves this.
* For security, npm also expected the files to be owned by the user that is running its process. Fedora and CentOS had a mountpoint to host which conflicted with the permissions with UID 1001 and root.

The privileges alone didn't solve all the problems:
* We used way too old npm and node versions in our Debian builds, so npm was using the wrong path during the ``prepare`` stage and referencing the ``node_modules/script/prepare.js`` directory (instead of ``./scripts/prepare.js``). I fixed this by forcing **Node 12**, just to ensure maximum compatibility and avoid further breakage.

We should switch to Node 14 as Node 12 is already in maintenance, but [we have still quite some time](https://nodejs.org/es/about/releases/) and this is something that can be perfectly done as soon as the CI migration to GH Actions is accomplished.
