### PR TITLE
Babel blurhash

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -92,7 +92,7 @@ module.exports = {
             },
             {
                 test: /\.(js|jsx)$/,
-                exclude: /node_modules[\\/](?!@uupaa[\\/]dynamic-import-polyfill|date-fns|epubjs|flv.js|libarchive.js)/,
+                exclude: /node_modules[\\/](?!@uupaa[\\/]dynamic-import-polyfill|blurhash|date-fns|epubjs|flv.js|libarchive.js)/,
                 use: [{
                     loader: 'babel-loader'
                 }]


### PR DESCRIPTION
**Changes**
Babel `blurhash`.

**Issues**
_Reported on Matrix_
Jellyfin doesn't work on Tizen 3 (+ Tizen 2.3/2.4 and webOS 1.2/2.0/3.0).
