### PR TITLE
Fix Blurhash worker on webOS 1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15360,6 +15360,46 @@
         }
       }
     },
+    "worker-loader": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/worker-loader/-/worker-loader-3.0.8.tgz",
+      "integrity": "sha512-XQyQkIFeRVC7f7uRhFdNMe/iJOdO6zxAaR3EWbDp45v3mDhrTi+++oswKNxShUNjPC/1xUp5DB29YKLhFo129g==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "@types/json-schema": {
+          "version": "7.0.9",
+          "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
+          "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+          "dev": true
+        },
+        "loader-utils": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "schema-utils": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+          "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.8",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        }
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "webpack-cli": "^4.9.1",
     "webpack-dev-server": "^4.7.2",
     "webpack-merge": "^5.8.0",
-    "workbox-webpack-plugin": "^6.2.4"
+    "workbox-webpack-plugin": "^6.2.4",
+    "worker-loader": "^3.0.8"
   },
   "dependencies": {
     "@fontsource/noto-sans": "^4.5.1",

--- a/src/components/images/imageLoader.js
+++ b/src/components/images/imageLoader.js
@@ -1,8 +1,9 @@
+import Worker from './blurhash.worker.ts'; // eslint-disable-line import/default
 import * as lazyLoader from '../lazyLoader/lazyLoaderIntersectionObserver';
 import * as userSettings from '../../scripts/settings/userSettings';
 import './style.scss';
 // eslint-disable-next-line compat/compat
-const worker = new Worker(new URL('./blurhash.worker.ts', import.meta.url));
+const worker = new Worker();
 const targetDic = {};
 worker.addEventListener(
     'message',

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -102,6 +102,14 @@ module.exports = {
                 }]
             },
             {
+                test: /\.worker\.ts$/,
+                exclude: /node_modules/,
+                use: [
+                    'worker-loader',
+                    'ts-loader'
+                ]
+            },
+            {
                 test: /\.(ts|tsx)$/,
                 exclude: /node_modules/,
                 use: [{


### PR DESCRIPTION
_Continuation of #3144_

Webpack 5 doesn't polyfill `Promise` in the worker, so we use (deprecated) `worker-loader`, which does until Webpack 5 gets a fix.

**Changes**
Load worker via `worker-loader`.

**Issues**
Runtime error on webOS 1.2: `ReferenceError: Can't find variable: Promise`