### PR TITLE
Log warning instead of error when dictionary has not loaded

### DIFF
--- a/src/scripts/globalize.js
+++ b/src/scripts/globalize.js
@@ -187,18 +187,22 @@ import * as userSettings from './settings/userSettings';
 
     function translateKeyFromModule(key, module) {
         let dictionary = getDictionary(module, getCurrentLocale());
-        if (!dictionary || !dictionary[key]) {
-            dictionary = getDictionary(module, fallbackCulture);
+        if (dictionary && dictionary[key]) {
+            return dictionary[key];
         }
-        if (!dictionary || !dictionary[key]) {
-            if (dictionary && isEmpty(dictionary)) {
-                console.warn('Translation dictionary is empty.');
-            } else {
-                console.error(`Translation key is missing from dictionary: ${key}`);
-            }
-            return key;
+
+        dictionary = getDictionary(module, fallbackCulture);
+        if (dictionary && dictionary[key]) {
+            return dictionary[key];
         }
-        return dictionary[key];
+
+        if (!dictionary || isEmpty(dictionary)) {
+            console.warn('Translation dictionary is empty.');
+        } else {
+            console.error(`Translation key is missing from dictionary: ${key}`);
+        }
+
+        return key;
     }
 
     function replaceAll(str, find, replace) {

--- a/src/scripts/globalize.js
+++ b/src/scripts/globalize.js
@@ -1,5 +1,7 @@
-import * as userSettings from './settings/userSettings';
 import { Events } from 'jellyfin-apiclient';
+import isEmpty from 'lodash-es/isEmpty';
+
+import * as userSettings from './settings/userSettings';
 
 /* eslint-disable indent */
 
@@ -189,7 +191,11 @@ import { Events } from 'jellyfin-apiclient';
             dictionary = getDictionary(module, fallbackCulture);
         }
         if (!dictionary || !dictionary[key]) {
-            console.error(`Translation key is missing from dictionary: ${key}`);
+            if (dictionary && isEmpty(dictionary)) {
+                console.warn('Translation dictionary is empty.');
+            } else {
+                console.error(`Translation key is missing from dictionary: ${key}`);
+            }
             return key;
         }
         return dictionary[key];


### PR DESCRIPTION
**Changes**
This prevents errors for missing translations from being logged on page load when the dictionary has not been loaded yet.

**Issues**
N/A
