### PR TITLE
Sort genres by SortName instead of Random

### DIFF
--- a/src/controllers/movies/moviegenres.js
+++ b/src/controllers/movies/moviegenres.js
@@ -17,7 +17,7 @@ import '../../elements/emby-button/emby-button';
             if (!pageData) {
                 pageData = data[key] = {
                     query: {
-                        SortBy: 'Random',
+                        SortBy: 'SortName',
                         SortOrder: 'Ascending',
                         IncludeItemTypes: 'Movie',
                         Recursive: true,

--- a/src/controllers/shows/tvgenres.js
+++ b/src/controllers/shows/tvgenres.js
@@ -17,7 +17,7 @@ import '../../elements/emby-button/emby-button';
             if (!pageData) {
                 pageData = data[key] = {
                     query: {
-                        SortBy: 'Random',
+                        SortBy: 'SortName',
                         SortOrder: 'Ascending',
                         IncludeItemTypes: 'Series',
                         Recursive: true,


### PR DESCRIPTION
Sort of fixes https://github.com/jellyfin/jellyfin/issues/6892

Might only work for new users because libraryBrowser.loadSavedQueryValues overrides the SortBy with the old Random stored on the server
