### PR TITLE
Remove network device option from add library dialog

### DIFF
--- a/src/components/directorybrowser/directorybrowser.js
+++ b/src/components/directorybrowser/directorybrowser.js
@@ -32,15 +32,11 @@ function refreshDirectoryBrowser(page, path, fileOptions, updatePathOnError) {
 
     const promises = [];
 
-    if (path === 'Network') {
-        promises.push(ApiClient.getNetworkDevices());
+    if (path) {
+        promises.push(ApiClient.getDirectoryContents(path, fileOptions));
+        promises.push(ApiClient.getParentPath(path));
     } else {
-        if (path) {
-            promises.push(ApiClient.getDirectoryContents(path, fileOptions));
-            promises.push(ApiClient.getParentPath(path));
-        } else {
-            promises.push(ApiClient.getDrives());
-        }
+        promises.push(ApiClient.getDrives());
     }
 
     Promise.all(promises).then(
@@ -59,10 +55,6 @@ function refreshDirectoryBrowser(page, path, fileOptions, updatePathOnError) {
                 const folder = folders[i];
                 const cssClass = folder.Type === 'File' ? 'lnkPath lnkFile' : 'lnkPath lnkDirectory';
                 html += getItem(cssClass, folder.Type, folder.Path, folder.Name);
-            }
-
-            if (!path) {
-                html += getItem('lnkPath lnkDirectory', '', 'Network', globalize.translate('ButtonNetwork'));
             }
 
             page.querySelector('.results').innerHTML = html;

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -85,7 +85,6 @@
     "ButtonLibraryAccess": "Library access",
     "ButtonManualLogin": "Manual Login",
     "ButtonMore": "More",
-    "ButtonNetwork": "Network",
     "ButtonNextTrack": "Next track",
     "ButtonOk": "Ok",
     "ButtonOpen": "Open",


### PR DESCRIPTION
**Changes**
Removes the "Network" option from the Folder list in the add library dialog since it is no longer supported

**Issues**
N/A
