### PR TITLE
Fix focus on Home tab

### DIFF
--- a/src/components/homesections/homesections.js
+++ b/src/components/homesections/homesections.js
@@ -73,8 +73,7 @@ import ServerConnections from '../ServerConnections';
 
                 return Promise.all(promises).then(function () {
                     return resume(elem, {
-                        refresh: true,
-                        returnPromise: false
+                        refresh: true
                     });
                 });
             } else {
@@ -127,10 +126,7 @@ import ServerConnections from '../ServerConnections';
             promises.push(elems[i].resume(options));
         }
 
-        const promise = Promise.all(promises);
-        if (!options || options.returnPromise !== false) {
-            return promise;
-        }
+        return Promise.all(promises);
     }
 
     function loadSection(page, apiClient, user, userSettings, userViews, allSections, index) {


### PR DESCRIPTION
:warning: Perhaps this is done so that you don't have to wait for all sections to load on a slow connection.

**Changes**
Remove the `returnPromise` option, i.e. always return Promise so that the focus is executed after the sections are loaded.

**Issues**
Fixes #3413
