### PR TITLE
Remove activate feature from Quick Connect page

### DIFF
--- a/src/controllers/user/menu/index.html
+++ b/src/controllers/user/menu/index.html
@@ -12,6 +12,15 @@
                     </div>
                 </a>
 
+                <a is="emby-linkbutton" data-ripple="false" href="#" style="display:block;padding:0;margin:0;" class="lnkQuickConnectPreferences listItem-border hide">
+                    <div class="listItem">
+                        <em class="material-icons listItemIcon listItemIcon-transparent">tap_and_play</em>
+                        <div class="listItemBody">
+                            <div class="listItemBodyText">${QuickConnect}</div>
+                        </div>
+                    </div>
+                </a>
+
                 <a is="emby-linkbutton" data-ripple="false" href="#" style="display:block;padding:0;margin:0;" class="lnkDisplayPreferences listItem-border">
                     <div class="listItem">
                         <span class="material-icons listItemIcon listItemIcon-transparent tv"></span>
@@ -44,16 +53,6 @@
                         <span class="material-icons listItemIcon listItemIcon-transparent closed_caption"></span>
                         <div class="listItemBody">
                             <div class="listItemBodyText">${Subtitles}</div>
-                        </div>
-                    </div>
-                </a>
-
-
-                <a is="emby-linkbutton" data-ripple="false" href="#" style="display:block;padding:0;margin:0;" class="lnkQuickConnectPreferences listItem-border hide">
-                    <div class="listItem">
-                        <em class="material-icons listItemIcon listItemIcon-transparent">tap_and_play</em>
-                        <div class="listItemBody">
-                            <div class="listItemBodyText">${QuickConnect}</div>
                         </div>
                     </div>
                 </a>

--- a/src/controllers/user/quickConnect/helper.js
+++ b/src/controllers/user/quickConnect/helper.js
@@ -1,6 +1,5 @@
 import globalize from '../../../scripts/globalize';
 import toast from '../../../components/toast/toast';
-import Dashboard from '../../../scripts/clientUtils';
 
 export const authorize = (code) => {
     const url = ApiClient.getUrl('/QuickConnect/Authorize?Code=' + code);
@@ -15,23 +14,4 @@ export const authorize = (code) => {
 
     // prevent bubbling
     return false;
-};
-
-export const activate = () => {
-    const url = ApiClient.getUrl('/QuickConnect/Activate');
-    return ApiClient.ajax({
-        type: 'POST',
-        url: url
-    }).then(() => {
-        toast(globalize.translate('QuickConnectActivationSuccessful'));
-        return true;
-    }).catch((e) => {
-        console.error('Error activating quick connect. Error:', e);
-        Dashboard.alert({
-            title: globalize.translate('HeaderError'),
-            message: globalize.translate('DefaultErrorMessage')
-        });
-
-        throw e;
-    });
 };

--- a/src/controllers/user/quickConnect/index.html
+++ b/src/controllers/user/quickConnect/index.html
@@ -1,19 +1,15 @@
 <div id="quickConnectPreferencesPage" data-role="page" class="page libraryPage userPreferencesPage noSecondaryNavPage" data-title="${QuickConnect}" data-backbutton="true" style="margin: 0 auto; max-width: 54em">
-    <div class="settingsContainer padded-left padded-right padded-bottom-page">
-        <button is="emby-button" id="btnQuickConnectActivate" type="button" class="raised button-submit block">
-            <span>${ButtonActivate}</span>
-        </button>
-
-        <form class="quickConnectSettingsContainer">
-            <div style="margin-bottom: 1em">
-                ${QuickConnectDescription}
-            </div>
+    <form class="quickConnectSettingsContainer">
+        <div class="verticalSection">
+            <h2 class="sectionTitle">${QuickConnect}</h2>
+            <div>${QuickConnectDescription}</div>
+            <br />
             <div class="inputContainer">
                 <input is="emby-input" type="number" min="0" max="999999" required id="txtQuickConnectCode" label="${LabelQuickConnectCode}" autocomplete="off" />
             </div>
             <button id="btnQuickConnectAuthorize" is="emby-button" type="submit" class="raised button-submit block">
                 <span>${Authorize}</span>
             </button>
-        </form>
-    </div>
+        </div>
+    </form>
 </div>

--- a/src/controllers/user/quickConnect/index.js
+++ b/src/controllers/user/quickConnect/index.js
@@ -1,4 +1,4 @@
-import { activate, authorize } from './helper';
+import { authorize } from './helper';
 import globalize from '../../../scripts/globalize';
 import toast from '../../../components/toast/toast';
 
@@ -6,52 +6,16 @@ export default function (view) {
     view.addEventListener('viewshow', function () {
         const codeElement = view.querySelector('#txtQuickConnectCode');
 
-        view.querySelector('#btnQuickConnectActivate').addEventListener('click', () => {
-            activate().then(() => {
-                renderPage();
-            });
-        });
+        view.querySelector('.quickConnectSettingsContainer').addEventListener('submit', (e) => {
+            e.preventDefault();
 
-        view.querySelector('#btnQuickConnectAuthorize').addEventListener('click', () => {
             if (!codeElement.validity.valid) {
                 toast(globalize.translate('QuickConnectInvalidCode'));
 
                 return;
             }
 
-            const code = codeElement.value;
-            authorize(code);
+            authorize(codeElement.value);
         });
-
-        view.querySelector('.quickConnectSettingsContainer').addEventListener('submit', (e) => {
-            e.preventDefault();
-        });
-
-        renderPage();
     });
-
-    function renderPage(forceActive = false) {
-        ApiClient.getQuickConnect('Status').then((status) => {
-            const btn = view.querySelector('#btnQuickConnectActivate');
-            const container = view.querySelector('.quickConnectSettingsContainer');
-
-            // The activation button should only be visible when quick connect is unavailable (with the text replaced with an error) or when it is available (so it can be activated)
-            // The authorization container is only usable when quick connect is active, so it should be hidden otherwise
-            container.style.display = 'none';
-
-            if (status === 'Unavailable') {
-                btn.textContent = globalize.translate('QuickConnectNotAvailable');
-                btn.disabled = true;
-                btn.classList.remove('button-submit');
-                btn.classList.add('button');
-            } else if (status === 'Active' || forceActive) {
-                container.style.display = '';
-                btn.style.display = 'none';
-            }
-
-            return true;
-        }).catch((e) => {
-            throw e;
-        });
-    }
 }


### PR DESCRIPTION
Also added a heading and updates the layout in general

**Changes**

- Redid the layout of the Quick Connect page
  - added a title
  - copied the layout from other preference pages
- Remove activate button from Quick Connect page
  - Feature is removed in my server PR
- Use submit event instead of click event
  - Who ever thought not allowing a user to submit a form with the enter key was a good idea
- Move quick connect button up in preferences menu
  - This makes it more visible and easier to access on mobile devices

note: Until my pull request to the server is merged the quick connect feature will not work as the client will not call the activate endpoint anymore.

Needs jellyfin/jellyfin/pull/6200

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
