### PR TITLE
Move "Remove" option in card menu item in Dashboard->Library to the last item

### DIFF
--- a/src/controllers/dashboard/library.js
+++ b/src/controllers/dashboard/library.js
@@ -104,11 +104,6 @@ import cardBuilder from '../../components/cardbuilder/cardBuilder';
             icon: 'folder'
         });
         menuItems.push({
-            name: globalize.translate('ButtonRemove'),
-            id: 'delete',
-            icon: 'delete'
-        });
-        menuItems.push({
             name: globalize.translate('ButtonRename'),
             id: 'rename',
             icon: 'mode_edit'
@@ -117,6 +112,11 @@ import cardBuilder from '../../components/cardbuilder/cardBuilder';
             name: globalize.translate('ScanLibrary'),
             id: 'refresh',
             icon: 'refresh'
+        });
+        menuItems.push({
+            name: globalize.translate('ButtonRemove'),
+            id: 'delete',
+            icon: 'delete'
         });
 
         import('../../components/actionSheet/actionSheet').then((actionsheet) => {


### PR DESCRIPTION
**Changes**
Issue #2779 addresses a valid point where the context menu for a library appears with Remove positioned so that it is the default item. This PR fixes that by making it the last item in the context menu instead of the 2nd item in the context menu.

**Issues**
Fixes #2779 