### PR TITLE
Automatically bump stable versions in build

### DIFF
--- a/.ci/azure-pipelines-package.yml
+++ b/.ci/azure-pipelines-package.yml
@@ -17,6 +17,14 @@ jobs:
     vmImage: 'ubuntu-latest'
 
   steps:
+  - script: echo "##vso[task.setvariable variable=JellyfinVersion]$( awk -F '/' '{ print $NF }' <<<'$(Build.SourceBranch)' | sed 's/^v//' )"
+    displayName: Set release version (stable)
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/v')
+
+  - script: './bump-version $(JellyfinVersion)'
+    displayName: Bump internal version (stable)
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/v')
+
   - script: 'docker build -f deployment/Dockerfile.$(BuildConfiguration) -t jellyfin-web-$(BuildConfiguration) deployment'
     displayName: 'Build Dockerfile'
     condition: or(startsWith(variables['Build.SourceBranch'], 'refs/tags'), startsWith(variables['Build.SourceBranch'], 'refs/heads/master'))
@@ -66,7 +74,11 @@ jobs:
   steps:
   - script: echo "##vso[task.setvariable variable=JellyfinVersion]$( awk -F '/' '{ print $NF }' <<<'$(Build.SourceBranch)' | sed 's/^v//' )"
     displayName: Set release version (stable)
-    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')  
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/v')
+
+  - script: './bump-version $(JellyfinVersion)'
+    displayName: Bump internal version (stable)
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/v')
 
   - task: Docker@2
     displayName: 'Push Unstable Image'

--- a/bump_version
+++ b/bump_version
@@ -32,19 +32,21 @@ npm --no-git-tag-version --allow-same-version version v${new_version_sed}
 
 # Set the build.yaml version to the specified new_version
 old_version_sed="$( sed 's/\./\\./g' <<<"${old_version}" )" # Escape the '.' chars
-sed -i "s/${old_version_sed}/${new_version}/g" ${build_file}
+sed -i "s/${old_version_sed}/${new_version_sed}/g" ${build_file}
 
 if [[ ${new_version} == *"-"* ]]; then
-    new_version_deb="$( sed 's/-/~/g' <<<"${new_version}" )"
+    new_version_pkg="$( sed 's/-/~/g' <<<"${new_version}" )"
+    new_version_deb_sup=""
 else
-    new_version_deb="${new_version}-1"
+    new_version_pkg="${new_version}"
+    new_version_deb_sup="-1"
 fi
 
 # Write out a temporary Debian changelog with our new stuff appended and some templated formatting
 debian_changelog_file="debian/changelog"
 debian_changelog_temp="$( mktemp )"
 # Create new temp file with our changelog
-echo -e "jellyfin-web (${new_version_deb}) unstable; urgency=medium
+echo -e "jellyfin-web (${new_version_pkg}${new_version_deb_sup}) unstable; urgency=medium
 
   * New upstream version ${new_version}; release changelog at https://github.com/jellyfin/jellyfin-web/releases/tag/v${new_version}
 
@@ -66,7 +68,7 @@ pushd ${fedora_spec_temp_dir}
 csplit jellyfin-web.spec  "/^%changelog/" # produces xx00 xx01
 # Update the version in xx00
 new_version_sed="$( sed 's/\./\\./g' <<<"${new_version}" )" # Escape the '.' chars
-sed -i "s/${old_version_sed}/${new_version_sed}/g" xx00
+sed -i "s/${old_version_sed}/${new_version_pkg}/g" xx00
 # Remove the header from xx01
 sed -i '/^%changelog/d' xx01
 # Create new temp file with our changelog
@@ -83,5 +85,5 @@ mv ${fedora_spec_temp} ${fedora_spec_file}
 rm -rf ${fedora_changelog_temp} ${fedora_spec_temp_dir}
 
 # Stage the changed files for commit
-git add ${build_file} ${debian_changelog_file} ${fedora_spec_file} ${package_file}
-git status
+git add .
+git status -v


### PR DESCRIPTION
Should prevent strangeness with building these for pre-releases or actual release versions (if the script wasn't manually run before). Whatever the Git tag is, becomes the package version. Could be expanded to avoid needing to manually bump_version at all ever if we put in placeholders, though this might break other builds. Would need careful evaluation before expanding that.

With a properly bumped stable release this shouldn't change anything, but for pre-releases it will change the version automatically.

Avoids needing to do jellyfin/jellyfin#6853 manually (for both Debian and Fedora/CentOS packages).

Basically, adds a run of bump_version to the build CI, taking the Git tag as the version to bump to.

Same changes as jellyfin/jellyfin#6974