### PR TITLE
Fix show sort by date played

### DIFF
--- a/src/controllers/shows/tvshows.js
+++ b/src/controllers/shows/tvshows.js
@@ -260,7 +260,7 @@ import '../../elements/emby-itemscontainer/emby-itemscontainer';
                         id: 'DateCreated,SortName'
                     }, {
                         name: globalize.translate('OptionDatePlayed'),
-                        id: 'DatePlayed,SortName'
+                        id: 'SeriesDatePlayed,SortName'
                     }, {
                         name: globalize.translate('OptionParentalRating'),
                         id: 'OfficialRating,SortName'


### PR DESCRIPTION
Shows don't directly have a date played, but the episodes within the show do.

**Changes**
* Use the [series-specific date played sort-by](https://github.com/jellyfin/jellyfin/blob/5825a0572bdcd11afad283f1e62c07f5e2c61c06/MediaBrowser.Model/Querying/ItemSortBy.cs#L104) to query the max played date of items within the show instead of the show played date

**Issues**
Fixes jellyfin/jellyfin#6712