### PR TITLE
Remove image proxying through API

### DIFF
--- a/src/components/imageDownloader/imageDownloader.js
+++ b/src/components/imageDownloader/imageDownloader.js
@@ -79,7 +79,7 @@ import template from './imageDownloader.template.html';
         let html = '';
 
         for (let i = 0, length = imagesResult.Images.length; i < length; i++) {
-            html += getRemoteImageHtml(imagesResult.Images[i], imageType, apiClient);
+            html += getRemoteImageHtml(imagesResult.Images[i], imageType);
         }
 
         const availableImagesList = page.querySelector('.availableImagesList');
@@ -150,7 +150,7 @@ import template from './imageDownloader.template.html';
         });
     }
 
-    function getRemoteImageHtml(image, imageType, apiClient) {
+    function getRemoteImageHtml(image, imageType) {
         const tagName = layoutManager.tv ? 'button' : 'div';
         const enableFooterButtons = !layoutManager.tv;
 

--- a/src/components/imageDownloader/imageDownloader.js
+++ b/src/components/imageDownloader/imageDownloader.js
@@ -150,10 +150,6 @@ import template from './imageDownloader.template.html';
         });
     }
 
-    function getDisplayUrl(url, apiClient) {
-        return apiClient.getUrl('Images/Remote', { imageUrl: url });
-    }
-
     function getRemoteImageHtml(image, imageType, apiClient) {
         const tagName = layoutManager.tv ? 'button' : 'div';
         const enableFooterButtons = !layoutManager.tv;
@@ -209,9 +205,9 @@ import template from './imageDownloader.template.html';
         html += '<div class="cardContent">';
 
         if (layoutManager.tv || !appHost.supports('externallinks')) {
-            html += '<div class="cardImageContainer lazy" data-src="' + getDisplayUrl(image.Url, apiClient) + '" style="background-position:center center;background-size:contain;"></div>';
+            html += '<div class="cardImageContainer lazy" data-src="' + image.Url + '" style="background-position:center center;background-size:contain;"></div>';
         } else {
-            html += '<a is="emby-linkbutton" target="_blank" href="' + getDisplayUrl(image.Url, apiClient) + '" class="button-link cardImageContainer lazy" data-src="' + getDisplayUrl(image.Url, apiClient) + '" style="background-position:center center;background-size:contain"></a>';
+            html += '<a is="emby-linkbutton" target="_blank" href="' + image.Url + '" class="button-link cardImageContainer lazy" data-src="' + image.Url + '" style="background-position:center center;background-size:contain"></a>';
         }
 
         html += '</div>';

--- a/src/components/itemidentifier/itemidentifier.js
+++ b/src/components/itemidentifier/itemidentifier.js
@@ -171,9 +171,8 @@ import template from './itemidentifier.template.html';
         let resultHtml = lines.join('<br/>');
 
         if (identifyResult.ImageUrl) {
-            const displayUrl = getSearchImageDisplayUrl(identifyResult.ImageUrl, identifyResult.SearchProviderName);
 
-            resultHtml = `<div style="display:flex;align-items:center;"><img src="${displayUrl}" style="max-height:240px;" /><div style="margin-left:1em;">${resultHtml}</div>`;
+            resultHtml = `<div style="display:flex;align-items:center;"><img src="${identifyResult.ImageUrl}" style="max-height:240px;" /><div style="margin-left:1em;">${resultHtml}</div>`;
         }
 
         page.querySelector('.selectedSearchResult').innerHTML = resultHtml;
@@ -218,9 +217,7 @@ import template from './itemidentifier.template.html';
         html += '<div class="cardContent searchImage">';
 
         if (result.ImageUrl) {
-            const displayUrl = getSearchImageDisplayUrl(result.ImageUrl, result.SearchProviderName);
-
-            html += `<div class="cardImageContainer coveredImage" style="background-image:url('${displayUrl}');"></div>`;
+            html += `<div class="cardImageContainer coveredImage" style="background-image:url('${result.ImageUrl}');"></div>`;
         } else {
             html += `<div class="cardImageContainer coveredImage defaultCardBackground defaultCardBackground1"><div class="cardText cardCenteredText">${result.Name}</div></div>`;
         }
@@ -256,16 +253,6 @@ import template from './itemidentifier.template.html';
         html += '</div>';
         html += '</button>';
         return html;
-    }
-
-    function getSearchImageDisplayUrl(url, provider) {
-        const apiClient = getApiClient();
-
-        return apiClient.getUrl('Items/RemoteSearch/Image', {
-            imageUrl: url,
-            ProviderName: provider,
-            api_key: apiClient.accessToken()
-        });
     }
 
     function submitIdentficationResult(page) {

--- a/src/components/itemidentifier/itemidentifier.js
+++ b/src/components/itemidentifier/itemidentifier.js
@@ -171,7 +171,6 @@ import template from './itemidentifier.template.html';
         let resultHtml = lines.join('<br/>');
 
         if (identifyResult.ImageUrl) {
-
             resultHtml = `<div style="display:flex;align-items:center;"><img src="${identifyResult.ImageUrl}" style="max-height:240px;" /><div style="margin-left:1em;">${resultHtml}</div>`;
         }
 

--- a/src/index.html
+++ b/src/index.html
@@ -11,6 +11,7 @@
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="application-name" content="Jellyfin">
     <meta name="robots" content="noindex, nofollow, noarchive">
+    <meta name="referrer" content="no-referrer">
     <meta property="og:title" content="Jellyfin">
     <meta property="og:site_name" content="Jellyfin">
     <meta property="og:url" content="http://jellyfin.org">


### PR DESCRIPTION
**Changes**
Removes the web interface image proxying through the `/Images/Remote`
and `/Items/RemoteSearch/Image` API endpoints, and replaces them with
direct calls to the remote image files. This appears to be those
endpoints' only usage in the web client.

**Issues**
N/A