### PR TITLE
Update dependabot frequency to run weekly

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,13 +1,13 @@
 version: 2
 updates:
-    - package-ecosystem: npm
-      directory: /
-      schedule:
-          interval: monthly
-      open-pull-requests-limit: 10
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
 
-    - package-ecosystem: github-actions
-      directory: '/'
-      schedule:
-        interval: monthly
-      open-pull-requests-limit: 10
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10


### PR DESCRIPTION
**Changes**
* Updates the dependabot frequency to weekly instead of monthly. This matches the server schedule and should help reduce the overhead of having an avalanche of update PRs once a month.
* Fixes some yaml formatting issues

**Issues**
N/A
