### PR TITLE
Fix remote fullscreen event handler

### DIFF
--- a/src/components/remotecontrol/remotecontrol.js
+++ b/src/components/remotecontrol/remotecontrol.js
@@ -718,11 +718,9 @@ export default function () {
             btnCommand[i].addEventListener('click', onBtnCommandClick);
         }
 
-        context.querySelector('.btnToggleFullscreen').addEventListener('click', function (e) {
+        context.querySelector('.btnToggleFullscreen').addEventListener('click', function () {
             if (currentPlayer) {
-                playbackManager.sendCommand({
-                    Name: e.target.getAttribute('data-command')
-                }, currentPlayer);
+                playbackManager.toggleFullscreen(currentPlayer);
             }
         });
         context.querySelector('.btnAudioTracks').addEventListener('click', function (e) {


### PR DESCRIPTION
**Changes**
Fixes a bug where clicking on some parts of the fullscreen button on remote player controls did not work because the event name was missing.

**Issues**
Fixes #2949 
