### PR TITLE
Bump jellyfin-apiclient to v1.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7809,9 +7809,9 @@
       "dev": true
     },
     "jellyfin-apiclient": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/jellyfin-apiclient/-/jellyfin-apiclient-1.9.1.tgz",
-      "integrity": "sha512-YRlfvtZNJwkYjQzbnR3CGa3TlgrrZNvqqenN234LJTvj4m68vMRleshqCFF3yfivB4+cCclUfiz69FEJBrIidA=="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/jellyfin-apiclient/-/jellyfin-apiclient-1.10.0.tgz",
+      "integrity": "sha512-Y7Py/xuAznOhSuADihalrw4et3uTaDLbaClAoYzPMPQaPEjdP8dIST1kFEskOU30Iw28pi+S0byTEHDbQglIvQ=="
     },
     "jest-worker": {
       "version": "26.6.2",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "headroom.js": "^0.12.0",
     "hls.js": "^0.14.17",
     "intersection-observer": "^0.12.0",
-    "jellyfin-apiclient": "^1.9.1",
+    "jellyfin-apiclient": "^1.10.0",
     "jquery": "^3.5.1",
     "jstree": "^3.3.12",
     "libarchive.js": "^1.3.0",


### PR DESCRIPTION
**Changes**
Updates to the latest version of the apiclient

**Issues**
N/A
