### PR TITLE
Update Name of search section video to video/Live Tv Channels

### DIFF
--- a/src/components/search/searchresults.template.html
+++ b/src/components/search/searchresults.template.html
@@ -65,7 +65,7 @@
 </div>
 
 <div class="hide verticalSection videoResults">
-    <h2 class="sectionTitle sectionTitle-cards focuscontainer-x padded-left padded-right">${Videos}</h2>
+    <h2 class="sectionTitle sectionTitle-cards focuscontainer-x padded-left padded-right">${Videos/Live TV Channels}</h2>
 
     <div is="emby-scroller" data-horizontal="true" data-centerfocus="card" class="padded-top-focusscale padded-bottom-focusscale">
         <div is="emby-itemscontainer" class="focuscontainer-x itemsContainer scrollSlider"></div>


### PR DESCRIPTION
Updated Videos section to say, Videos/Live TV Channels

Videos section in the search results is pulling in live tv channels. The name of the section needs to be updated to reflect the content in the section. 

**Changes**
Update Name of search section video to video/Live Tv Channels

**Issues**
No issues, just renaming the section
