### PR TITLE
webOS: fix Favorites tab

### DIFF
--- a/src/controllers/favorites.js
+++ b/src/controllers/favorites.js
@@ -256,6 +256,8 @@ import ServerConnections from '../components/ServerConnections';
         }
 
         elem.innerHTML = html;
+        window.CustomElements.upgradeSubtree(elem);
+
         const elems = elem.querySelectorAll('.itemsContainer');
 
         for (let i = 0, length = elems.length; i < length; i++) {


### PR DESCRIPTION
In webOS 1.2 emulator, Favorites tab only works on the second click.

**Changes**
Upgrade the inserted items manually.

**Issues**
Runtime error: `resume` is `undefined`.
https://github.com/jellyfin/jellyfin-web/blob/63a355518fe618638631468405cfce5917c075cf/src/controllers/favorites.js#L284
