### PR TITLE
Improve audio player UI for small mobile screen

### DIFF
--- a/src/components/remotecontrol/remotecontrol.scss
+++ b/src/components/remotecontrol/remotecontrol.scss
@@ -403,6 +403,7 @@
     }
 
     .nowPlayingPageImage.nowPlayingPageImageAudio {
+        width: auto;
         max-width: 100%;
         max-height: 100%;
     }

--- a/src/components/remotecontrol/remotecontrol.scss
+++ b/src/components/remotecontrol/remotecontrol.scss
@@ -326,8 +326,12 @@
     }
 
     .nowPlayingPageImageContainer {
-        width: 100%;
+        width: auto;
+        max-width: 100%;
+        max-height: 100%;
+        min-height: 25%;
         margin: auto auto 0.5em;
+        flex-shrink: 1;
     }
 
     .nowPlayingPageImageContainerNoAlbum .cardImageContainer .cardImageIcon {
@@ -399,7 +403,8 @@
     }
 
     .nowPlayingPageImage.nowPlayingPageImageAudio {
-        width: 100%;
+        max-width: 100%;
+        max-height: 100%;
     }
 
     .nowPlayingPageImageContainer.nowPlayingPageImagePoster {


### PR DESCRIPTION
Shrink the cover image so elements don't overlap when using a small mobile screen (360 x 548 or less).

**Changes**
Use the flex-shrink and max-width / max-height attribute to allow the cover image to fit correctly the screen size.

| Before  | After |
| ------------- | ------------- |
| ![smallscreen-360x548-before](https://user-images.githubusercontent.com/1403150/133365083-b54f5320-a1b4-4eca-a82b-0c0ad8ba9436.png) | ![smallscreen-360x548-after](https://user-images.githubusercontent.com/1403150/133365092-f248bbcf-d040-4514-9c47-d78c3f5daee2.png)
  |