### PR TITLE
Add hardware encoding status to playback data

### DIFF
--- a/src/components/playerstats/playerstats.js
+++ b/src/components/playerstats/playerstats.js
@@ -173,6 +173,10 @@ import ServerConnections from '../ServerConnections';
                     value: session.TranscodingInfo.TranscodeReasons.map(translateReason).join('<br/>')
                 });
             }
+            sessionStats.push({
+                label: globalize.translate('LabelHardwareEncoding'),
+                value: session.TranscodingInfo.IsHardwareEncode
+            });
         }
 
         return sessionStats;

--- a/src/components/playerstats/playerstats.js
+++ b/src/components/playerstats/playerstats.js
@@ -175,7 +175,7 @@ import ServerConnections from '../ServerConnections';
             }
             sessionStats.push({
                 label: globalize.translate('LabelHardwareEncoding'),
-                value: session.TranscodingInfo.IsHardwareEncode
+                value: session.TranscodingInfo.HardwareAccelerationType
             });
         }
 

--- a/src/components/playerstats/playerstats.js
+++ b/src/components/playerstats/playerstats.js
@@ -173,10 +173,12 @@ import ServerConnections from '../ServerConnections';
                     value: session.TranscodingInfo.TranscodeReasons.map(translateReason).join('<br/>')
                 });
             }
-            sessionStats.push({
-                label: globalize.translate('LabelHardwareEncoding'),
-                value: session.TranscodingInfo.HardwareAccelerationType
-            });
+            if (session.TranscodingInfo.HardwareAccelerationType) {
+                sessionStats.push({
+                    label: globalize.translate('LabelHardwareEncoding'),
+                    value: session.TranscodingInfo.HardwareAccelerationType
+                });
+            }
         }
 
         return sessionStats;

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -644,6 +644,7 @@
     "LabelH265Crf": "H265 encoding CRF:",
     "LabelHardwareAccelerationType": "Hardware acceleration:",
     "LabelHardwareAccelerationTypeHelp": "Hardware acceleration requires additional configuration.",
+    "LabelHardwareEncoding": "Hardware encoding:",
     "LabelHDHomerunPortRange": "HD Homerun port range:",
     "LabelHDHomerunPortRangeHelp": "Restricts the HD Homerun UDP port range to this value. (Default is 1024 - 645535).",
     "LabelHomeNetworkQuality": "Home network quality:",


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->
Hi, this is my first contribution to jellyfin. Let me know if I need to change/fix anything!

**Changes**
Inside Playback Info, add hardware encoding information.
![image](https://user-images.githubusercontent.com/10103146/124368256-2c8fa480-dc14-11eb-97f2-4e413822a0c8.png)
![image](https://user-images.githubusercontent.com/10103146/124368260-403b0b00-dc14-11eb-8adc-4fcaa75fb5e0.png)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Resolves https://github.com/jellyfin/jellyfin/issues/6087

Connected PR: https://github.com/jellyfin/jellyfin/pull/6258