### PR TITLE
Reorder item details sections

### DIFF
--- a/src/assets/css/librarybrowser.scss
+++ b/src/assets/css/librarybrowser.scss
@@ -1170,7 +1170,7 @@ div:not(.sectionTitleContainer-cards) > .sectionTitle-cards {
 }
 
 .itemDetailsGroup {
-    margin-bottom: 1.5em;
+    margin-top: 1.5em;
 }
 
 .trackSelections {

--- a/src/controllers/itemDetails/index.html
+++ b/src/controllers/itemDetails/index.html
@@ -92,23 +92,6 @@
                     <div class="detailSection">
                         <div class="itemMiscInfo nativeName hide"></div>
 
-                        <div class="itemDetailsGroup">
-                            <div class="detailsGroupItem genresGroup hide">
-                                <div class="genresLabel label"></div>
-                                <div class="genres content focuscontainer-x"></div>
-                            </div>
-
-                            <div class="detailsGroupItem directorsGroup hide">
-                                <div class="directorsLabel label"></div>
-                                <div class="directors content focuscontainer-x"></div>
-                            </div>
-
-                            <div class="detailsGroupItem writersGroup hide">
-                                <div class="writersLabel label"></div>
-                                <div class="writers content focuscontainer-x"></div>
-                            </div>
-                        </div>
-
                         <form class="trackSelections hide focuscontainer-x">
                             <div class="selectContainer selectSourceContainer hide trackSelectionFieldContainer flex-shrink-zero">
                                 <select is="emby-select" class="selectSource detailTrackSelect" label=""></select>
@@ -125,6 +108,7 @@
                         </form>
 
                         <div class="recordingFields hide" style="margin: 0.5em 0 1.5em;"></div>
+
                         <div class="detailSectionContent">
                             <div class="itemLastPlayed hide"></div>
 
@@ -142,6 +126,23 @@
                             <div class="itemTags focuscontainer-x hide" style="margin: 0.7em 0; font-size: 92%;"></div>
                             <div class="itemExternalLinks focuscontainer-x hide" style="margin: 0.7em 0; font-size: 92%;"></div>
                             <div class="seriesRecordingEditor"></div>
+                        </div>
+
+                        <div class="itemDetailsGroup">
+                            <div class="detailsGroupItem genresGroup hide">
+                                <div class="genresLabel label"></div>
+                                <div class="genres content focuscontainer-x"></div>
+                            </div>
+
+                            <div class="detailsGroupItem directorsGroup hide">
+                                <div class="directorsLabel label"></div>
+                                <div class="directors content focuscontainer-x"></div>
+                            </div>
+
+                            <div class="detailsGroupItem writersGroup hide">
+                                <div class="writersLabel label"></div>
+                                <div class="writers content focuscontainer-x"></div>
+                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
**Changes**
Reorders the sections of the item details screen so that genres, director, and writer are below the movie description.

![Screenshot 2021-09-05 at 01-39-35 Jellyfin](https://user-images.githubusercontent.com/3450688/132116659-e05da9c3-90aa-436d-b1b3-d194c157666e.png)

**Issues**
N/A
