### PR TITLE
Add support for custom menu links in config.json

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -23,6 +23,7 @@
       "id": "wmc"
     }
   ],
+  "menuLinks": [],
   "servers": [],
   "plugins": [
     "playAccessValidation/plugin",

--- a/src/scripts/libraryMenu.js
+++ b/src/scripts/libraryMenu.js
@@ -11,6 +11,7 @@ import groupSelectionMenu from '../components/syncPlay/ui/groupSelectionMenu';
 import browser from './browser';
 import globalize from './globalize';
 import imageHelper from './imagehelper';
+import { getMenuLinks } from '../scripts/settings/webSettings';
 import '../elements/emby-button/paper-icon-button-light';
 import 'material-design-icons-iconfont';
 import '../assets/css/scrollstyles.scss';
@@ -294,9 +295,11 @@ import Headroom from 'headroom.js';
         html += '<div style="height:.5em;"></div>';
         html += '<a is="emby-linkbutton" class="navMenuOption lnkMediaFolder" href="#!/home.html"><span class="material-icons navMenuOptionIcon home"></span><span class="navMenuOptionText">' + globalize.translate('Home') + '</span></a>';
 
+        // placeholder for custom menu links
+        html += '<div class="customMenuOptions"></div>';
+
         // libraries are added here
-        html += '<div class="libraryMenuOptions">';
-        html += '</div>';
+        html += '<div class="libraryMenuOptions"></div>';
 
         if (user.localUser && user.localUser.Policy.IsAdministrator) {
             html += '<div class="adminMenuOptions">';
@@ -659,6 +662,32 @@ import Headroom from 'headroom.js';
 
         const userId = Dashboard.getCurrentUserId();
         const apiClient = getCurrentApiClient();
+
+        const customMenuOptions = document.querySelector('.customMenuOptions');
+        if (customMenuOptions) {
+            getMenuLinks().then(links => {
+                links.forEach(link => {
+                    const option = document.createElement('a');
+                    option.setAttribute('is', 'emby-linkbutton');
+                    option.className = 'navMenuOption lnkMediaFolder';
+                    option.rel = 'noopener noreferrer';
+                    option.target = '_blank';
+                    option.href = link.url;
+
+                    const icon = document.createElement('span');
+                    icon.className = `material-icons navMenuOptionIcon ${link.icon || 'link'}`;
+                    option.appendChild(icon);
+
+                    const label = document.createElement('span');
+                    label.className = 'navMenuOptionText';
+                    label.textContent = link.name;
+                    option.appendChild(label);
+
+                    customMenuOptions.appendChild(option);
+                });
+            });
+        }
+
         const libraryMenuOptions = document.querySelector('.libraryMenuOptions');
 
         if (libraryMenuOptions) {

--- a/src/scripts/settings/webSettings.js
+++ b/src/scripts/settings/webSettings.js
@@ -126,6 +126,18 @@ export function getThemes() {
 
 export const getDefaultTheme = () => internalDefaultTheme;
 
+export function getMenuLinks() {
+    return getConfig().then(config => {
+        if (!config.menuLinks) {
+            console.error('web config is invalid, missing menuLinks:', config);
+        }
+        return config.menuLinks || [];
+    }).catch(error => {
+        console.log('cannot get web config:', error);
+        return [];
+    });
+}
+
 export function getPlugins() {
     return getConfig().then(config => {
         if (!config.plugins) {


### PR DESCRIPTION
**Changes**
Adds the ability to configure custom menu links in config.json. Links are defined in the following way:

```json
"menuLinks": [
    {
      "name": "Custom Link",
      "url": "https://jellyfin.org"
    },
    {
      "name": "Custom Link w. Icon",
      "icon": "attach_money",
      "url": "https://jellyfin.org"
    }
]
```

An optional icon can be specified by using the name of an icon from https://jossef.github.io/material-design-icons-iconfont/.

Links are listed below the Home link in the menu.

![Screenshot 2021-06-10 at 13-32-58 Jellyfin](https://user-images.githubusercontent.com/3450688/121572050-bec7d280-c9f1-11eb-9f67-e737286fc155.png)

**Issues**
N/A
