### PR TITLE
Album Art to not force media buttons behind playlist buttons for 

### DIFF
--- a/src/components/remotecontrol/remotecontrol.scss
+++ b/src/components/remotecontrol/remotecontrol.scss
@@ -328,6 +328,7 @@
     .nowPlayingPageImageContainer {
         width: 100%;
         margin: auto auto 0.5em;
+        height: calc(100% - 20vh - 4.2em);
     }
 
     .nowPlayingPageImageContainerNoAlbum .cardImageContainer .cardImageIcon {
@@ -399,7 +400,12 @@
     }
 
     .nowPlayingPageImage.nowPlayingPageImageAudio {
-        width: 100%;
+        width: auto;
+        max-width: 100%;
+        height: auto;
+        max-height: 100%;
+        filter: drop-shadow(0px 0px 1px grey);
+        object-fit: scale-down;
     }
 
     .nowPlayingPageImageContainer.nowPlayingPageImagePoster {

--- a/src/components/remotecontrol/remotecontrol.scss
+++ b/src/components/remotecontrol/remotecontrol.scss
@@ -328,7 +328,7 @@
     .nowPlayingPageImageContainer {
         width: 100%;
         margin: auto auto 0.5em;
-        height: calc(100% - 20vh - 4.2em);
+        height: calc(100% - 16vh - 6.2em);
     }
 
     .nowPlayingPageImageContainerNoAlbum .cardImageContainer .cardImageIcon {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Changes Mobile Now Playing (Remote Control) Album Art .scss to prevent it from pushing the Media Navigation buttons behind the Playlist buttons (rendering the former inoperable).

Affected by mobile devices with short screens. (Just taller than square. ex. iPhone SE web client)

Before/After
![image](https://user-images.githubusercontent.com/44987569/119747193-ca46c580-be57-11eb-9106-91d2f5d03d03.png)



