### PR TITLE
Send vp8 and vp9 over vpx as transcode profiles

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -47,6 +47,7 @@
  - [Stephane Senart](https://github.com/ssenart)
  - [Ömer Erdinç Yağmurlu](https://github.com/omeryagmurlu)
  - [Keegan Dahm](https://github.com/keegandahm)
+ - [GodTamIt](https://github.com/GodTamIt)
 
 # Emby Contributors
 

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -668,11 +668,37 @@ import browser from './browser';
         }
 
         if (canPlayVp8) {
+            // TODO: Remove vpx entry once servers are migrated
             profile.TranscodingProfiles.push({
                 Container: 'webm',
                 Type: 'Video',
-                AudioCodec: 'vorbis',
+                AudioCodec: webmAudioCodecs.includes('opus') ? 'opus' : 'vorbis',
                 VideoCodec: 'vpx',
+                Context: 'Streaming',
+                Protocol: 'http',
+                // If audio transcoding is needed, limit channels to number of physical audio channels
+                // Trying to transcode to 5 channels when there are only 2 speakers generally does not sound good
+                MaxAudioChannels: physicalAudioChannels.toString()
+            });
+            profile.TranscodingProfiles.push({
+                Container: 'webm',
+                Type: 'Video',
+                AudioCodec: webmAudioCodecs.includes('opus') ? 'opus' : 'vorbis',
+                VideoCodec: 'vp8',
+                Context: 'Streaming',
+                Protocol: 'http',
+                // If audio transcoding is needed, limit channels to number of physical audio channels
+                // Trying to transcode to 5 channels when there are only 2 speakers generally does not sound good
+                MaxAudioChannels: physicalAudioChannels.toString()
+            });
+        }
+
+        if (canPlayVp9) {
+            profile.TranscodingProfiles.push({
+                Container: 'webm',
+                Type: 'Video',
+                AudioCodec: webmAudioCodecs.includes('opus') ? 'opus' : 'vorbis',
+                VideoCodec: 'vp9',
                 Context: 'Streaming',
                 Protocol: 'http',
                 // If audio transcoding is needed, limit channels to number of physical audio channels

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -667,38 +667,13 @@ import browser from './browser';
             }
         }
 
-        if (canPlayVp8) {
-            // TODO: Remove vpx entry once servers are migrated
+        if (webmAudioCodecs.length && webmVideoCodecs.length) {
             profile.TranscodingProfiles.push({
                 Container: 'webm',
                 Type: 'Video',
-                AudioCodec: webmAudioCodecs.includes('opus') ? 'opus' : 'vorbis',
-                VideoCodec: 'vpx',
-                Context: 'Streaming',
-                Protocol: 'http',
-                // If audio transcoding is needed, limit channels to number of physical audio channels
-                // Trying to transcode to 5 channels when there are only 2 speakers generally does not sound good
-                MaxAudioChannels: physicalAudioChannels.toString()
-            });
-            profile.TranscodingProfiles.push({
-                Container: 'webm',
-                Type: 'Video',
-                AudioCodec: webmAudioCodecs.includes('opus') ? 'opus' : 'vorbis',
-                VideoCodec: 'vp8',
-                Context: 'Streaming',
-                Protocol: 'http',
-                // If audio transcoding is needed, limit channels to number of physical audio channels
-                // Trying to transcode to 5 channels when there are only 2 speakers generally does not sound good
-                MaxAudioChannels: physicalAudioChannels.toString()
-            });
-        }
-
-        if (canPlayVp9) {
-            profile.TranscodingProfiles.push({
-                Container: 'webm',
-                Type: 'Video',
-                AudioCodec: webmAudioCodecs.includes('opus') ? 'opus' : 'vorbis',
-                VideoCodec: 'vp9',
+                AudioCodec: webmAudioCodecs.join(','),
+                // TODO: Remove workaround when servers migrate away from 'vpx' for transcoding profiles.
+                VideoCodec: (canPlayVp8 ? webmVideoCodecs.concat('vpx') : webmVideoCodecs).join(','),
                 Context: 'Streaming',
                 Protocol: 'http',
                 // If audio transcoding is needed, limit channels to number of physical audio channels


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
This change sends `vp8` and `vp9` along with `vpx` as a transition to being more specific about the codecs.

**Issues**
Progress on jellyfin/jellyfin#6455
