### PR TITLE
Restore missing placeholder error message

### DIFF
--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1260,6 +1260,7 @@
     "PlayAllFromHere": "Play all from here",
     "PlaybackData": "Playback Data",
     "PlaybackErrorNoCompatibleStream": "This client isn't compatible with the media and the server isn't sending a compatible media format.",
+    "PlaybackErrorPlaceHolder": "This is a placeholder for physical media that Jellyfin cannot play. Please insert the disc to play.",
     "PlaybackRate": "Playback Rate",
     "PlayCount": "Play count",
     "Played": "Played",


### PR DESCRIPTION
**Changes**
Restores an error message when trying to play a placeholder item that was removed in 10.3 and adjusts the language used.

**Issues**
N/A
