### PR TITLE
Fix video UI for LiveTV

### DIFF
--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -182,7 +182,7 @@ import { appRouter } from '../../../components/appRouter';
                 view.querySelector('.btnAudio').classList.add('hide');
             }
 
-            if (currentItem.Chapters.length > 1) {
+            if (currentItem.Chapters?.length > 1) {
                 view.querySelector('.btnPreviousChapter').classList.remove('hide');
                 view.querySelector('.btnNextChapter').classList.remove('hide');
             } else {


### PR DESCRIPTION
From here we fall to the `catch` block:
 https://github.com/jellyfin/jellyfin-web/blob/9778f2db657a3be6ec44173e618768873d186ff6/src/controllers/playback/video/index.js#L185 

**Changes**
Check the `Chapters` property first.

**Issues**
Video UI isn't displayed for LiveTV.

P.S.:
We should handle the exception properly (instead of just going home):
https://github.com/jellyfin/jellyfin-web/blob/9778f2db657a3be6ec44173e618768873d186ff6/src/controllers/playback/video/index.js#L1335-L1337
