### PR TITLE
Draft: Get fresh ApiClient when starting SyncPlay playback

### DIFF
--- a/src/components/syncPlay/core/Helper.js
+++ b/src/components/syncPlay/core/Helper.js
@@ -4,6 +4,7 @@
  */
 
 import { Events } from 'jellyfin-apiclient';
+import ServerConnections from '../../ServerConnections';
 
 /**
  * Constants
@@ -72,7 +73,11 @@ export function stringToGuid(input) {
     return input.replace(/([0-z]{8})([0-z]{4})([0-z]{4})([0-z]{4})([0-z]{12})/, '$1-$2-$3-$4-$5');
 }
 
-export function getItemsForPlayback(apiClient, query) {
+export function getItemsForPlayback(_apiClient, query) {
+    const serverId = _apiClient.serverId();
+
+    const apiClient = ServerConnections.getApiClient(serverId);
+
     if (query.Ids && query.Ids.split(',').length === 1) {
         const itemId = query.Ids.split(',');
 
@@ -103,7 +108,7 @@ function mergePlaybackQueries(obj1, obj2) {
     return query;
 }
 
-export function translateItemsForPlayback(apiClient, items, options) {
+export function translateItemsForPlayback(_apiClient, items, options) {
     if (items.length > 1 && options && options.ids) {
         // Use the original request id array for sorting the result in the proper order.
         items.sort(function (a, b) {
@@ -113,6 +118,10 @@ export function translateItemsForPlayback(apiClient, items, options) {
 
     const firstItem = items[0];
     let promise;
+
+    const serverId = firstItem.ServerId;
+
+    const apiClient = ServerConnections.getApiClient(serverId);
 
     const queryOptions = options.queryOptions || {};
 


### PR DESCRIPTION
**Changes**
Get a fresh `ApiClient` from `ServerConnections` instead of reusing the same one.

**Help Needed**
With this change SyncPlay seems to be working again but, honestly, I have no idea on why the "cached" ApiClient is not working anymore. Should I refactor the code to **not** store any reference to any ApiClient?

The only difference I could see is this `GET http://localhost:8096/jellyfin/Items/[ID]` now becoming `GET http://localhost:8096/Users/[ID]/Items/[ID]`.

Update: SyncPlay is using an unauthenticated instance of ApiClient.

**Issues**
Fixes [#6291](https://github.com/jellyfin/jellyfin/issues/6291).
