### PR TITLE
Fix live reload

### DIFF
--- a/src/serviceworker.js
+++ b/src/serviceworker.js
@@ -44,6 +44,10 @@ self.addEventListener('notificationclick', function (event) {
     event.waitUntil(executeAction(action, data, serverId));
 }, false);
 
-// this is needed by the webpack Workbox plugin
-/* eslint-disable-next-line no-restricted-globals,no-undef */
-precacheAndRoute(self.__WB_MANIFEST);
+// Do not precache files in development so live reload works as expected
+/* eslint-disable-next-line no-undef -- NODE_ENV is replaced by webpack */
+if (process.env.NODE_ENV === 'production') {
+    // this is needed by the webpack Workbox plugin
+    /* eslint-disable-next-line no-restricted-globals,no-undef */
+    precacheAndRoute(self.__WB_MANIFEST);
+}

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,7 +1,6 @@
 const path = require('path');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const CopyPlugin = require('copy-webpack-plugin');
-const WorkboxPlugin = require('workbox-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 const Assets = [
@@ -72,10 +71,6 @@ module.exports = {
                     to: path.resolve(__dirname, './dist/libraries/wasm-gen')
                 };
             })
-        }),
-        new WorkboxPlugin.InjectManifest({
-            swSrc: path.resolve(__dirname, 'src/serviceworker.js'),
-            swDest: 'serviceworker.js'
         })
     ],
     output: {

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -3,6 +3,8 @@ const common = require('./webpack.common');
 const merge = require('webpack-merge');
 
 module.exports = merge(common, {
+    // In order for live reload to work we must use "web" as the target not "browserlist"
+    target: 'web',
     mode: 'development',
     entry: './scripts/site.js',
     devtool: 'source-map',

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,7 +1,15 @@
+const path = require('path');
 const common = require('./webpack.common');
 const merge = require('webpack-merge');
+const WorkboxPlugin = require('workbox-webpack-plugin');
 
 module.exports = merge(common, {
     mode: 'production',
-    entry: './scripts/site.js'
+    entry: './scripts/site.js',
+    plugins: [
+        new WorkboxPlugin.InjectManifest({
+            swSrc: path.resolve(__dirname, 'src/serviceworker.js'),
+            swDest: 'serviceworker.js'
+        })
+    ]
 });


### PR DESCRIPTION
**Changes**
* Changes the webpack target in development to "web" so live reload works
* Moves workbox precaching to production webpack config so pages are not cached on reload

https://user-images.githubusercontent.com/3450688/120659805-b5b88d80-c454-11eb-8a97-382625a6938d.mp4

**Issues**
N/A
