### PR TITLE
Fix JavascriptSubtitlesOctopus dispose

### DIFF
--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1062,6 +1062,9 @@ function tryRemoveElement(elem) {
                 workerUrl: `${appRouter.baseUrl()}/libraries/subtitles-octopus-worker.js`,
                 legacyWorkerUrl: `${appRouter.baseUrl()}/libraries/subtitles-octopus-worker-legacy.js`,
                 onError() {
+                    // HACK: Clear JavascriptSubtitlesOctopus: it gets disposed when an error occurs
+                    htmlVideoPlayer.#currentSubtitlesOctopus = null;
+
                     onErrorInternal(htmlVideoPlayer, 'mediadecodeerror');
                 },
                 timeOffset: (this._currentPlayOptions.transcodingOffsetTicks || 0) / 10000000,

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1065,7 +1065,10 @@ function tryRemoveElement(elem) {
                     // HACK: Clear JavascriptSubtitlesOctopus: it gets disposed when an error occurs
                     htmlVideoPlayer.#currentSubtitlesOctopus = null;
 
-                    onErrorInternal(htmlVideoPlayer, 'mediadecodeerror');
+                    // HACK: Give JavascriptSubtitlesOctopus time to dispose itself
+                    setTimeout(() => {
+                        onErrorInternal(htmlVideoPlayer, 'mediadecodeerror');
+                    }, 0);
                 },
                 timeOffset: (this._currentPlayOptions.transcodingOffsetTicks || 0) / 10000000,
 

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -675,13 +675,13 @@ function tryRemoveElement(elem) {
                 }
 
                 onEndedInternal(this, elem, this.onError);
-
-                if (destroyPlayer) {
-                    this.destroy();
-                }
             }
 
             this.destroyCustomTrack(elem);
+
+            if (destroyPlayer) {
+                this.destroy();
+            }
 
             return Promise.resolve();
         }


### PR DESCRIPTION
`JavascriptSubtitlesOctopus` has the [`dispose` call](https://github.com/jellyfin/JavascriptSubtitlesOctopus/blob/f4625ac313b318bd5d2e0ae18679ff516370bae6/src/subtitles-octopus.js#L99) in the error handler.
This makes it hard to control the disposing flow of elements.

**Changes**
- 2 hacks to clear resources after JSO error occurs.
_It would be better to remove that `dispose` call. But we need to discuss this with the upstream._
- Dispose JSO first (before destroying the player).

**Issues**
JSO is trying to remove canvas from the video element, but we already removed the latter from the DOM:
https://github.com/jellyfin/JavascriptSubtitlesOctopus/blob/f4625ac313b318bd5d2e0ae18679ff516370bae6/src/subtitles-octopus.js#L863
```
Uncaught DOMException: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
    at SubtitlesOctopus.self.dispose (http://.../web/JavascriptSubtitlesOctopus_dist_js_subtitles-octopus_js.33eb72ced6222e91e928.chunk.js:1616:29)
    at Worker.SubtitlesOctopus.self.workerError (http://.../web/JavascriptSubtitlesOctopus_dist_js_subtitles-octopus_js.33eb72ced6222e91e928.chunk.js:1113:12)
```

**Steps To Reproduce**
1. Copy SRT subtitles as ASS (change extension).
2. Refresh metadata.
3. Select `bad ASS` subtitles.
4. Play the video.
5. Error occurs 3 times.

_There is an error with the error message history, but I will fix this in the next PR (just to make things atomic)._