### PR TITLE
Add episode details to live TV DVR schedule

### DIFF
--- a/src/components/cardbuilder/card.scss
+++ b/src/components/cardbuilder/card.scss
@@ -333,6 +333,7 @@ button::-moz-focus-inner {
     width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
+    text-align: left;
 }
 
 .innerCardFooter > .cardText {
@@ -355,7 +356,8 @@ button::-moz-focus-inner {
     background-position: center center;
 }
 
-.cardTextCentered {
+.cardTextCentered,
+.cardTextCentered > .textActionButton {
     text-align: center;
 }
 

--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -771,6 +771,7 @@ import ServerConnections from '../ServerConnections';
          * @returns {string} HTML markup of the card's footer text element.
          */
         function getCardFooterText(item, apiClient, options, showTitle, forceName, overlayText, imgUrl, footerClass, progressHtml, logoUrl, isOuterFooter) {
+            item = item.ProgramInfo || item;
             let html = '';
 
             if (logoUrl) {

--- a/src/components/itemHelper.js
+++ b/src/components/itemHelper.js
@@ -20,7 +20,7 @@ export function getDisplayName(item, options = {}) {
     }
     if (item.Type === 'Episode' && item.ParentIndexNumber === 0) {
         name = globalize.translate('ValueSpecialEpisodeName', name);
-    } else if ((item.Type === 'Episode' || item.Type === 'Program') && item.IndexNumber != null && item.ParentIndexNumber != null && options.includeIndexNumber !== false) {
+    } else if ((item.Type === 'Episode' || item.Type === 'Program' || item.Type === 'Recording') && item.IndexNumber != null && item.ParentIndexNumber != null && options.includeIndexNumber !== false) {
         let displayIndexNumber = item.IndexNumber;
 
         let number = displayIndexNumber;

--- a/src/controllers/livetv/livetvschedule.js
+++ b/src/controllers/livetv/livetvschedule.js
@@ -61,7 +61,7 @@ function renderActiveRecordings(context, promise) {
             defaultShape: getBackdropShape(),
             showParentTitle: false,
             showParentTitleOrTitle: true,
-            showTitle: false,
+            showTitle: true,
             showAirTime: true,
             showAirEndTime: true,
             showChannelName: true,

--- a/src/scripts/livetvcomponents.js
+++ b/src/scripts/livetvcomponents.js
@@ -79,6 +79,7 @@ function getTimersHtml(timers, options) {
         html += cardBuilder.getCardsHtml({
             items: group.items,
             shape: getBackdropShape(),
+            showTitle: true,
             showParentTitleOrTitle: true,
             showAirTime: true,
             showAirEndTime: true,


### PR DESCRIPTION
###  Display Sxx:Eyy for episodes in DVR 

### Before:
![image](https://user-images.githubusercontent.com/991618/149047659-2b8ec19d-32ed-48d9-a802-2797e23f3f5f.png)

### After:
![image](https://user-images.githubusercontent.com/991618/149044251-4e1b71dd-21c1-4098-be0c-b5ce199b6f24.png)


More live recording tweaks. Display Parent info (SX:EXX) and Title

### Home section 
Before
![image](https://user-images.githubusercontent.com/991618/146622097-671a4259-603e-41f6-9c5f-8c67a30a64ac.png)
After
![image](https://user-images.githubusercontent.com/991618/146622113-cbb981ae-2437-4def-9e4c-d02fe41acdec.png)


### Live TV->Recordings
Before
![image](https://user-images.githubusercontent.com/991618/146622144-4ae5a27c-8d9a-4387-bd6f-68d077c6be32.png)
After
![image](https://user-images.githubusercontent.com/991618/146622161-0413e4e3-805c-4943-851b-af1bd1b07901.png)

### Live TV->Schedule
Before
![image](https://user-images.githubusercontent.com/991618/146622178-7b26b854-a943-4f0e-8f8a-3386b428a4dd.png)
After
![image](https://user-images.githubusercontent.com/991618/146622189-a553ea86-3eb7-498b-8a20-5fe82dcd482f.png)
