### PR TITLE
Disable warnings in webpack dev server overlay

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -24,6 +24,12 @@ module.exports = merge(common, {
         ]
     },
     devServer: {
-        compress: true
+        compress: true,
+        client: {
+            overlay: {
+                errors: true,
+                warnings: false
+            }
+        }
     }
 });


### PR DESCRIPTION
**Changes**
This disables warning messages in the client overlay displayed in browser when running webpack-dev-server. This was a bit annoying due to an upstream warning in epub.js (https://github.com/futurepress/epub.js/pull/1202) that we are (seemingly) unable to resolve.

**Issues**
N/A
