### PR TITLE
Hide AlphaPicker on Search page for real TVs

### DIFF
--- a/src/components/search/searchfields.js
+++ b/src/components/search/searchfields.js
@@ -62,19 +62,13 @@ import template from './searchfields.template.html';
     }
 
     function embed(elem, instance) {
-        let html = globalize.translateHtml(template, 'core');
-
-        if (browser.tizen || browser.orsay) {
-            html = html.replace('<input ', '<input readonly ');
-        }
-
-        elem.innerHTML = html;
+        elem.innerHTML = globalize.translateHtml(template, 'core');
 
         elem.classList.add('searchFields');
 
         const txtSearch = elem.querySelector('.searchfields-txtSearch');
 
-        if (layoutManager.tv) {
+        if (layoutManager.tv && !browser.tv) {
             const alphaPickerElement = elem.querySelector('.alphaPicker');
 
             elem.querySelector('.alphaPicker').classList.remove('hide');


### PR DESCRIPTION
We could rip it out and force users who connect the TV to a PC to use some kind of browser extension to add a normal virtual keyboard.
One argument in favor of this is that there are fields for which there is no AlphaPicker - login, password.
Secondly, AlphaPicker has only latin letters and digits.

**Changes**
Hide AlphaPicker on Search page for real TVs

**Issues**
Fixes #2597
Fixes https://github.com/jellyfin/jellyfin-webos/issues/48
