### PR TITLE
Slideshow autoplay

### DIFF
--- a/src/components/slideshow/slideshow.js
+++ b/src/components/slideshow/slideshow.js
@@ -172,6 +172,8 @@ export default function (options) {
 
             html += '<div class="topActionButtons">';
             if (actionButtonsOnTop) {
+                html += getIcon('play_arrow', 'btnSlideshowPause slideshowButton', true);
+
                 if (appHost.supports('filedownload') && options.user && options.user.Policy.EnableContentDownloading) {
                     html += getIcon('file_download', 'btnDownload slideshowButton', true);
                 }

--- a/src/components/slideshow/slideshow.js
+++ b/src/components/slideshow/slideshow.js
@@ -349,7 +349,7 @@ export default function (options) {
                 minRatio: 1,
                 toggle: true
             },
-            autoplay: !options.interactive,
+            autoplay: !options.interactive || !!options.autoplay,
             keyboard: {
                 enabled: true
             },
@@ -378,6 +378,8 @@ export default function (options) {
         if (useFakeZoomImage) {
             swiperInstance.on('zoomChange', onZoomChange);
         }
+
+        if (swiperInstance.autoplay?.running) onAutoplayStart();
     }
 
     /**

--- a/src/controllers/list.js
+++ b/src/controllers/list.js
@@ -666,12 +666,14 @@ class ItemsView {
 
             if (currentItem && !self.hasFilters) {
                 playbackManager.play({
-                    items: [currentItem]
+                    items: [currentItem],
+                    autoplay: true
                 });
             } else {
                 getItems(self, self.params, currentItem, null, null, 300).then(function (result) {
                     playbackManager.play({
-                        items: result.Items
+                        items: result.Items,
+                        autoplay: true
                     });
                 });
             }
@@ -701,7 +703,8 @@ class ItemsView {
             } else {
                 getItems(self, self.params, currentItem, 'Random', null, 300).then(function (result) {
                     playbackManager.play({
-                        items: result.Items
+                        items: result.Items,
+                        autoplay: true
                     });
                 });
             }

--- a/src/plugins/photoPlayer/plugin.js
+++ b/src/plugins/photoPlayer/plugin.js
@@ -22,6 +22,8 @@ export default class PhotoPlayer {
                         startIndex: index,
                         interval: 11000,
                         interactive: true,
+                        // playbackManager.shuffle has no options. So treat 'shuffle' as a 'play' action
+                        autoplay: options.autoplay || options.shuffle,
                         user: result
                     });
 


### PR DESCRIPTION
**Changes**
- Add the `Play/Pause` button to the top menu for `Mobile`.
- Fix the `Play All` and `Shuffle` actions.

**Issues**
Almost fixes #2752

The `Play All` action on the photo library itself doesn't work.
_I believe there was also a separate issue about this._

The photo library is `CollectionFolder` and we use: https://github.com/jellyfin/jellyfin-web/blob/7747aab4e73464b8f4eea14b2fe4cac3a825e08d/src/components/playback/playbackmanager.js#L1826-L1834
But there is no `Photo` in the `MediaTypes` filter.

Adding `Photo` to the `MediaTypes` filter fixes the playback. But it is probably better to pass media types from the library, because we are not good in mixed-type libraries that require switching players.