### PR TITLE
Check permission in multiselect

### DIFF
--- a/src/components/multiSelect/multiSelect.js
+++ b/src/components/multiSelect/multiSelect.js
@@ -8,6 +8,7 @@ import ServerConnections from '../ServerConnections';
 import alert from '../alert';
 import playlistEditor from '../playlisteditor/playlisteditor';
 import confirm from '../confirm/confirm';
+import itemHelper from '../itemHelper';
 
 /* eslint-disable indent */
 
@@ -170,129 +171,136 @@ import confirm from '../confirm/confirm';
         const apiClient = ServerConnections.currentApiClient();
 
         apiClient.getCurrentUser().then(user => {
-            const menuItems = [];
+            // get first selected item to perform metadata refresh permission check
+            apiClient.getItem(apiClient.getCurrentUserId(), selectedItems[0]).then(firstItem => {
+                const menuItems = [];
 
-            menuItems.push({
-                name: globalize.translate('AddToCollection'),
-                id: 'addtocollection',
-                icon: 'add'
-            });
-
-            menuItems.push({
-                name: globalize.translate('AddToPlaylist'),
-                id: 'playlist',
-                icon: 'playlist_add'
-            });
-
-            // TODO: Be more dynamic based on what is selected
-            if (user.Policy.EnableContentDeletion) {
                 menuItems.push({
-                    name: globalize.translate('Delete'),
-                    id: 'delete',
-                    icon: 'delete'
+                    name: globalize.translate('AddToCollection'),
+                    id: 'addtocollection',
+                    icon: 'add'
                 });
-            }
 
-            if (user.Policy.EnableContentDownloading && appHost.supports('filedownload')) {
-                // Disabled because there is no callback for this item
-                /*
                 menuItems.push({
-                    name: globalize.translate('Download'),
-                    id: 'download',
-                    icon: 'file_download'
+                    name: globalize.translate('AddToPlaylist'),
+                    id: 'playlist',
+                    icon: 'playlist_add'
                 });
-                */
-            }
 
-            if (user.Policy.IsAdministrator) {
+                // TODO: Be more dynamic based on what is selected
+                if (user.Policy.EnableContentDeletion) {
+                    menuItems.push({
+                        name: globalize.translate('Delete'),
+                        id: 'delete',
+                        icon: 'delete'
+                    });
+                }
+
+                if (user.Policy.EnableContentDownloading && appHost.supports('filedownload')) {
+                    // Disabled because there is no callback for this item
+                    /*
+                    menuItems.push({
+                        name: globalize.translate('Download'),
+                        id: 'download',
+                        icon: 'file_download'
+                    });
+                    */
+                }
+
+                if (user.Policy.IsAdministrator) {
+                    menuItems.push({
+                        name: globalize.translate('GroupVersions'),
+                        id: 'groupvideos',
+                        icon: 'call_merge'
+                    });
+                }
+
                 menuItems.push({
-                    name: globalize.translate('GroupVersions'),
-                    id: 'groupvideos',
-                    icon: 'call_merge'
+                    name: globalize.translate('MarkPlayed'),
+                    id: 'markplayed',
+                    icon: 'check_box'
                 });
-            }
 
-            menuItems.push({
-                name: globalize.translate('MarkPlayed'),
-                id: 'markplayed',
-                icon: 'check_box'
-            });
+                menuItems.push({
+                    name: globalize.translate('MarkUnplayed'),
+                    id: 'markunplayed',
+                    icon: 'check_box_outline_blank'
+                });
 
-            menuItems.push({
-                name: globalize.translate('MarkUnplayed'),
-                id: 'markunplayed',
-                icon: 'check_box_outline_blank'
-            });
+                // this assues that if the user can refresh metadata for the first item
+                // they can refresh metadata for all items
+                if (itemHelper.canRefreshMetadata(firstItem, user)) {
+                    menuItems.push({
+                        name: globalize.translate('RefreshMetadata'),
+                        id: 'refresh',
+                        icon: 'refresh'
+                    });
+                }
 
-            menuItems.push({
-                name: globalize.translate('RefreshMetadata'),
-                id: 'refresh',
-                icon: 'refresh'
-            });
+                import('../actionSheet/actionSheet').then((actionsheet) => {
+                    actionsheet.show({
+                        items: menuItems,
+                        positionTo: e.target,
+                        callback: function (id) {
+                            const items = selectedItems.slice(0);
+                            const serverId = apiClient.serverInfo().Id;
 
-            import('../actionSheet/actionSheet').then((actionsheet) => {
-                actionsheet.show({
-                    items: menuItems,
-                    positionTo: e.target,
-                    callback: function (id) {
-                        const items = selectedItems.slice(0);
-                        const serverId = apiClient.serverInfo().Id;
-
-                        switch (id) {
-                            case 'addtocollection':
-                                import('../collectionEditor/collectionEditor').then(({default: collectionEditor}) => {
-                                    new collectionEditor({
+                            switch (id) {
+                                case 'addtocollection':
+                                    import('../collectionEditor/collectionEditor').then(({default: collectionEditor}) => {
+                                        new collectionEditor({
+                                            items: items,
+                                            serverId: serverId
+                                        });
+                                    });
+                                    hideSelections();
+                                    dispatchNeedsRefresh();
+                                    break;
+                                case 'playlist':
+                                    new playlistEditor({
                                         items: items,
                                         serverId: serverId
                                     });
-                                });
-                                hideSelections();
-                                dispatchNeedsRefresh();
-                                break;
-                            case 'playlist':
-                                new playlistEditor({
-                                    items: items,
-                                    serverId: serverId
-                                });
-                                hideSelections();
-                                dispatchNeedsRefresh();
-                                break;
-                            case 'delete':
-                                deleteItems(apiClient, items).then(dispatchNeedsRefresh);
-                                hideSelections();
-                                dispatchNeedsRefresh();
-                                break;
-                            case 'groupvideos':
-                                combineVersions(apiClient, items);
-                                break;
-                            case 'markplayed':
-                                items.forEach(itemId => {
-                                    apiClient.markPlayed(apiClient.getCurrentUserId(), itemId);
-                                });
-                                hideSelections();
-                                dispatchNeedsRefresh();
-                                break;
-                            case 'markunplayed':
-                                items.forEach(itemId => {
-                                    apiClient.markUnplayed(apiClient.getCurrentUserId(), itemId);
-                                });
-                                hideSelections();
-                                dispatchNeedsRefresh();
-                                break;
-                            case 'refresh':
-                                import('../refreshdialog/refreshdialog').then(({default: refreshDialog}) => {
-                                    new refreshDialog({
-                                        itemIds: items,
-                                        serverId: serverId
-                                    }).show();
-                                });
-                                hideSelections();
-                                dispatchNeedsRefresh();
-                                break;
-                            default:
-                                break;
+                                    hideSelections();
+                                    dispatchNeedsRefresh();
+                                    break;
+                                case 'delete':
+                                    deleteItems(apiClient, items).then(dispatchNeedsRefresh);
+                                    hideSelections();
+                                    dispatchNeedsRefresh();
+                                    break;
+                                case 'groupvideos':
+                                    combineVersions(apiClient, items);
+                                    break;
+                                case 'markplayed':
+                                    items.forEach(itemId => {
+                                        apiClient.markPlayed(apiClient.getCurrentUserId(), itemId);
+                                    });
+                                    hideSelections();
+                                    dispatchNeedsRefresh();
+                                    break;
+                                case 'markunplayed':
+                                    items.forEach(itemId => {
+                                        apiClient.markUnplayed(apiClient.getCurrentUserId(), itemId);
+                                    });
+                                    hideSelections();
+                                    dispatchNeedsRefresh();
+                                    break;
+                                case 'refresh':
+                                    import('../refreshdialog/refreshdialog').then(({default: refreshDialog}) => {
+                                        new refreshDialog({
+                                            itemIds: items,
+                                            serverId: serverId
+                                        }).show();
+                                    });
+                                    hideSelections();
+                                    dispatchNeedsRefresh();
+                                    break;
+                                default:
+                                    break;
+                            }
                         }
-                    }
+                    });
                 });
             });
         });


### PR DESCRIPTION
**Changes**
Only add the option to refresh metadata in the multi select if the user has permission to update metadata
The GitHub diff is very ugly, due to indentation changes.

**Issues**
Fixes jellyfin/jellyfin#6545