### PR TITLE
Add LogIn/LogOut event handlers to NativeShell

### DIFF
--- a/src/components/ServerConnections.js
+++ b/src/components/ServerConnections.js
@@ -8,8 +8,12 @@ class ServerConnections extends ConnectionManager {
         super(...arguments);
         this.localApiClient = null;
 
-        Events.on(this, 'localusersignedout', function () {
+        Events.on(this, 'localusersignedout', function (eventName, logoutInfo) {
             setUserInfo(null, null);
+
+            if (window.NativeShell && typeof window.NativeShell.onLocalUserSignedOut === 'function') {
+                window.NativeShell.onLocalUserSignedOut(logoutInfo);
+            }
         });
     }
 
@@ -62,7 +66,12 @@ class ServerConnections extends ConnectionManager {
     onLocalUserSignedIn(user) {
         const apiClient = this.getApiClient(user.ServerId);
         this.setLocalApiClient(apiClient);
-        return setUserInfo(user.Id, apiClient);
+        return setUserInfo(user.Id, apiClient).then(() => {
+            if (window.NativeShell && typeof window.NativeShell.onLocalUserSignedIn === 'function') {
+                return window.NativeShell.onLocalUserSignedIn(user, apiClient.accessToken());
+            }
+            return Promise.resolve();
+        });
     }
 }
 


### PR DESCRIPTION
Android app uses credentials for native parts, but authentication is preformed by webui.
To grab them it uses this [workaround](https://github.com/jellyfin/jellyfin-android/blob/43a734f281b398eeb02680b92d3e225fffddb80c/app/src/main/java/org/jellyfin/mobile/fragment/WebViewFragment.kt#L151-L165).

**Changes**
Add LogIn/LogOut event handlers to NativeShell

**Issues**
N/A
For future apiclient improvements - just to decouple app from the storage of credentials.
