### PR TITLE
Compute menu positions using nominal size #825

### DIFF
--- a/src/components/actionSheet/actionSheet.js
+++ b/src/components/actionSheet/actionSheet.js
@@ -42,8 +42,8 @@ function getPosition(options, dlg) {
 
     pos.left += (pos.width || 0) / 2;
 
-    const height = dlg.offsetHeight || 300;
-    const width = dlg.offsetWidth || 160;
+    const height = dlg.nominalOffsetHeight || 300;
+    const width = dlg.nominalOffsetWidth || 160;
 
     // Account for popup size
     pos.top -= height / 2;

--- a/src/components/dialogHelper/dialogHelper.js
+++ b/src/components/dialogHelper/dialogHelper.js
@@ -450,6 +450,9 @@ import '../../assets/css/scrollstyles.scss';
             dlg.classList.add(`dialog-${options.size}`);
         }
 
+        dlg.nominalOffsetHeight = dlg.offsetHeight;
+        dlg.nominalOffsetWidth = dlg.offsetWidth;
+
         if (enableAnimation()) {
             switch (dlg.animationConfig.entry.name) {
                 case 'fadein':


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

Animation of the menu that occurred during position calculation for initial placement caused size of the menu and thus the position to be incorrectly calculated on Firefox.

By stashing the nominal size of the dialog before starting the animation the correct size can be used to compute the location during positioning.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

#825