### PR TITLE
Display physical dimensions of player

### DIFF
--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1869,9 +1869,10 @@ function tryRemoveElement(elem) {
         };
         categories.push(videoCategory);
 
+        const devicePixelRatio = window.devicePixelRatio || 1;
         const rect = mediaElement.getBoundingClientRect ? mediaElement.getBoundingClientRect() : {};
-        let height = parseInt(rect.height);
-        let width = parseInt(rect.width);
+        let height = Math.round(rect.height * devicePixelRatio);
+        let width = Math.round(rect.width * devicePixelRatio);
 
         // Don't show player dimensions on smart TVs because the app UI could be lower resolution than the video and this causes users to think there is a problem
         if (width && height && !browser.tv) {


### PR DESCRIPTION
When using browser or system-wide scaling, the player size changes, misleading the user.

**Changes**
Multiply dimensions by `window.devicePixelRatio`.

**Issues**
Fixes #3418

I am not sure if we should use https://stackoverflow.com/a/35244519

:question: On the other hand, could the original values be useful? :thinking: 