### PR TITLE
Fix regression after PR #3046

### DIFF
--- a/src/components/alert.js
+++ b/src/components/alert.js
@@ -30,8 +30,9 @@ import globalize from '../scripts/globalize';
             options = text;
         }
 
+        await appRouter.ready();
+
         if (useNativeAlert()) {
-            await appRouter.ready();
             alert(replaceAll(options.text || '', '<br/>', '\n'));
             return Promise.resolve();
         } else {

--- a/src/components/confirm/confirm.js
+++ b/src/components/confirm/confirm.js
@@ -35,7 +35,7 @@ async function nativeConfirm(options) {
     }
 }
 
-function customConfirm(text, title) {
+async function customConfirm(text, title) {
     let options;
     if (typeof text === 'string') {
         options = {
@@ -61,6 +61,8 @@ function customConfirm(text, title) {
     });
 
     options.buttons = items;
+
+    await appRouter.ready();
 
     return dialog.show(options).then(result => {
         if (result === 'ok') {

--- a/src/components/dialogHelper/dialogHelper.js
+++ b/src/components/dialogHelper/dialogHelper.js
@@ -184,9 +184,7 @@ import '../../assets/css/scrollstyles.scss';
         return dlg.getAttribute('data-history') === 'true';
     }
 
-    export async function open(dlg) {
-        await appRouter.ready();
-
+    export function open(dlg) {
         if (globalOnOpenCallback) {
             globalOnOpenCallback(dlg);
         }


### PR DESCRIPTION
`dialogHelper.open` has become async and it is not possible to perform any action immediately after calling it.

For example, positioning the menu: https://github.com/jellyfin/jellyfin-web/blob/5d456c4ca2d27ba3331aeed7b5fd49219995d9d3/src/components/actionSheet/actionSheet.js#L308-L317

There are too many `dialogHelper.open` calls, so I moved `await` from `dialogHelper` (revert) to where it was supposed to be used - alert dialog.

**Changes**
Use `await appRouter.ready()` as little as possible.

**Issues**
Menus are poorly positioned.
