### PR TITLE
Fix re-emptying image

### DIFF
--- a/src/components/images/imageLoader.js
+++ b/src/components/images/imageLoader.js
@@ -109,6 +109,9 @@ import './style.scss';
     }
 
     function emptyImageElement(elem) {
+        // block repeated call - requestAnimationFrame twice for one image
+        if (elem.getAttribute('data-src')) return;
+
         let url;
 
         if (elem.tagName !== 'IMG') {


### PR DESCRIPTION
`emptyImageElement` is called twice.
The first call moves `background` to `data-src`.
The second call empties `data-src`.
https://github.com/jellyfin/jellyfin-web/blob/832a2041302681061c3d28c1cb9687020527d97b/src/components/images/imageLoader.js#L111
This can happen because of repeated animation frame request for the same element.
https://github.com/jellyfin/jellyfin-web/blob/832a2041302681061c3d28c1cb9687020527d97b/src/components/images/imageLoader.js#L70-L72

**Changes**
Fix re-emptying image

**Issues**
Fixes #3140

Alternatively, we could collect the affected elements into an array and request the animation frame once.
https://github.com/dmitrylyzo/jellyfin-web/tree/fix-genre-image-2