### PR TITLE
Fix unstyled emby-select field when rendered with React

### DIFF
--- a/src/components/dashboard/users/SelectSyncPlayAccessElement.tsx
+++ b/src/components/dashboard/users/SelectSyncPlayAccessElement.tsx
@@ -3,7 +3,7 @@ import globalize from '../../../scripts/globalize';
 
 const createSelectElement = ({ className, id, label }) => ({
     __html: `<select
-        className="${className}"
+        class="${className}"
         is="emby-select"
         id="${id}"
         label="${label}"

--- a/src/elements/emby-select/emby-select.js
+++ b/src/elements/emby-select/emby-select.js
@@ -138,15 +138,15 @@ import 'webcomponents.js/webcomponents-lite';
         label.innerHTML = this.getAttribute('label') || '';
         label.classList.add('selectLabel');
         label.htmlFor = this.id;
-        this.parentNode.insertBefore(label, this);
+        this.parentNode?.insertBefore(label, this);
 
         if (this.classList.contains('emby-select-withcolor')) {
-            this.parentNode.insertAdjacentHTML('beforeend', '<div class="selectArrowContainer"><div style="visibility:hidden;display:none;">0</div><span class="selectArrow material-icons keyboard_arrow_down"></span></div>');
+            this.parentNode?.insertAdjacentHTML('beforeend', '<div class="selectArrowContainer"><div style="visibility:hidden;display:none;">0</div><span class="selectArrow material-icons keyboard_arrow_down"></span></div>');
         }
     };
 
     EmbySelectPrototype.setLabel = function (text) {
-        const label = this.parentNode.querySelector('label');
+        const label = this.parentNode?.querySelector('label');
 
         label.innerHTML = text;
     };


### PR DESCRIPTION
**Changes**
Fixes the login provider being unstyled due to the parentNode being null in the emby-select component. This seems to be happening on re-renders in React for some reason.
Fixes the SelectSyncPlayAccessElement using the wrong parameter for classes.

**Issues**
N/A
