### PR TITLE
Fix continue watching card shapes

### DIFF
--- a/src/components/homesections/homesections.js
+++ b/src/components/homesections/homesections.js
@@ -397,7 +397,7 @@ import ServerConnections from '../ServerConnections';
 
         const itemsContainer = elem.querySelector('.itemsContainer');
         itemsContainer.fetchData = getItemsToResumeFn(mediaType, apiClient.serverId());
-        itemsContainer.getItemsHtml = getItemsToResumeHtmlFn(userSettings.useEpisodeImagesInNextUpAndResume());
+        itemsContainer.getItemsHtml = getItemsToResumeHtmlFn(userSettings.useEpisodeImagesInNextUpAndResume(), mediaType);
         itemsContainer.parentContainer = elem;
     }
 
@@ -428,14 +428,14 @@ import ServerConnections from '../ServerConnections';
         };
     }
 
-    function getItemsToResumeHtmlFn(useEpisodeImages) {
+    function getItemsToResumeHtmlFn(useEpisodeImages, mediaType) {
         return function (items) {
             const cardLayout = false;
             return cardBuilder.getCardsHtml({
                 items: items,
                 preferThumb: true,
                 inheritThumb: !useEpisodeImages,
-                defaultShape: getThumbShape(),
+                shape: (mediaType === 'Book') ? getPortraitShape() : getThumbShape(),
                 overlayText: false,
                 showTitle: true,
                 showParentTitle: true,


### PR DESCRIPTION
**Changes**
Fixes an issue introduced in https://github.com/jellyfin/jellyfin-web/pull/2704 where the continue watching cards for videos used the thumb image but cropped in the poster aspect ratio.

CardBuilder's options make no sense whatsoever. :man_facepalming: 

**Issues**
N/A
