### PR TITLE
Enable AV1 codec on webOS 5+ FHD

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -173,7 +173,7 @@ import browser from './browser';
     function testCanPlayAv1(videoTestElement) {
         if (browser.tizenVersion >= 5.5) {
             return true;
-        } else if (browser.web0sVersion >= 5 && window.outerHeight >= 2160) {
+        } else if (browser.web0sVersion >= 5) {
             return true;
         }
 


### PR DESCRIPTION
https://github.com/jellyfin/jellyfin-web/issues/3375#issuecomment-1028943399

`window.outerHeight` can be 1080 on UHD TVs, and LG probably specifies the `Maximum Data Transmission Rate` (not the supported codecs) in that table on their [website](https://webostv.developer.lge.com/discover/specifications/supported-media-formats/webos-50/).

So we are probably free to enable AV1 on webOS 5+ FHD.

**Changes**
Enable AV1 codec on webOS 5+ FHD

**Issues**
#3375
