### PR TITLE
Fix issue where wrong plugin could be disabled

### DIFF
--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -137,11 +137,11 @@ function loadPlugins() {
     return getPlugins().then(function (list) {
         if (!appHost.supports('remotecontrol')) {
             // Disable remote player plugins if not supported
-            list.splice(list.indexOf('sessionPlayer'), 1);
-            list.splice(list.indexOf('chromecastPlayer'), 1);
+            list = list.filter(plugin => !plugin.startsWith('sessionPlayer')
+                && !plugin.startsWith('chromecastPlayer'));
         } else if (!browser.chrome && !browser.edgeChromium && !browser.opera) {
             // Disable chromecast player in unsupported browsers
-            list.splice(list.indexOf('chromecastPlayer'), 1);
+            list = list.filter(plugin => !plugin.startsWith('chromecastPlayer'));
         }
 
         // add any native plugins


### PR DESCRIPTION
**Changes**
Our code to disable the chromecast and session plugins in unsupported browsers were only working because they were last in the list of plugins because the wrong plugin name was used in the lookup. This fixes the plugin names and prevents removing other plugins if they are not found.

**Issues**
N/A
