### PR TITLE
Fix view style selection dialog (ES6 migration)

### DIFF
--- a/src/controllers/movies/moviecollections.js
+++ b/src/controllers/movies/moviecollections.js
@@ -234,7 +234,7 @@ import '../../elements/emby-itemscontainer/emby-itemscontainer';
                 });
             });
             const btnSelectView = tabContent.querySelector('.btnSelectView');
-            btnSelectView.addEventListener('click', function (e) {
+            btnSelectView.addEventListener('click', (e) => {
                 libraryBrowser.showLayoutMenu(e.target, this.getCurrentViewStyle(), 'List,Poster,PosterCard,Thumb,ThumbCard'.split(','));
             });
             btnSelectView.addEventListener('layoutchange', function (e) {

--- a/src/controllers/movies/movies.js
+++ b/src/controllers/movies/movies.js
@@ -238,8 +238,8 @@ import '../../elements/emby-itemscontainer/emby-itemscontainer';
                 });
             }
             const btnSelectView = tabContent.querySelector('.btnSelectView');
-            btnSelectView.addEventListener('click', function (e) {
-                libraryBrowser.showLayoutMenu(e.target, this.getCurrentViewStyle, 'Banner,List,Poster,PosterCard,Thumb,ThumbCard'.split(','));
+            btnSelectView.addEventListener('click', (e) => {
+                libraryBrowser.showLayoutMenu(e.target, this.getCurrentViewStyle(), 'Banner,List,Poster,PosterCard,Thumb,ThumbCard'.split(','));
             });
             btnSelectView.addEventListener('layoutchange', function (e) {
                 const viewStyle = e.detail.viewStyle;

--- a/src/controllers/movies/movietrailers.js
+++ b/src/controllers/movies/movietrailers.js
@@ -229,7 +229,7 @@ import '../../elements/emby-itemscontainer/emby-itemscontainer';
             alphaPickerElement.classList.add('alphaPicker-fixed-right');
             itemsContainer.classList.add('padded-right-withalphapicker');
 
-            tabContent.querySelector('.btnFilter').addEventListener('click', function () {
+            tabContent.querySelector('.btnFilter').addEventListener('click', () => {
                 this.showFilterMenu();
             });
             tabContent.querySelector('.btnSort').addEventListener('click', function (e) {

--- a/src/controllers/music/musicartists.js
+++ b/src/controllers/music/musicartists.js
@@ -218,7 +218,7 @@ import '../../elements/emby-itemscontainer/emby-itemscontainer';
                 this.showFilterMenu();
             });
             const btnSelectView = tabContent.querySelector('.btnSelectView');
-            btnSelectView.addEventListener('click', function (e) {
+            btnSelectView.addEventListener('click', (e) => {
                 libraryBrowser.showLayoutMenu(e.target, this.getCurrentViewStyle(), 'List,Poster,PosterCard'.split(','));
             });
             btnSelectView.addEventListener('layoutchange', function (e) {


### PR DESCRIPTION
**Changes**
- Use arrow function to fix `this` reference.
- Call `getCurrentViewStyle`.

**Issues**
View style selection dialog is broken (`Movies`, `Collections` tabs in `Movies` library; `Album Artists`, `Artists` in `Music` library).
Filter dialog is broken (`Trailers` tab).
