### PR TITLE
Fix dialog style conflict

### DIFF
--- a/src/components/dialogHelper/dialoghelper.scss
+++ b/src/components/dialogHelper/dialoghelper.scss
@@ -122,6 +122,8 @@
         right: 0 !important;
         margin: 0 !important;
         box-shadow: none;
+        width: auto !important;
+        height: auto !important;
     }
 }
 


### PR DESCRIPTION
**Changes**
Fixes a style conflict where both the fullscreen styles and small dialog styles are both applied when the window is exactly 80em wide.

Current state on master:
![Screenshot 2021-10-25 at 09-59-37 Jellyfin](https://user-images.githubusercontent.com/3450688/138710578-37499d79-f35a-47fe-a5b4-acddb8d3eee9.png)

**Issues**
N/A
