### PR TITLE
Set scrollbar width in TV mode.

### DIFF
--- a/src/themes/blueradiance/theme.css
+++ b/src/themes/blueradiance/theme.css
@@ -478,8 +478,8 @@ html {
 
 .layout-desktop ::-webkit-scrollbar,
 .layout-tv ::-webkit-scrollbar {
-    width: 0.4em;
-    height: 0.4em;
+    width: 1em;
+    height: 1em;
 }
 
 ::-webkit-scrollbar-thumb:horizontal,

--- a/src/themes/blueradiance/theme.css
+++ b/src/themes/blueradiance/theme.css
@@ -476,9 +476,10 @@ html {
     background-color: #3b3b3b;
 }
 
-.layout-desktop ::-webkit-scrollbar {
-    width: 1em;
-    height: 1em;
+.layout-desktop ::-webkit-scrollbar,
+.layout-tv ::-webkit-scrollbar {
+    width: 0.4em;
+    height: 0.4em;
 }
 
 ::-webkit-scrollbar-thumb:horizontal,

--- a/src/themes/dark/theme.css
+++ b/src/themes/dark/theme.css
@@ -450,7 +450,8 @@ html {
     background-color: #3b3b3b;
 }
 
-.layout-desktop ::-webkit-scrollbar {
+.layout-desktop ::-webkit-scrollbar,
+.layout-tv ::-webkit-scrollbar {
     width: 0.4em;
     height: 0.4em;
 }

--- a/src/themes/purplehaze/theme.css
+++ b/src/themes/purplehaze/theme.css
@@ -595,9 +595,10 @@ a[data-role=button] {
     background-color: rgba(59, 59, 59, 0.5);
 }
 
-.layout-desktop ::-webkit-scrollbar {
+.layout-desktop ::-webkit-scrollbar,
+.layout-tv ::-webkit-scrollbar {
     width: 0.4em;
-    height: 1em;
+    height: 0.4em;
 }
 
 ::-webkit-scrollbar-thumb:horizontal,

--- a/src/themes/purplehaze/theme.css
+++ b/src/themes/purplehaze/theme.css
@@ -598,7 +598,7 @@ a[data-role=button] {
 .layout-desktop ::-webkit-scrollbar,
 .layout-tv ::-webkit-scrollbar {
     width: 0.4em;
-    height: 0.4em;
+    height: 1em;
 }
 
 ::-webkit-scrollbar-thumb:horizontal,

--- a/src/themes/wmc/theme.css
+++ b/src/themes/wmc/theme.css
@@ -458,8 +458,8 @@ html {
 
 .layout-desktop ::-webkit-scrollbar,
 .layout-tv ::-webkit-scrollbar {
-    width: 0.4em;
-    height: 0.4em;
+    width: 1em;
+    height: 1em;
 }
 
 ::-webkit-scrollbar-thumb:horizontal,

--- a/src/themes/wmc/theme.css
+++ b/src/themes/wmc/theme.css
@@ -456,9 +456,10 @@ html {
     background-color: #081b3b;
 }
 
-.layout-desktop ::-webkit-scrollbar {
-    width: 1em;
-    height: 1em;
+.layout-desktop ::-webkit-scrollbar,
+.layout-tv ::-webkit-scrollbar {
+    width: 0.4em;
+    height: 0.4em;
 }
 
 ::-webkit-scrollbar-thumb:horizontal,


### PR DESCRIPTION
**Changes**
 - Set the scrollbar width in TV mode. It seems this is required for the other custom scrollbar styling to take effect, at least in JMP.

Before:
![image](https://user-images.githubusercontent.com/8078788/115967054-723a3d80-a4fe-11eb-82dd-94b9f3ef34d1.png)

After:
![image](https://user-images.githubusercontent.com/8078788/115967150-f42a6680-a4fe-11eb-92fb-861e66e53435.png)

*This has been tested and can be backported if desired.*