### PR TITLE
Fix nowplayingbar not displaying when restoring the view

### DIFF
--- a/src/components/nowPlayingBar/nowPlayingBar.js
+++ b/src/components/nowPlayingBar/nowPlayingBar.js
@@ -733,10 +733,10 @@ import { appRouter } from '../appRouter';
         updatePlayerVolumeState(player.isMuted(), player.getVolume());
     }
 
-    function refreshFromPlayer(player) {
+    function refreshFromPlayer(player, type) {
         const state = playbackManager.getPlayerState(player);
 
-        onStateChanged.call(player, { type: 'init' }, state);
+        onStateChanged.call(player, { type }, state);
     }
 
     function bindToPlayer(player) {
@@ -752,7 +752,7 @@ import { appRouter } from '../appRouter';
             return;
         }
 
-        refreshFromPlayer(player);
+        refreshFromPlayer(player, 'init');
 
         Events.on(player, 'playbackstart', onPlaybackStart);
         Events.on(player, 'statechange', onPlaybackStart);
@@ -780,7 +780,7 @@ import { appRouter } from '../appRouter';
         } else if (!isVisibilityAllowed) {
             isVisibilityAllowed = true;
             if (currentPlayer) {
-                refreshFromPlayer(currentPlayer);
+                refreshFromPlayer(currentPlayer, 'refresh');
             } else {
                 hideNowPlayingBar();
             }


### PR DESCRIPTION
`init` message was skipped in 2d5e7f745f54da7917ad6768d3e9b58fcadf3e69 :sweat: 

**Changes**
Use `refresh` type message to allow show/hide.
_I believe I can just remove `refreshFromPlayer` call in `bindToPlayer`._ :thinking: 
_Or we need to set [that `IsFullscreen` property](https://github.com/jellyfin/jellyfin-web/blob/f94b64ad99e6f14789227ae40df54de48e1c0bb7/src/components/nowPlayingBar/nowPlayingBar.js#L669) before playback starts._ :man_shrugging: 

**Issues**
N/A

**Steps for Reproduce**
1. Run music
2. Click nowPlayingBar to go to Queue
3. Click Back
4. NowPlayingBar is hidden