### PR TITLE
Add option to season image downloader to pick from series images

### DIFF
--- a/src/components/imageDownloader/imageDownloader.js
+++ b/src/components/imageDownloader/imageDownloader.js
@@ -31,11 +31,16 @@ import template from './imageDownloader.template.html';
     let browsableImageStartIndex = 0;
     let browsableImageType = 'Primary';
     let selectedProvider;
+    let browsableParentId;
 
-    function getBaseRemoteOptions() {
+    function getBaseRemoteOptions(page) {
         const options = {};
 
-        options.itemId = currentItemId;
+        if (page.querySelector('#chkShowParentImages').checked && browsableParentId) {
+            options.itemId = browsableParentId;
+        } else {
+            options.itemId = currentItemId;
+        }
 
         return options;
     }
@@ -43,7 +48,7 @@ import template from './imageDownloader.template.html';
     function reloadBrowsableImages(page, apiClient) {
         loading.show();
 
-        const options = getBaseRemoteOptions();
+        const options = getBaseRemoteOptions(page);
 
         options.type = browsableImageType;
         options.startIndex = browsableImageStartIndex;
@@ -135,7 +140,7 @@ import template from './imageDownloader.template.html';
     }
 
     function downloadRemoteImage(page, apiClient, url, type, provider) {
-        const options = getBaseRemoteOptions();
+        const options = getBaseRemoteOptions(page);
 
         options.Type = type;
         options.ImageUrl = url;
@@ -273,26 +278,31 @@ import template from './imageDownloader.template.html';
         return html;
     }
 
+    function reloadBrowsableImagesFirstPage(page, apiClient) {
+        browsableImageStartIndex = 0;
+        reloadBrowsableImages(page, apiClient);
+    }
+
     function initEditor(page, apiClient) {
         page.querySelector('#selectBrowsableImageType').addEventListener('change', function () {
             browsableImageType = this.value;
-            browsableImageStartIndex = 0;
             selectedProvider = null;
 
-            reloadBrowsableImages(page, apiClient);
+            reloadBrowsableImagesFirstPage(page, apiClient);
         });
 
         page.querySelector('#selectImageProvider').addEventListener('change', function () {
-            browsableImageStartIndex = 0;
             selectedProvider = this.value;
 
-            reloadBrowsableImages(page, apiClient);
+            reloadBrowsableImagesFirstPage(page, apiClient);
         });
 
         page.querySelector('#chkAllLanguages').addEventListener('change', function () {
-            browsableImageStartIndex = 0;
+            reloadBrowsableImagesFirstPage(page, apiClient);
+        });
 
-            reloadBrowsableImages(page, apiClient);
+        page.querySelector('#chkShowParentImages').addEventListener('change', function () {
+            reloadBrowsableImagesFirstPage(page, apiClient);
         });
 
         page.addEventListener('click', function (e) {
@@ -336,6 +346,10 @@ import template from './imageDownloader.template.html';
             scrollHelper.centerFocus.on(dlg, false);
         }
 
+        if (browsableParentId) {
+            dlg.querySelector('#lblShowParentImages').classList.remove('hide');
+        }
+
         // Has to be assigned a z-index after the call to .open()
         dlg.addEventListener('close', onDialogClosed);
 
@@ -366,7 +380,7 @@ import template from './imageDownloader.template.html';
         }
     }
 
-export function show(itemId, serverId, itemType, imageType) {
+export function show(itemId, serverId, itemType, imageType, parentId) {
     return new Promise(function (resolve, reject) {
         currentResolve = resolve;
         currentReject = reject;
@@ -374,6 +388,7 @@ export function show(itemId, serverId, itemType, imageType) {
         browsableImageStartIndex = 0;
         browsableImageType = imageType || 'Primary';
         selectedProvider = null;
+        browsableParentId = parentId;
         showEditor(itemId, serverId, itemType);
     });
 }

--- a/src/components/imageDownloader/imageDownloader.template.html
+++ b/src/components/imageDownloader/imageDownloader.template.html
@@ -39,6 +39,10 @@
                 <input id="chkAllLanguages" type="checkbox" is="emby-checkbox" />
                 <span>${AllLanguages}</span>
             </label>
+            <label id="lblShowParentImages" class="hide" style="margin: 0 0 0 1em;width:auto;">
+                <input id="chkShowParentImages" type="checkbox" is="emby-checkbox" />
+                <span>${ShowParentImages}</span>
+            </label>
         </div>
 
         <div class="availableImagesList vertical-wrap centered"></div>

--- a/src/components/imageeditor/imageeditor.js
+++ b/src/components/imageeditor/imageeditor.js
@@ -280,7 +280,13 @@ import template from './imageeditor.template.html';
 
     function showImageDownloader(page, imageType) {
         import('../imageDownloader/imageDownloader').then((ImageDownloader) => {
-            ImageDownloader.show(currentItem.Id, currentItem.ServerId, currentItem.Type, imageType).then(function () {
+            ImageDownloader.show(
+                currentItem.Id,
+                currentItem.ServerId,
+                currentItem.Type,
+                imageType,
+                currentItem.Type == 'Season' ? currentItem.ParentId : null
+            ).then(function () {
                 hasChanges = true;
                 reload(page);
             });

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1384,6 +1384,7 @@
     "ShowIndicatorsFor": "Show indicators for:",
     "ShowLess": "Show less",
     "ShowMore": "Show more",
+    "ShowParentImages": "Show series images",
     "Shows": "Shows",
     "ShowTitle": "Show the title",
     "ShowYear": "Show the year",


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->


**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
When searching for images for a TV Season, new option to display series level images. 

I have several series where there aren't many options at the season level for images. But there are season specific images (based on cast changes, etc) tagged at the series level at image providers. Now users can check the box and pick from those images. Does not affect how automatic image downloads work.

![image](https://user-images.githubusercontent.com/991618/152247510-89a5b8ac-2bdc-4e88-b9cf-7a1c6d3c6362.png)