### PR TITLE
Fix webpack config for bundle caching

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -33,7 +33,9 @@ module.exports = {
         new CleanWebpackPlugin(),
         new HtmlWebpackPlugin({
             filename: 'index.html',
-            template: 'index.html'
+            template: 'index.html',
+            // Append file hashes to bundle urls for cache busting
+            hash: true
         }),
         new CopyPlugin({
             patterns: [
@@ -75,7 +77,8 @@ module.exports = {
         })
     ],
     output: {
-        filename: '[name].[contenthash].bundle.js',
+        filename: '[name].bundle.js',
+        chunkFilename: '[name].[contenthash].chunk.js',
         path: path.resolve(__dirname, 'dist'),
         publicPath: ''
     },


### PR DESCRIPTION
**Changes**
This fixes the issue where the web interface will fail to load without a refresh after an update. This was caused by the cached version of the index.html file pointing to the old main js bundle due to the hashes being included in the filename. This change breaks it out so bundles no longer include the hash in the filename, but the hash is appended as a query string to the bundle url by the html webpack plugin.

**Issues**
N/A
