### PR TITLE
Save playback speed rate, and restore when playing a video again

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -113,3 +113,4 @@
  - [tikuf](https://github.com/tikuf/)
  - [Tim Hobbs](https://github.com/timhobbs)
  - [SvenVandenbrande](https://github.com/SvenVandenbrande)
+ - [jomp16](https://github.com/jomp16)

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -3602,6 +3602,9 @@ class PlaybackManager {
     setPlaybackRate(value, player = this._currentPlayer) {
         if (player && player.setPlaybackRate) {
             player.setPlaybackRate(value);
+
+            // Save the new playback rate in the browser session, to restore when playing a new video.
+            sessionStorage.setItem('playbackRateSpeed', value);
         }
     }
 

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -446,6 +446,7 @@ import { appRouter } from '../../../components/appRouter';
                 updatePlayerStateInternal(event, player, state);
                 updatePlaylist();
                 enableStopOnBack(true);
+                updatePlaybackRate(player);
             }
         }
 
@@ -1250,6 +1251,14 @@ import { appRouter } from '../../../components/appRouter';
 
             if (enabled && playbackManager.isPlayingVideo(currentPlayer)) {
                 view.addEventListener('viewbeforehide', onViewHideStopPlayback);
+            }
+        }
+
+        function updatePlaybackRate(player) {
+            // Restore playback speed control, if it exists in the session.
+            const playbackRateSpeed = sessionStorage.getItem('playbackRateSpeed');
+            if (playbackRateSpeed !== null) {
+                player.setPlaybackRate(playbackRateSpeed);
             }
         }
 


### PR DESCRIPTION
**Changes**

Saves the playback speet rate on the browser session, and restore it when playing a new video. No need to the user to change it again.

**Issues**

Fixes #2406
