### PR TITLE
Use new Quick Connect enabled endpoint

### DIFF
--- a/src/controllers/session/login/index.js
+++ b/src/controllers/session/login/index.js
@@ -260,9 +260,9 @@ import cardBuilder from '../../../components/cardbuilder/cardBuilder';
 
             const apiClient = getApiClient();
 
-            apiClient.getQuickConnect('Status')
-                .then(status => {
-                    if (status !== 'Unavailable') {
+            apiClient.getQuickConnect('Enabled')
+                .then(enabled => {
+                    if (enabled === true) {
                         view.querySelector('.btnQuick').classList.remove('hide');
                     }
                 })

--- a/src/controllers/user/menu/index.js
+++ b/src/controllers/user/menu/index.js
@@ -38,16 +38,15 @@ export default function (view, params) {
 
         page.querySelector('.lnkControlsPreferences').classList.toggle('hide', layoutManager.mobile);
 
-        ApiClient.getQuickConnect('Status')
-            .then(status => {
-                if (status !== 'Unavailable') {
+        ApiClient.getQuickConnect('Enabled')
+            .then(enabled => {
+                if (enabled === true) {
                     page.querySelector('.lnkQuickConnectPreferences').classList.remove('hide');
                 }
             })
             .catch(() => {
                 console.debug('Failed to get QuickConnect status');
             });
-
         ApiClient.getUser(userId).then(function (user) {
             page.querySelector('.headerUsername').innerHTML = user.Name;
             if (user.Policy.IsAdministrator && !layoutManager.tv) {


### PR DESCRIPTION
**Changes**
- Use `/quickconnect/enabled` instead of `/quickconnect/status`
  - Now returns a boolean instead of an enum

note: Until my pull request to the server is merged this will not work properly and the buttons will not show up if quick connect is enabled.

Needs jellyfin/jellyfin/pull/6200

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
