### PR TITLE
Revert "fix: redirect to login if stored credentials are invalid"

### DIFF
--- a/src/components/appRouter.js
+++ b/src/components/appRouter.js
@@ -425,18 +425,14 @@ class AppRouter {
     onRequestFail(e, data) {
         const apiClient = this;
 
-        // 401 means the credentials are broken
-        if (data.status === 401) {
-            console.debug('Invalid stored credentials, redirecting to login');
-            appRouter.showLocalLogin(apiClient.serverId());
-        } else if (data.status === 403) {
+        if (data.status === 403) {
             if (data.errorCode === 'ParentalControl') {
-                const isCurrentAllowed = appRouter.currentRouteInfo ? (appRouter.currentRouteInfo.route.anonymous || appRouter.currentRouteInfo.route.startup) : true;
+                const isCurrentAllowed = this.currentRouteInfo ? (this.currentRouteInfo.route.anonymous || this.currentRouteInfo.route.startup) : true;
 
                 // Bounce to the login screen, but not if a password entry fails, obviously
                 if (!isCurrentAllowed) {
-                    appRouter.showForcedLogoutMessage(globalize.translate('AccessRestrictedTryAgainLater'));
-                    appRouter.showLocalLogin(apiClient.serverId());
+                    this.showForcedLogoutMessage(globalize.translate('AccessRestrictedTryAgainLater'));
+                    this.showLocalLogin(apiClient.serverId());
                 }
             }
         }

--- a/src/components/appRouter.js
+++ b/src/components/appRouter.js
@@ -427,12 +427,12 @@ class AppRouter {
 
         if (data.status === 403) {
             if (data.errorCode === 'ParentalControl') {
-                const isCurrentAllowed = this.currentRouteInfo ? (this.currentRouteInfo.route.anonymous || this.currentRouteInfo.route.startup) : true;
+                const isCurrentAllowed = appRouter.currentRouteInfo ? (appRouter.currentRouteInfo.route.anonymous || appRouter.currentRouteInfo.route.startup) : true;
 
                 // Bounce to the login screen, but not if a password entry fails, obviously
                 if (!isCurrentAllowed) {
-                    this.showForcedLogoutMessage(globalize.translate('AccessRestrictedTryAgainLater'));
-                    this.showLocalLogin(apiClient.serverId());
+                    appRouter.showForcedLogoutMessage(globalize.translate('AccessRestrictedTryAgainLater'));
+                    appRouter.showLocalLogin(apiClient.serverId());
                 }
             }
         }


### PR DESCRIPTION
Semi reverts jellyfin/jellyfin-web#2536. Only the login redirect is reverted, the other still needs to go in.

The implementation isn't correct. If the user gets a 401 due to access constraints eg. library access, they get redirected to login.

It would be better to fix it, but I'm busy today... merge this if someone doesn't beat me to a proper fix.