### PR TITLE
Fix #369 : Episode Details Premiere date

### DIFF
--- a/src/components/mediainfo/mediainfo.js
+++ b/src/components/mediainfo/mediainfo.js
@@ -131,7 +131,8 @@ import '../../elements/emby-button/emby-button';
         if ((item.Type === 'Episode' || item.MediaType === 'Photo') && options.originalAirDate !== false) {
             if (item.PremiereDate) {
                 try {
-                    date = datetime.parseISO8601Date(item.PremiereDate);
+                    //don't modify date to locale if episode. Only Dates (not times) are stored, or editable in the edit metadata dialog
+                    date = datetime.parseISO8601Date(item.PremiereDate, item.Type !== 'Episode');
 
                     text = datetime.toLocaleDateString(date);
                     miscInfo.push(text);


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
Don't translate date to locale (timezone shift). Only date (and not time) is displayed or editable in edit metadata dialog. In UTC-X timezones, this would result in date displayed being before date in edit metadata dialog. Data presented in episode details page is now consistent with data presented in edit metadata dialog for the same episode. 

**Issues**
Fixes #369

**Dailyshow 27x42 example Episode Metadata**
![image](https://user-images.githubusercontent.com/991618/146657490-a0fab940-64c6-44e6-bbbd-7d0921ea8ae9.png)

**Before**
![image](https://user-images.githubusercontent.com/991618/146657531-4c3d50c4-7481-4734-bec7-bb67c0620711.png)

**After**
![image](https://user-images.githubusercontent.com/991618/146657569-3c300f40-6753-4f60-8c28-34462d949b27.png)