### PR TITLE
Update mixed library label

### DIFF
--- a/src/components/mediaLibraryCreator/mediaLibraryCreator.js
+++ b/src/components/mediaLibraryCreator/mediaLibraryCreator.js
@@ -87,12 +87,11 @@ import template from './mediaLibraryCreator.template.html';
                 if (index != -1) {
                     const name = this.options[index].innerHTML.replace('*', '').replace('&amp;', '&');
                     $('#txtValue', dlg).val(name);
-                    const folderOption = collectionTypeOptions.filter(i => {
-                        return i.value == value;
-                    })[0];
-                    $('.collectionTypeFieldDescription', dlg).html(folderOption.message || '');
                 }
             }
+
+            const folderOption = collectionTypeOptions.find(i => i.value === value);
+            $('.collectionTypeFieldDescription', dlg).html(folderOption?.message || '');
         });
         page.querySelector('.btnAddFolder').addEventListener('click', onAddButtonClick);
         page.querySelector('.btnSubmit').addEventListener('click', onAddLibrary);

--- a/src/controllers/dashboard/library.js
+++ b/src/controllers/dashboard/library.js
@@ -242,7 +242,7 @@ import cardBuilder from '../../components/cardbuilder/cardBuilder';
             name: globalize.translate('MusicVideos'),
             value: 'musicvideos'
         }, {
-            name: globalize.translate('Other'),
+            name: globalize.translate('MixedMoviesShows'),
             value: 'mixed',
             message: globalize.translate('MessageUnsetContentHelp')
         }];

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1095,6 +1095,7 @@
     "MillisecondsUnit": "ms",
     "MinutesAfter": "minutes after",
     "MinutesBefore": "minutes before",
+    "MixedMoviesShows": "Mixed Movies and Shows",
     "Mixer": "Mixer",
     "Mobile": "Mobile",
     "Monday": "Monday",


### PR DESCRIPTION
**Changes**
* Updates the label of the "mixed" library type to be "Mixed Movies and Shows" instead of "Other" since this has been a constant source of confusion.
* Fixes the description text not being displayed for the "mixed" library type

![Screenshot 2022-02-22 at 16-23-45 Jellyfin](https://user-images.githubusercontent.com/3450688/155221909-cbebb8c7-f318-4096-9c0d-72c9f0925ab7.png)

**Issues**
N/A
