### PR TITLE
Allow web player to buffer ahead a reasonable amount of data

### DIFF
--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -385,7 +385,6 @@ function tryRemoveElement(elem) {
             return new Promise((resolve, reject) => {
                 requireHlsPlayer(async () => {
                     let maxBufferLength = 30;
-                    let maxMaxBufferLength = 600;
 
                     // Some browsers cannot handle huge fragments in high bitrate.
                     // This issue usually happens when using HWA encoders with a high bitrate setting.
@@ -393,7 +392,6 @@ function tryRemoveElement(elem) {
                     // https://github.com/video-dev/hls.js/issues/876
                     if ((browser.chrome || browser.edgeChromium || browser.firefox) && playbackManager.getMaxStreamingBitrate(this) >= 25000000) {
                         maxBufferLength = 6;
-                        maxMaxBufferLength = 6;
                     }
 
                     const includeCorsCredentials = await getIncludeCorsCredentials();
@@ -401,7 +399,6 @@ function tryRemoveElement(elem) {
                     const hls = new Hls({
                         manifestLoadingTimeOut: 20000,
                         maxBufferLength: maxBufferLength,
-                        maxMaxBufferLength: maxMaxBufferLength,
                         xhrSetup(xhr) {
                             xhr.withCredentials = includeCorsCredentials;
                         }


### PR DESCRIPTION
The hls.js maxBufferLength parameter sets the minimum amount of video
that hls.js will try to buffer. We used to have this set to 30
seconds, but this caused problems with high-bitrate videos trying to
buffer too much data and making Chrome/Firefox cranky, so
maxBufferLength was reduced in #2148 and #2224.

However, those PRs *also* reduced maxMaxBufferLength to 6 seconds,
which doesn't make sense -- basically this is telling hls.js that it
must *never* buffer more than 6 seconds at a time, even if there's
plenty of memory and it wouldn't make the browser cranky at all. And
obviously such a tiny buffer makes it very easy for small network
glitches to cause user-visible playback problems.

So this PR removes the maxMaxBufferLength configuration entirely,
accepting hls.js's default (which is currently 600 seconds).

Fixes #2856