### PR TITLE
Prevent Buttons from Sitting Over Text

### DIFF
--- a/src/plugins/bookPlayer/plugin.js
+++ b/src/plugins/bookPlayer/plugin.js
@@ -267,10 +267,14 @@ export class BookPlayer {
                 const downloadHref = apiClient.getItemDownloadUrl(item.Id);
                 const book = epubjs(downloadHref, {openAs: 'epub'});
 
+                // We need to calculate the height of the window beforehand because using 100% is not accurate when the dialog is opening.
+                // In addition we don't render to the full height so that we have space for the top buttons.
+                const clientHeight = document.body.clientHeight;
+                const renderHeight = clientHeight - (clientHeight * 0.0425);
+
                 const rendition = book.renderTo('bookPlayerContainer', {
                     width: '100%',
-                    // Calculate the height of the window because using 100% is not accurate when the dialog is opening
-                    height: document.body.clientHeight,
+                    height: renderHeight,
                     // TODO: Add option for scrolled-doc
                     flow: 'paginated'
                 });

--- a/src/plugins/bookPlayer/style.scss
+++ b/src/plugins/bookPlayer/style.scss
@@ -11,8 +11,6 @@
 
     .topButtons {
         z-index: 1002;
-        position: absolute;
-        top: 0;
         width: 100%;
         color: #000;
         opacity: 0.7;


### PR DESCRIPTION
**Changes**
Tweaked the CSS to prevent buttons from sitting over text on small screens like this:
![image](https://user-images.githubusercontent.com/5712543/116838202-8b488b80-ab9b-11eb-9575-aba027e2ae6c.png)

Please note that I'm pretty hopeless at CSS, so there may be a better way to do this but I can't figure it out.
