### PR TITLE
Fix AC3/EAC3 playback in jellyfin-expo

### DIFF
--- a/src/components/apphost.js
+++ b/src/components/apphost.js
@@ -1,4 +1,4 @@
-import { version as appVersion } from '../../package.json';
+import { version as webVersion } from '../../package.json';
 import appSettings from '../scripts/settings/appSettings';
 import browser from '../scripts/browser';
 import { Events } from 'jellyfin-apiclient';
@@ -33,7 +33,7 @@ function getDeviceProfile(item) {
         let profile;
 
         if (window.NativeShell) {
-            profile = window.NativeShell.AppHost.getDeviceProfile(profileBuilder, appVersion);
+            profile = window.NativeShell.AppHost.getDeviceProfile(profileBuilder, webVersion);
         } else {
             const builderOpts = getBaseProfileOptions(item);
             profile = profileBuilder(builderOpts);
@@ -373,7 +373,7 @@ export const appHost = {
     },
     appVersion: function () {
         return window.NativeShell?.AppHost?.appVersion
-            ? window.NativeShell.AppHost.appVersion() : appVersion;
+            ? window.NativeShell.AppHost.appVersion() : webVersion;
     },
     getPushTokenInfo: function () {
         return {};


### PR DESCRIPTION
**Changes**
- **jellyfin-expo** client requires the version of **jellyfin-web** to check if the Dolby audio should be disabled.
https://github.com/jellyfin/jellyfin-expo/blob/8372b140dd8ca50a8794ee99f9b192cd62fded6d/assets/js/NativeShell.staticjs#L75