### PR TITLE
Fix ES6 migration

### DIFF
--- a/src/controllers/session/addServer/index.js
+++ b/src/controllers/session/addServer/index.js
@@ -64,7 +64,7 @@ import ServerConnections from '../../../components/ServerConnections';
         }
 
         function goBack() {
-            import('../../../components/appRouter').then(({default: appRouter}) => {
+            import('../../../components/appRouter').then(({appRouter}) => {
                 appRouter.back();
             });
         }


### PR DESCRIPTION
`appRouter` has no default export.

**Changes**
Use named export.

**Issues**
Runtime error on `Back` on `Add Server` page.
