### PR TITLE
ScrollManager: fix parent search

### DIFF
--- a/src/components/scrollManager.js
+++ b/src/components/scrollManager.js
@@ -201,6 +201,19 @@ import layoutManager from './layoutManager';
      */
     const documentScroller = new DocumentScroller();
 
+    const scrollerHints = {
+        x: {
+            nameScroll: 'scrollWidth',
+            nameClient: 'clientWidth',
+            nameStyle: 'overflowX'
+        },
+        y: {
+            nameScroll: 'scrollHeight',
+            nameClient: 'clientHeight',
+            nameStyle: 'overflowY'
+        }
+    };
+
     /**
      * Returns parent element that can be scrolled. If no such, returns document scroller.
      *
@@ -210,24 +223,26 @@ import layoutManager from './layoutManager';
      */
     function getScrollableParent(element, vertical) {
         if (element) {
-            let nameScroll = 'scrollWidth';
-            let nameClient = 'clientWidth';
-            let nameClass = 'scrollX';
-
-            if (vertical) {
-                nameScroll = 'scrollHeight';
-                nameClient = 'clientHeight';
-                nameClass = 'scrollY';
-            }
+            const scrollerHint = vertical ? scrollerHints.y : scrollerHints.x;
 
             let parent = element.parentElement;
 
-            while (parent) {
+            while (parent && parent !== document.body) {
                 // Skip 'emby-scroller' and 'emby-tabs' because they scroll by themselves
                 if (!parent.classList.contains('emby-scroller') &&
-                    !parent.classList.contains('emby-tabs') &&
-                    parent[nameScroll] > parent[nameClient] && parent.classList.contains(nameClass)) {
-                    return parent;
+                    !parent.classList.contains('emby-tabs')) {
+                    const styles = window.getComputedStyle(parent);
+
+                    // Stop on fixed parent
+                    if (styles.position === 'fixed') {
+                        return parent;
+                    }
+
+                    const overflow = styles[scrollerHint.nameStyle];
+
+                    if (overflow === 'scroll' || overflow === 'auto' && parent[scrollerHint.nameScroll] > parent[scrollerHint.nameClient]) {
+                        return parent;
+                    }
                 }
 
                 parent = parent.parentElement;

--- a/src/libraries/scroller.js
+++ b/src/libraries/scroller.js
@@ -630,6 +630,8 @@ const scrollerFactory = function (frame, options) {
             //passive: true
         });
 
+        scrollSource.removeAttribute(`data-scroll-mode-${o.horizontal ? 'x' : 'y'}`);
+
         // Reset initialized status and return the instance
         self.initialized = 0;
         return self;
@@ -750,6 +752,8 @@ const scrollerFactory = function (frame, options) {
                 slideeElement.classList.add('animatedScrollY');
             }
         }
+
+        scrollSource.setAttribute(`data-scroll-mode-${o.horizontal ? 'x' : 'y'}`, 'custom');
 
         if (transform || layoutManager.tv) {
             // This can prevent others from being able to listen to mouse events

--- a/src/scripts/scrollHelper.js
+++ b/src/scripts/scrollHelper.js
@@ -103,6 +103,8 @@ function centerOnFocusVertical(e) {
 
 export const centerFocus = {
     on: function (element, horizontal) {
+        element.setAttribute(`data-scroll-mode-${horizontal ? 'x' : 'y'}`, 'custom');
+
         if (horizontal) {
             dom.addEventListener(element, 'focus', centerOnFocusHorizontal, {
                 capture: true,
@@ -116,6 +118,8 @@ export const centerFocus = {
         }
     },
     off: function (element, horizontal) {
+        element.removeAttribute(`data-scroll-mode-${horizontal ? 'x' : 'y'}`);
+
         if (horizontal) {
             dom.removeEventListener(element, 'focus', centerOnFocusHorizontal, {
                 capture: true,


### PR DESCRIPTION
`ScrollManager` will stop on scrollable or fixed parent.

**Changes**
Check an overflow value and stop on fixed parent

**Issues**
Fixes #2608
Also fixes page scrolling when navigating in filter/sort dialog (mentioned in #2538).

_Depends on #2622_

**To reproduce (filter/sort dialog)**
1. Turn on TV display mode.
2. Open Music library (need a scrollable library).
3. Open Sort dialog.
4. Navigate down. The page scrolls in the background.

**To reproduce (#2608)**
1. Setup custom theme. `@import url('https://ctalvio.github.io/Monochromic/default_style.css');`
2. Turn on TV display mode.
3. Load home page.
4. Navigate down. The page doesn't scroll.