### PR TITLE
Fix plugin image URL

### DIFF
--- a/src/controllers/dashboard/plugins/installed/index.js
+++ b/src/controllers/dashboard/plugins/installed/index.js
@@ -70,7 +70,8 @@ function getPluginCardHtml(plugin, pluginConfigurationPages) {
     }
 
     if (plugin.HasImage) {
-        html += `<img src="/Plugins/${plugin.Id}/${plugin.Version}/Image" style="width:100%" />`;
+        const imageUrl = ApiClient.getUrl(`/Plugins/${plugin.Id}/${plugin.Version}/Image`);
+        html += `<img src="${imageUrl}" style="width:100%" />`;
     } else {
         html += `<div class="cardImage flex align-items-center justify-content-center ${cardBuilder.getDefaultBackgroundClass()}">`;
         html += '<span class="cardImageIcon material-icons extension"></span>';


### PR DESCRIPTION
**Changes**
Use `ApiClient.getUrl` to generate the correct URL for the plugin image.

**Issues**
Fixes #3145

Theoretically, this is backportable to 10.7 (cherry-pick works).