### PR TITLE
Fix page layouts for webOS

### DIFF
--- a/src/controllers/list.html
+++ b/src/controllers/list.html
@@ -1,7 +1,7 @@
-<div data-role="page" class="view flex flex-direction-column page libraryPage noSecondaryNavPage" data-backbutton="true">
+<div data-role="page" class="flex flex-direction-column page libraryPage noSecondaryNavPage" data-backbutton="true">
     <div class="alphaPicker alphaPicker-vertical alphaPicker-fixed focuscontainer-y hide">
     </div>
-    <div class="flex-grow padded-left padded-right padded-bottom-page pageContainerTopPadding">
+    <div class="flex-grow padded-left padded-right padded-bottom-page">
         <div class="flex align-items-center focuscontainer-x itemsViewSettingsContainer padded-top padded-bottom flex-wrap-wrap">
             <div class="paging"></div>
             <button is="emby-button" class="btnPlay button-flat hide listTextButton-autohide">

--- a/src/controllers/list.html
+++ b/src/controllers/list.html
@@ -1,7 +1,7 @@
-<div data-role="page" class="flex flex-direction-column page libraryPage noSecondaryNavPage" data-backbutton="true">
+<div data-role="page" class="page libraryPage noSecondaryNavPage" data-backbutton="true">
     <div class="alphaPicker alphaPicker-vertical alphaPicker-fixed focuscontainer-y hide">
     </div>
-    <div class="flex-grow padded-left padded-right padded-bottom-page">
+    <div class="padded-left padded-right padded-bottom-page">
         <div class="flex align-items-center focuscontainer-x itemsViewSettingsContainer padded-top padded-bottom flex-wrap-wrap">
             <div class="paging"></div>
             <button is="emby-button" class="btnPlay button-flat hide listTextButton-autohide">

--- a/src/controllers/music/music.html
+++ b/src/controllers/music/music.html
@@ -8,7 +8,7 @@
             }
         }
     </style>
-    <div class="pageTabContent pageTabContent" id="albumsTab" data-index="0">
+    <div class="pageTabContent" id="albumsTab" data-index="0">
         <div class="flex align-items-center justify-content-center flex-wrap-wrap padded-top padded-left padded-right padded-bottom focuscontainer-x">
             <div class="paging"></div>
             <button is="paper-icon-button-light" class="btnPlayAll musicglobalButton" title="${HeaderPlayAll}"><span class="material-icons play_arrow"></span></button>
@@ -27,7 +27,7 @@
             <div class="paging"></div>
         </div>
     </div>
-    <div class="pageTabContent pageTabContent" id="suggestionsTab" data-index="1">
+    <div class="pageTabContent" id="suggestionsTab" data-index="1">
 
         <div class="verticalSection">
 

--- a/src/controllers/session/login/index.html
+++ b/src/controllers/session/login/index.html
@@ -1,4 +1,4 @@
-<div id="loginPage" data-role="page" class="page standalonePage flex flex-direction-column" data-backbutton="false">
+<div id="loginPage" data-role="page" class="page standalonePage" data-backbutton="false">
     <div class="padded-left padded-right padded-bottom-page margin-auto-y">
         <form class="manualLoginForm margin-auto-x hide">
             <div class="padded-left padded-right flex align-items-center justify-content-center">

--- a/src/controllers/session/selectServer/index.html
+++ b/src/controllers/session/selectServer/index.html
@@ -1,5 +1,5 @@
-<div id="selectServerPage" data-role="page" class="page noSecondaryNavPage standalonePage pageContainer flex flex-direction-column">
-    <div class="margin-auto-y">
+<div id="selectServerPage" data-role="page" class="page noSecondaryNavPage standalonePage pageContainer">
+    <div class="margin-auto-y padded-bottom-page">
         <div class="verticalSection flex-shrink-zero w-100 flex flex-direction-column">
             <div class="padded-left padded-right flex align-items-center justify-content-center">
                 <h1 class="sectionTitle sectionTitle-cards">${SelectServer}</h1>

--- a/src/controllers/session/selectServer/index.html
+++ b/src/controllers/session/selectServer/index.html
@@ -1,4 +1,4 @@
-<div id="selectServerPage" data-role="page" class="page noSecondaryNavPage standalonePage pageContainer fullWidthContent vertical flex flex-direction-column">
+<div id="selectServerPage" data-role="page" class="page noSecondaryNavPage standalonePage pageContainer flex flex-direction-column">
     <div class="margin-auto-y">
         <div class="verticalSection flex-shrink-zero w-100 flex flex-direction-column">
             <div class="padded-left padded-right flex align-items-center justify-content-center">


### PR DESCRIPTION
It turns out that in webOS 1.2 the `flex` container (page) breaks calculation (applying) of the `padding-bottom` property.

**Changes**
- Remove unused styles
- Remove using of `flex` when it is unnecessary
- Add bottom padding on SelectServer page

**Issues**
No padding at the bottom on some pages in webOS 1.2:
- Login
- SelectServer
- Photos library
