### PR TITLE
Bump jellyfin-apiclient to 1.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6406,9 +6406,9 @@
       "dev": true
     },
     "jellyfin-apiclient": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/jellyfin-apiclient/-/jellyfin-apiclient-1.7.0.tgz",
-      "integrity": "sha512-aaUmhdvox02ge/ROSc8bsdmghjvfbP1QZ28yEPHaMHzY2GBaFczcCWXvEtl6dcQW+lfkemmFtf8D4OSvLHiFzw=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/jellyfin-apiclient/-/jellyfin-apiclient-1.8.0.tgz",
+      "integrity": "sha512-fwAF1G89amm3uO2Yw0E26fW5X6JoyRUnOdBEeuSN04/NpdKKVHD4u53dgqF0jHzXNuKdn5eh0AuV37cMKzBanA=="
     },
     "jest-worker": {
       "version": "26.6.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "headroom.js": "^0.12.0",
     "hls.js": "^0.14.17",
     "intersection-observer": "^0.12.0",
-    "jellyfin-apiclient": "^1.7.0",
+    "jellyfin-apiclient": "^1.8.0",
     "jquery": "^3.5.1",
     "jstree": "^3.3.11",
     "libarchive.js": "^1.3.0",


### PR DESCRIPTION
**Changes**
Updates the jellyfin apiclient to the latest release

**Issues**
N/A
