### PR TITLE
Add connection response handling

### DIFF
--- a/src/components/appRouter.js
+++ b/src/components/appRouter.js
@@ -503,23 +503,28 @@ class AppRouter {
         const firstResult = this.firstConnectionResult;
 
         this.firstConnectionResult = null;
-        if (firstResult && firstResult.State === 'ServerSignIn') {
-            const url = firstResult.ApiClient.serverAddress() + '/System/Info/Public';
-            fetch(url).then(response => {
-                if (!response.ok) return Promise.reject('fetch failed');
-                return response.json();
-            }).then(data => {
-                if (data !== null && data.StartupWizardCompleted === false) {
-                    ServerConnections.setLocalApiClient(firstResult.ApiClient);
-                    Dashboard.navigate('wizardstart.html');
-                } else {
-                    this.handleConnectionResult(firstResult);
-                }
-            }).catch(error => {
-                console.error(error);
-            });
+        if (firstResult) {
+            if (firstResult.State === 'ServerSignIn') {
+                const url = firstResult.ApiClient.serverAddress() + '/System/Info/Public';
+                fetch(url).then(response => {
+                    if (!response.ok) return Promise.reject('fetch failed');
+                    return response.json();
+                }).then(data => {
+                    if (data !== null && data.StartupWizardCompleted === false) {
+                        ServerConnections.setLocalApiClient(firstResult.ApiClient);
+                        Dashboard.navigate('wizardstart.html');
+                    } else {
+                        this.handleConnectionResult(firstResult);
+                    }
+                }).catch(error => {
+                    console.error(error);
+                });
 
-            return;
+                return;
+            } else if (firstResult.State !== 'SignedIn') {
+                this.handleConnectionResult(firstResult);
+                return;
+            }
         }
 
         const apiClient = ServerConnections.currentApiClient();


### PR DESCRIPTION
_Cannot reopen #2558 due to the force-push._
_Review with `Hide whitespace changes`_

Return handling of connection results that was removed in cb1d2887fa1d5d8fffafbbebb4636d58d97b6bf0.
```js
if (firstResult.State !== 'SignedIn' && !route.anonymous) {
    this.handleConnectionResult(firstResult);
    return;
}
```
It was still invalid for the current situation (see below), but it handled the other connection results (currently unhandled).

**Changes**
Add connection response handling

**Issues**
Web gets stuck if the server was selected and turned off (for bundled/standalone web) or changed its hash and you are trying to open an anonymous page.

If you are opening a non-anonymous page, [this](https://github.com/jellyfin/jellyfin-web/blob/98814a5b66813c4c23fcd9f4254239b89b939506/src/components/appRouter.js#L532-L536) will take care. But not in mentioned situation:
`!shouldExitApp -> true`
`!apiClient -> false`
`!apiClient.isLoggedIn() -> true`
`!route.anonymous -> false` - login page (removed code would not work for the same reason)

**Steps To Reproduce**
1. Connect to the server but do not log in.
2. Change server hash in `localStorage`.
3. Refresh page (login page).
4. Get "Circle of Death" issue.

To test a server down situation, you need a standalone or bundled web (app).
