### PR TITLE
Fix dialog history

### DIFF
--- a/src/components/appRouter.js
+++ b/src/components/appRouter.js
@@ -25,6 +25,7 @@ class AppRouter {
     msgTimeout;
     popstateOccurred = false;
     resolveOnNextShow;
+    previousRoute = {};
     /**
      * Pages of "no return" (when "Go back" should behave differently, probably quitting the application).
      */
@@ -633,8 +634,13 @@ class AppRouter {
     getHandler(route) {
         return (ctx, next) => {
             ctx.isBack = this.popstateOccurred;
-            this.handleRoute(ctx, next, route);
             this.popstateOccurred = false;
+
+            const ignore = route.dummyRoute === true || this.previousRoute.dummyRoute === true;
+            this.previousRoute = route;
+            if (ignore) return;
+
+            this.handleRoute(ctx, next, route);
         };
     }
 

--- a/src/components/dialogHelper/dialogHelper.js
+++ b/src/components/dialogHelper/dialogHelper.js
@@ -142,7 +142,7 @@ import '../../assets/css/scrollstyles.scss';
         animateDialogOpen(dlg);
 
         if (isHistoryEnabled(dlg)) {
-            appRouter.pushState({ dialogId: hash }, 'Dialog', `#${hash}`);
+            appRouter.show('/dialog', { dialogId: hash });
 
             window.addEventListener('popstate', onHashChange);
         } else {

--- a/src/components/playback/playersettingsmenu.js
+++ b/src/components/playback/playersettingsmenu.js
@@ -41,8 +41,7 @@ function showQualityMenu(player, btn) {
 
     return actionsheet.show({
         items: menuItems,
-        positionTo: btn,
-        enableHistory: false
+        positionTo: btn
     }).then(function (id) {
         const bitrate = parseInt(id);
         if (bitrate !== selectedBitrate) {
@@ -78,8 +77,7 @@ function showRepeatModeMenu(player, btn) {
 
     return actionsheet.show({
         items: menuItems,
-        positionTo: btn,
-        enableHistory: false
+        positionTo: btn
     }).then(function (mode) {
         if (mode) {
             playbackManager.setRepeatMode(mode, player);
@@ -140,8 +138,7 @@ function showAspectRatioMenu(player, btn) {
 
     return actionsheet.show({
         items: menuItems,
-        positionTo: btn,
-        enableHistory: false
+        positionTo: btn
     }).then(function (id) {
         if (id) {
             playbackManager.setAspectRatio(id, player);
@@ -163,8 +160,7 @@ function showPlaybackRateMenu(player, btn) {
 
     return actionsheet.show({
         items: menuItems,
-        positionTo: btn,
-        enableHistory: false
+        positionTo: btn
     }).then(function (id) {
         if (id) {
             playbackManager.setPlaybackRate(id, player);
@@ -241,8 +237,7 @@ function showWithUser(options, player, user) {
 
     return actionsheet.show({
         items: menuItems,
-        positionTo: options.positionTo,
-        enableHistory: false
+        positionTo: options.positionTo
     }).then(function (id) {
         return handleSelectedOption(id, options, player);
     });

--- a/src/components/syncPlay/ui/groupSelectionMenu.js
+++ b/src/components/syncPlay/ui/groupSelectionMenu.js
@@ -63,8 +63,7 @@ class GroupSelectionMenu {
                     items: menuItems,
                     positionTo: button,
                     resolveOnClick: true,
-                    border: true,
-                    enableHistory: false
+                    border: true
                 };
 
                 actionsheet.show(menuOptions).then(function (id) {
@@ -133,8 +132,7 @@ class GroupSelectionMenu {
             items: menuItems,
             positionTo: button,
             resolveOnClick: true,
-            border: true,
-            enableHistory: false
+            border: true
         };
 
         actionsheet.show(menuOptions).then(function (id) {

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -903,8 +903,7 @@ import { appRouter } from '../../../components/appRouter';
                 actionsheet.show({
                     items: menuItems,
                     title: globalize.translate('Audio'),
-                    positionTo: positionTo,
-                    enableHistory: false
+                    positionTo: positionTo
                 }).then(function (id) {
                     const index = parseInt(id);
 
@@ -950,8 +949,7 @@ import { appRouter } from '../../../components/appRouter';
                 actionsheet.show({
                     title: globalize.translate('Subtitles'),
                     items: menuItems,
-                    positionTo: positionTo,
-                    enableHistory: false
+                    positionTo: positionTo
                 }).then(function (id) {
                     const index = parseInt(id);
 

--- a/src/scripts/routes.js
+++ b/src/scripts/routes.js
@@ -561,6 +561,11 @@ import { appRouter } from '../components/appRouter';
     });
 
     defineRoute({
+        path: '/dialog',
+        dummyRoute: true
+    });
+
+    defineRoute({
         path: '',
         isDefaultRoute: true,
         autoFocus: false


### PR DESCRIPTION
It seems that #2660 is not enough.

<details>
<summary>There was a special handling in the customized `page.js`</summary>

https://github.com/jellyfin/jellyfin-web/blob/c25db80cbdf036807b898b6ce19d3b7455d77157/src/libraries/pagejs/page.js#L615-L627
</details>

<details>
<summary>and the router part (called by `dialogHelper`)</summary>

https://github.com/jellyfin/jellyfin-web/blob/c25db80cbdf036807b898b6ce19d3b7455d77157/src/components/appRouter.js#L667-L670
</details>

So `page.js` didn't reload the view in this case.

**Changes**
- Add a dummy route for dialogs.
- Don't reload the view when go to or return from a dummy route.
- Re-enable history for some dialogs.

**Issues**
Fixes #2888
