### PR TITLE
Fix webOS DTS audio support

### DIFF
--- a/src/scripts/browser.js
+++ b/src/scripts/browser.js
@@ -95,6 +95,39 @@ function iOSversion() {
     return [];
 }
 
+function web0sVersion(browser) {
+    // Detect webOS version by web engine version
+
+    if (browser.chrome) {
+        if (browser.versionMajor >= 79) {
+            return 6;
+        } else if (browser.versionMajor >= 68) {
+            return 5;
+        } else if (browser.versionMajor >= 53) {
+            return 4;
+        } else if (browser.versionMajor >= 38) {
+            return 3;
+        } else if (browser.versionMajor >= 34) {
+            // webOS 2 browser
+            return 2;
+        } else if (browser.versionMajor >= 26) {
+            // webOS 1 browser
+            return 1;
+        }
+    } else if (browser.versionMajor >= 538) {
+        // webOS 2 app
+        return 2;
+    } else if (browser.versionMajor >= 537) {
+        // webOS 1 app
+        return 1;
+    }
+
+    console.error('Unable to detect webOS version - assume 1');
+
+    // Let's assume that we have 1.
+    return 1;
+}
+
 let _supportsCssAnimation;
 let _supportsCssAnimationWithPrefix;
 function supportsCssAnimation(allowPrefix) {
@@ -237,14 +270,16 @@ browser.tizen = userAgent.toLowerCase().indexOf('tizen') !== -1 || window.tizen 
 browser.web0s = userAgent.toLowerCase().indexOf('Web0S'.toLowerCase()) !== -1;
 browser.edgeUwp = browser.edge && (userAgent.toLowerCase().indexOf('msapphost') !== -1 || userAgent.toLowerCase().indexOf('webview') !== -1);
 
-if (!browser.tizen) {
-    browser.orsay = userAgent.toLowerCase().indexOf('smarthub') !== -1;
-} else {
+if (browser.web0s) {
+    browser.web0sVersion = web0sVersion(browser);
+} else if (browser.tizen) {
     // UserAgent string contains 'Safari' and 'safari' is set by matched browser, but we only want 'tizen' to be true
     delete browser.safari;
 
     const v = (navigator.appVersion).match(/Tizen (\d+).(\d+)/);
     browser.tizenVersion = parseInt(v[1]);
+} else {
+    browser.orsay = userAgent.toLowerCase().indexOf('smarthub') !== -1;
 }
 
 if (browser.edgeUwp) {

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -389,8 +389,8 @@ import browser from './browser';
 
         let supportsDts = browser.tizen || browser.web0s || options.supportsDts || videoTestElement.canPlayType('video/mp4; codecs="dts-"').replace(/no/, '') || videoTestElement.canPlayType('video/mp4; codecs="dts+"').replace(/no/, '');
 
-        // DTS audio not supported in 2018 models (Tizen 4.0)
-        if (browser.tizenVersion >= 4) {
+        // DTS audio is not supported by Samsung TV 2018+ (Tizen 4.0+) and LG TV 2020+ (webOS 5.0+) models
+        if (browser.tizenVersion >= 4 || browser.web0sVersion >= 5) {
             supportsDts = false;
         }
 


### PR DESCRIPTION
_previously: #2942_

_After discussion on Matrix, we decided to make a new PR._

As far as I understand, LG has discontinued supporting DTS on 2020 TV models.
I can't find an official statement, and [the documentation](https://webostv.developer.lge.com/discover/specifications/supported-media-formats/webos-50/) is inconsistent (DTS is in `mkv`, but at least it's not in `avi`).

**Changes**
- Add webOS version detection
- Disable DTS on webOS 5+

**Issues**
https://github.com/jellyfin/jellyfin-webos/issues/56

To support this in webOS browser, we need to detect `NetCast` as webOS (#2781).