### PR TITLE
Decode blurhash in a WebWorker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3082,7 +3082,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
       "integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@webpack-cli/info": {
       "version": "1.4.0",
@@ -3097,7 +3098,8 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
       "integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@xmldom/xmldom": {
       "version": "0.7.5",
@@ -3142,13 +3144,15 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
       "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "aggregate-error": {
       "version": "3.1.0",
@@ -3205,7 +3209,8 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -4648,7 +4653,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-2.0.1.tgz",
       "integrity": "sha512-i8vLRZTnEH9ubIyfdZCAdIdgnHAUeQeByEeQ2I7oTilvP9oHO6RScpeq3GsFUVqeB8uZgOQ9pw8utofNn32hhQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "csso": {
       "version": "4.2.0",
@@ -5801,7 +5807,8 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
       "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-rule-composer": {
       "version": "0.3.0",
@@ -6025,7 +6032,8 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/expose-loader/-/expose-loader-3.1.0.tgz",
       "integrity": "sha512-2RExSo0yJiqP+xiUue13jQa2IHE8kLDzTI7b6kn+vUlBVvlzNSiLDzo4e5Pp5J039usvTUnxZ8sUOhv0Kg15NA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "express": {
       "version": "4.17.2",
@@ -7030,7 +7038,8 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "idb": {
       "version": "6.1.2",
@@ -7762,8 +7771,8 @@
       "integrity": "sha512-EkQfRXt9DhWwj6BnEA2TNpOf4jTnzSTUPGgE+iFxcdNqjktY8GitbDeHnx8qZA0/IukNyyBUR3oQKRdYkO+HFg=="
     },
     "libass-wasm": {
-      "version": "git+https://github.com/jellyfin/JavascriptSubtitlesOctopus.git#f4625ac313b318bd5d2e0ae18679ff516370bae6",
-      "from": "git+https://github.com/jellyfin/JavascriptSubtitlesOctopus.git#4.0.0-jf-4"
+      "version": "git+ssh://git@github.com/jellyfin/JavascriptSubtitlesOctopus.git#f4625ac313b318bd5d2e0ae18679ff516370bae6",
+      "from": "libass-wasm@git+https://github.com/jellyfin/JavascriptSubtitlesOctopus.git#4.0.0-jf-4"
     },
     "lie": {
       "version": "3.1.1",
@@ -9058,25 +9067,29 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.0.1.tgz",
       "integrity": "sha512-lgZBPTDvWrbAYY1v5GYEv8fEO/WhKOu/hmZqmCYfrpD6eyDWWzAOsl2rF29lpvziKO02Gc5GJQtlpkTmakwOWg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-duplicates": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.0.1.tgz",
       "integrity": "sha512-svx747PWHKOGpAXXQkCc4k/DsWo+6bc5LsVrAsw+OU+Ibi7klFZCyX54gjYzX4TH+f2uzXjRviLARxkMurA2bA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-empty": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.0.1.tgz",
       "integrity": "sha512-vfU8CxAQ6YpMxV2SvMcMIyF2LX1ZzWpy0lqHDsOdaKKLQVQGVP1pzhrI9JlsO65s66uQTfkQBKBD/A5gp9STFw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-overridden": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.0.1.tgz",
       "integrity": "sha512-Y28H7y93L2BpJhrdUR2SR2fnSsT+3TVx1NmVQLbcnZWwIUpJ7mfcTC6Za9M2PG6w8j7UQRfzxqn8jU2VwFxo3Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-double-position-gradients": {
       "version": "3.0.4",
@@ -9692,7 +9705,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
       "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -9748,7 +9762,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.0.1.tgz",
       "integrity": "sha512-6J40l6LNYnBdPSk+BHZ8SF+HAkS4q2twe5jnocgd+xWpz/mx/5Sa32m3W1AA8uE8XaXN+eg8trIlfu8V9x61eg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-normalize-display-values": {
       "version": "5.0.1",
@@ -10150,7 +10165,8 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.2.tgz",
       "integrity": "sha512-xfdkU128CkKKKVAwkyt0M8OdnelJ3MRcIRAPPQkRpoPeuzWY3RIeg7piRCpZ79MK7Q16diLXMMAD9dN5mauPlQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-selector-not": {
       "version": "5.0.0",
@@ -10225,7 +10241,8 @@
       "version": "0.36.2",
       "resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
       "integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-unique-selectors": {
       "version": "5.0.2",
@@ -11495,6 +11512,14 @@
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "string-width": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
@@ -11540,14 +11565,6 @@
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "requires": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "stringify-entities": {
@@ -11633,7 +11650,8 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
       "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "style-search": {
       "version": "0.1.0",
@@ -11845,7 +11863,8 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
           "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "postcss-selector-parser": {
           "version": "6.0.8",
@@ -13663,7 +13682,8 @@
           "version": "7.0.1",
           "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-7.0.1.tgz",
           "integrity": "sha512-iLBFYz6VRYyLJEJsBJ8M3TCqNcckVzz4wFounSc5Oez35ogE/X+aoC5fFu103Ot7NyvjU3/xqIXn93Gp3kJk4g==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -15338,15 +15358,6 @@
           "integrity": "sha512-Nu8X4R4Is3g8uzEJ6qwbW2CGVpzntW/cSf8OfsQGIKQR0nt84FAKzP2cLDaNLp3L/iV9TuhZgCTZzkMiap5/OQ==",
           "dev": true
         }
-      }
-    },
-    "worker-plugin": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/worker-plugin/-/worker-plugin-5.0.1.tgz",
-      "integrity": "sha512-Pn7+19jIiANcGuTSGdy+vrzyF+SGH03A5wV8iu4jRTMAOfAC9bNeiHo4+l5tPS7F0uvICMBv+h8UCvL7lunxcA==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "^1.1.0"
       }
     },
     "wrappy": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7771,7 +7771,7 @@
       "integrity": "sha512-EkQfRXt9DhWwj6BnEA2TNpOf4jTnzSTUPGgE+iFxcdNqjktY8GitbDeHnx8qZA0/IukNyyBUR3oQKRdYkO+HFg=="
     },
     "libass-wasm": {
-      "version": "git+ssh://git@github.com/jellyfin/JavascriptSubtitlesOctopus.git#f4625ac313b318bd5d2e0ae18679ff516370bae6",
+      "version": "git+https://github.com/jellyfin/JavascriptSubtitlesOctopus.git#f4625ac313b318bd5d2e0ae18679ff516370bae6",
       "from": "libass-wasm@git+https://github.com/jellyfin/JavascriptSubtitlesOctopus.git#4.0.0-jf-4"
     },
     "lie": {

--- a/package.json
+++ b/package.json
@@ -55,8 +55,7 @@
     "webpack-cli": "^4.9.1",
     "webpack-dev-server": "^4.7.2",
     "webpack-merge": "^5.8.0",
-    "workbox-webpack-plugin": "^6.2.4",
-    "worker-plugin": "^5.0.1"
+    "workbox-webpack-plugin": "^6.2.4"
   },
   "dependencies": {
     "@fontsource/noto-sans": "^4.5.1",

--- a/src/components/images/blurhash.worker.ts
+++ b/src/components/images/blurhash.worker.ts
@@ -1,0 +1,25 @@
+import { decode } from 'blurhash';
+import { expose } from 'comlink';
+
+/**
+ * Decodes blurhash outside the main thread, in a web worker
+ *
+ * @param {string} hash - Hash to decode.
+ * @param {number} width - Width of the decoded pixel array
+ * @param {number} height - Height of the decoded pixel array.
+ * @param {number} punch - Contrast of the decoded pixels
+ * @returns {Uint8ClampedArray} - Returns the decoded pixels in the proxied response by Comlink
+ */
+function getPixels({
+    hash,
+    width,
+    height
+}): Uint8ClampedArray {
+    try {
+        return decode(hash, width, height);
+    } catch {
+        throw new TypeError(`Blurhash ${hash} is not valid`);
+    }
+}
+
+expose(getPixels);

--- a/src/components/images/blurhash.worker.ts
+++ b/src/components/images/blurhash.worker.ts
@@ -1,25 +1,16 @@
+/* eslint-disable no-restricted-globals */
 import { decode } from 'blurhash';
-import { expose } from 'comlink';
 
-/**
- * Decodes blurhash outside the main thread, in a web worker
- *
- * @param {string} hash - Hash to decode.
- * @param {number} width - Width of the decoded pixel array
- * @param {number} height - Height of the decoded pixel array.
- * @param {number} punch - Contrast of the decoded pixels
- * @returns {Uint8ClampedArray} - Returns the decoded pixels in the proxied response by Comlink
- */
-function getPixels({
-    hash,
-    width,
-    height
-}): Uint8ClampedArray {
+self.onmessage = ({ data: { hash, width, height } }): void => {
     try {
-        return decode(hash, width, height);
+        self.postMessage({
+            pixels: decode(hash, width, height),
+            hsh: hash,
+            width: width,
+            height: height
+        });
     } catch {
         throw new TypeError(`Blurhash ${hash} is not valid`);
     }
-}
-
-expose(getPixels);
+};
+/* eslint-enable no-restricted-globals */

--- a/src/components/images/imageLoader.js
+++ b/src/components/images/imageLoader.js
@@ -48,7 +48,7 @@ worker.addEventListener(
 
     function itemBlurhashing(target, hash) {
         try {
-            // Although the default values recommended by Blurhash developers is 32x32, a size of 18x18 seems to be the sweet spot for us,
+            // Although the default values recommended by Blurhash developers is 32x32, a size of 20x20 seems to be the sweet spot for us,
             // improving the performance and reducing the memory usage, while retaining almost full blur quality.
             // Lower values had more visible pixelation
             const width = 20;

--- a/src/components/images/imageLoader.js
+++ b/src/components/images/imageLoader.js
@@ -23,8 +23,8 @@ import './style.scss';
             // Although the default values recommended by Blurhash developers is 32x32, a size of 18x18 seems to be the sweet spot for us,
             // improving the performance and reducing the memory usage, while retaining almost full blur quality.
             // Lower values had more visible pixelation
-            const width = 32;
-            const height = 32;
+            const width = 20;
+            const height = 20;
             const pixels = await getPixels({
                 hash,
                 width,

--- a/src/components/images/imageLoader.js
+++ b/src/components/images/imageLoader.js
@@ -54,7 +54,8 @@ worker.addEventListener(
             // Lower values had more visible pixelation
             const width = 20;
             const height = 20;
-            targetDic[hash] = target;
+            targetDic[hash] = (targetDic[hash] || []).filter(item => item !== target);
+            targetDic[hash].push(target);
 
             worker.postMessage({
                 hash,

--- a/src/components/images/imageLoader.js
+++ b/src/components/images/imageLoader.js
@@ -106,11 +106,23 @@ import './style.scss';
                     elem.classList.add('lazy-image-fadein');
                 }
 
-                const canvas = elem.previousSibling;
-                if (elem.classList.contains('blurhashed') && canvas && canvas.tagName === 'CANVAS') {
-                    canvas.classList.remove('lazy-image-fadein-fast', 'lazy-image-fadein');
-                    canvas.classList.add('lazy-hidden');
-                }
+                elem.addEventListener('transitionend', () => {
+                    requestIdleCallback(() => {
+                        const canvas = elem.previousSibling;
+                        if (
+                            elem.classList.contains('blurhashed') &&
+                            canvas &&
+                            canvas.tagName === 'CANVAS'
+                        ) {
+                            canvas.classList.remove(
+                                'lazy-image-fadein-fast',
+                                'lazy-image-fadein'
+                            );
+                            canvas.classList.add('lazy-hidden');
+                        }
+                    });
+                    // Run the event listener only once after being added
+                }, false);
             });
         });
     }

--- a/src/components/images/style.scss
+++ b/src/components/images/style.scss
@@ -1,17 +1,3 @@
-.lazy-image-fadein {
-    opacity: 1;
-    transition: opacity 0.5s;
-}
-
-.lazy-image-fadein-fast {
-    opacity: 1;
-    transition: opacity 0.1s;
-}
-
-.lazy-hidden {
-    opacity: 0;
-}
-
 @keyframes fadein {
     from {
         opacity: 0;
@@ -22,12 +8,18 @@
     }
 }
 
-.lazy-blurhash-fadein-fast {
+.lazy-image-fadein {
+    opacity: 1;
+    animation: fadein 0.5s;
+}
+
+.lazy-image-fadein-fast {
+    opacity: 1;
     animation: fadein 0.1s;
 }
 
-.lazy-blurhash-fadein {
-    animation: fadein 0.4s;
+.lazy-hidden {
+    opacity: 0;
 }
 
 .blurhash-canvas {

--- a/src/components/lazyLoader/lazyLoaderIntersectionObserver.js
+++ b/src/components/lazyLoader/lazyLoaderIntersectionObserver.js
@@ -13,7 +13,10 @@
                         callback(entry);
                     });
                 },
-                {rootMargin: '25%'});
+                {
+                    rootMargin: '50%',
+                    threshold: 0
+                });
 
             this.observer = observer;
         }


### PR DESCRIPTION
"Backported" some good stuff from Vue that I attempted here but was not possible before ES6 :)

* Decode blurhash in a web worker. 
* Increased the resolution of the sample by 2x2, which is even a sweeter spot than 18x18 (as we have "extra" capabilities now without blocking the main thread).
* Wait for transitions to end before switching image and blurhash: https://github.com/jellyfin/jellyfin-web/pull/1823 was a necessary fix, but it added some flashing while switching. Was partly fixed by https://github.com/jellyfin/jellyfin-web/pull/2309 but still some flashing appearing while scrolling fast. I was not happy with the result either, so I took the chance of this PR to do another revisit, so now everything is correctly timed and looks like the original implementation :)
