### PR TITLE
Reload backdrop on restore

### DIFF
--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -2096,6 +2096,7 @@ export default function (view, params) {
                 if (currentItem) {
                     appRouter.setTitle('');
                     renderTrackSelections(page, self, currentItem, true);
+                    renderBackdrop(currentItem);
                 }
             } else {
                 reload(self, page, params);


### PR DESCRIPTION
Backdrop doesn't belong to the `itemDetails` view and must be reloaded explicitly.

**Changes**
Reload backdrop on restore

**Issues**
Fixes #2797
