### PR TITLE
Rollback hls.js to 0.14

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,6 +5,9 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: hls.js
+        update-types: [ version-update:semver-major ]
 
   - package-ecosystem: github-actions
     directory: /

--- a/package-lock.json
+++ b/package-lock.json
@@ -6073,8 +6073,7 @@
     "eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "dev": true
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
     "events": {
       "version": "3.3.0",
@@ -6894,9 +6893,13 @@
       "integrity": "sha512-iXnAafUm3FdzfJ91uixLws2hkKI1jC8bAKK/pt7XYr8Ie1jO7xbK48Ycpl9tUPyBgkzuj1p/PhJS0fy4E/5anA=="
     },
     "hls.js": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.0.12.tgz",
-      "integrity": "sha512-YnyujGMZAofraBzl5PjPI6kw7HMt/Dhpnr+PrTtmoIApKUPFmeKWqvdIGhdmxQcrSHoCHDEqSX79m+Zpu924Kg=="
+      "version": "0.14.7",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-0.14.7.tgz",
+      "integrity": "sha512-9JY0D9nwMrfQPRWc8/kEJTKK0TYfDTzIs6Xq+gdCvasRxdvQKQ2T76rdueTkS0AsFV6sQlJN0wxbnI44aRvvUA==",
+      "requires": {
+        "eventemitter3": "^4.0.3",
+        "url-toolkit": "^2.1.6"
+      }
     },
     "hosted-git-info": {
       "version": "2.8.9",
@@ -15680,6 +15683,11 @@
           "dev": true
         }
       }
+    },
+    "url-toolkit": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/url-toolkit/-/url-toolkit-2.2.3.tgz",
+      "integrity": "sha512-Da75SQoxsZ+2wXS56CZBrj2nukQ4nlGUZUP/dqUBG5E1su5GKThgT94Q00x81eVII7AyS1Pn+CtTTZ4Z0pLUtQ=="
     },
     "use": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "fast-text-encoding": "^1.0.3",
     "flv.js": "^1.6.2",
     "headroom.js": "^0.12.0",
-    "hls.js": "^1.0.12",
+    "hls.js": "^0.14.7",
     "intersection-observer": "^0.12.0",
     "jellyfin-apiclient": "^1.9.1",
     "jquery": "^3.5.1",


### PR DESCRIPTION
**Changes**
This rollsback hls.js to 0.14 and prevents dependabot from opening PRs for major version upgrades due to this upstream issue: https://github.com/video-dev/hls.js/issues/4367

**Issues**
Fixes #3158 
