### PR TITLE
Fix server candidates on apps

### DIFF
--- a/src/scripts/clientUtils.js
+++ b/src/scripts/clientUtils.js
@@ -27,19 +27,22 @@ export async function serverAddress() {
     const urls = await webSettings.getServers();
 
     if (urls.length === 0) {
-        // Don't use app URL as server URL
-        if (window.NativeShell) {
+        // Otherwise use computed base URL
+        let url;
+        const index = window.location.href.toLowerCase().lastIndexOf('/web');
+        if (index != -1) {
+            url = window.location.href.substring(0, index);
+        } else {
+            // fallback to location without path
+            url = window.location.origin;
+        }
+
+        // Don't use bundled app URL (file:) as server URL
+        if (url.startsWith('file:')) {
             return Promise.resolve();
         }
 
-        // Otherwise use computed base URL
-        const index = window.location.href.toLowerCase().lastIndexOf('/web');
-        if (index != -1) {
-            urls.push(window.location.href.substring(0, index));
-        } else {
-            // fallback to location without path
-            urls.push(window.location.origin);
-        }
+        urls.push(url);
     }
 
     console.debug('URL candidates:', urls);


### PR DESCRIPTION
A small regression that I made :sweat_smile: #2664

**Changes**
Don't use `file:` protocol (app URL) as server URL.

**Issues**
Webview apps go to server selection page instead of login page.
