### PR TITLE
Fix repository url link not opening as external

### DIFF
--- a/src/controllers/dashboard/plugins/repositories/index.js
+++ b/src/controllers/dashboard/plugins/repositories/index.js
@@ -64,7 +64,7 @@ function getRepositoryHtml(repository) {
     let html = '';
 
     html += '<div class="listItem listItem-border">';
-    html += `<a is="emby-linkbutton" style="margin:0;padding:0" class="clearLink listItemIconContainer" href="${repository.Url}">`;
+    html += `<a is="emby-linkbutton" style="margin:0;padding:0" class="clearLink listItemIconContainer" href="${repository.Url}" rel="noopener noreferrer" target="_blank">`;
     html += '<span class="material-icons listItemIcon open_in_new"></span>';
     html += '</a>';
     html += '<div class="listItemBody two-line">';


### PR DESCRIPTION
**Changes**
Fixes repository url links not being treated as external links. This would break web wrapper apps since the link would be opened in the webview instead of calling the NativeShell handler.

**Issues**
N/A
