### PR TITLE
Fixes resuming of books

### DIFF
--- a/src/plugins/pdfPlayer/plugin.js
+++ b/src/plugins/pdfPlayer/plugin.js
@@ -203,7 +203,7 @@ export class PdfPlayer {
 
                 const percentageTicks = options.startPositionTicks / 10000;
                 if (percentageTicks !== 0) {
-                    this.loadPage(percentageTicks);
+                    this.loadPage(percentageTicks + 1);
                     this.progress = percentageTicks;
                 } else {
                     this.loadPage(1);


### PR DESCRIPTION
**Changes**
This will increase the page number by one when it's calculated using `percentageTicks` as the progress can starts from 0 for page 1.

**Issues**
I haven't notice an issue for this raised but spotted it by using the books feature myself. 

Backend PR: https://github.com/jellyfin/jellyfin/pull/5997

**Other Info**
Not fixed as part of this PR but I noticed whilst testing this that progress is fetched from the `data-progress` attribute. When closing the PDF viewer or video player the media screen doesn't reload it's data and will have the old progress values, upon clicking `play` again it will use this old value. Raising it as a side note for now as it's existing functionality :)