### PR TITLE
Remove chown -R root:root from specfile

### DIFF
--- a/fedora/jellyfin-web.spec
+++ b/fedora/jellyfin-web.spec
@@ -27,7 +27,6 @@ Jellyfin is a free software media system that puts you in control of managing an
 %build
 
 %install
-chown root:root -R .
 npm ci --no-audit --unsafe-perm
 %{__mkdir} -p %{buildroot}%{_datadir}
 mv dist %{buildroot}%{_datadir}/jellyfin-web


### PR DESCRIPTION
**Changes**
`%install` is run as non-root and as such, chown root is not allowed to be done it.

The correct way of achieving a setting of ownership in RPM specfiles is to do it
in the `%files` section(s) (as it is already done).

Signed-off-by: Brian J. Murrell <brian@interlinx.bc.ca>