### PR TITLE
Remove OPUS from supported HLS audio formats

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -414,8 +414,10 @@ import browser from './browser';
 
         if (canPlayAudioFormat('opus')) {
             videoAudioCodecs.push('opus');
-            hlsInTsVideoAudioCodecs.push('opus');
             webmAudioCodecs.push('opus');
+            if (browser.tizen) {
+                hlsInTsVideoAudioCodecs.push('opus');
+            }
         }
 
         if (canPlayAudioFormat('flac')) {


### PR DESCRIPTION
**Changes**
- Remove OPUS from supported HLS audio formats

OPUS is not a standard HLS audio format, it's not mentioned in Apple's HLS document.
Remuxing/Direct Streaming films with OPUS audio to Android Chrome will result in no sound.
Thus leave it only for DirectPlay and Tizen.

**Issues**
Fixes https://github.com/jellyfin/jellyfin/issues/5116
