### PR TITLE
Only use comic pages for internal calculations and ignore metadata files

### DIFF
--- a/src/plugins/comicsPlayer/plugin.js
+++ b/src/plugins/comicsPlayer/plugin.js
@@ -259,7 +259,15 @@ class ArchiveSource {
         this.raw = await this.archive.getFilesArray();
         await this.archive.extractFiles();
 
-        const files = await this.archive.getFilesArray();
+        // the comic book archive supports any kind of image format as it's just a zip archive
+        const supportedFormats = ['jpg', 'png', 'avif', 'gif', 'bmp', 'dib', 'tiff', 'tif'];
+
+        let files = await this.archive.getFilesArray();
+        files = files.filter((file) => {
+            const name = file.file.name;
+            const index = name.lastIndexOf('.');
+            return supportedFormats.includes(name.substr(index + 1));
+        });
         files.sort((a, b) => {
             if (a.file.name < b.file.name) {
                 return -1;


### PR DESCRIPTION
**Changes**
A comic book archive stores pages as images, but can store other
information like metadata within the file, too.

This change uses only the image based files as pages and ignores other
files.

The most commonly used image formats seems to be JPEG and PNG, but other formats gif, tiff etc. are sometimes used, too. :O Technically, a comic book archive can use any picture formats as pages.

Thx to @dmitrylyzo for his help with JS.

**Issues**
Fixes #3352 
