### PR TITLE
Fix xss via displaymessage

### DIFF
--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -22,7 +22,7 @@ export default function (options) {
 
     const elem = document.createElement('div');
     elem.classList.add('toast');
-    elem.innerHTML = options.text;
+    elem.textContent = options.text;
 
     document.body.appendChild(elem);
 


### PR DESCRIPTION
**Changes**
Fixes the reported XSS vulnerability when an admin sends a DisplayMessage to a client. I reviewed all calls to toast and did not find any that would intentionally use HTML.

**Issues**
Fixes #2674
