### PR TITLE
Removed Tag filter limit of 50

### DIFF
--- a/src/components/filterdialog/filterdialog.js
+++ b/src/components/filterdialog/filterdialog.js
@@ -32,9 +32,6 @@ import template from './filterdialog.template.html';
     }
 
     function renderFilters(context, result, query) {
-        if (result.Tags) {
-            result.Tags.length = Math.min(result.Tags.length, 50);
-        }
         renderOptions(context, '.genreFilters', 'chkGenreFilter', result.Genres, function (i) {
             const delimeter = '|';
             return (delimeter + (query.Genres || '') + delimeter).includes(delimeter + i + delimeter);


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Fixes that only the first 50 Tags are shown when filtering.
This has already been fixed a year ago (https://github.com/jellyfin/jellyfin-web/commit/8eba4fb8663c5e88dd7c5ba986abba623743af95#diff-04cd35e1ff4c22b7c3f3bac1e485790e2135724384f95d4051b94a9020519c13), but then was accidently reintroduced later when migrating the file to a new format (https://github.com/jellyfin/jellyfin-web/commit/3549bd5700d4dad210ec1c5da1098508eb122c1a#diff-04cd35e1ff4c22b7c3f3bac1e485790e2135724384f95d4051b94a9020519c13)

**Issues**
None related
