### PR TITLE
Fix TV item details UX

### DIFF
--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -367,6 +367,14 @@ function reloadPlayButtons(page, item) {
         hideAll(page, 'btnShuffle');
     }
 
+    const btnResume = page.querySelector('.mainDetailButtons .btnResume');
+    const btnPlay = page.querySelector('.mainDetailButtons .btnPlay');
+    if (layoutManager.tv && !btnResume.classList.contains('hide')) {
+        btnResume.classList.add('fab');
+    } else if (layoutManager.tv && btnResume.classList.contains('hide')) {
+        btnPlay.classList.add('fab');
+    }
+
     return canPlay;
 }
 
@@ -2062,16 +2070,6 @@ export default function (view, params) {
 
     function init() {
         const apiClient = getApiClient();
-
-        const btnResume = view.querySelector('.mainDetailButtons .btnResume');
-        const btnPlay = view.querySelector('.mainDetailButtons .btnPlay');
-        if (layoutManager.tv && !btnResume.classList.contains('hide')) {
-            btnResume.classList.add('fab');
-            btnResume.classList.add('detailFloatingButton');
-        } else if (layoutManager.tv && btnResume.classList.contains('hide')) {
-            btnPlay.classList.add('fab');
-            btnPlay.classList.add('detailFloatingButton');
-        }
 
         view.querySelectorAll('.btnPlay');
         bindAll(view, '.btnPlay', 'click', onPlayClick);


### PR DESCRIPTION
**Changes**

- Fix the TV UX so that two buttons no longer appear to be selected at the same time by removing the `detailFloatingButton` class
- Move logic so the resume button is the main action when an item can be resumed

Before:
![image](https://user-images.githubusercontent.com/16425113/126662681-46c5f004-aea3-4de0-bd1f-632fd151ba52.png)


After:
![image](https://user-images.githubusercontent.com/16425113/126662577-682639b3-4cf8-4cd2-80c3-279b195a097a.png)


**Issues**
UX issue mentioned in jellyfin/jellyfin-webos#46
