### PR TITLE
Add "jellyfin" to output file names

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -77,7 +77,7 @@ module.exports = {
         })
     ],
     output: {
-        filename: '[name].bundle.js',
+        filename: '[name].jellyfin.bundle.js',
         chunkFilename: '[name].[contenthash].chunk.js',
         path: path.resolve(__dirname, 'dist'),
         publicPath: ''


### PR DESCRIPTION
This fixes a regression from #2790 that caused the injection code from the Android app to fail.

**Changes**
- Add ".jellyfin.bundle.js" to output file name so the injection for the android app keeps working - this also gives us a better name to match to in the future.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
