### PR TITLE
Fix starting of book player with a blank page

### DIFF
--- a/src/plugins/bookPlayer/plugin.js
+++ b/src/plugins/bookPlayer/plugin.js
@@ -284,7 +284,7 @@ export class BookPlayer {
 
                 return rendition.display().then(() => {
                     const epubElem = document.querySelector('.epub-container');
-                    epubElem.style.display = 'none';
+                    epubElem.style.opacity = '0';
 
                     this.bindEvents();
 
@@ -298,7 +298,7 @@ export class BookPlayer {
                         }
 
                         this.loaded = true;
-                        epubElem.style.display = 'block';
+                        epubElem.style.opacity = '';
                         rendition.on('relocated', (locations) => {
                             this.progress = book.locations.percentageFromCfi(locations.start.cfi);
                             Events.trigger(this, 'timeupdate');


### PR DESCRIPTION
**Changes**
Hide book player with `opacity` instead of `display`.

**Issues**
Setting `display: none` on the book player breaks internal calculations, which results in opening a blank page, and the last location is not restored.