### PR TITLE
Implement per-frame playback navigation

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -3486,6 +3486,48 @@ class PlaybackManager {
         this.seekRelative(offsetTicks, player);
     }
 
+    calculateFrameInMs(player = this._currentPlayer) {
+        const source = this.currentMediaSource(player);
+        for (const stream of source.MediaStreams) {
+            if (stream.type === 'video') {
+                const frameRate = stream.RealFrameRate || stream.AverageFrameRate;
+
+                if (frameRate) {
+                    return 1000 / frameRate;
+                }
+            }
+        }
+
+        // Assume 30FPS
+        return 1000 / 30;
+    }
+
+    fastForwardOneFrame(player = this._currentPlayer) {
+        const timeToSkip = this.calculateFrameInMs(player);
+
+        if (player.rewind != null) {
+            player.rewind(timeToSkip);
+            return;
+        }
+
+        const offsetTicks = timeToSkip * 10000;
+
+        this.seekRelative(offsetTicks, player);
+    }
+
+    rewindOneFrame(player = this._currentPlayer) {
+        const timeToSkip = this.calculateFrameInMs(player);
+
+        if (player.rewind != null) {
+            player.rewind(timeToSkip);
+            return;
+        }
+
+        const offsetTicks = 0 - (timeToSkip * 10000);
+
+        this.seekRelative(offsetTicks, player);
+    }
+
     seekPercent(percent, player = this._currentPlayer) {
         let ticks = this.duration(player) || 0;
 

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1074,6 +1074,14 @@ import { appRouter } from '../../../components/appRouter';
                     playbackManager.rewind(currentPlayer);
                     showOsd();
                     break;
+                case ',':
+                    playbackManager.rewindOneFrame(currentPlayer);
+                    showOsd();
+                    break;
+                case '.':
+                    playbackManager.fastForwardOneFrame(currentPlayer);
+                    showOsd();
+                    break;
                 case 'f':
                     if (!e.ctrlKey && !e.metaKey) {
                         playbackManager.toggleFullscreen(currentPlayer);


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
As mentioned in #3087, I wanted the ability to scrub a video frame-by-frame. This PR implements this functionality by adding `,` and `.` (as is on YouTube) to the key listener in the playback controller, and adding functions to fast forward or rewind by one frame in the playback manager.

Open to feedback on additional keys that could be used, or improvements to the tick calculation logic. Currently I've implemented it by checking the framerate of the media source video media stream, but every 5-6 navigations I get the same still twice so further investigation is needed.
