### PR TITLE
Fix browser history for dialog

### DIFF
--- a/src/components/dialogHelper/dialogHelper.js
+++ b/src/components/dialogHelper/dialogHelper.js
@@ -379,7 +379,7 @@ import '../../assets/css/scrollstyles.scss';
             dlg.setAttribute('data-lockscroll', 'true');
         }
 
-        if (options.enableHistory === true) {
+        if (options.enableHistory !== false) {
             dlg.setAttribute('data-history', 'true');
         }
 

--- a/src/components/playback/playersettingsmenu.js
+++ b/src/components/playback/playersettingsmenu.js
@@ -41,7 +41,8 @@ function showQualityMenu(player, btn) {
 
     return actionsheet.show({
         items: menuItems,
-        positionTo: btn
+        positionTo: btn,
+        enableHistory: false
     }).then(function (id) {
         const bitrate = parseInt(id);
         if (bitrate !== selectedBitrate) {
@@ -77,7 +78,8 @@ function showRepeatModeMenu(player, btn) {
 
     return actionsheet.show({
         items: menuItems,
-        positionTo: btn
+        positionTo: btn,
+        enableHistory: false
     }).then(function (mode) {
         if (mode) {
             playbackManager.setRepeatMode(mode, player);
@@ -138,7 +140,8 @@ function showAspectRatioMenu(player, btn) {
 
     return actionsheet.show({
         items: menuItems,
-        positionTo: btn
+        positionTo: btn,
+        enableHistory: false
     }).then(function (id) {
         if (id) {
             playbackManager.setAspectRatio(id, player);
@@ -160,7 +163,8 @@ function showPlaybackRateMenu(player, btn) {
 
     return actionsheet.show({
         items: menuItems,
-        positionTo: btn
+        positionTo: btn,
+        enableHistory: false
     }).then(function (id) {
         if (id) {
             playbackManager.setPlaybackRate(id, player);
@@ -237,7 +241,8 @@ function showWithUser(options, player, user) {
 
     return actionsheet.show({
         items: menuItems,
-        positionTo: options.positionTo
+        positionTo: options.positionTo,
+        enableHistory: false
     }).then(function (id) {
         return handleSelectedOption(id, options, player);
     });

--- a/src/components/syncPlay/ui/groupSelectionMenu.js
+++ b/src/components/syncPlay/ui/groupSelectionMenu.js
@@ -63,7 +63,8 @@ class GroupSelectionMenu {
                     items: menuItems,
                     positionTo: button,
                     resolveOnClick: true,
-                    border: true
+                    border: true,
+                    enableHistory: false
                 };
 
                 actionsheet.show(menuOptions).then(function (id) {
@@ -132,7 +133,8 @@ class GroupSelectionMenu {
             items: menuItems,
             positionTo: button,
             resolveOnClick: true,
-            border: true
+            border: true,
+            enableHistory: false
         };
 
         actionsheet.show(menuOptions).then(function (id) {

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -902,7 +902,8 @@ import { appRouter } from '../../../components/appRouter';
                 actionsheet.show({
                     items: menuItems,
                     title: globalize.translate('Audio'),
-                    positionTo: positionTo
+                    positionTo: positionTo,
+                    enableHistory: false
                 }).then(function (id) {
                     const index = parseInt(id);
 
@@ -948,7 +949,8 @@ import { appRouter } from '../../../components/appRouter';
                 actionsheet.show({
                     title: globalize.translate('Subtitles'),
                     items: menuItems,
-                    positionTo: positionTo
+                    positionTo: positionTo,
+                    enableHistory: false
                 }).then(function (id) {
                     const index = parseInt(id);
 


### PR DESCRIPTION
Fix browser history for dialog except for playersettingsmenu, groupSelectionMenu & playback video(Audio, Subtitles)

**Issues**
Fixes #1006 : Dialogs don't close on browser history back
Fixes #2337 : "Hardware" back button not working as expected
