### PR TITLE
Fix video filters hiding

### DIFF
--- a/src/components/filterdialog/filterdialog.template.html
+++ b/src/components/filterdialog/filterdialog.template.html
@@ -3,18 +3,18 @@
     <div is="emby-collapse" title="${Filters}">
         <div class="collapseContent">
             <div class="checkboxList">
-                <label>
-                    <input type="checkbox" is="emby-checkbox" class="chkStandardFilter videoStandard"
+                <label class="videoStandard">
+                    <input type="checkbox" is="emby-checkbox" class="chkStandardFilter"
                         data-filter="IsPlayed" />
                     <span>${Played}</span>
                 </label>
-                <label>
-                    <input type="checkbox" is="emby-checkbox" class="chkStandardFilter videoStandard"
+                <label class="videoStandard">
+                    <input type="checkbox" is="emby-checkbox" class="chkStandardFilter"
                         data-filter="IsUnPlayed" />
                     <span>${Unplayed}</span>
                 </label>
-                <label>
-                    <input type="checkbox" is="emby-checkbox" class="chkStandardFilter videoStandard"
+                <label class="videoStandard">
+                    <input type="checkbox" is="emby-checkbox" class="chkStandardFilter"
                         data-filter="IsResumable" />
                     <span>${OptionResumable}</span>
                 </label>


### PR DESCRIPTION
**Changes**
Move `videoStandard` class to the checkbox container (label).

**Issues**
`hide` class was applied to the wrong element (checkbox), so `Music` library had `Played`, `Unplayed`, and `Resumable` filters. Moreover, they cannot be focused using keyboard in TV layout.
