### PR TITLE
Add card padder icon for items with an image

### DIFF
--- a/src/components/cardbuilder/card.scss
+++ b/src/components/cardbuilder/card.scss
@@ -227,6 +227,10 @@ button::-moz-focus-inner {
     background-color: transparent;
 }
 
+.cardPadder {
+    position: relative; // For centering the cardImageIcon
+}
+
 .cardBox:not(.visualCardBox) .cardPadder {
     border-radius: 0.2em;
     background-color: #242424;
@@ -375,6 +379,14 @@ button::-moz-focus-inner {
 .cardImageIcon {
     font-size: 5em;
     color: inherit;
+}
+
+.cardPadder .cardImageIcon {
+    color: #111;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
 }
 
 .cardIndicators {

--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -1503,6 +1503,7 @@ import ServerConnections from '../ServerConnections';
                     return '<span class="cardImageIcon material-icons audiotrack"></span>';
                 case 'Movie':
                     return '<span class="cardImageIcon material-icons movie"></span>';
+                case 'Episode':
                 case 'Series':
                     return '<span class="cardImageIcon material-icons tv"></span>';
                 case 'Book':

--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -1344,7 +1344,13 @@ import ServerConnections from '../ServerConnections';
 
             const cardScalableClass = 'cardScalable';
 
-            cardImageContainerOpen = '<div class="' + cardBoxClass + '"><div class="' + cardScalableClass + '"><div class="cardPadder cardPadder-' + shape + '"></div>' + cardImageContainerOpen;
+            let cardPadderIcon = '';
+
+            if (imgUrl) {
+                cardPadderIcon = getDefaultText(item, options);
+            }
+
+            cardImageContainerOpen = `<div class="${cardBoxClass}"><div class="${cardScalableClass}"><div class="cardPadder cardPadder-${shape}">${cardPadderIcon}</div>${cardImageContainerOpen}`;
             cardBoxClose = '</div>';
             cardScalableClose = '</div>';
 

--- a/src/themes/appletv/theme.css
+++ b/src/themes/appletv/theme.css
@@ -481,6 +481,10 @@ a[data-role=button] {
     color: #00a4dc !important;
 }
 
+.cardPadder .cardImageIcon {
+    color: rgba(0, 0, 0, 0.1);
+}
+
 .card:focus .cardBox.visualCardBox,
 .card:focus .cardBox:not(.visualCardBox) .cardScalable {
     border-radius: 0.5rem;

--- a/src/themes/blueradiance/theme.css
+++ b/src/themes/blueradiance/theme.css
@@ -475,6 +475,10 @@ a[data-role=button] {
     background-color: rgba(0, 0, 0, 0.5);
 }
 
+.cardPadder .cardImageIcon {
+    color: rgba(0, 0, 0, 0.5);
+}
+
 .card:focus .cardBox.visualCardBox,
 .card:focus .cardBox:not(.visualCardBox) .cardScalable {
     border-color: #00a4dc !important;

--- a/src/themes/light/theme.css
+++ b/src/themes/light/theme.css
@@ -466,6 +466,10 @@ a[data-role=button] {
     background-color: #fff;
 }
 
+.cardPadder .cardImageIcon {
+    color: #ddd;
+}
+
 .card:focus .cardBox.visualCardBox,
 .card:focus .cardBox:not(.visualCardBox) .cardScalable {
     border-color: #00a4dc !important;

--- a/src/themes/purplehaze/theme.css
+++ b/src/themes/purplehaze/theme.css
@@ -577,6 +577,10 @@ a[data-role=button] {
     border-radius: 0.8em;
 }
 
+.cardPadder .cardImageIcon {
+    color: rgba(0, 0, 0, 0.5);
+}
+
 .card:focus .cardBox.visualCardBox,
 .card:focus .cardBox:not(.visualCardBox) .cardScalable {
     border-color: #ff77f1 !important;

--- a/src/themes/wmc/theme.css
+++ b/src/themes/wmc/theme.css
@@ -456,6 +456,10 @@ a[data-role=button] {
     background-color: #0f3562;
 }
 
+.cardPadder .cardImageIcon {
+    color: rgba(0, 0, 0, 0.4);
+}
+
 .card:focus .cardBox.visualCardBox,
 .card:focus .cardBox:not(.visualCardBox) .cardScalable {
     border-color: #fff !important;


### PR DESCRIPTION
Implementation of https://github.com/jellyfin/jellyfin-web/pull/909#issuecomment-605913197
_I did this for reactified ItemCard._

**Changes**
- Add card padder icon for items with an image.
- Add icon to `Episode` item type (same as for `Series`).

**Issues**
N/A

**Screenshots**
![padder](https://user-images.githubusercontent.com/56478732/155026236-4f737a6e-a5c9-4c58-8ab4-71950de65a36.png)
