### PR TITLE
Fix H264 52 Level available but not detected Fixes #3090

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -749,7 +749,8 @@ import browser from './browser';
         }
 
         // Support H264 Level 52 (Tizen 5.0) - app only
-        if (browser.tizenVersion >= 5 && window.NativeShell) {
+        if ((browser.tizenVersion >= 5 && window.NativeShell) ||
+            videoTestElement.canPlayType('video/mp4; codecs="avc1.640834"').replace(/no/, '')) {
             maxH264Level = 52;
         }
 


### PR DESCRIPTION
**Changes**
H264 level 52 test support added to prevent transcoding (VideoLevelNotSupported) when video can be decoded directly by the web client.

**Issues**
Fixes #3090
