### PR TITLE
Use the same duration format

### DIFF
--- a/src/components/mediainfo/mediainfo.js
+++ b/src/components/mediainfo/mediainfo.js
@@ -118,7 +118,7 @@ import '../../elements/emby-button/emby-button';
             }
 
             if (item.RunTimeTicks) {
-                miscInfo.push(datetime.getDisplayRunningTime(item.RunTimeTicks));
+                miscInfo.push(datetime.getDisplayDuration(item.RunTimeTicks));
             }
         } else if (item.Type === 'PhotoAlbum' || item.Type === 'BoxSet') {
             count = item.ChildCount;
@@ -256,15 +256,7 @@ import '../../elements/emby-button/emby-button';
             if (item.Type === 'Audio') {
                 miscInfo.push(datetime.getDisplayRunningTime(item.RunTimeTicks));
             } else {
-                const totalMinutes = Math.round(item.RunTimeTicks / 600000000) || 1;
-                const totalHours = Math.floor(totalMinutes / 60);
-                const remainderMinutes = totalMinutes % 60;
-                const result = [];
-                if (totalHours > 0) {
-                    result.push(`${totalHours}h`);
-                }
-                result.push(`${remainderMinutes}m`);
-                miscInfo.push(result.join(' '));
+                miscInfo.push(datetime.getDisplayDuration(item.RunTimeTicks));
             }
         }
 

--- a/src/scripts/datetime.js
+++ b/src/scripts/datetime.js
@@ -57,6 +57,22 @@ import globalize from './globalize';
         return new Date(ms);
     }
 
+    /**
+     * Return a string in '{}h {}m' format for duration.
+     * @param {number} ticks - Duration in ticks.
+     */
+    export function getDisplayDuration(ticks) {
+        const totalMinutes = Math.round(ticks / 600000000) || 1;
+        const totalHours = Math.floor(totalMinutes / 60);
+        const remainderMinutes = totalMinutes % 60;
+        const result = [];
+        if (totalHours > 0) {
+            result.push(`${totalHours}h`);
+        }
+        result.push(`${remainderMinutes}m`);
+        return result.join(' ');
+    }
+
     export function getDisplayRunningTime(ticks) {
         const ticksPerHour = 36000000000;
         const ticksPerMinute = 600000000;
@@ -255,6 +271,7 @@ import globalize from './globalize';
     export default {
         parseISO8601Date: parseISO8601Date,
         getDisplayRunningTime: getDisplayRunningTime,
+        getDisplayDuration,
         toLocaleDateString: toLocaleDateString,
         toLocaleString: toLocaleString,
         getDisplayTime: getDisplayTime,


### PR DESCRIPTION
**Music album**
was
![Screenshot_20210911_124107](https://user-images.githubusercontent.com/56478732/132943807-8e65d954-7ba2-47ed-8a14-7f78dd56039f.png)
now
![Screenshot_20210911_124030](https://user-images.githubusercontent.com/56478732/132943812-24ebc491-6a82-4331-bba4-a08b2d403bbf.png)

With #2944, the track count will be displayed for playlists as well.

**Changes**
- Extract the duration string formatting.
- Use the same format for the music album (not only?) duration.

**Issues**
N/A
