### PR TITLE
Make Live TV Guide scrollbar visible.

### DIFF
--- a/src/themes/light/theme.css
+++ b/src/themes/light/theme.css
@@ -1,6 +1,5 @@
 * {
     scrollbar-width: thin;
-    scrollbar-color: #999 #303030;
 }
 
 .skinHeader,

--- a/src/themes/light/theme.css
+++ b/src/themes/light/theme.css
@@ -475,7 +475,6 @@ html {
     box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
 }
 
-
 .layout-desktop ::-webkit-scrollbar,
 .layout-tv ::-webkit-scrollbar {
     width: 0.4em;

--- a/src/themes/light/theme.css
+++ b/src/themes/light/theme.css
@@ -1,3 +1,8 @@
+* {
+    scrollbar-width: thin;
+    scrollbar-color: #999 #303030;
+}
+
 .skinHeader,
 html {
     color: #222;
@@ -463,6 +468,29 @@ html {
 .card:focus .cardBox.visualCardBox,
 .card:focus .cardBox:not(.visualCardBox) .cardScalable {
     border-color: #00a4dc !important;
+}
+
+::-webkit-scrollbar-track {
+    -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
+    box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
+}
+
+
+.layout-desktop ::-webkit-scrollbar,
+.layout-tv ::-webkit-scrollbar {
+    width: 0.4em;
+    height: 0.4em;
+}
+
+::-webkit-scrollbar-thumb:horizontal,
+::-webkit-scrollbar-thumb:vertical {
+    border-radius: 2px;
+    -webkit-border-radius: 2px;
+    background: center no-repeat #999;
+}
+
+.timeslotHeaders-desktop::-webkit-scrollbar {
+    height: 0.7em;
 }
 
 .metadataSidebarIcon {


### PR DESCRIPTION
Copied some missing elements from dark theme.css and made a couple tweaks. Not sure if everyone will love the look. But the scrollbar is now visible.

Scrollbar !
![image](https://user-images.githubusercontent.com/991618/149036657-d0bcc676-f1c3-4ff3-892d-ac5124b122ed.png)

Fixes #3316