### PR TITLE
Fix auto focus on Play/Resume

### DIFF
--- a/src/components/autoFocuser.js
+++ b/src/components/autoFocuser.js
@@ -59,6 +59,9 @@ import layoutManager from './layoutManager';
                 candidates.push(container.querySelector('.btnPreviousPage'));
             } else if (activeElement.classList.contains('btnSelectView')) {
                 candidates.push(container.querySelector('.btnSelectView'));
+            } else if (activeElement.classList.contains('btnPlay')) {
+                // Resume has priority over Play
+                candidates = candidates.concat(Array.from(container.querySelectorAll('.btnResume')));
             }
 
             candidates.push(activeElement);

--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -374,12 +374,12 @@ function reloadPlayButtons(page, item) {
         hideAll(page, 'btnShuffle');
     }
 
-    const btnResume = page.querySelector('.mainDetailButtons .btnResume');
-    const btnPlay = page.querySelector('.mainDetailButtons .btnPlay');
-    if (layoutManager.tv && !btnResume.classList.contains('hide')) {
-        btnResume.classList.add('fab');
-    } else if (layoutManager.tv && btnResume.classList.contains('hide')) {
-        btnPlay.classList.add('fab');
+    if (layoutManager.tv) {
+        const btnResume = page.querySelector('.mainDetailButtons .btnResume');
+        const btnPlay = page.querySelector('.mainDetailButtons .btnPlay');
+        const resumeHidden = btnResume.classList.contains('hide');
+        btnResume.classList.toggle('fab', !resumeHidden);
+        btnPlay.classList.toggle('fab', resumeHidden);
     }
 
     return canPlay;

--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -378,8 +378,8 @@ function reloadPlayButtons(page, item) {
         const btnResume = page.querySelector('.mainDetailButtons .btnResume');
         const btnPlay = page.querySelector('.mainDetailButtons .btnPlay');
         const resumeHidden = btnResume.classList.contains('hide');
-        btnResume.classList.toggle('fab', !resumeHidden);
-        btnPlay.classList.toggle('fab', resumeHidden);
+        btnResume.classList.toggle('raised', !resumeHidden);
+        btnPlay.classList.toggle('raised', resumeHidden);
     }
 
     return canPlay;

--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -33,6 +33,12 @@ import ServerConnections from '../../components/ServerConnections';
 import confirm from '../../components/confirm/confirm';
 import { download } from '../../scripts/fileDownloader';
 
+function autoFocus(container) {
+    import('../../components/autoFocuser').then(({ default: autoFocuser }) => {
+        autoFocuser.autoFocus(container);
+    });
+}
+
 function getPromise(apiClient, params) {
     const id = params.id;
 
@@ -727,9 +733,7 @@ function reloadFromItem(instance, page, params, item, user) {
         hideAll(page, 'btnDownload', true);
     }
 
-    import('../../components/autoFocuser').then(({ default: autoFocuser }) => {
-        autoFocuser.autoFocus(page);
-    });
+    autoFocus(page);
 }
 
 function logoImageUrl(item, apiClient, options) {
@@ -1756,9 +1760,7 @@ function renderCollectionItems(page, parentItem, types, items) {
 
     // HACK: Call autoFocuser again because btnPlay may be hidden, but focused by reloadFromItem
     // FIXME: Sometimes focus does not move until all (?) sections are loaded
-    import('../../components/autoFocuser').then(({ default: autoFocuser }) => {
-        autoFocuser.autoFocus(page);
-    });
+    autoFocus(page);
 }
 
 function renderCollectionItemType(page, parentItem, type, items) {
@@ -2060,6 +2062,7 @@ export default function (view, params) {
                 currentItem.UserData = userData;
                 reloadPlayButtons(view, currentItem);
                 refreshImage(view, currentItem);
+                autoFocus(view);
             }
         }
     }


### PR DESCRIPTION
After stopping video playback we get the item state via WebSocket, so we need to refocus the "most valid" button in the WebSocket handler.

**Changes**
- Add `Resume` as a candidate if `Play` was focused.
- Add `autoFocus` call to WebSocket handler.
- Make ~`fab`~ class mutually exclusive. `fab` is changed to `raised`.

**Issues**
Fixes #3320
