### PR TITLE
Unhide some options on TVs

### DIFF
--- a/src/components/displaySettings/displaySettings.js
+++ b/src/components/displaySettings/displaySettings.js
@@ -100,16 +100,6 @@ import template from './displaySettings.template.html';
             context.querySelector('.fldDateTimeLocale').classList.add('hide');
         }
 
-        if (!browser.tizen && !browser.web0s) {
-            context.querySelector('.fldBackdrops').classList.remove('hide');
-            context.querySelector('.fldThemeSong').classList.remove('hide');
-            context.querySelector('.fldThemeVideo').classList.remove('hide');
-        } else {
-            context.querySelector('.fldBackdrops').classList.add('hide');
-            context.querySelector('.fldThemeSong').classList.add('hide');
-            context.querySelector('.fldThemeVideo').classList.add('hide');
-        }
-
         fillThemes(context.querySelector('#selectTheme'), userSettings.theme());
         fillThemes(context.querySelector('#selectDashboardTheme'), userSettings.dashboardTheme());
 

--- a/src/components/displaySettings/displaySettings.template.html
+++ b/src/components/displaySettings/displaySettings.template.html
@@ -231,7 +231,7 @@
         <div class="fieldDescription checkboxFieldDescription">${EnableDetailsBannerHelp}</div>
     </div>
 
-    <div class="checkboxContainer checkboxContainer-withDescription fldBackdrops hide">
+    <div class="checkboxContainer checkboxContainer-withDescription fldBackdrops">
         <label>
             <input type="checkbox" is="emby-checkbox" id="chkBackdrops" />
             <span>${Backdrops}</span>
@@ -239,7 +239,7 @@
         <div class="fieldDescription checkboxFieldDescription">${EnableBackdropsHelp}</div>
     </div>
 
-    <div class="checkboxContainer checkboxContainer-withDescription fldThemeSong hide">
+    <div class="checkboxContainer checkboxContainer-withDescription fldThemeSong">
         <label>
             <input type="checkbox" is="emby-checkbox" id="chkThemeSong" />
             <span>${ThemeSongs}</span>
@@ -247,7 +247,7 @@
         <div class="fieldDescription checkboxFieldDescription">${EnableThemeSongsHelp}</div>
     </div>
 
-    <div class="checkboxContainer checkboxContainer-withDescription fldThemeVideo hide">
+    <div class="checkboxContainer checkboxContainer-withDescription fldThemeVideo">
         <label>
             <input type="checkbox" is="emby-checkbox" id="chkThemeVideo" />
             <span>${ThemeVideos}</span>

--- a/src/components/playbackSettings/playbackSettings.js
+++ b/src/components/playbackSettings/playbackSettings.js
@@ -176,12 +176,6 @@ import template from './playbackSettings.template.html';
             context.querySelector('.fldChromecastQuality').classList.add('hide');
         }
 
-        if (browser.tizen || browser.web0s) {
-            context.querySelector('.fldEnableNextVideoOverlay').classList.add('hide');
-        } else {
-            context.querySelector('.fldEnableNextVideoOverlay').classList.remove('hide');
-        }
-
         context.querySelector('.chkPlayDefaultAudioTrack').checked = user.Configuration.PlayDefaultAudioTrack || false;
         context.querySelector('.chkPreferFmp4HlsContainer').checked = userSettings.preferFmp4HlsContainer();
         context.querySelector('.chkEnableCinemaMode').checked = userSettings.enableCinemaMode();

--- a/src/components/playbackSettings/playbackSettings.template.html
+++ b/src/components/playbackSettings/playbackSettings.template.html
@@ -90,7 +90,7 @@
             <div class="fieldDescription checkboxFieldDescription">${SetUsingLastTracksHelp}</div>
         </div>
 
-        <div class="checkboxContainer checkboxContainer-withDescription fldEnableNextVideoOverlay hide">
+        <div class="checkboxContainer checkboxContainer-withDescription fldEnableNextVideoOverlay">
             <label>
                 <input type="checkbox" is="emby-checkbox" class="chkEnableNextVideoOverlay" />
                 <span>${EnableNextVideoInfoOverlay}</span>


### PR DESCRIPTION
`EnableNextVideoOverlay` is enabled by default, but it cannot be disabled.

`Backdrops`, `ThemeSong` and `ThemeVideo` are disabled by default, but they cannot be enabled.
_Mostly due to the lack of performance of the TV hardware._

**Changes**
- Unhide `EnableNextVideoOverlay`
- Unhide `Backdrops`
- Unhide `ThemeSong`
- Unhide `ThemeVideo`

**Issues**
You can't disable/enable them.
