### PR TITLE
Fix theme song player

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -3016,6 +3016,9 @@ class PlaybackManager {
             }
 
             return promise.then(function () {
+                // Clear the data since we were not listening 'stopped'
+                getPlayerData(activePlayer).streamInfo = null;
+
                 bindStopped(activePlayer);
 
                 if (enableLocalPlaylistManagement(activePlayer)) {


### PR DESCRIPTION
`streamInfo` in the player data isn't cleared on playback changing.

`state.NowPlayingItem` is set, but not `state.IsFullscreen`, and `nowPlayingBar` shows up.
https://github.com/jellyfin/jellyfin-web/blob/d67998c226bb9cb058b7e65ddd284fede80c4a8a/src/components/nowPlayingBar/nowPlayingBar.js#L664

Then, the player starts the theme song, and `state.IsFullscreen` is updated to `false`, `nowPlayingBar` hides. But `transitionend` event isn't triggered, so we have a visible footer.

**Changes**
Clear player data on playback changing.

**Issues**
Fixes #2598
