### PR TITLE
Fix theme song playback when switching items with different themes

### DIFF
--- a/src/components/nowPlayingBar/nowPlayingBar.js
+++ b/src/components/nowPlayingBar/nowPlayingBar.js
@@ -658,6 +658,11 @@ import { appRouter } from '../appRouter';
     }
 
     function onStateChanged(event, state) {
+        if (event.type === 'init') {
+            // skip non-ready state
+            return;
+        }
+
         console.debug('nowplaying event: ' + event.type);
         const player = this;
 

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -2385,8 +2385,11 @@ class PlaybackManager {
 
                     streamInfo.fullscreen = playOptions.fullscreen;
 
-                    getPlayerData(player).isChangingStream = false;
-                    getPlayerData(player).maxStreamingBitrate = maxBitrate;
+                    const playerData = getPlayerData(player);
+
+                    playerData.isChangingStream = false;
+                    playerData.maxStreamingBitrate = maxBitrate;
+                    playerData.streamInfo = streamInfo;
 
                     return player.play(streamInfo).then(function () {
                         loading.hide();


### PR DESCRIPTION
_More spaghetti to playback manager_ :spaghetti: 

You need 2 items with different theme songs and accessible from each other via `More Like This`.

In TV mode:
1. Open first item - first theme starts.
2. Open second item via `More Like This`.
3. Runtime error occurs.

The error is coming from Backdrop, which is trying to check if the video is playing.
https://github.com/jellyfin/jellyfin-web/blob/0d3550c534e5a5ce68a42ba751b9846e0a895a57/src/components/backdrop/backdrop.js#L279
The player is playing (has the current item), but its `steamInfo` is `null` - it will be set after playback actually starts.

I set `steamInfo` before starting playback to make the state consistent.
But this brings back the old problem, which was fixed in #2908
So I skip the `init` event in nowPlayingBar because `state` is incomplete.
The old fix is also valid, but with a different meaning - we need to clear `streamInfo` as we clear the current item in the player.

**Changes**
- Set streamInfo before starting playback to make the state consistent
- Skip non-ready state of player in nowPlayingBar

**Issues**
N/A
