### PR TITLE
Fix back on load [Tizen 2.x]

### DIFF
--- a/src/components/appRouter.js
+++ b/src/components/appRouter.js
@@ -30,8 +30,16 @@ class AppRouter {
     startPages = ['home', 'login', 'selectserver'];
 
     constructor() {
-        window.addEventListener('popstate', () => {
-            this.popstateOccurred = true;
+        // WebKit fires a popstate event on document load
+        // Skip it using timeout
+        // For Tizen 2.x
+        // https://stackoverflow.com/a/12214354
+        window.addEventListener('load', () => {
+            setTimeout(() => {
+                window.addEventListener('popstate', () => {
+                    this.popstateOccurred = true;
+                });
+            }, 0);
         });
 
         document.addEventListener('viewshow', () => {


### PR DESCRIPTION
_With the help of_ @HimbeersaftLP _https://github.com/jellyfin/jellyfin-tizen/issues/19#issuecomment-836954718_

WebKit fires a `popstate` event on document load. This makes Tizen 2.x (WebKit) ask about exit.
Found a thread about the "popstate" problem. Maybe [this](https://stackoverflow.com/a/12214354) trick will help.

**Changes**
Delay listening a `popstate` event.

**Issues**
Tizen 2.x (WebKit) asks about exit on page load.
