### PR TITLE
Avoid requesting mjpeg attachements during ass subtitle playback

### DIFF
--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1048,12 +1048,16 @@ function tryRemoveElement(elem) {
          * @private
          */
         renderSsaAss(videoElement, track, item) {
+            const supportedFonts = ['application/x-truetype-font', 'font/otf', 'font/ttf', 'font/woff', 'font/woff2'];
             const avaliableFonts = [];
             const attachments = this._currentPlayOptions.mediaSource.MediaAttachments || [];
             const apiClient = ServerConnections.getApiClient(item);
-            attachments.map(function (i) {
-                // embedded font url
-                return avaliableFonts.push(apiClient.getUrl(i.DeliveryUrl));
+            attachments.forEach(i => {
+                // we only require font files and ignore embedded media attachments like covers as there are cases where ffmpeg fails to extract those
+                if (supportedFonts.includes(i.MimeType)) {
+                    // embedded font url
+                    avaliableFonts.push(apiClient.getUrl(i.DeliveryUrl));
+                }
             });
             const fallbackFontList = apiClient.getUrl('/FallbackFont/Fonts', {
                 api_key: apiClient.accessToken()


### PR DESCRIPTION
When attempting to play an mkv file with embeded ass subtitles and a jpeg cover the video playback stops after a few seconds with "Playback Error".

There a few locations that might need to handle this issue to improve the user experience even if this might just be a content issue:
1. the html video player should probably not request the mjpeg cover as it is interested in the font files (kind of addressed by this PR by introducing a simple filter)
2. maybe have [VideoAttachmentsController](https://github.com/jellyfin/jellyfin/blob/ce61dff4aae0875cfc359c9d8dc1a8a15f9409cd/Jellyfin.Api/Controllers/VideoAttachmentsController.cs#L76)  catch the InvalidOperationException thrown by the [AttachmentExtractor](https://github.com/jellyfin/jellyfin/blob/ce61dff4aae0875cfc359c9d8dc1a8a15f9409cd/MediaBrowser.MediaEncoding/Attachments/AttachmentExtractor.cs#L229) and report a cleared error and message
3. have the html video player gracefully handle the HTTP 500 error reported as the playback can probably continue even if an attachment is missing (this might be more confusing for the end user if the subtitles break without reporting anything)

```
ffprobe version 4.4-full_build-www.gyan.dev Copyright (c) 2007-2021 the FFmpeg developers
  built with gcc 10.2.0 (Rev6, Built by MSYS2 project)
  configuration: --enable-gpl --enable-version3 --enable-static --disable-w32threads --disable-autodetect --enable-fontconfig --enable-iconv --enable-gnutls --enable-libxml2 --enable-gmp --enable-lzma --enable-libsnappy --enable-zlib --enable-librist --enable-libsrt --enable-libssh --enable-libzmq --enable-avisynth --enable-libbluray --enable-libcaca --enable-sdl2 --enable-libdav1d --enable-libzvbi --enable-librav1e --enable-libsvtav1 --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxvid --enable-libaom --enable-libopenjpeg --enable-libvpx --enable-libass --enable-frei0r --enable-libfreetype --enable-libfribidi --enable-libvidstab --enable-libvmaf --enable-libzimg --enable-amf --enable-cuda-llvm --enable-cuvid --enable-ffnvcodec --enable-nvdec --enable-nvenc --enable-d3d11va --enable-dxva2 --enable-libmfx --enable-libglslang --enable-vulkan --enable-opencl --enable-libcdio --enable-libgme --enable-libmodplug --enable-libopenmpt --enable-libopencore-amrwb --enable-libmp3lame --enable-libshine --enable-libtheora --enable-libtwolame --enable-libvo-amrwbenc --enable-libilbc --enable-libgsm --enable-libopencore-amrnb --enable-libopus --enable-libspeex --enable-libvorbis --enable-ladspa --enable-libbs2b --enable-libflite --enable-libmysofa --enable-librubberband --enable-libsoxr --enable-chromaprint
  libavutil      56. 70.100 / 56. 70.100
  libavcodec     58.134.100 / 58.134.100
  libavformat    58. 76.100 / 58. 76.100
  libavdevice    58. 13.100 / 58. 13.100
  libavfilter     7.110.100 /  7.110.100
  libswscale      5.  9.100 /  5.  9.100
  libswresample   3.  9.100 /  3.  9.100
  libpostproc    55.  9.100 / 55.  9.100
[matroska,webm @ 000001a0cacaacc0] Could not find codec parameters for stream 3 (Attachment: none): unknown codec
Consider increasing the value for the 'analyzeduration' (0) and 'probesize' (5000000) options
[matroska,webm @ 000001a0cacaacc0] Could not find codec parameters for stream 4 (Attachment: none): unknown codec
Consider increasing the value for the 'analyzeduration' (0) and 'probesize' (5000000) options
[matroska,webm @ 000001a0cacaacc0] Could not find codec parameters for stream 5 (Attachment: none): unknown codec
Consider increasing the value for the 'analyzeduration' (0) and 'probesize' (5000000) options
[matroska,webm @ 000001a0cacaacc0] Could not find codec parameters for stream 6 (Attachment: none): unknown codec
Consider increasing the value for the 'analyzeduration' (0) and 'probesize' (5000000) options
[matroska,webm @ 000001a0cacaacc0] Could not find codec parameters for stream 7 (Attachment: none): unknown codec
Consider increasing the value for the 'analyzeduration' (0) and 'probesize' (5000000) options
[matroska,webm @ 000001a0cacaacc0] Could not find codec parameters for stream 8 (Attachment: none): unknown codec
Consider increasing the value for the 'analyzeduration' (0) and 'probesize' (5000000) options
[matroska,webm @ 000001a0cacaacc0] Could not find codec parameters for stream 9 (Attachment: none): unknown codec
Consider increasing the value for the 'analyzeduration' (0) and 'probesize' (5000000) options
[matroska,webm @ 000001a0cacaacc0] Could not find codec parameters for stream 10 (Attachment: none): unknown codec
Consider increasing the value for the 'analyzeduration' (0) and 'probesize' (5000000) options
[matroska,webm @ 000001a0cacaacc0] Could not find codec parameters for stream 11 (Attachment: none): unknown codec
Consider increasing the value for the 'analyzeduration' (0) and 'probesize' (5000000) options
[matroska,webm @ 000001a0cacaacc0] Could not find codec parameters for stream 12 (Attachment: none): unknown codec
Consider increasing the value for the 'analyzeduration' (0) and 'probesize' (5000000) options
[matroska,webm @ 000001a0cacaacc0] Could not find codec parameters for stream 13 (Attachment: none): unknown codec
Consider increasing the value for the 'analyzeduration' (0) and 'probesize' (5000000) options
Input #0, matroska,webm, from 'video.mkv':
  Metadata:
    title           : video
    encoder         : libebml v1.4.2 + libmatroska v1.6.4
    creation_time   : 2021-12-17T18:25:01.000000Z
  Duration: 00:23:52.10, start: 0.000000, bitrate: 1968 kb/s
  Chapters:
    Chapter #0:0: start 0.000000, end 30.000000
      Metadata:
        title           : Intro
    Chapter #0:1: start 30.000000, end 120.000000
      Metadata:
        title           : OP
    Chapter #0:2: start 120.000000, end 706.000000
      Metadata:
        title           : Part A
    Chapter #0:3: start 706.000000, end 1341.000000
      Metadata:
        title           : Part B
    Chapter #0:4: start 1341.000000, end 1432.096000
      Metadata:
        title           : ED
  Stream #0:0: Video: hevc (Main 10), yuv420p10le(tv, bt709), 1920x1080, SAR 1:1 DAR 16:9, 23.81 fps, 23.81 tbr, 1k tbn, 23.98 tbc (default)
    Metadata:
      title           : SOME TITLE
      BPS             : 1758749
      DURATION        : 00:23:52.056000000
      NUMBER_OF_FRAMES: 34335
      NUMBER_OF_BYTES : 314828391
      _STATISTICS_WRITING_APP: mkvmerge v63.0.0 ('Everything') 64-bit
      _STATISTICS_WRITING_DATE_UTC: 2021-12-17 18:25:01
      _STATISTICS_TAGS: BPS DURATION NUMBER_OF_FRAMES NUMBER_OF_BYTES
  Stream #0:1(jpn): Audio: eac3, 48000 Hz, stereo, fltp, 128 kb/s (default)
    Metadata:
      BPS             : 128000
      DURATION        : 00:23:52.096000000
      NUMBER_OF_FRAMES: 44753
      NUMBER_OF_BYTES : 22913536
      _STATISTICS_WRITING_APP: mkvmerge v63.0.0 ('Everything') 64-bit
      _STATISTICS_WRITING_DATE_UTC: 2021-12-17 18:25:01
      _STATISTICS_TAGS: BPS DURATION NUMBER_OF_FRAMES NUMBER_OF_BYTES
  Stream #0:2(eng): Subtitle: ass (default)
    Metadata:
      title           : NAME
      BPS             : 9233
      DURATION        : 00:23:49.480000000
      NUMBER_OF_FRAMES: 7493
      NUMBER_OF_BYTES : 1649888
      _STATISTICS_WRITING_APP: mkvmerge v63.0.0 ('Everything') 64-bit
      _STATISTICS_WRITING_DATE_UTC: 2021-12-17 18:25:01
      _STATISTICS_TAGS: BPS DURATION NUMBER_OF_FRAMES NUMBER_OF_BYTES
  Stream #0:3: Attachment: none
    Metadata:
      filename        : FOT-BudoStd-L.otf
      mimetype        : font/otf
  Stream #0:4: Attachment: none
    Metadata:
      filename        : GandhiSans-Bold.otf
      mimetype        : font/otf
  Stream #0:5: Attachment: none
    Metadata:
      filename        : GandhiSans-BoldItalic.otf
      mimetype        : font/otf
  Stream #0:6: Attachment: none
    Metadata:
      filename        : grain.ttf
      mimetype        : font/ttf
  Stream #0:7: Attachment: none
    Metadata:
      filename        : HANDGL~1.OTF
      mimetype        : font/otf
  Stream #0:8: Attachment: none
    Metadata:
      filename        : Komyushou.ttf
      mimetype        : font/ttf
  Stream #0:9: Attachment: none
    Metadata:
      filename        : arial.ttf
      mimetype        : font/ttf
  Stream #0:10: Attachment: none
    Metadata:
      filename        : arialbd.ttf
      mimetype        : font/ttf
  Stream #0:11: Attachment: none
    Metadata:
      filename        : ariali.ttf
      mimetype        : font/ttf
  Stream #0:12: Attachment: none
    Metadata:
      filename        : Daily Life.ttf
      mimetype        : font/ttf
  Stream #0:13: Attachment: none
    Metadata:
      filename        : ERASDUST.TTF
      mimetype        : font/ttf
  Stream #0:14: Video: mjpeg (Progressive), yuvj420p(pc, bt470bg/unknown/unknown), 400x566 [SAR 96:96 DAR 200:283], 90k tbr, 90k tbn, 90k tbc (attached pic)
    Metadata:
      filename        : cover.jpg
      mimetype        : image/jpeg
Unsupported codec with id 0 for input stream 3
Unsupported codec with id 0 for input stream 4
Unsupported codec with id 0 for input stream 5
Unsupported codec with id 0 for input stream 6
Unsupported codec with id 0 for input stream 7
Unsupported codec with id 0 for input stream 8
Unsupported codec with id 0 for input stream 9
Unsupported codec with id 0 for input stream 10
Unsupported codec with id 0 for input stream 11
Unsupported codec with id 0 for input stream 12
Unsupported codec with id 0 for input stream 13
```

[#6981](https://github.com/jellyfin/jellyfin/issues/6981)