### PR TITLE
Only hide OSD header when playing video

### DIFF
--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -223,9 +223,11 @@ import { appRouter } from '../../../components/appRouter';
         }
 
         function hideOsd() {
-            slideUpToHide(headerElement);
-            hideMainOsdControls();
-            mouseManager.hideCursor();
+            if (playbackManager.isFullscreen(currentPlayer)) {
+                slideUpToHide(headerElement);
+                hideMainOsdControls();
+                mouseManager.hideCursor();
+            }
         }
 
         function toggleOsd() {


### PR DESCRIPTION
This PR currently addresses the first instance (refer to issue).

Playing audio results in logic for playing video to occur; thus, hiding some elements that should stay visible. I'd assume it should work the other way around. If that's not the case this PR should fix that.

Don't hide the OSD header if we're playing audio

**Changes**
Check if player is fullscreened before hiding osd

**Issues**
Fixes #3382
