### PR TITLE
Use .placeholder for EncoderAppPathDisplay when EncoderAppPath is empty

### DIFF
--- a/src/controllers/dashboard/encodingsettings.js
+++ b/src/controllers/dashboard/encodingsettings.js
@@ -21,7 +21,13 @@ import alert from '../../components/alert';
         $('#selectThreadCount', page).val(config.EncodingThreadCount);
         $('#txtDownMixAudioBoost', page).val(config.DownMixAudioBoost);
         page.querySelector('#txtMaxMuxingQueueSize').value = config.MaxMuxingQueueSize || '';
-        page.querySelector('.txtEncoderPath').value = config.EncoderAppPathDisplay || '';
+        // if EncoderAppPath is empty that means the path hasn't been set by the user
+        if (config.EncoderAppPath) {
+            page.querySelector('.txtEncoderPath').value = config.EncoderAppPathDisplay || '';
+        } else {
+            page.querySelector('.txtEncoderPath').placeholder = config.EncoderAppPathDisplay || '';
+        }
+        
         $('#txtTranscodingTempPath', page).val(systemInfo.TranscodingTempPath || '');
         page.querySelector('#txtFallbackFontPath').value = config.FallbackFontPath || '';
         page.querySelector('#chkEnableFallbackFont').checked = config.EnableFallbackFont;


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
If `EncoderAppPath` is empty it hasn't been explicitly set by the user and shouldn't be overwritten. An alternative solution is to save it only if it differs from EncoderAppPathDisplay

**Issues**
Fixes https://github.com/jellyfin/jellyfin/issues/4449 in a way
