### PR TITLE
Dialog history and actionSheet resolving

### DIFF
--- a/src/components/dialogHelper/dialogHelper.js
+++ b/src/components/dialogHelper/dialogHelper.js
@@ -87,7 +87,7 @@ import '../../assets/css/scrollstyles.scss';
             if (!self.closedByBack && isHistoryEnabled(dlg)) {
                 const state = window.history.state || {};
                 if (state.dialogId === hash) {
-                    window.history.back();
+                    appRouter.back();
                 }
             }
 
@@ -213,7 +213,7 @@ import '../../assets/css/scrollstyles.scss';
     export function close(dlg) {
         if (isOpened(dlg)) {
             if (isHistoryEnabled(dlg)) {
-                window.history.back();
+                appRouter.back();
             } else {
                 closeDialog(dlg);
             }

--- a/src/components/dialogHelper/dialogHelper.js
+++ b/src/components/dialogHelper/dialogHelper.js
@@ -142,7 +142,7 @@ import '../../assets/css/scrollstyles.scss';
         animateDialogOpen(dlg);
 
         if (isHistoryEnabled(dlg)) {
-            appRouter.show('/dialog', { dialogId: hash });
+            appRouter.show(`/dialog?dlg=${hash}`, { dialogId: hash });
 
             window.addEventListener('popstate', onHashChange);
         } else {

--- a/src/components/syncPlay/ui/groupSelectionMenu.js
+++ b/src/components/syncPlay/ui/groupSelectionMenu.js
@@ -62,7 +62,6 @@ class GroupSelectionMenu {
                     title: globalize.translate('HeaderSyncPlaySelectGroup'),
                     items: menuItems,
                     positionTo: button,
-                    resolveOnClick: true,
                     border: true
                 };
 
@@ -131,7 +130,6 @@ class GroupSelectionMenu {
             title: groupInfo.GroupName,
             items: menuItems,
             positionTo: button,
-            resolveOnClick: true,
             border: true
         };
 


### PR DESCRIPTION
`resolveOnClick` is used to resolve `actionSheet.show` promise by click instead of dialog closing.

This doesn't work with history-driven dialog chains:
- On click-resolving, a new dialog opens.
- It pushes a new state.
- Then, the previous dialog pops this state instead of its own.

Also, some changes that I should have included in the previous history PR (#2889).

**Changes**
- Remove `resolveOnClick` from SyncPlay `groupSelection` dialog.
- Use only `appRouter.back`.
- Add dialog id to hashbang.