### PR TITLE
Make dialog buttons smaller on TV

### DIFF
--- a/src/components/formdialog.scss
+++ b/src/components/formdialog.scss
@@ -84,11 +84,6 @@
     flex-basis: 12em;
 }
 
-.layout-tv .formDialogFooterItem {
-    flex-grow: 1;
-    flex-basis: 0;
-}
-
 .formDialogFooterItem-vertical {
     max-width: none !important;
     width: 100%;


### PR DESCRIPTION
In #1222, the buttons were changed for Desktop and Mobile, but were left "as is" for the TV layout.

|Before|After|
|-|-|
| ![before](https://user-images.githubusercontent.com/56478732/137540221-0278d16d-f638-45ba-9eb1-98619298b958.png) | ![after](https://user-images.githubusercontent.com/56478732/137540232-b956a13c-fba8-49d4-a821-7875724c7b68.png) |
| ![before2](https://user-images.githubusercontent.com/56478732/137540293-73b87e59-5cfc-4389-8628-7226fb5e4466.png) |  ![after2](https://user-images.githubusercontent.com/56478732/137540299-3605ad64-c686-4ccb-b438-d3b4d3675628.png) |
| ![before3](https://user-images.githubusercontent.com/56478732/137540321-c248eb34-daf5-401f-b58b-d6dffb339a4f.png) |  ![after3](https://user-images.githubusercontent.com/56478732/137540342-a42cbad5-53d0-475b-9dc3-2e7c83826386.png) |
| | _We may have a problem with Samsung because the active button is hard to distinguish from the inactive one._ |
| ![before4](https://user-images.githubusercontent.com/56478732/137540366-212dc937-d655-418c-a7a8-f5f408042f0f.png) |  ![after4](https://user-images.githubusercontent.com/56478732/137540386-cb5fdfea-e750-4aa2-abc0-5642627c7b1f.png) |

**Changes**
Make dialog buttons smaller on TV

**Issues**
Fixes #3030 
