### PR TITLE
Disable any type warnings

### DIFF
--- a/src/components/dashboard/users/UserCardBox.tsx
+++ b/src/components/dashboard/users/UserCardBox.tsx
@@ -25,7 +25,7 @@ const createButtonElement = () => ({
 });
 
 type IProps = {
-    user?: Record<string, any>;
+    user?: Record<string, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 const getLastSeenText = (lastActivityDate) => {

--- a/src/components/search/LiveTVSearchResults.tsx
+++ b/src/components/search/LiveTVSearchResults.tsx
@@ -73,7 +73,7 @@ const LiveTVSearchResults: FunctionComponent<LiveTVSearchResultsProps> = ({ serv
 
         if (query && collectionType === 'livetv') {
             // TODO: Remove type casting once we're using a properly typed API client
-            const apiClient = (ServerConnections as any).getApiClient(serverId);
+            const apiClient = (ServerConnections as any).getApiClient(serverId); // eslint-disable-line @typescript-eslint/no-explicit-any
 
             // Movies row
             fetchItems(apiClient, {

--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -100,7 +100,7 @@ const SearchResults: FunctionComponent<SearchResultsProps> = ({ serverId, parent
 
         if (query) {
             // TODO: Remove type casting once we're using a properly typed API client
-            const apiClient = (ServerConnections as any).getApiClient(serverId);
+            const apiClient = (ServerConnections as any).getApiClient(serverId); // eslint-disable-line @typescript-eslint/no-explicit-any
 
             // Movie libraries
             if (!collectionType || isMovies()) {

--- a/src/components/search/SearchResultsRow.tsx
+++ b/src/components/search/SearchResultsRow.tsx
@@ -17,8 +17,9 @@ const createScroller = ({ title = '' }) => ({
 
 type SearchResultsRowProps = {
     title?: string;
-    items?: Array<any>; // TODO: Should be Array<BaseItemDto> once we have a typed API client
-    cardOptions?: Record<string, any>;
+    // TODO: Should be Array<BaseItemDto> once we have a typed API client
+    items?: Array<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+    cardOptions?: Record<string, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 const SearchResultsRow: FunctionComponent<SearchResultsRowProps> = ({ title, items = [], cardOptions = {} }: SearchResultsRowProps) => {

--- a/src/components/search/SearchSuggestions.tsx
+++ b/src/components/search/SearchSuggestions.tsx
@@ -28,7 +28,7 @@ const SearchSuggestions: FunctionComponent<SearchSuggestionsProps> = ({ serverId
 
     useEffect(() => {
         // TODO: Remove type casting once we're using a properly typed API client
-        const apiClient = (ServerConnections as any).getApiClient(serverId);
+        const apiClient = (ServerConnections as any).getApiClient(serverId); // eslint-disable-line @typescript-eslint/no-explicit-any
 
         apiClient.getItems(apiClient.getCurrentUserId(), {
             SortBy: 'IsFavoriteOrLiked,Random',

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,5 +1,5 @@
 export declare global {
     interface Window {
-        ApiClient: any;
+        ApiClient: any; // eslint-disable-line @typescript-eslint/no-explicit-any
     }
 }


### PR DESCRIPTION
**Changes**
Disables warnings for using the `any` type in places where types are currently unavailable (api objects).

**Issues**
N/A
