### PR TITLE
Fix ATV 0.11 using wrong icon

### DIFF
--- a/src/scripts/imagehelper.js
+++ b/src/scripts/imagehelper.js
@@ -13,6 +13,7 @@
             case 'Kodi':
                 return baseUrl + 'kodi.svg';
             case 'Jellyfin Android':
+            case 'AndroidTV':
             case 'Android TV':
                 return baseUrl + 'android.svg';
             case 'Jellyfin Web':


### PR DESCRIPTION
**Changes**
Android TV <= 0.11.x uses "AndroidTV" without a space as the app name, so the correct icon was not being displayed.

**Issues**
N/A
