### PR TITLE
Display MediaSourceCount for all media Types

### DIFF
--- a/src/components/homesections/homesections.js
+++ b/src/components/homesections/homesections.js
@@ -607,7 +607,7 @@ import ServerConnections from '../ServerConnections';
             oldestDateForNextUp.setDate(oldestDateForNextUp.getDate() - userSettings.maxDaysForNextUp());
             return apiClient.getNextUpEpisodes({
                 Limit: enableScrollX() ? 24 : 15,
-                Fields: 'PrimaryImageAspectRatio,DateCreated,BasicSyncInfo,Path',
+                Fields: 'PrimaryImageAspectRatio,DateCreated,BasicSyncInfo,Path,MediaSourceCount',
                 UserId: apiClient.getCurrentUserId(),
                 ImageTypeLimit: 1,
                 EnableImageTypes: 'Primary,Backdrop,Banner,Thumb',

--- a/src/components/listview/listview.js
+++ b/src/components/listview/listview.js
@@ -282,6 +282,11 @@ import ServerConnections from '../ServerConnections';
                     html += '<div class="' + imageClass + ' cardImageContainer ' + cardBuilder.getDefaultBackgroundClass(item.Name) + '">' + cardBuilder.getDefaultText(item, options);
                 }
 
+                const mediaSourceCount = item.MediaSourceCount || 1;
+                if (mediaSourceCount > 1 && options.disableIndicators !== true) {
+                    html += '<div class="mediaSourceIndicator">' + mediaSourceCount + '</div>';
+                }
+
                 let indicatorsHtml = '';
                 indicatorsHtml += indicators.getPlayedIndicatorHtml(item);
 

--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -865,7 +865,7 @@ function renderNextUp(page, item, user) {
     ServerConnections.getApiClient(item.ServerId).getNextUpEpisodes({
         SeriesId: item.Id,
         UserId: user.Id,
-        Fields: 'MediaSourceCount',
+        Fields: 'MediaSourceCount'
     }).then(function (result) {
         if (result.Items.length) {
             section.classList.remove('hide');

--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -864,7 +864,8 @@ function renderNextUp(page, item, user) {
 
     ServerConnections.getApiClient(item.ServerId).getNextUpEpisodes({
         SeriesId: item.Id,
-        UserId: user.Id
+        UserId: user.Id,
+        Fields: 'MediaSourceCount',
     }).then(function (result) {
         if (result.Items.length) {
             section.classList.remove('hide');

--- a/src/controllers/list.js
+++ b/src/controllers/list.js
@@ -251,7 +251,7 @@ import { appRouter } from '../components/appRouter';
         if (params.type === 'nextup') {
             return apiClient.getNextUpEpisodes(modifyQueryWithFilters(instance, {
                 Limit: limit,
-                Fields: 'PrimaryImageAspectRatio,DateCreated,BasicSyncInfo',
+                Fields: 'PrimaryImageAspectRatio,DateCreated,BasicSyncInfo,MediaSourceCount',
                 UserId: apiClient.getCurrentUserId(),
                 ImageTypeLimit: 1,
                 EnableImageTypes: 'Primary,Backdrop,Thumb',
@@ -320,7 +320,7 @@ import { appRouter } from '../components/appRouter';
         return apiClient.getItems(apiClient.getCurrentUserId(), modifyQueryWithFilters(instance, {
             StartIndex: startIndex,
             Limit: limit,
-            Fields: 'PrimaryImageAspectRatio,SortName,Path,SongCount,ChildCount',
+            Fields: 'PrimaryImageAspectRatio,SortName,Path,SongCount,ChildCount,MediaSourceCount',
             ImageTypeLimit: 1,
             ParentId: item.Id,
             SortBy: sortBy

--- a/src/controllers/shows/tvrecommended.js
+++ b/src/controllers/shows/tvrecommended.js
@@ -178,7 +178,7 @@ import autoFocuser from '../../components/autoFocuser';
         const query = {
             userId: userId,
             Limit: 24,
-            Fields: 'PrimaryImageAspectRatio,DateCreated,BasicSyncInfo',
+            Fields: 'PrimaryImageAspectRatio,DateCreated,BasicSyncInfo,MediaSourceCount',
             ParentId: parentId,
             ImageTypeLimit: 1,
             EnableImageTypes: 'Primary,Backdrop,Thumb',


### PR DESCRIPTION
All items support alternate local versions, even if it's not documented. Tested with episode and musicVideo types. Added MSC to list items as well.

![image](https://user-images.githubusercontent.com/991618/150429436-e12b8b90-ccc0-44df-a935-a28b3b5e0a20.png)
![image](https://user-images.githubusercontent.com/991618/150429511-42ea0f22-559f-43b0-9bd2-762fbc9ae3d5.png)
![image](https://user-images.githubusercontent.com/991618/150429542-46b681e0-217e-43c0-a953-c43237554004.png)
