### PR TITLE
Ensure that fillHeight gets set on image requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5975,9 +5975,9 @@
       "dev": true
     },
     "jellyfin-apiclient": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/jellyfin-apiclient/-/jellyfin-apiclient-1.6.0.tgz",
-      "integrity": "sha512-LL8YwUQJYTFdlx6VwA5C3+KWkLEM0V56fJGruUDwCVUCFQQVJ+E6hpHIO1lMeo26ZxURtebf5VtCCG35ZHugbg=="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/jellyfin-apiclient/-/jellyfin-apiclient-1.7.0.tgz",
+      "integrity": "sha512-aaUmhdvox02ge/ROSc8bsdmghjvfbP1QZ28yEPHaMHzY2GBaFczcCWXvEtl6dcQW+lfkemmFtf8D4OSvLHiFzw=="
     },
     "jest-worker": {
       "version": "26.6.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "headroom.js": "^0.12.0",
     "hls.js": "^0.14.17",
     "intersection-observer": "^0.12.0",
-    "jellyfin-apiclient": "^1.6.0",
+    "jellyfin-apiclient": "^1.7.0",
     "jquery": "^3.5.1",
     "jstree": "^3.3.11",
     "libarchive.js": "^1.3.0",

--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -498,7 +498,7 @@ import ServerConnections from '../ServerConnections';
             let imgUrl = null;
             let imgTag = null;
             let coverImage = false;
-            let uiAspect = null;
+            let uiAspect = getDesiredAspect(shape);
             let imgType = null;
             let itemId = null;
 
@@ -543,11 +543,8 @@ import ServerConnections from '../ServerConnections';
                     forceName = true;
                 }
 
-                if (primaryImageAspectRatio) {
-                    uiAspect = getDesiredAspect(shape);
-                    if (uiAspect) {
-                        coverImage = (Math.abs(primaryImageAspectRatio - uiAspect) / uiAspect) <= 0.2;
-                    }
+                if (primaryImageAspectRatio && uiAspect) {
+                    coverImage = (Math.abs(primaryImageAspectRatio - uiAspect) / uiAspect) <= 0.2;
                 }
             } else if (item.SeriesPrimaryImageTag) {
                 imgType = 'Primary';
@@ -563,11 +560,8 @@ import ServerConnections from '../ServerConnections';
                     forceName = true;
                 }
 
-                if (primaryImageAspectRatio) {
-                    uiAspect = getDesiredAspect(shape);
-                    if (uiAspect) {
-                        coverImage = (Math.abs(primaryImageAspectRatio - uiAspect) / uiAspect) <= 0.2;
-                    }
+                if (primaryImageAspectRatio && uiAspect) {
+                    coverImage = (Math.abs(primaryImageAspectRatio - uiAspect) / uiAspect) <= 0.2;
                 }
             } else if (item.ParentPrimaryImageTag) {
                 imgType = 'Primary';
@@ -579,11 +573,8 @@ import ServerConnections from '../ServerConnections';
                 itemId = item.AlbumId;
                 height = width && primaryImageAspectRatio ? Math.round(width / primaryImageAspectRatio) : null;
 
-                if (primaryImageAspectRatio) {
-                    uiAspect = getDesiredAspect(shape);
-                    if (uiAspect) {
-                        coverImage = (Math.abs(primaryImageAspectRatio - uiAspect) / uiAspect) <= 0.2;
-                    }
+                if (primaryImageAspectRatio && uiAspect) {
+                    coverImage = (Math.abs(primaryImageAspectRatio - uiAspect) / uiAspect) <= 0.2;
                 }
             } else if (item.Type === 'Season' && item.ImageTags && item.ImageTags.Thumb) {
                 imgType = 'Thumb';
@@ -613,10 +604,15 @@ import ServerConnections from '../ServerConnections';
             }
 
             if (imgTag && imgType) {
+                // TODO: This place is a mess. Could do with a good spring cleaning.
+                if (!height && width && uiAspect) {
+                    height = width / uiAspect;
+                }
                 imgUrl = apiClient.getScaledImageUrl(itemId, {
                     type: imgType,
                     fillHeight: height,
                     fillWidth: width,
+                    quality: 96,
                     tag: imgTag
                 });
             }

--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -498,7 +498,7 @@ import ServerConnections from '../ServerConnections';
             let imgUrl = null;
             let imgTag = null;
             let coverImage = false;
-            let uiAspect = getDesiredAspect(shape);
+            const uiAspect = getDesiredAspect(shape);
             let imgType = null;
             let itemId = null;
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
- Ensure that fillHeight gets set in the image request
- Request quality of 96, for up to 16 less jpeg
- Bump apiclient to 1.7.0

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
- Fixes #2191 
- Fixes #2587 

**Notes**

The backport requires the yarn lockfile (`yarn.lock`) updated rather than the npm one (`package-lock.json`).
Discard the changes to `package-lock.json`, and generate the update to `yarn.lock` from `package.json` using the following command;
`docker run -it -v "$(pwd):/mnt" --rm node:lts bash -c 'cd /mnt; yarn install'` (takes a long time, downloads all deps too)

The result of this can be seen at this branch targeting the release branch: https://github.com/jellyfin/jellyfin-web/compare/v10.7.2...oddstr13:pr-imagefix
