### PR TITLE
Added Quit App to main menu

### DIFF
--- a/src/components/apphost.js
+++ b/src/components/apphost.js
@@ -199,7 +199,6 @@ const supportedFeatures = function () {
     if (browser.operaTv || browser.tizen || browser.orsay || browser.web0s) {
         features.push('exit');
     } else {
-        features.push('exitmenu');
         features.push('plugins');
     }
 

--- a/src/controllers/user/menu/index.html
+++ b/src/controllers/user/menu/index.html
@@ -112,6 +112,15 @@
                         </div>
                     </div>
                 </a>
+
+                <a is="emby-linkbutton" data-ripple="false" href="#" style="display:block;padding:0;margin:0;" class="quitApp listItem-border">
+                    <div class="listItem">
+                        <span class="material-icons listItemIcon listItemIcon-transparent close"></span>
+                        <div class="listItemBody">
+                            <div class="listItemBodyText">${ButtonQuitApp}</div>
+                        </div>
+                    </div>
+                </a>
             </div>
         </div>
     </div>

--- a/src/controllers/user/menu/index.html
+++ b/src/controllers/user/menu/index.html
@@ -113,11 +113,11 @@
                     </div>
                 </a>
 
-                <a is="emby-linkbutton" data-ripple="false" href="#" style="display:block;padding:0;margin:0;" class="quitApp listItem-border">
+                <a is="emby-linkbutton" data-ripple="false" href="#" style="display:block;padding:0;margin:0;" class="exitApp listItem-border">
                     <div class="listItem">
                         <span class="material-icons listItemIcon listItemIcon-transparent close"></span>
                         <div class="listItemBody">
-                            <div class="listItemBodyText">${ButtonQuitApp}</div>
+                            <div class="listItemBodyText">${ButtonExitApp}</div>
                         </div>
                     </div>
                 </a>

--- a/src/controllers/user/menu/index.js
+++ b/src/controllers/user/menu/index.js
@@ -17,8 +17,8 @@ export default function (view, params) {
         window.NativeShell.openClientSettings();
     });
 
