### PR TITLE
Try to determine the number of speakers before falling back to hardcoded values

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -294,12 +294,55 @@ import browser from './browser';
                     (browser.tizen && isTizenFhd ? 20000000 : null)));
     }
 
+    function getSpeakerCount() {
+        const AudioContext = window.AudioContext || window.webkitAudioContext || false; /* eslint-disable-line compat/compat */
+
+        if (AudioContext) {
+            const audioCtx = new AudioContext();
+
+            return audioCtx.destination.maxChannelCount;
+        }
+
+        return -1;
+    }
+
+    function getPhysicalAudioChannels(options) {
+        const allowedAudioChannels = parseInt(userSettings.allowedAudioChannels(), 10);
+
+        if (allowedAudioChannels > 0) {
+            return allowedAudioChannels;
+        }
+
+        if (options.audioChannels) {
+            return options.audioChannels;
+        }
+
+        const isSurroundSoundSupportedBrowser = browser.safari || browser.chrome || browser.edgeChromium || browser.firefox || browser.tv || browser.ps4 || browser.xboxOne;
+        const speakerCount = getSpeakerCount();
+
+        if (speakerCount > 2) {
+            if (isSurroundSoundSupportedBrowser) {
+                return speakerCount;
+            }
+
+            return 2;
+        }
+
+        if (speakerCount > 0) {
+            return speakerCount;
+        }
+
+        if (isSurroundSoundSupportedBrowser) {
+            return 6;
+        }
+
+        return 2;
+    }
+
     export default function (options) {
         options = options || {};
 
-        const isSurroundSoundSupportedBrowser = browser.safari || browser.chrome || browser.edgeChromium || browser.firefox;
-        const allowedAudioChannels = parseInt(userSettings.allowedAudioChannels() || '-1');
-        const physicalAudioChannels = (allowedAudioChannels > 0 ? allowedAudioChannels : null) || options.audioChannels || (isSurroundSoundSupportedBrowser || browser.tv || browser.ps4 || browser.xboxOne ? 6 : 2);
+        const physicalAudioChannels = getPhysicalAudioChannels(options);
 
         const bitrateSetting = getMaxBitrate();
 


### PR DESCRIPTION
This is split from my old PR: https://github.com/jellyfin/jellyfin-web/pull/2511

**Changes**
If the user hasn't specified his desired number of audio channels, try to determine it from the browser. This effectively reduces the number of audio channels from 6 to 2 for most users when transcoding.