### PR TITLE
Add support for MPEG-1 Layer II audio for Chrome and Firefox

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -370,8 +370,15 @@ import browser from './browser';
                                     || videoTestElement.canPlayType('video/mp4; codecs="avc1.640029, mp4a.6B"').replace(/no/, '')
                                     || videoTestElement.canPlayType('video/mp4; codecs="avc1.640029, mp3"').replace(/no/, '');
 
-        // Not sure how to test for this
-        const supportsMp2VideoAudio = browser.edgeUwp || browser.tizen || browser.web0s;
+        let supportsMp2VideoAudio = options.supportsMp2VideoAudio;
+        if (supportsMp2VideoAudio == null) {
+            supportsMp2VideoAudio = browser.edgeUwp || browser.tizen || browser.web0s;
+
+            // If the browser supports MP3, it presumably supports MP2 as well
+            if (supportsMp3VideoAudio && (browser.chrome || browser.edgeChromium || (browser.firefox && browser.versionMajor >= 83))) {
+                supportsMp2VideoAudio = true;
+            }
+        }
 
         /* eslint-disable compat/compat */
         let maxVideoWidth = browser.xboxOne ?
@@ -428,6 +435,8 @@ import browser from './browser';
 
         if (supportsMp2VideoAudio) {
             videoAudioCodecs.push('mp2');
+            hlsInTsVideoAudioCodecs.push('mp2');
+            hlsInFmp4VideoAudioCodecs.push('mp2');
         }
 
         let supportsDts = options.supportsDts;


### PR DESCRIPTION
If these browsers support MP3, they support MP2 as well, at least when muxed with video (or in the mp4 container). Tested on latest Chrome, Edge Chromium, Firefox and Tizen 2020 TV.

**Changes**
- Added Chrome, Edge Chromium and Firefox to browsers supporting MP2 audio with video
- Enabled MP2 in HLS

**Before**
![image](https://user-images.githubusercontent.com/24361046/153314169-9013acbe-7dea-4475-8346-1f972b32a478.png)

**After**
![image](https://user-images.githubusercontent.com/24361046/153314196-334e4968-7407-4a7f-bf6e-3bc878a521b9.png)