-    view.querySelector('.quitApp').addEventListener('click', function () {
-        window.NativeShell.quitApp();
+    view.querySelector('.exitApp').addEventListener('click', function () {
+        appHost.exit();
     });
 
     view.addEventListener('viewshow', function () {
@@ -37,8 +37,8 @@ export default function (view, params) {
         const supportsClientSettings = appHost.supports('clientsettings');
         page.querySelector('.clientSettings').classList.toggle('hide', !supportsClientSettings);
 
-        const supportsQuitApp = appHost.supports('quitapp');
-        page.querySelector('.quitApp').classList.toggle('hide', !supportsQuitApp);
+        const supportsExitMenu = appHost.supports('exitmenu');
+        page.querySelector('.exitApp').classList.toggle('hide', !supportsExitMenu);
 
         const supportsMultiServer = appHost.supports('multiserver');
         page.querySelector('.selectServer').classList.toggle('hide', !supportsMultiServer);

--- a/src/controllers/user/menu/index.js
+++ b/src/controllers/user/menu/index.js
@@ -17,6 +17,10 @@ export default function (view, params) {
         window.NativeShell.openClientSettings();
     });
 
+    view.querySelector('.quitApp').addEventListener('click', function () {
+        window.NativeShell.quitApp();
+    });
+
     view.addEventListener('viewshow', function () {
         // this page can also be used by admins to change user preferences from the user edit page
         const userId = params.userId || Dashboard.getCurrentUserId();
@@ -32,6 +36,9 @@ export default function (view, params) {
 
         const supportsClientSettings = appHost.supports('clientsettings');
         page.querySelector('.clientSettings').classList.toggle('hide', !supportsClientSettings);
+
+        const supportsQuitApp = appHost.supports('quitapp');
+        page.querySelector('.quitApp').classList.toggle('hide', !supportsQuitApp);
 
         const supportsMultiServer = appHost.supports('multiserver');
         page.querySelector('.selectServer').classList.toggle('hide', !supportsMultiServer);

--- a/src/scripts/libraryMenu.js
+++ b/src/scripts/libraryMenu.js
@@ -323,6 +323,11 @@ import Headroom from 'headroom.js';
             btnSettings.addEventListener('click', onSettingsClick);
         }
 
+        const btnExit = navDrawerScrollContainer.querySelector('.exitApp');
+        if (btnExit) {
+            btnExit.addEventListener('click', onExitAppClick);
+        }
+
         const btnLogout = navDrawerScrollContainer.querySelector('.btnLogout');
         if (btnLogout) {
             btnLogout.addEventListener('click', onLogoutClick);
@@ -709,6 +714,10 @@ import Headroom from 'headroom.js';
 
     function onSettingsClick() {
         Dashboard.navigate('mypreferencesmenu.html');
+    }
+
+    function onExitAppClick() {
+        appHost.exit();
     }
 
     function onLogoutClick() {

--- a/src/scripts/libraryMenu.js
+++ b/src/scripts/libraryMenu.js
@@ -302,6 +302,11 @@ import Headroom from 'headroom.js';
 
             html += '<a is="emby-linkbutton" class="navMenuOption lnkMediaFolder btnSettings" data-itemid="settings" href="#"><span class="material-icons navMenuOptionIcon settings"></span><span class="navMenuOptionText">' + globalize.translate('Settings') + '</span></a>';
             html += '<a is="emby-linkbutton" class="navMenuOption lnkMediaFolder btnLogout" data-itemid="logout" href="#"><span class="material-icons navMenuOptionIcon exit_to_app"></span><span class="navMenuOptionText">' + globalize.translate('ButtonSignOut') + '</span></a>';
+
+            if (appHost.supports('quitapp')) {
+                html += '<a is="emby-linkbutton" class="navMenuOption lnkMediaFolder quitApp" data-itemid="quitapp" href="#"><span class="material-icons navMenuOptionIcon close"></span><span class="navMenuOptionText">' + globalize.translate('ButtonQuitApp') + '</span></a>';
+            }
+
             html += '</div>';
         }
 

--- a/src/scripts/libraryMenu.js
+++ b/src/scripts/libraryMenu.js
@@ -303,8 +303,8 @@ import Headroom from 'headroom.js';
             html += '<a is="emby-linkbutton" class="navMenuOption lnkMediaFolder btnSettings" data-itemid="settings" href="#"><span class="material-icons navMenuOptionIcon settings"></span><span class="navMenuOptionText">' + globalize.translate('Settings') + '</span></a>';
             html += '<a is="emby-linkbutton" class="navMenuOption lnkMediaFolder btnLogout" data-itemid="logout" href="#"><span class="material-icons navMenuOptionIcon exit_to_app"></span><span class="navMenuOptionText">' + globalize.translate('ButtonSignOut') + '</span></a>';
 
-            if (appHost.supports('quitapp')) {
-                html += '<a is="emby-linkbutton" class="navMenuOption lnkMediaFolder quitApp" data-itemid="quitapp" href="#"><span class="material-icons navMenuOptionIcon close"></span><span class="navMenuOptionText">' + globalize.translate('ButtonQuitApp') + '</span></a>';
+            if (appHost.supports('exitmenu')) {
+                html += '<a is="emby-linkbutton" class="navMenuOption lnkMediaFolder exitApp" data-itemid="exitapp" href="#"><span class="material-icons navMenuOptionIcon close"></span><span class="navMenuOptionText">' + globalize.translate('ButtonExitApp') + '</span></a>';
             }
 
             html += '</div>';

--- a/src/strings/en-gb.json
+++ b/src/strings/en-gb.json
@@ -134,7 +134,7 @@
     "ButtonShutdown": "Shutdown",
     "ButtonSignIn": "Sign In",
     "ButtonSignOut": "Sign Out",
-    "ButtonQuitApp": "Quit Application",
+    "ButtonExitApp": "Exit Application",
     "ButtonStart": "Start",
     "ButtonStop": "Stop",
     "ButtonSubmit": "Submit",

--- a/src/strings/en-gb.json
+++ b/src/strings/en-gb.json
@@ -134,6 +134,7 @@
     "ButtonShutdown": "Shutdown",
     "ButtonSignIn": "Sign In",
     "ButtonSignOut": "Sign Out",
+    "ButtonQuitApp": "Quit Application",
     "ButtonStart": "Start",
     "ButtonStop": "Stop",
     "ButtonSubmit": "Submit",

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -106,7 +106,7 @@
     "ButtonShutdown": "Shutdown",
     "ButtonSignIn": "Sign In",
     "ButtonSignOut": "Sign Out",
-    "ButtonQuitApp": "Quit Application",
+    "ButtonExitApp": "Exit Application",
     "ButtonSplit": "Split",
     "ButtonStart": "Start",
     "ButtonStop": "Stop",

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -106,6 +106,7 @@
     "ButtonShutdown": "Shutdown",
     "ButtonSignIn": "Sign In",
     "ButtonSignOut": "Sign Out",
+    "ButtonQuitApp": "Quit Application",
     "ButtonSplit": "Split",
     "ButtonStart": "Start",
     "ButtonStop": "Stop",


### PR DESCRIPTION
I'm using the Jellyfin Media Player in TV mode as a full screen app (open via Flex Launcher) and needed a way to close the program via the keyboard navigation. To resolve this I've added a Quit Application link below the Sign Out menu item.

Unfortunately I haven't been able to test this in the JMP yet so requires testing but the menu item exists in the menu and is hidden using the `appHost.supports()` function as per the other menu items. I'm not sure if further conditional checks to determine if this should appear (eg if its an embedded or iOS/Android app the Quit Application link should not appear) need to happen here or if that is determined in the Jellyfin Media Player.

I'm also not sure if this should be a function that requires a user confirmation (eg Are you sure you want to exit?).

It also requires translations for other languages.

Is this something that the Jellyfin Community would consider adding to the application?

**Changes**
Add a Quit Application button to the main menu.
