### PR TITLE
Fix Light theme text color

### DIFF
--- a/src/components/remotecontrol/remotecontrol.scss
+++ b/src/components/remotecontrol/remotecontrol.scss
@@ -203,6 +203,7 @@
 .layout-desktop .playlistSectionButton,
 .layout-tv .playlistSectionButton {
     background: none;
+    color: inherit;
 }
 
 .layout-desktop .nowPlayingPlaylist,

--- a/src/themes/light/theme.css
+++ b/src/themes/light/theme.css
@@ -27,8 +27,6 @@ html {
     background-color: #303030;
     color: #ccc;
     color: rgba(255, 255, 255, 0.87);
-    -webkit-box-shadow: 0 0.0725em 0.29em 0 rgba(0, 0, 0, 0.37);
-    box-shadow: 0 0.0725em 0.29em 0 rgba(0, 0, 0, 0.37);
 }
 
 .osdHeader {
@@ -44,6 +42,7 @@ html {
 
 .layout-tv .skinHeader.semiTransparent {
     background: none;
+    color: inherit;
 }
 
 .pageTitleWithDefaultLogo {
@@ -253,12 +252,11 @@ html {
     background-color: #303030;
     color: #ccc;
     color: rgba(255, 255, 255, 0.87);
-    -webkit-box-shadow: 0 0.0725em 0.29em 0 rgba(0, 0, 0, 0.37);
-    box-shadow: 0 0.0725em 0.29em 0 rgba(0, 0, 0, 0.37);
 }
 
 .layout-tv .detailRibbon {
     background: none;
+    color: inherit;
 }
 
 .detailTableBodyRow-shaded:nth-child(even) {


### PR DESCRIPTION
We need to revert (inherit) the color of the text when the background has become transparent.

**Changes**
- Inherit text color if background is transparent.
- Remove the shadows, because Dark (no theme actually) doesn't use them.

**Issues**
- Item details page is broken on Light theme (TV).
- Now playing page is broken on Light theme - Save and More buttons are too light (Desktop, TV).

**Screenshots**
Before:
<img src="https://user-images.githubusercontent.com/56478732/150388103-1ed1374b-404f-422e-9b7d-b59738639205.png" width="50%">

After:
<img src="https://user-images.githubusercontent.com/56478732/150388145-e4345eaf-9b0f-48f9-9ca5-109a88b39f2b.png" width="50%">
