### PR TITLE
Made volume slider exponential rather than linear

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -46,6 +46,7 @@
  - [danieladov](https://github.com/danieladov)
  - [Stephane Senart](https://github.com/ssenart)
  - [Ömer Erdinç Yağmurlu](https://github.com/omeryagmurlu)
+ - [Keegan Dahm](https://github.com/keegandahm)
 
 # Emby Contributors
 

--- a/src/plugins/htmlAudioPlayer/plugin.js
+++ b/src/plugins/htmlAudioPlayer/plugin.js
@@ -457,14 +457,14 @@ class HtmlAudioPlayer {
     setVolume(val) {
         const mediaElement = this._mediaElement;
         if (mediaElement) {
-            mediaElement.volume = Math.pow(val / 100, 2);
+            mediaElement.volume = Math.pow(val / 100, 3);
         }
     }
 
     getVolume() {
         const mediaElement = this._mediaElement;
         if (mediaElement) {
-            return Math.min(Math.round(Math.pow(mediaElement.volume, 0.5) * 100), 100);
+            return Math.min(Math.round(Math.pow(mediaElement.volume, 1 / 3) * 100), 100);
         }
     }
 

--- a/src/plugins/htmlAudioPlayer/plugin.js
+++ b/src/plugins/htmlAudioPlayer/plugin.js
@@ -457,14 +457,14 @@ class HtmlAudioPlayer {
     setVolume(val) {
         const mediaElement = this._mediaElement;
         if (mediaElement) {
-            mediaElement.volume = val / 100;
+            mediaElement.volume = Math.pow(val / 100, 2);
         }
     }
 
     getVolume() {
         const mediaElement = this._mediaElement;
         if (mediaElement) {
-            return Math.min(Math.round(mediaElement.volume * 100), 100);
+            return Math.min(Math.round(Math.pow(mediaElement.volume, 0.5) * 100), 100);
         }
     }
 

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1708,14 +1708,14 @@ function tryRemoveElement(elem) {
     setVolume(val) {
         const mediaElement = this.#mediaElement;
         if (mediaElement) {
-            mediaElement.volume = Math.pow(val / 100, 2);
+            mediaElement.volume = Math.pow(val / 100, 3);
         }
     }
 
     getVolume() {
         const mediaElement = this.#mediaElement;
         if (mediaElement) {
-            return Math.min(Math.round(Math.pow(mediaElement.volume, 0.5) * 100), 100);
+            return Math.min(Math.round(Math.pow(mediaElement.volume, 1 / 3) * 100), 100);
         }
     }
 

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1708,14 +1708,14 @@ function tryRemoveElement(elem) {
     setVolume(val) {
         const mediaElement = this.#mediaElement;
         if (mediaElement) {
-            mediaElement.volume = val / 100;
+            mediaElement.volume = Math.pow(val / 100, 2);
         }
     }
 
     getVolume() {
         const mediaElement = this.#mediaElement;
         if (mediaElement) {
-            return Math.min(Math.round(mediaElement.volume * 100), 100);
+            return Math.min(Math.round(Math.pow(mediaElement.volume, 0.5) * 100), 100);
         }
     }
 


### PR DESCRIPTION
This makes the web volume slider exponential rather than linear, making it easier to pick a good volume as we perceive loudness on a logarithmic scale. Please see [this UX stackoverflow answer](https://ux.stackexchange.com/a/116300), and the webpage it links to, for why this is desirable.

**Changes**
Updates both the htmlAudioPlayer and htmlVideoPlayer to set the mediaElement volume on an exponential scale.

**Issues**
This has an open [Issue #2401](https://github.com/jellyfin/jellyfin-web/issues/2401).