### PR TITLE
build.sh: Allow docker build on non debian systems

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -39,7 +39,7 @@ do_build_native() {
 }
 
 do_build_docker() {
-    if ! dpkg --print-architecture | grep -q 'amd64'; then
+    if ! [ $(uname -m) = "x86_64" ]; then
         echo "Docker-based builds only support amd64-based cross-building; use a 'native' build instead."
         exit 1
     fi


### PR DESCRIPTION
**Changes**

use `uname -m` instead of `dkpg --print-architectur` to determine the architecture

**Issues**

This fixes #3003