### PR TITLE
Fix playbackstop event handling

### DIFF
--- a/src/controllers/movies/moviesrecommended.js
+++ b/src/controllers/movies/moviesrecommended.js
@@ -359,7 +359,9 @@ import Dashboard from '../../scripts/clientUtils';
             }));
         }
 
-        function onPlaybackStop(e, state) {
+        function onPlaybackStop(e, stopInfo) {
+            const state = stopInfo.state;
+
             if (state.NowPlayingItem && state.NowPlayingItem.MediaType == 'Video') {
                 renderedTabs = [];
                 mainTabsManager.getTabsElement().triggerTabChange();
@@ -409,6 +411,7 @@ import Dashboard from '../../scripts/clientUtils';
             inputManager.on(window, onInputCommand);
         });
         view.addEventListener('viewbeforehide', function () {
+            Events.off(playbackManager, 'playbackstop', onPlaybackStop);
             inputManager.off(window, onInputCommand);
         });
         for (const tabController of tabControllers) {

--- a/src/controllers/shows/tvrecommended.js
+++ b/src/controllers/shows/tvrecommended.js
@@ -317,7 +317,9 @@ import autoFocuser from '../../components/autoFocuser';
             });
         }
 
-        function onPlaybackStop(e, state) {
+        function onPlaybackStop(e, stopInfo) {
+            const state = stopInfo.state;
+
             if (state.NowPlayingItem && state.NowPlayingItem.MediaType == 'Video') {
                 renderedTabs = [];
                 mainTabsManager.getTabsElement().triggerTabChange();


### PR DESCRIPTION
This PR is draft because this code is fixed but never called.
Maybe the code should be removed, or there is something I don't see.

**What is fixed (it is broken probably from the beginning)**
View connects to `playbackstop` from `playbackManager`, but handles it wrong: should be `playbackStopInfo`, not directly `state`.

**Why never called**
View disconnects from the mentioned event when `viewbeforehide` occurs (after starting the video player). I dunno how playback of video can be stopped when those views are active.
_Disconnecting of `tvrecommended` was already here._