### PR TITLE
Add theme color support

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -4,23 +4,29 @@
   "themes": [
     {
       "name": "Apple TV",
-      "id": "appletv"
+      "id": "appletv",
+      "color": "#bcbcbc"
     }, {
       "name": "Blue Radiance",
-      "id": "blueradiance"
+      "id": "blueradiance",
+      "color": "#011432"
     }, {
       "name": "Dark",
       "id": "dark",
+      "color": "#202020",
       "default": true
     }, {
       "name": "Light",
-      "id": "light"
+      "id": "light",
+      "color": "#303030"
     }, {
       "name": "Purple Haze",
-      "id": "purplehaze"
+      "id": "purplehaze",
+      "color": "#000420"
     }, {
       "name": "WMC",
-      "id": "wmc"
+      "id": "wmc",
+      "color": "#0c2450"
     }
   ],
   "menuLinks": [],

--- a/src/index.html
+++ b/src/index.html
@@ -17,6 +17,9 @@
     <meta property="og:url" content="http://jellyfin.org">
     <meta property="og:description" content="The Free Software Media System">
     <meta property="og:type" content="article">
+
+    <meta id="themeColor" name="theme-color" content="#202020">
+
     <link rel="apple-touch-icon" sizes="180x180" href="touchicon.png">
 
     <!-- iPhone 5 -->

--- a/src/scripts/themeManager.js
+++ b/src/scripts/themeManager.js
@@ -31,7 +31,8 @@ function getThemeStylesheetInfo(id) {
 
         return {
             stylesheetPath: 'themes/' + theme.id + '/theme.css',
-            themeId: theme.id
+            themeId: theme.id,
+            color: theme.color
         };
     });
 }
@@ -74,6 +75,8 @@ function setTheme(id) {
             link.setAttribute('href', linkUrl);
             themeStyleElement = link;
             currentThemeId = info.themeId;
+
+            document.getElementById('themeColor').content = info.color;
         });
     });
 }


### PR DESCRIPTION
**Changes**
Adds support for theme colors as used for the safari header in iOS 15

**Apple TV**
![appletv](https://user-images.githubusercontent.com/3450688/134615186-4a5ca8bc-c39f-4c86-bb43-af228dba04a2.jpeg)

**Blue Radiance**
![blueradiance](https://user-images.githubusercontent.com/3450688/134615230-8435a5d2-ac10-42e5-9bb5-8917127b9ccb.jpeg)

**Dark**
![dark](https://user-images.githubusercontent.com/3450688/134615394-671fbb6c-d281-46c8-81e2-22af7f0b999c.jpeg)

**Light**
![light](https://user-images.githubusercontent.com/3450688/134615367-330f56bf-d304-49b0-8199-209d79e23bd0.jpeg)

**Purple Haze**
![purplehaze](https://user-images.githubusercontent.com/3450688/134615342-44b31034-84a8-428a-b4b6-37fe62ef6003.jpeg)

**WMC**
![wmc](https://user-images.githubusercontent.com/3450688/134615292-e7e01221-834d-4f44-a5d8-c6123e999874.jpeg)

**Issues**
N/A
