### PR TITLE
Handle command 'Back'

### DIFF
--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -399,6 +399,15 @@ import { appRouter } from '../../../components/appRouter';
 
                 case 'togglestats':
                     toggleStats();
+                    break;
+
+                case 'back':
+                    // Ignore command when some dialog is opened
+                    if (currentVisibleMenu === 'osd' && !getOpenedDialog()) {
+                        hideOsd();
+                        e.preventDefault();
+                    }
+                    break;
             }
         }
 


### PR DESCRIPTION
**Changes**
Add handling of command 'Back'.

**Issues**
User can't hide the OSD using Remote control (Play On).
https://github.com/jellyfin/jellyfin-web/issues/1865#issuecomment-986249748

<img src="https://user-images.githubusercontent.com/56478732/144754583-c4cbc020-46ff-46ed-9e56-7f583ab8e116.png" width="33%">
