### PR TITLE
fix: Oculus browser is no longer marked as TV

### DIFF
--- a/src/scripts/browser.js
+++ b/src/scripts/browser.js
@@ -2,6 +2,11 @@ function isTv() {
     // This is going to be really difficult to get right
     const userAgent = navigator.userAgent.toLowerCase();
 
+    // The OculusBrowsers userAgent also has the samsungbrowser defined but is not a tv.
+    if (userAgent.indexOf('oculusbrowser') !== -1) {
+        return false;
+    }
+
     if (userAgent.indexOf('tv') !== -1) {
         return true;
     }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Changed the browser feature detection to correctly identify the oculus browser. Now all features are working and the oculus browsers built in VR support is also working for 3D videos.
