### PR TITLE
Check OPUS support on webOS

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -123,12 +123,7 @@ import browser from './browser';
                 return true;
             }
         } else if (format === 'opus') {
-            if (!browser.web0s) {
-                typeString = 'audio/ogg; codecs="opus"';
-                return !!document.createElement('audio').canPlayType(typeString).replace(/no/, '');
-            }
-
-            return false;
+            typeString = 'audio/ogg; codecs="opus"';
         } else if (format === 'alac') {
             if (browser.iOS || browser.osx) {
                 return true;
@@ -142,7 +137,7 @@ import browser from './browser';
             typeString = 'audio/webm';
         } else if (format === 'mp2') {
             typeString = 'audio/mpeg';
-        } else {
+        } else if (!typeString) {
             typeString = 'audio/' + format;
         }
 


### PR DESCRIPTION
I'm not sure of the minimum version of webOS, but we can probably use `canPlayType`. _Need to test_
[Here](https://www.universalmediaserver.com/forum/viewtopic.php?t=10494) webOS 3.5

**Changes**
Don't ignore webOS when checking OPUS support

**Issues**
Fixes #3429

**Remarks**
Disabling OPUS on webOS: #724
We can switch to version checking if `canPlayType` doesn't work.