### PR TITLE
Fix wizard not being translated to selected language

### DIFF
--- a/src/components/appRouter.js
+++ b/src/components/appRouter.js
@@ -3,7 +3,7 @@ import appSettings from '../scripts/settings/appSettings';
 import backdrop from './backdrop/backdrop';
 import browser from '../scripts/browser';
 import { Events } from 'jellyfin-apiclient';
-import globalize from '../scripts/globalize';
+import globalize, { setServerCulture, updateCurrentCulture } from '../scripts/globalize';
 import itemHelper from './itemHelper';
 import loading from './loading/loading';
 import page from 'page';
@@ -550,7 +550,14 @@ class AppRouter {
                 }).then(data => {
                     if (data !== null && data.StartupWizardCompleted === false) {
                         ServerConnections.setLocalApiClient(firstResult.ApiClient);
-                        Dashboard.navigate('wizardstart.html');
+                        firstResult.ApiClient.getJSON(firstResult.ApiClient.getUrl('Startup/Configuration'))
+                            .then(config => {
+                                // Update the default server language
+                                setServerCulture(config.UICulture);
+                                updateCurrentCulture();
+                                // Start the wizard
+                                Dashboard.navigate('wizardstart.html');
+                            });
                     } else {
                         this.handleConnectionResult(firstResult);
                     }

--- a/src/controllers/wizard/start/index.js
+++ b/src/controllers/wizard/start/index.js
@@ -3,6 +3,7 @@ import loading from '../../../components/loading/loading';
 import '../../../elements/emby-button/emby-button';
 import '../../../elements/emby-select/emby-select';
 import Dashboard from '../../../scripts/clientUtils';
+import { setServerCulture, updateCurrentCulture } from '../../../scripts/globalize';
 
 function loadPage(page, config, languageOptions) {
     $('#selectLocalizationLanguage', page).html(languageOptions.map(function (l) {
@@ -16,6 +17,10 @@ function save(page) {
     const apiClient = ApiClient;
     apiClient.getJSON(apiClient.getUrl('Startup/Configuration')).then(function (config) {
         config.UICulture = $('#selectLocalizationLanguage', page).val();
+        // Update the current UI language
+        setServerCulture(config.UICulture);
+        updateCurrentCulture();
+        // Save the configuration
         apiClient.ajax({
             type: 'POST',
             data: JSON.stringify(config),

--- a/src/scripts/globalize.js
+++ b/src/scripts/globalize.js
@@ -9,6 +9,7 @@ import * as userSettings from './settings/userSettings';
 
     const allTranslations = {};
     let currentCulture;
+    let serverCulture;
     let currentDateTimeCulture;
 
     export function getCurrentLocale() {
@@ -38,6 +39,10 @@ import * as userSettings from './settings/userSettings';
         return fallbackCulture;
     }
 
+    export function setServerCulture(culture) {
+        serverCulture = culture;
+    }
+
     export function updateCurrentCulture() {
         let culture;
         try {
@@ -45,7 +50,7 @@ import * as userSettings from './settings/userSettings';
         } catch (err) {
             console.error('no language set in user settings');
         }
-        culture = culture || getDefaultLanguage();
+        culture = culture || serverCulture || getDefaultLanguage();
 
         currentCulture = normalizeLocaleName(culture);
 
@@ -249,6 +254,8 @@ import * as userSettings from './settings/userSettings';
         }
     });
 
+/* eslint-enable indent */
+
 export default {
     translate,
     translateHtml,
@@ -259,5 +266,3 @@ export default {
     register,
     updateCurrentCulture
 };
-
-/* eslint-enable indent */


### PR DESCRIPTION
**Changes**
Fixes the wizard not being translated to the language selected by the user.

We have a number of sources for selecting the display language:

- User Language
  - Display language in user settings
- UI Language (server configuration)
  - First screen of the wizard
- Browser Language
- Fallback Language (en-us)

I'm not sure which should take precedence between the UI language and browser language. This change only uses the UI Language for the startup wizard, but we may want to consider using it in all cases.

**Issues**
N/A
