### PR TITLE
Fix multiselect not being scoped to current container

### DIFF
--- a/src/components/multiSelect/multiSelect.js
+++ b/src/components/multiSelect/multiSelect.js
@@ -11,141 +11,6 @@ import itemHelper from '../itemHelper';
 
 import './multiSelect.scss';
 
-let selectedItems = [];
-let selectedElements = [];
-let currentSelectionCommandsPanel;
-
-function hideSelections() {
-    const selectionCommandsPanel = currentSelectionCommandsPanel;
-    if (selectionCommandsPanel) {
-        selectionCommandsPanel.parentNode.removeChild(selectionCommandsPanel);
-        currentSelectionCommandsPanel = null;
-
-        selectedItems = [];
-        selectedElements = [];
-        const elems = document.querySelectorAll('.itemSelectionPanel');
-        for (let i = 0, length = elems.length; i < length; i++) {
-            const parent = elems[i].parentNode;
-            parent.removeChild(elems[i]);
-            parent.classList.remove('withMultiSelect');
-        }
-    }
-}
-
-function onItemSelectionPanelClick(e, itemSelectionPanel) {
-    // toggle the checkbox, if it wasn't clicked on
-    if (!dom.parentWithClass(e.target, 'chkItemSelect')) {
-        const chkItemSelect = itemSelectionPanel.querySelector('.chkItemSelect');
-
-        if (chkItemSelect) {
-            if (chkItemSelect.classList.contains('checkedInitial')) {
-                chkItemSelect.classList.remove('checkedInitial');
-            } else {
-                const newValue = !chkItemSelect.checked;
-                chkItemSelect.checked = newValue;
-                updateItemSelection(chkItemSelect, newValue);
-            }
-        }
-    }
-
-    e.preventDefault();
-    e.stopPropagation();
-    return false;
-}
-
-function updateItemSelection(chkItemSelect, selected) {
-    const id = dom.parentWithAttribute(chkItemSelect, 'data-id').getAttribute('data-id');
-
-    if (selected) {
-        const current = selectedItems.filter(i => {
-            return i === id;
-        });
-
-        if (!current.length) {
-            selectedItems.push(id);
-            selectedElements.push(chkItemSelect);
-        }
-    } else {
-        selectedItems = selectedItems.filter(i => {
-            return i !== id;
-        });
-        selectedElements = selectedElements.filter(i => {
-            return i !== chkItemSelect;
-        });
-    }
-
-    if (selectedItems.length) {
-        const itemSelectionCount = document.querySelector('.itemSelectionCount');
-        if (itemSelectionCount) {
-            itemSelectionCount.innerHTML = selectedItems.length;
-        }
-    } else {
-        hideSelections();
-    }
-}
-
-function onSelectionChange() {
-    updateItemSelection(this, this.checked);
-}
-
-function showSelection(item, isChecked) {
-    let itemSelectionPanel = item.querySelector('.itemSelectionPanel');
-
-    if (!itemSelectionPanel) {
-        itemSelectionPanel = document.createElement('div');
-        itemSelectionPanel.classList.add('itemSelectionPanel');
-
-        const parent = item.querySelector('.cardBox') || item.querySelector('.cardContent');
-        parent.classList.add('withMultiSelect');
-        parent.appendChild(itemSelectionPanel);
-
-        let cssClass = 'chkItemSelect';
-        if (isChecked && !browser.firefox) {
-            // In firefox, the initial tap hold doesnt' get treated as a click
-            // In other browsers it does, so we need to make sure that initial click is ignored
-            cssClass += ' checkedInitial';
-        }
-        const checkedAttribute = isChecked ? ' checked' : '';
-        itemSelectionPanel.innerHTML = `<label class="checkboxContainer"><input type="checkbox" is="emby-checkbox" data-outlineclass="multiSelectCheckboxOutline" class="${cssClass}"${checkedAttribute}/><span></span></label>`;
-        const chkItemSelect = itemSelectionPanel.querySelector('.chkItemSelect');
-        chkItemSelect.addEventListener('change', onSelectionChange);
-    }
-}
-
-function showSelectionCommands() {
-    let selectionCommandsPanel = currentSelectionCommandsPanel;
-
-    if (!selectionCommandsPanel) {
-        selectionCommandsPanel = document.createElement('div');
-        selectionCommandsPanel.classList.add('selectionCommandsPanel');
-
-        document.body.appendChild(selectionCommandsPanel);
-        currentSelectionCommandsPanel = selectionCommandsPanel;
-
-        let html = '';
-
-        html += '<button is="paper-icon-button-light" class="btnCloseSelectionPanel autoSize"><span class="material-icons close" aria-hidden="true"></span></button>';
-        html += '<h1 class="itemSelectionCount"></h1>';
-
-        const moreIcon = 'more_vert';
-        html += `<button is="paper-icon-button-light" class="btnSelectionPanelOptions autoSize" style="margin-left:auto;"><span class="material-icons ${moreIcon}" aria-hidden="true"></span></button>`;
-
-        selectionCommandsPanel.innerHTML = html;
-
-        selectionCommandsPanel.querySelector('.btnCloseSelectionPanel').addEventListener('click', hideSelections);
-
-        const btnSelectionPanelOptions = selectionCommandsPanel.querySelector('.btnSelectionPanelOptions');
-
-        dom.addEventListener(btnSelectionPanelOptions, 'click', showMenuForSelectedItems, { passive: true });
-    }
-}
-
-function alertText(options) {
-    return new Promise((resolve) => {
-        alert(options).then(resolve, resolve);
-    });
-}
-
 function deleteItems(apiClient, itemIds) {
     return new Promise((resolve, reject) => {
         let msg = globalize.translate('ConfirmDeleteItem');
@@ -160,230 +25,463 @@ function deleteItems(apiClient, itemIds) {
             const promises = itemIds.map(itemId => apiClient.deleteItem(itemId));
 
             Promise.all(promises).then(resolve, () => {
-                alertText(globalize.translate('ErrorDeletingItem')).then(reject, reject);
+                alert(globalize.translate('ErrorDeletingItem')).finally(reject);
             });
         }, reject);
     });
 }
 
-function showMenuForSelectedItems(e) {
-    const apiClient = ServerConnections.currentApiClient();
+const getTouches = e => e.changedTouches || e.targetTouches || e.touches;
 
-    apiClient.getCurrentUser().then(user => {
-        // get first selected item to perform metadata refresh permission check
-        apiClient.getItem(apiClient.getCurrentUserId(), selectedItems[0]).then(firstItem => {
-            const menuItems = [];
+class MultiSelect {
+    selectedItems = [];
+    selectedElements = [];
+    currentSelectionCommandsPanel;
 
-            menuItems.push({
-                name: globalize.translate('SelectAll'),
-                id: 'selectall',
-                icon: 'select_all'
-            });
+    touchTarget;
+    touchStartTimeout;
+    touchStartX;
+    touchStartY;
 
-            menuItems.push({
-                name: globalize.translate('AddToCollection'),
-                id: 'addtocollection',
-                icon: 'add'
-            });
+    // TODO: Remove bindOnClick (always false)
+    constructor({ container, bindOnClick }) {
+        this.container = container;
 
-            menuItems.push({
-                name: globalize.translate('AddToPlaylist'),
-                id: 'playlist',
-                icon: 'playlist_add'
-            });
+        this.initEventListeners();
 
-            // TODO: Be more dynamic based on what is selected
-            if (user.Policy.EnableContentDeletion) {
-                menuItems.push({
-                    name: globalize.translate('Delete'),
-                    id: 'delete',
-                    icon: 'delete'
+        if (bindOnClick !== false) {
+            container.addEventListener('click', this.onContainerClick.bind(this));
+        }
+
+        document.addEventListener('viewbeforehide', this.hideSelections.bind(this));
+    }
+
+    initEventListeners() {
+        // mobile safari doesn't allow contextmenu override
+        if (browser.touch && !browser.safari) {
+            this.container.addEventListener('contextmenu', this.onTapHold.bind(this));
+        } else {
+            dom.addEventListener(
+                this.container,
+                'touchstart',
+                this.onTouchStart.bind(this),
+                { passive: true }
+            );
+            dom.addEventListener(
+                this.container,
+                'touchmove',
+                this.onTouchMove.bind(this),
+                { passive: true }
+            );
+            dom.addEventListener(
+                this.container,
+                'touchend',
+                this.onTouchEnd.bind(this),
+                { passive: true }
+            );
+            dom.addEventListener(
+                this.container,
+                'touchcancel',
+                this.onTouchEnd.bind(this),
+                { passive: true }
+            );
+            dom.addEventListener(
+                this.container,
+                'mousedown',
+                this.onMouseDown.bind(this),
+                { passive: true }
+            );
+            dom.addEventListener(
+                this.container,
+                'mouseleave',
+                this.onMouseOut.bind(this),
+                { passive: true }
+            );
+            dom.addEventListener(
+                this.container,
+                'mouseup',
+                this.onMouseOut.bind(this),
+                { passive: true }
+            );
+        }
+    }
+
+    destroy() {
+        this.container.removeEventListener('click', this.onContainerClick.bind(this));
+        this.container.removeEventListener('contextmenu', this.onTapHold.bind(this));
+
+        dom.removeEventListener(
+            this.container,
+            'touchstart',
+            this.onTouchStart.bind(this),
+            { passive: true }
+        );
+        dom.removeEventListener(
+            this.container,
+            'touchmove',
+            this.onTouchMove.bind(this),
+            { passive: true }
+        );
+        dom.removeEventListener(
+            this.container,
+            'touchend',
+            this.onTouchEnd.bind(this),
+            { passive: true }
+        );
+        dom.removeEventListener(
+            this.container,
+            'mousedown',
+            this.onMouseDown.bind(this),
+            { passive: true }
+        );
+        dom.removeEventListener(
+            this.container,
+            'mouseleave',
+            this.onMouseOut.bind(this),
+            { passive: true }
+        );
+        dom.removeEventListener(
+            this.container,
+            'mouseup',
+            this.onMouseOut.bind(this),
+            { passive: true }
+        );
+    }
+
+    showSelections(initialCard) {
+        import('../../elements/emby-checkbox/emby-checkbox').then(() => {
+            Array.from(document.querySelectorAll('.card'))
+                .forEach(card => {
+                    this.showSelection(card, initialCard === card);
                 });
+
+            this.showSelectionCommands();
+            this.updateItemSelection(initialCard, true);
+        });
+    }
+
+    showSelection(item, isChecked) {
+        let itemSelectionPanel = item.querySelector('.itemSelectionPanel');
+
+        if (!itemSelectionPanel) {
+            itemSelectionPanel = document.createElement('div');
+            itemSelectionPanel.classList.add('itemSelectionPanel');
+
+            const parent = item.querySelector('.cardBox') || item.querySelector('.cardContent');
+            parent.classList.add('withMultiSelect');
+            parent.appendChild(itemSelectionPanel);
+
+            let cssClass = 'chkItemSelect';
+            if (isChecked && !browser.firefox) {
+                // In firefox, the initial tap hold doesnt' get treated as a click
+                // In other browsers it does, so we need to make sure that initial click is ignored
+                cssClass += ' checkedInitial';
             }
 
-            if (user.Policy.EnableContentDownloading && appHost.supports('filedownload')) {
-                // Disabled because there is no callback for this item
-                /*
-                menuItems.push({
-                    name: globalize.translate('Download'),
-                    id: 'download',
-                    icon: 'file_download'
-                });
-                */
-            }
+            const checkedAttribute = isChecked ? ' checked' : '';
+            itemSelectionPanel.innerHTML = `<label class="checkboxContainer"><input type="checkbox" is="emby-checkbox" data-outlineclass="multiSelectCheckboxOutline" class="${cssClass}"${checkedAttribute}/><span></span></label>`;
 
-            if (user.Policy.IsAdministrator) {
-                menuItems.push({
-                    name: globalize.translate('GroupVersions'),
-                    id: 'groupvideos',
-                    icon: 'call_merge'
-                });
-            }
-
-            menuItems.push({
-                name: globalize.translate('MarkPlayed'),
-                id: 'markplayed',
-                icon: 'check_box'
+            const chkItemSelect = itemSelectionPanel.querySelector('.chkItemSelect');
+            chkItemSelect.addEventListener('change', () => {
+                this.updateItemSelection(chkItemSelect, chkItemSelect.checked);
             });
+        }
+    }
 
-            menuItems.push({
-                name: globalize.translate('MarkUnplayed'),
-                id: 'markunplayed',
-                icon: 'check_box_outline_blank'
-            });
+    showSelectionCommands() {
+        if (!this.currentSelectionCommandsPanel) {
+            const selectionCommandsPanel = document.createElement('div');
+            selectionCommandsPanel.classList.add('selectionCommandsPanel');
 
-            // this assues that if the user can refresh metadata for the first item
-            // they can refresh metadata for all items
-            if (itemHelper.canRefreshMetadata(firstItem, user)) {
+            document.body.appendChild(selectionCommandsPanel);
+            this.currentSelectionCommandsPanel = selectionCommandsPanel;
+
+            let html = '';
+            html += '<button is="paper-icon-button-light" class="btnCloseSelectionPanel autoSize"><span class="material-icons close" aria-hidden="true"></span></button>';
+            html += '<h1 class="itemSelectionCount"></h1>';
+            html += '<button is="paper-icon-button-light" class="btnSelectionPanelOptions autoSize" style="margin-left:auto;"><span class="material-icons more_vert" aria-hidden="true"></span></button>';
+
+            selectionCommandsPanel.innerHTML = html;
+
+            selectionCommandsPanel.querySelector('.btnCloseSelectionPanel').addEventListener('click', this.hideSelections.bind(this));
+
+            dom.addEventListener(
+                selectionCommandsPanel.querySelector('.btnSelectionPanelOptions'),
+                'click',
+                this.showMenuForSelectedItems.bind(this),
+                { passive: true }
+            );
+        }
+    }
+
+    showMenuForSelectedItems(e) {
+        const apiClient = ServerConnections.currentApiClient();
+
+        apiClient.getCurrentUser().then(user => {
+            // get first selected item to perform metadata refresh permission check
+            apiClient.getItem(apiClient.getCurrentUserId(), this.selectedItems[0]).then(firstItem => {
+                const menuItems = [];
+
                 menuItems.push({
-                    name: globalize.translate('RefreshMetadata'),
-                    id: 'refresh',
-                    icon: 'refresh'
+                    name: globalize.translate('SelectAll'),
+                    id: 'selectall',
+                    icon: 'select_all'
                 });
-            }
 
-            import('../actionSheet/actionSheet').then((actionsheet) => {
-                actionsheet.show({
-                    items: menuItems,
-                    positionTo: e.target,
-                    callback: function (id) {
-                        const items = selectedItems.slice(0);
-                        const serverId = apiClient.serverInfo().Id;
+                menuItems.push({
+                    name: globalize.translate('AddToCollection'),
+                    id: 'addtocollection',
+                    icon: 'add'
+                });
 
-                        switch (id) {
-                            case 'selectall':
-                                {
-                                    const elems = document.querySelectorAll('.itemSelectionPanel');
-                                    for (let i = 0, length = elems.length; i < length; i++) {
-                                        const chkItemSelect = elems[i].querySelector('.chkItemSelect');
+                menuItems.push({
+                    name: globalize.translate('AddToPlaylist'),
+                    id: 'playlist',
+                    icon: 'playlist_add'
+                });
 
-                                        if (chkItemSelect && !chkItemSelect.classList.contains('checkedInitial') && !chkItemSelect.checked && chkItemSelect.getBoundingClientRect().width != 0) {
-                                            chkItemSelect.checked = true;
-                                            updateItemSelection(chkItemSelect, true);
-                                        }
+                // TODO: Be more dynamic based on what is selected
+                if (user.Policy.EnableContentDeletion) {
+                    menuItems.push({
+                        name: globalize.translate('Delete'),
+                        id: 'delete',
+                        icon: 'delete'
+                    });
+                }
+
+                if (user.Policy.EnableContentDownloading && appHost.supports('filedownload')) {
+                    // Disabled because there is no callback for this item
+                    /*
+                    menuItems.push({
+                        name: globalize.translate('Download'),
+                        id: 'download',
+                        icon: 'file_download'
+                    });
+                    */
+                }
+
+                if (user.Policy.IsAdministrator) {
+                    menuItems.push({
+                        name: globalize.translate('GroupVersions'),
+                        id: 'groupvideos',
+                        icon: 'call_merge'
+                    });
+                }
+
+                menuItems.push({
+                    name: globalize.translate('MarkPlayed'),
+                    id: 'markplayed',
+                    icon: 'check_box'
+                });
+
+                menuItems.push({
+                    name: globalize.translate('MarkUnplayed'),
+                    id: 'markunplayed',
+                    icon: 'check_box_outline_blank'
+                });
+
+                // this assues that if the user can refresh metadata for the first item
+                // they can refresh metadata for all items
+                if (itemHelper.canRefreshMetadata(firstItem, user)) {
+                    menuItems.push({
+                        name: globalize.translate('RefreshMetadata'),
+                        id: 'refresh',
+                        icon: 'refresh'
+                    });
+                }
+
+                import('../actionSheet/actionSheet').then(actionsheet => {
+                    actionsheet.show({
+                        items: menuItems,
+                        positionTo: e.target,
+                        callback: id => {
+                            const items = this.selectedItems.slice(0);
+                            const serverId = apiClient.serverInfo().Id;
+
+                            switch (id) {
+                                case 'selectall':
+                                    {
+                                        // FIXME: Only work on items in container
+                                        Array.from(document.querySelectorAll('.itemSelectionPanel'))
+                                            .forEach(element => {
+                                                const chkItemSelect = element.querySelector('.chkItemSelect');
+
+                                                if (chkItemSelect && !chkItemSelect.classList.contains('checkedInitial') && !chkItemSelect.checked && chkItemSelect.getBoundingClientRect().width != 0) {
+                                                    chkItemSelect.checked = true;
+                                                    this.updateItemSelection(chkItemSelect, true);
+                                                }
+                                            });
                                     }
-                                }
-                                break;
-                            case 'addtocollection':
-                                import('../collectionEditor/collectionEditor').then(({default: collectionEditor}) => {
-                                    new collectionEditor({
+                                    break;
+                                case 'addtocollection':
+                                    import('../collectionEditor/collectionEditor').then(({default: collectionEditor}) => {
+                                        new collectionEditor({
+                                            items: items,
+                                            serverId: serverId
+                                        });
+                                    });
+                                    this.hideSelections();
+                                    this.dispatchNeedsRefresh();
+                                    break;
+                                case 'playlist':
+                                    new playlistEditor({
                                         items: items,
                                         serverId: serverId
                                     });
-                                });
-                                hideSelections();
-                                dispatchNeedsRefresh();
-                                break;
-                            case 'playlist':
-                                new playlistEditor({
-                                    items: items,
-                                    serverId: serverId
-                                });
-                                hideSelections();
-                                dispatchNeedsRefresh();
-                                break;
-                            case 'delete':
-                                deleteItems(apiClient, items).then(dispatchNeedsRefresh);
-                                hideSelections();
-                                dispatchNeedsRefresh();
-                                break;
-                            case 'groupvideos':
-                                combineVersions(apiClient, items);
-                                break;
-                            case 'markplayed':
-                                items.forEach(itemId => {
-                                    apiClient.markPlayed(apiClient.getCurrentUserId(), itemId);
-                                });
-                                hideSelections();
-                                dispatchNeedsRefresh();
-                                break;
-                            case 'markunplayed':
-                                items.forEach(itemId => {
-                                    apiClient.markUnplayed(apiClient.getCurrentUserId(), itemId);
-                                });
-                                hideSelections();
-                                dispatchNeedsRefresh();
-                                break;
-                            case 'refresh':
-                                import('../refreshdialog/refreshdialog').then(({default: refreshDialog}) => {
-                                    new refreshDialog({
-                                        itemIds: items,
-                                        serverId: serverId
-                                    }).show();
-                                });
-                                hideSelections();
-                                dispatchNeedsRefresh();
-                                break;
-                            default:
-                                break;
+                                    this.hideSelections();
+                                    this.dispatchNeedsRefresh();
+                                    break;
+                                case 'delete':
+                                    deleteItems(apiClient, items).then(() => this.dispatchNeedsRefresh());
+                                    this.hideSelections();
+                                    this.dispatchNeedsRefresh();
+                                    break;
+                                case 'groupvideos':
+                                    this.combineVersions(apiClient, items);
+                                    break;
+                                case 'markplayed':
+                                    items.forEach(itemId => {
+                                        apiClient.markPlayed(apiClient.getCurrentUserId(), itemId);
+                                    });
+                                    this.hideSelections();
+                                    this.dispatchNeedsRefresh();
+                                    break;
+                                case 'markunplayed':
+                                    items.forEach(itemId => {
+                                        apiClient.markUnplayed(apiClient.getCurrentUserId(), itemId);
+                                    });
+                                    this.hideSelections();
+                                    this.dispatchNeedsRefresh();
+                                    break;
+                                case 'refresh':
+                                    import('../refreshdialog/refreshdialog').then(({default: refreshDialog}) => {
+                                        new refreshDialog({
+                                            itemIds: items,
+                                            serverId: serverId
+                                        }).show();
+                                    });
+                                    this.hideSelections();
+                                    this.dispatchNeedsRefresh();
+                                    break;
+                                default:
+                                    break;
+                            }
                         }
-                    }
+                    });
                 });
             });
         });
-    });
-}
-
-function dispatchNeedsRefresh() {
-    const elems = [];
-
-    [].forEach.call(selectedElements, i => {
-        const container = dom.parentWithAttribute(i, 'is', 'emby-itemscontainer');
-
-        if (container && !elems.includes(container)) {
-            elems.push(container);
-        }
-    });
-
-    for (let i = 0, length = elems.length; i < length; i++) {
-        elems[i].notifyRefreshNeeded(true);
     }
-}
 
-function combineVersions(apiClient, selection) {
-    if (selection.length < 2) {
-        alert({
-            text: globalize.translate('PleaseSelectTwoItems')
+    hideSelections() {
+        const selectionCommandsPanel = this.currentSelectionCommandsPanel;
+        if (selectionCommandsPanel) {
+            selectionCommandsPanel.parentNode.removeChild(selectionCommandsPanel);
+
+            this.currentSelectionCommandsPanel = null;
+            this.selectedItems = [];
+            this.selectedElements = [];
+
+            Array.from(document.querySelectorAll('.itemSelectionPanel'))
+                .forEach(panel => {
+                    const parent = panel.parentNode;
+                    parent.removeChild(panel);
+                    parent.classList.remove('withMultiSelect');
+                });
+        }
+    }
+
+    combineVersions(apiClient, selection) {
+        if (selection.length < 2) {
+            alert({
+                text: globalize.translate('PleaseSelectTwoItems')
+            });
+
+            return;
+        }
+
+        loading.show();
+
+        apiClient.ajax({
+            type: 'POST',
+            url: apiClient.getUrl('Videos/MergeVersions', { Ids: selection.join(',') })
+        }).then(() => {
+            loading.hide();
+            this.hideSelections();
+            this.dispatchNeedsRefresh();
+        });
+    }
+
+    dispatchNeedsRefresh() {
+        const elements = [];
+
+        Array.from(this.selectedElements).forEach(i => {
+            const container = dom.parentWithAttribute(i, 'is', 'emby-itemscontainer');
+
+            if (container && !elements.includes(container)) {
+                elements.push(container);
+            }
         });
 
-        return;
+        elements.forEach(elem => elem.notifyRefreshNeeded(true));
     }
 
-    loading.show();
+    updateItemSelection(chkItemSelect, selected) {
+        const id = dom.parentWithAttribute(chkItemSelect, 'data-id').getAttribute('data-id');
 
-    apiClient.ajax({
+        if (selected) {
+            const current = this.selectedItems.filter(i => i === id);
 
-        type: 'POST',
-        url: apiClient.getUrl('Videos/MergeVersions', { Ids: selection.join(',') })
-
-    }).then(() => {
-        loading.hide();
-        hideSelections();
-        dispatchNeedsRefresh();
-    });
-}
-
-function showSelections(initialCard) {
-    import('../../elements/emby-checkbox/emby-checkbox').then(() => {
-        const cards = document.querySelectorAll('.card');
-        for (let i = 0, length = cards.length; i < length; i++) {
-            showSelection(cards[i], initialCard === cards[i]);
+            if (!current.length) {
+                this.selectedItems.push(id);
+                this.selectedElements.push(chkItemSelect);
+            }
+        } else {
+            this.selectedItems = this.selectedItems.filter(i => i !== id);
+            this.selectedElements = this.selectedElements.filter(e => e !== chkItemSelect);
         }
 
-        showSelectionCommands();
-        updateItemSelection(initialCard, true);
-    });
-}
+        if (this.selectedItems.length) {
+            const itemSelectionCount = document.querySelector('.itemSelectionCount');
+            if (itemSelectionCount) {
+                itemSelectionCount.innerHTML = this.selectedItems.length;
+            }
+        } else {
+            this.hideSelections();
+        }
+    }
 
-function onContainerClick(e) {
-    const target = e.target;
+    onContainerClick(e) {
+        const target = e.target;
 
-    if (selectedItems.length) {
-        const card = dom.parentWithClass(target, 'card');
-        if (card) {
-            const itemSelectionPanel = card.querySelector('.itemSelectionPanel');
-            if (itemSelectionPanel) {
-                return onItemSelectionPanelClick(e, itemSelectionPanel);
+        if (this.selectedItems.length) {
+            const card = dom.parentWithClass(target, 'card');
+            if (card) {
+                const itemSelectionPanel = card.querySelector('.itemSelectionPanel');
+                if (itemSelectionPanel) {
+                    return this.onItemSelectionPanelClick(e, itemSelectionPanel);
+                }
+            }
+
+            e.preventDefault();
+            e.stopPropagation();
+            return false;
+        }
+    }
+
+    onItemSelectionPanelClick(e, itemSelectionPanel) {
+        // toggle the checkbox, if it wasn't clicked on
+        if (!dom.parentWithClass(e.target, 'chkItemSelect')) {
+            const chkItemSelect = itemSelectionPanel.querySelector('.chkItemSelect');
+
+            if (chkItemSelect) {
+                if (chkItemSelect.classList.contains('checkedInitial')) {
+                    chkItemSelect.classList.remove('checkedInitial');
+                } else {
+                    const newValue = !chkItemSelect.checked;
+                    chkItemSelect.checked = newValue;
+                    this.updateItemSelection(chkItemSelect, newValue);
+                }
             }
         }
 
@@ -391,20 +489,12 @@ function onContainerClick(e) {
         e.stopPropagation();
         return false;
     }
-}
 
-document.addEventListener('viewbeforehide', hideSelections);
-
-export default function (options) {
-    const self = this;
-
-    const container = options.container;
-
-    function onTapHold(e) {
+    onTapHold(e) {
         const card = dom.parentWithClass(e.target, 'card');
 
         if (card) {
-            showSelections(card);
+            this.showSelections(card);
         }
 
         e.preventDefault();
@@ -415,43 +505,35 @@ export default function (options) {
         return false;
     }
 
-    function getTouches(e) {
-        return e.changedTouches || e.targetTouches || e.touches;
-    }
-
-    let touchTarget;
-    let touchStartTimeout;
-    let touchStartX;
-    let touchStartY;
-    function onTouchStart(e) {
+    onTouchStart(e) {
         const touch = getTouches(e)[0];
-        touchTarget = null;
-        touchStartX = 0;
-        touchStartY = 0;
+        this.touchTarget = null;
+        this.touchStartX = 0;
+        this.touchStartY = 0;
 
         if (touch) {
-            touchStartX = touch.clientX;
-            touchStartY = touch.clientY;
+            this.touchStartX = touch.clientX;
+            this.touchStartY = touch.clientY;
             const element = touch.target;
 
             if (element) {
                 const card = dom.parentWithClass(element, 'card');
 
                 if (card) {
-                    if (touchStartTimeout) {
-                        clearTimeout(touchStartTimeout);
-                        touchStartTimeout = null;
+                    if (this.touchStartTimeout) {
+                        clearTimeout(this.touchStartTimeout);
+                        this.touchStartTimeout = null;
                     }
 
-                    touchTarget = card;
-                    touchStartTimeout = setTimeout(onTouchStartTimerFired, 550);
+                    this.touchTarget = card;
+                    this.touchStartTimeout = setTimeout(this.onTouchStartTimerFired.bind(this), 550);
                 }
             }
         }
     }
 
-    function onTouchMove(e) {
-        if (touchTarget) {
+    onTouchMove(e) {
+        if (this.touchTarget) {
             const touch = getTouches(e)[0];
             let deltaX;
             let deltaY;
@@ -459,113 +541,52 @@ export default function (options) {
             if (touch) {
                 const touchEndX = touch.clientX || 0;
                 const touchEndY = touch.clientY || 0;
-                deltaX = Math.abs(touchEndX - (touchStartX || 0));
-                deltaY = Math.abs(touchEndY - (touchStartY || 0));
+                deltaX = Math.abs(touchEndX - (this.touchStartX || 0));
+                deltaY = Math.abs(touchEndY - (this.touchStartY || 0));
             } else {
                 deltaX = 100;
                 deltaY = 100;
             }
             if (deltaX >= 5 || deltaY >= 5) {
-                onMouseOut();
+                this.onMouseOut();
             }
         }
     }
 
-    function onTouchEnd() {
-        onMouseOut();
+    onTouchEnd() {
+        this.onMouseOut();
     }
 
-    function onMouseDown(e) {
-        if (touchStartTimeout) {
-            clearTimeout(touchStartTimeout);
-            touchStartTimeout = null;
+    onMouseDown(e) {
+        if (this.touchStartTimeout) {
+            clearTimeout(this.touchStartTimeout);
+            this.touchStartTimeout = null;
         }
 
-        touchTarget = e.target;
-        touchStartTimeout = setTimeout(onTouchStartTimerFired, 550);
+        this.touchTarget = e.target;
+        this.touchStartTimeout = setTimeout(this.onTouchStartTimerFired.bind(this), 550);
     }
 
-    function onMouseOut() {
-        if (touchStartTimeout) {
-            clearTimeout(touchStartTimeout);
-            touchStartTimeout = null;
+    onMouseOut() {
+        if (this.touchStartTimeout) {
+            clearTimeout(this.touchStartTimeout);
+            this.touchStartTimeout = null;
         }
-        touchTarget = null;
+        this.touchTarget = null;
     }
 
-    function onTouchStartTimerFired() {
-        if (!touchTarget) {
+    onTouchStartTimerFired() {
+        if (!this.touchTarget) {
             return;
         }
 
-        const card = dom.parentWithClass(touchTarget, 'card');
-        touchTarget = null;
+        const card = dom.parentWithClass(this.touchTarget, 'card');
+        this.touchTarget = null;
 
         if (card) {
-            showSelections(card);
+            this.showSelections(card);
         }
     }
-
-    function initTapHold(element) {
-        // mobile safari doesn't allow contextmenu override
-        if (browser.touch && !browser.safari) {
-            element.addEventListener('contextmenu', onTapHold);
-        } else {
-            dom.addEventListener(element, 'touchstart', onTouchStart, {
-                passive: true
-            });
-            dom.addEventListener(element, 'touchmove', onTouchMove, {
-                passive: true
-            });
-            dom.addEventListener(element, 'touchend', onTouchEnd, {
-                passive: true
-            });
-            dom.addEventListener(element, 'touchcancel', onTouchEnd, {
-                passive: true
-            });
-            dom.addEventListener(element, 'mousedown', onMouseDown, {
-                passive: true
-            });
-            dom.addEventListener(element, 'mouseleave', onMouseOut, {
-                passive: true
-            });
-            dom.addEventListener(element, 'mouseup', onMouseOut, {
-                passive: true
-            });
-        }
-    }
-
-    initTapHold(container);
-
-    if (options.bindOnClick !== false) {
-        container.addEventListener('click', onContainerClick);
-    }
-
-    self.onContainerClick = onContainerClick;
-
-    self.destroy = () => {
-        container.removeEventListener('click', onContainerClick);
-        container.removeEventListener('contextmenu', onTapHold);
-
-        const element = container;
-
-        dom.removeEventListener(element, 'touchstart', onTouchStart, {
-            passive: true
-        });
-        dom.removeEventListener(element, 'touchmove', onTouchMove, {
-            passive: true
-        });
-        dom.removeEventListener(element, 'touchend', onTouchEnd, {
-            passive: true
-        });
-        dom.removeEventListener(element, 'mousedown', onMouseDown, {
-            passive: true
-        });
-        dom.removeEventListener(element, 'mouseleave', onMouseOut, {
-            passive: true
-        });
-        dom.removeEventListener(element, 'mouseup', onMouseOut, {
-            passive: true
-        });
-    };
 }
+
+export default MultiSelect;

--- a/src/components/multiSelect/multiSelect.js
+++ b/src/components/multiSelect/multiSelect.js
@@ -46,100 +46,46 @@ class MultiSelect {
     constructor({ container }) {
         this.container = container;
 
+        this.hideSelections = this.hideSelections.bind(this);
+        this.onTouchStartTimerFired = this.onTouchStartTimerFired.bind(this);
+        this.showMenuForSelectedItems = this.showMenuForSelectedItems.bind(this);
+
+        this.onTapHold = this.onTapHold.bind(this);
+        this.onTouchStart = this.onTouchStart.bind(this);
+        this.onTouchMove = this.onTouchMove.bind(this);
+        this.onTouchEnd = this.onTouchEnd.bind(this);
+        this.onMouseDown = this.onMouseDown.bind(this);
+        this.onMouseOut = this.onMouseOut.bind(this);
+
         this.initEventListeners();
 
-        document.addEventListener('viewbeforehide', this.hideSelections.bind(this));
+        document.addEventListener('viewbeforehide', this.hideSelections);
     }
 
     initEventListeners() {
         // mobile safari doesn't allow contextmenu override
         if (browser.touch && !browser.safari) {
-            this.container.addEventListener('contextmenu', this.onTapHold.bind(this));
+            this.container.addEventListener('contextmenu', this.onTapHold);
         } else {
-            dom.addEventListener(
-                this.container,
-                'touchstart',
-                this.onTouchStart.bind(this),
-                { passive: true }
-            );
-            dom.addEventListener(
-                this.container,
-                'touchmove',
-                this.onTouchMove.bind(this),
-                { passive: true }
-            );
-            dom.addEventListener(
-                this.container,
-                'touchend',
-                this.onTouchEnd.bind(this),
-                { passive: true }
-            );
-            dom.addEventListener(
-                this.container,
-                'touchcancel',
-                this.onTouchEnd.bind(this),
-                { passive: true }
-            );
-            dom.addEventListener(
-                this.container,
-                'mousedown',
-                this.onMouseDown.bind(this),
-                { passive: true }
-            );
-            dom.addEventListener(
-                this.container,
-                'mouseleave',
-                this.onMouseOut.bind(this),
-                { passive: true }
-            );
-            dom.addEventListener(
-                this.container,
-                'mouseup',
-                this.onMouseOut.bind(this),
-                { passive: true }
-            );
+            dom.addEventListener(this.container, 'touchstart', this.onTouchStart, { passive: true });
+            dom.addEventListener(this.container, 'touchmove', this.onTouchMove, { passive: true });
+            dom.addEventListener(this.container, 'touchend', this.onTouchEnd, { passive: true });
+            dom.addEventListener(this.container, 'touchcancel', this.onTouchEnd, { passive: true });
+            dom.addEventListener(this.container, 'mousedown', this.onMouseDown, { passive: true });
+            dom.addEventListener(this.container, 'mouseleave', this.onMouseOut, { passive: true });
+            dom.addEventListener(this.container, 'mouseup', this.onMouseOut, { passive: true });
         }
     }
 
     destroy() {
-        this.container.removeEventListener('contextmenu', this.onTapHold.bind(this));
+        this.container.removeEventListener('contextmenu', this.onTapHold);
 
-        dom.removeEventListener(
-            this.container,
-            'touchstart',
-            this.onTouchStart.bind(this),
-            { passive: true }
-        );
-        dom.removeEventListener(
-            this.container,
-            'touchmove',
-            this.onTouchMove.bind(this),
-            { passive: true }
-        );
-        dom.removeEventListener(
-            this.container,
-            'touchend',
-            this.onTouchEnd.bind(this),
-            { passive: true }
-        );
-        dom.removeEventListener(
-            this.container,
-            'mousedown',
-            this.onMouseDown.bind(this),
-            { passive: true }
-        );
-        dom.removeEventListener(
-            this.container,
-            'mouseleave',
-            this.onMouseOut.bind(this),
-            { passive: true }
-        );
-        dom.removeEventListener(
-            this.container,
-            'mouseup',
-            this.onMouseOut.bind(this),
-            { passive: true }
-        );
+        dom.removeEventListener(this.container, 'touchstart', this.onTouchStart, { passive: true });
+        dom.removeEventListener(this.container, 'touchmove', this.onTouchMove, { passive: true });
+        dom.removeEventListener(this.container, 'touchend', this.onTouchEnd, { passive: true });
+        dom.removeEventListener(this.container, 'mousedown', this.onMouseDown, { passive: true });
+        dom.removeEventListener(this.container, 'mouseleave', this.onMouseOut, { passive: true });
+        dom.removeEventListener(this.container, 'mouseup', this.onMouseOut, { passive: true });
     }
 
     showSelections(initialCard) {
@@ -197,12 +143,12 @@ class MultiSelect {
 
             selectionCommandsPanel.innerHTML = html;
 
-            selectionCommandsPanel.querySelector('.btnCloseSelectionPanel').addEventListener('click', this.hideSelections.bind(this));
+            selectionCommandsPanel.querySelector('.btnCloseSelectionPanel').addEventListener('click', this.hideSelections);
 
             dom.addEventListener(
                 selectionCommandsPanel.querySelector('.btnSelectionPanelOptions'),
                 'click',
-                this.showMenuForSelectedItems.bind(this),
+                this.showMenuForSelectedItems,
                 { passive: true }
             );
         }
@@ -478,7 +424,7 @@ class MultiSelect {
                     }
 
                     this.touchTarget = card;
-                    this.touchStartTimeout = setTimeout(this.onTouchStartTimerFired.bind(this), 550);
+                    this.touchStartTimeout = setTimeout(this.onTouchStartTimerFired, 550);
                 }
             }
         }
@@ -516,7 +462,7 @@ class MultiSelect {
         }
 
         this.touchTarget = e.target;
-        this.touchStartTimeout = setTimeout(this.onTouchStartTimerFired.bind(this), 550);
+        this.touchStartTimeout = setTimeout(this.onTouchStartTimerFired, 550);
     }
 
     onMouseOut() {

--- a/src/components/multiSelect/multiSelect.js
+++ b/src/components/multiSelect/multiSelect.js
@@ -43,15 +43,10 @@ class MultiSelect {
     touchStartX;
     touchStartY;
 
-    // TODO: Remove bindOnClick (always false)
-    constructor({ container, bindOnClick }) {
+    constructor({ container }) {
         this.container = container;
 
         this.initEventListeners();
-
-        if (bindOnClick !== false) {
-            container.addEventListener('click', this.onContainerClick.bind(this));
-        }
 
         document.addEventListener('viewbeforehide', this.hideSelections.bind(this));
     }
@@ -107,7 +102,6 @@ class MultiSelect {
     }
 
     destroy() {
-        this.container.removeEventListener('click', this.onContainerClick.bind(this));
         this.container.removeEventListener('contextmenu', this.onTapHold.bind(this));
 
         dom.removeEventListener(
@@ -446,45 +440,6 @@ class MultiSelect {
         } else {
             this.hideSelections();
         }
-    }
-
-    onContainerClick(e) {
-        const target = e.target;
-
-        if (this.selectedItems.length) {
-            const card = dom.parentWithClass(target, 'card');
-            if (card) {
-                const itemSelectionPanel = card.querySelector('.itemSelectionPanel');
-                if (itemSelectionPanel) {
-                    return this.onItemSelectionPanelClick(e, itemSelectionPanel);
-                }
-            }
-
-            e.preventDefault();
-            e.stopPropagation();
-            return false;
-        }
-    }
-
-    onItemSelectionPanelClick(e, itemSelectionPanel) {
-        // toggle the checkbox, if it wasn't clicked on
-        if (!dom.parentWithClass(e.target, 'chkItemSelect')) {
-            const chkItemSelect = itemSelectionPanel.querySelector('.chkItemSelect');
-
-            if (chkItemSelect) {
-                if (chkItemSelect.classList.contains('checkedInitial')) {
-                    chkItemSelect.classList.remove('checkedInitial');
-                } else {
-                    const newValue = !chkItemSelect.checked;
-                    chkItemSelect.checked = newValue;
-                    this.updateItemSelection(chkItemSelect, newValue);
-                }
-            }
-        }
-
-        e.preventDefault();
-        e.stopPropagation();
-        return false;
     }
 
     onTapHold(e) {

--- a/src/components/multiSelect/multiSelect.js
+++ b/src/components/multiSelect/multiSelect.js
@@ -388,6 +388,45 @@ class MultiSelect {
         }
     }
 
+    onContainerClick(e) {
+        const target = e.target;
+
+        if (this.selectedItems?.length) {
+            const card = dom.parentWithClass(target, 'card');
+            if (card) {
+                const itemSelectionPanel = card.querySelector('.itemSelectionPanel');
+                if (itemSelectionPanel) {
+                    return this.onItemSelectionPanelClick(e, itemSelectionPanel);
+                }
+            }
+
+            e.preventDefault();
+            e.stopPropagation();
+            return false;
+        }
+    }
+
+    onItemSelectionPanelClick(e, itemSelectionPanel) {
+        // toggle the checkbox, if it wasn't clicked on
+        if (!dom.parentWithClass(e.target, 'chkItemSelect')) {
+            const chkItemSelect = itemSelectionPanel.querySelector('.chkItemSelect');
+
+            if (chkItemSelect) {
+                if (chkItemSelect.classList.contains('checkedInitial')) {
+                    chkItemSelect.classList.remove('checkedInitial');
+                } else {
+                    const newValue = !chkItemSelect.checked;
+                    chkItemSelect.checked = newValue;
+                    this.updateItemSelection(chkItemSelect, newValue);
+                }
+            }
+        }
+
+        e.preventDefault();
+        e.stopPropagation();
+        return false;
+    }
+
     onTapHold(e) {
         const card = dom.parentWithClass(e.target, 'card');
 

--- a/src/components/multiSelect/multiSelect.js
+++ b/src/components/multiSelect/multiSelect.js
@@ -150,7 +150,7 @@ class MultiSelect {
 
     showSelections(initialCard) {
         import('../../elements/emby-checkbox/emby-checkbox').then(() => {
-            Array.from(document.querySelectorAll('.card'))
+            Array.from(this.container.querySelectorAll('.card'))
                 .forEach(card => {
                     this.showSelection(card, initialCard === card);
                 });
@@ -300,18 +300,15 @@ class MultiSelect {
 
                             switch (id) {
                                 case 'selectall':
-                                    {
-                                        // FIXME: Only work on items in container
-                                        Array.from(document.querySelectorAll('.itemSelectionPanel'))
-                                            .forEach(element => {
-                                                const chkItemSelect = element.querySelector('.chkItemSelect');
+                                    Array.from(this.container.querySelectorAll('.itemSelectionPanel'))
+                                        .forEach(element => {
+                                            const chkItemSelect = element.querySelector('.chkItemSelect');
 
-                                                if (chkItemSelect && !chkItemSelect.classList.contains('checkedInitial') && !chkItemSelect.checked && chkItemSelect.getBoundingClientRect().width != 0) {
-                                                    chkItemSelect.checked = true;
-                                                    this.updateItemSelection(chkItemSelect, true);
-                                                }
-                                            });
-                                    }
+                                            if (chkItemSelect && !chkItemSelect.classList.contains('checkedInitial') && !chkItemSelect.checked) {
+                                                chkItemSelect.checked = true;
+                                                this.updateItemSelection(chkItemSelect, true);
+                                            }
+                                        });
                                     break;
                                 case 'addtocollection':
                                     import('../collectionEditor/collectionEditor').then(({default: collectionEditor}) => {

--- a/src/components/multiSelect/multiSelect.js
+++ b/src/components/multiSelect/multiSelect.js
@@ -3,49 +3,387 @@ import { appHost } from '../apphost';
 import loading from '../loading/loading';
 import globalize from '../../scripts/globalize';
 import dom from '../../scripts/dom';
-import './multiSelect.scss';
 import ServerConnections from '../ServerConnections';
 import alert from '../alert';
 import playlistEditor from '../playlisteditor/playlisteditor';
 import confirm from '../confirm/confirm';
 import itemHelper from '../itemHelper';
 
-/* eslint-disable indent */
+import './multiSelect.scss';
 
-    let selectedItems = [];
-    let selectedElements = [];
-    let currentSelectionCommandsPanel;
+let selectedItems = [];
+let selectedElements = [];
+let currentSelectionCommandsPanel;
 
-    function hideSelections() {
-        const selectionCommandsPanel = currentSelectionCommandsPanel;
-        if (selectionCommandsPanel) {
-            selectionCommandsPanel.parentNode.removeChild(selectionCommandsPanel);
-            currentSelectionCommandsPanel = null;
+function hideSelections() {
+    const selectionCommandsPanel = currentSelectionCommandsPanel;
+    if (selectionCommandsPanel) {
+        selectionCommandsPanel.parentNode.removeChild(selectionCommandsPanel);
+        currentSelectionCommandsPanel = null;
 
-            selectedItems = [];
-            selectedElements = [];
-            const elems = document.querySelectorAll('.itemSelectionPanel');
-            for (let i = 0, length = elems.length; i < length; i++) {
-                const parent = elems[i].parentNode;
-                parent.removeChild(elems[i]);
-                parent.classList.remove('withMultiSelect');
+        selectedItems = [];
+        selectedElements = [];
+        const elems = document.querySelectorAll('.itemSelectionPanel');
+        for (let i = 0, length = elems.length; i < length; i++) {
+            const parent = elems[i].parentNode;
+            parent.removeChild(elems[i]);
+            parent.classList.remove('withMultiSelect');
+        }
+    }
+}
+
+function onItemSelectionPanelClick(e, itemSelectionPanel) {
+    // toggle the checkbox, if it wasn't clicked on
+    if (!dom.parentWithClass(e.target, 'chkItemSelect')) {
+        const chkItemSelect = itemSelectionPanel.querySelector('.chkItemSelect');
+
+        if (chkItemSelect) {
+            if (chkItemSelect.classList.contains('checkedInitial')) {
+                chkItemSelect.classList.remove('checkedInitial');
+            } else {
+                const newValue = !chkItemSelect.checked;
+                chkItemSelect.checked = newValue;
+                updateItemSelection(chkItemSelect, newValue);
             }
         }
     }
 
-    function onItemSelectionPanelClick(e, itemSelectionPanel) {
-        // toggle the checkbox, if it wasn't clicked on
-        if (!dom.parentWithClass(e.target, 'chkItemSelect')) {
-            const chkItemSelect = itemSelectionPanel.querySelector('.chkItemSelect');
+    e.preventDefault();
+    e.stopPropagation();
+    return false;
+}
 
-            if (chkItemSelect) {
-                if (chkItemSelect.classList.contains('checkedInitial')) {
-                    chkItemSelect.classList.remove('checkedInitial');
-                } else {
-                    const newValue = !chkItemSelect.checked;
-                    chkItemSelect.checked = newValue;
-                    updateItemSelection(chkItemSelect, newValue);
-                }
+function updateItemSelection(chkItemSelect, selected) {
+    const id = dom.parentWithAttribute(chkItemSelect, 'data-id').getAttribute('data-id');
+
+    if (selected) {
+        const current = selectedItems.filter(i => {
+            return i === id;
+        });
+
+        if (!current.length) {
+            selectedItems.push(id);
+            selectedElements.push(chkItemSelect);
+        }
+    } else {
+        selectedItems = selectedItems.filter(i => {
+            return i !== id;
+        });
+        selectedElements = selectedElements.filter(i => {
+            return i !== chkItemSelect;
+        });
+    }
+
+    if (selectedItems.length) {
+        const itemSelectionCount = document.querySelector('.itemSelectionCount');
+        if (itemSelectionCount) {
+            itemSelectionCount.innerHTML = selectedItems.length;
+        }
+    } else {
+        hideSelections();
+    }
+}
+
+function onSelectionChange() {
+    updateItemSelection(this, this.checked);
+}
+
+function showSelection(item, isChecked) {
+    let itemSelectionPanel = item.querySelector('.itemSelectionPanel');
+
+    if (!itemSelectionPanel) {
+        itemSelectionPanel = document.createElement('div');
+        itemSelectionPanel.classList.add('itemSelectionPanel');
+
+        const parent = item.querySelector('.cardBox') || item.querySelector('.cardContent');
+        parent.classList.add('withMultiSelect');
+        parent.appendChild(itemSelectionPanel);
+
+        let cssClass = 'chkItemSelect';
+        if (isChecked && !browser.firefox) {
+            // In firefox, the initial tap hold doesnt' get treated as a click
+            // In other browsers it does, so we need to make sure that initial click is ignored
+            cssClass += ' checkedInitial';
+        }
+        const checkedAttribute = isChecked ? ' checked' : '';
+        itemSelectionPanel.innerHTML = `<label class="checkboxContainer"><input type="checkbox" is="emby-checkbox" data-outlineclass="multiSelectCheckboxOutline" class="${cssClass}"${checkedAttribute}/><span></span></label>`;
+        const chkItemSelect = itemSelectionPanel.querySelector('.chkItemSelect');
+        chkItemSelect.addEventListener('change', onSelectionChange);
+    }
+}
+
+function showSelectionCommands() {
+    let selectionCommandsPanel = currentSelectionCommandsPanel;
+
+    if (!selectionCommandsPanel) {
+        selectionCommandsPanel = document.createElement('div');
+        selectionCommandsPanel.classList.add('selectionCommandsPanel');
+
+        document.body.appendChild(selectionCommandsPanel);
+        currentSelectionCommandsPanel = selectionCommandsPanel;
+
+        let html = '';
+
+        html += '<button is="paper-icon-button-light" class="btnCloseSelectionPanel autoSize"><span class="material-icons close" aria-hidden="true"></span></button>';
+        html += '<h1 class="itemSelectionCount"></h1>';
+
+        const moreIcon = 'more_vert';
+        html += `<button is="paper-icon-button-light" class="btnSelectionPanelOptions autoSize" style="margin-left:auto;"><span class="material-icons ${moreIcon}" aria-hidden="true"></span></button>`;
+
+        selectionCommandsPanel.innerHTML = html;
+
+        selectionCommandsPanel.querySelector('.btnCloseSelectionPanel').addEventListener('click', hideSelections);
+
+        const btnSelectionPanelOptions = selectionCommandsPanel.querySelector('.btnSelectionPanelOptions');
+
+        dom.addEventListener(btnSelectionPanelOptions, 'click', showMenuForSelectedItems, { passive: true });
+    }
+}
+
+function alertText(options) {
+    return new Promise((resolve) => {
+        alert(options).then(resolve, resolve);
+    });
+}
+
+function deleteItems(apiClient, itemIds) {
+    return new Promise((resolve, reject) => {
+        let msg = globalize.translate('ConfirmDeleteItem');
+        let title = globalize.translate('HeaderDeleteItem');
+
+        if (itemIds.length > 1) {
+            msg = globalize.translate('ConfirmDeleteItems');
+            title = globalize.translate('HeaderDeleteItems');
+        }
+
+        confirm(msg, title).then(() => {
+            const promises = itemIds.map(itemId => apiClient.deleteItem(itemId));
+
+            Promise.all(promises).then(resolve, () => {
+                alertText(globalize.translate('ErrorDeletingItem')).then(reject, reject);
+            });
+        }, reject);
+    });
+}
+
+function showMenuForSelectedItems(e) {
+    const apiClient = ServerConnections.currentApiClient();
+
+    apiClient.getCurrentUser().then(user => {
+        // get first selected item to perform metadata refresh permission check
+        apiClient.getItem(apiClient.getCurrentUserId(), selectedItems[0]).then(firstItem => {
+            const menuItems = [];
+
+            menuItems.push({
+                name: globalize.translate('SelectAll'),
+                id: 'selectall',
+                icon: 'select_all'
+            });
+
+            menuItems.push({
+                name: globalize.translate('AddToCollection'),
+                id: 'addtocollection',
+                icon: 'add'
+            });
+
+            menuItems.push({
+                name: globalize.translate('AddToPlaylist'),
+                id: 'playlist',
+                icon: 'playlist_add'
+            });
+
+            // TODO: Be more dynamic based on what is selected
+            if (user.Policy.EnableContentDeletion) {
+                menuItems.push({
+                    name: globalize.translate('Delete'),
+                    id: 'delete',
+                    icon: 'delete'
+                });
+            }
+
+            if (user.Policy.EnableContentDownloading && appHost.supports('filedownload')) {
+                // Disabled because there is no callback for this item
+                /*
+                menuItems.push({
+                    name: globalize.translate('Download'),
+                    id: 'download',
+                    icon: 'file_download'
+                });
+                */
+            }
+
+            if (user.Policy.IsAdministrator) {
+                menuItems.push({
+                    name: globalize.translate('GroupVersions'),
+                    id: 'groupvideos',
+                    icon: 'call_merge'
+                });
+            }
+
+            menuItems.push({
+                name: globalize.translate('MarkPlayed'),
+                id: 'markplayed',
+                icon: 'check_box'
+            });
+
+            menuItems.push({
+                name: globalize.translate('MarkUnplayed'),
+                id: 'markunplayed',
+                icon: 'check_box_outline_blank'
+            });
+
+            // this assues that if the user can refresh metadata for the first item
+            // they can refresh metadata for all items
+            if (itemHelper.canRefreshMetadata(firstItem, user)) {
+                menuItems.push({
+                    name: globalize.translate('RefreshMetadata'),
+                    id: 'refresh',
+                    icon: 'refresh'
+                });
+            }
+
+            import('../actionSheet/actionSheet').then((actionsheet) => {
+                actionsheet.show({
+                    items: menuItems,
+                    positionTo: e.target,
+                    callback: function (id) {
+                        const items = selectedItems.slice(0);
+                        const serverId = apiClient.serverInfo().Id;
+
+                        switch (id) {
+                            case 'selectall':
+                                {
+                                    const elems = document.querySelectorAll('.itemSelectionPanel');
+                                    for (let i = 0, length = elems.length; i < length; i++) {
+                                        const chkItemSelect = elems[i].querySelector('.chkItemSelect');
+
+                                        if (chkItemSelect && !chkItemSelect.classList.contains('checkedInitial') && !chkItemSelect.checked && chkItemSelect.getBoundingClientRect().width != 0) {
+                                            chkItemSelect.checked = true;
+                                            updateItemSelection(chkItemSelect, true);
+                                        }
+                                    }
+                                }
+                                break;
+                            case 'addtocollection':
+                                import('../collectionEditor/collectionEditor').then(({default: collectionEditor}) => {
+                                    new collectionEditor({
+                                        items: items,
+                                        serverId: serverId
+                                    });
+                                });
+                                hideSelections();
+                                dispatchNeedsRefresh();
+                                break;
+                            case 'playlist':
+                                new playlistEditor({
+                                    items: items,
+                                    serverId: serverId
+                                });
+                                hideSelections();
+                                dispatchNeedsRefresh();
+                                break;
+                            case 'delete':
+                                deleteItems(apiClient, items).then(dispatchNeedsRefresh);
+                                hideSelections();
+                                dispatchNeedsRefresh();
+                                break;
+                            case 'groupvideos':
+                                combineVersions(apiClient, items);
+                                break;
+                            case 'markplayed':
+                                items.forEach(itemId => {
+                                    apiClient.markPlayed(apiClient.getCurrentUserId(), itemId);
+                                });
+                                hideSelections();
+                                dispatchNeedsRefresh();
+                                break;
+                            case 'markunplayed':
+                                items.forEach(itemId => {
+                                    apiClient.markUnplayed(apiClient.getCurrentUserId(), itemId);
+                                });
+                                hideSelections();
+                                dispatchNeedsRefresh();
+                                break;
+                            case 'refresh':
+                                import('../refreshdialog/refreshdialog').then(({default: refreshDialog}) => {
+                                    new refreshDialog({
+                                        itemIds: items,
+                                        serverId: serverId
+                                    }).show();
+                                });
+                                hideSelections();
+                                dispatchNeedsRefresh();
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+                });
+            });
+        });
+    });
+}
+
+function dispatchNeedsRefresh() {
+    const elems = [];
+
+    [].forEach.call(selectedElements, i => {
+        const container = dom.parentWithAttribute(i, 'is', 'emby-itemscontainer');
+
+        if (container && !elems.includes(container)) {
+            elems.push(container);
+        }
+    });
+
+    for (let i = 0, length = elems.length; i < length; i++) {
+        elems[i].notifyRefreshNeeded(true);
+    }
+}
+
+function combineVersions(apiClient, selection) {
+    if (selection.length < 2) {
+        alert({
+            text: globalize.translate('PleaseSelectTwoItems')
+        });
+
+        return;
+    }
+
+    loading.show();
+
+    apiClient.ajax({
+
+        type: 'POST',
+        url: apiClient.getUrl('Videos/MergeVersions', { Ids: selection.join(',') })
+
+    }).then(() => {
+        loading.hide();
+        hideSelections();
+        dispatchNeedsRefresh();
+    });
+}
+
+function showSelections(initialCard) {
+    import('../../elements/emby-checkbox/emby-checkbox').then(() => {
+        const cards = document.querySelectorAll('.card');
+        for (let i = 0, length = cards.length; i < length; i++) {
+            showSelection(cards[i], initialCard === cards[i]);
+        }
+
+        showSelectionCommands();
+        updateItemSelection(initialCard, true);
+    });
+}
+
+function onContainerClick(e) {
+    const target = e.target;
+
+    if (selectedItems.length) {
+        const card = dom.parentWithClass(target, 'card');
+        if (card) {
+            const itemSelectionPanel = card.querySelector('.itemSelectionPanel');
+            if (itemSelectionPanel) {
+                return onItemSelectionPanelClick(e, itemSelectionPanel);
             }
         }
 
@@ -53,522 +391,181 @@ import itemHelper from '../itemHelper';
         e.stopPropagation();
         return false;
     }
+}
 
-    function updateItemSelection(chkItemSelect, selected) {
-        const id = dom.parentWithAttribute(chkItemSelect, 'data-id').getAttribute('data-id');
+document.addEventListener('viewbeforehide', hideSelections);
 
-        if (selected) {
-            const current = selectedItems.filter(i => {
-                return i === id;
-            });
+export default function (options) {
+    const self = this;
 
-            if (!current.length) {
-                selectedItems.push(id);
-                selectedElements.push(chkItemSelect);
-            }
-        } else {
-            selectedItems = selectedItems.filter(i => {
-                return i !== id;
-            });
-            selectedElements = selectedElements.filter(i => {
-                return i !== chkItemSelect;
-            });
+    const container = options.container;
+
+    function onTapHold(e) {
+        const card = dom.parentWithClass(e.target, 'card');
+
+        if (card) {
+            showSelections(card);
         }
 
-        if (selectedItems.length) {
-            const itemSelectionCount = document.querySelector('.itemSelectionCount');
-            if (itemSelectionCount) {
-                itemSelectionCount.innerHTML = selectedItems.length;
-            }
-        } else {
-            hideSelections();
+        e.preventDefault();
+        // It won't have this if it's a hammer event
+        if (e.stopPropagation) {
+            e.stopPropagation();
         }
+        return false;
     }
 
-    function onSelectionChange() {
-        updateItemSelection(this, this.checked);
+    function getTouches(e) {
+        return e.changedTouches || e.targetTouches || e.touches;
     }
 
-    function showSelection(item, isChecked) {
-        let itemSelectionPanel = item.querySelector('.itemSelectionPanel');
+    let touchTarget;
+    let touchStartTimeout;
+    let touchStartX;
+    let touchStartY;
+    function onTouchStart(e) {
+        const touch = getTouches(e)[0];
+        touchTarget = null;
+        touchStartX = 0;
+        touchStartY = 0;
 
-        if (!itemSelectionPanel) {
-            itemSelectionPanel = document.createElement('div');
-            itemSelectionPanel.classList.add('itemSelectionPanel');
+        if (touch) {
+            touchStartX = touch.clientX;
+            touchStartY = touch.clientY;
+            const element = touch.target;
 
-            const parent = item.querySelector('.cardBox') || item.querySelector('.cardContent');
-            parent.classList.add('withMultiSelect');
-            parent.appendChild(itemSelectionPanel);
+            if (element) {
+                const card = dom.parentWithClass(element, 'card');
 
-            let cssClass = 'chkItemSelect';
-            if (isChecked && !browser.firefox) {
-                // In firefox, the initial tap hold doesnt' get treated as a click
-                // In other browsers it does, so we need to make sure that initial click is ignored
-                cssClass += ' checkedInitial';
-            }
-            const checkedAttribute = isChecked ? ' checked' : '';
-            itemSelectionPanel.innerHTML = `<label class="checkboxContainer"><input type="checkbox" is="emby-checkbox" data-outlineclass="multiSelectCheckboxOutline" class="${cssClass}"${checkedAttribute}/><span></span></label>`;
-            const chkItemSelect = itemSelectionPanel.querySelector('.chkItemSelect');
-            chkItemSelect.addEventListener('change', onSelectionChange);
-        }
-    }
+                if (card) {
+                    if (touchStartTimeout) {
+                        clearTimeout(touchStartTimeout);
+                        touchStartTimeout = null;
+                    }
 
-    function showSelectionCommands() {
-        let selectionCommandsPanel = currentSelectionCommandsPanel;
-
-        if (!selectionCommandsPanel) {
-            selectionCommandsPanel = document.createElement('div');
-            selectionCommandsPanel.classList.add('selectionCommandsPanel');
-
-            document.body.appendChild(selectionCommandsPanel);
-            currentSelectionCommandsPanel = selectionCommandsPanel;
-
-            let html = '';
-
-            html += '<button is="paper-icon-button-light" class="btnCloseSelectionPanel autoSize"><span class="material-icons close" aria-hidden="true"></span></button>';
-            html += '<h1 class="itemSelectionCount"></h1>';
-
-            const moreIcon = 'more_vert';
-            html += `<button is="paper-icon-button-light" class="btnSelectionPanelOptions autoSize" style="margin-left:auto;"><span class="material-icons ${moreIcon}" aria-hidden="true"></span></button>`;
-
-            selectionCommandsPanel.innerHTML = html;
-
-            selectionCommandsPanel.querySelector('.btnCloseSelectionPanel').addEventListener('click', hideSelections);
-
-            const btnSelectionPanelOptions = selectionCommandsPanel.querySelector('.btnSelectionPanelOptions');
-
-            dom.addEventListener(btnSelectionPanelOptions, 'click', showMenuForSelectedItems, { passive: true });
-        }
-    }
-
-    function alertText(options) {
-        return new Promise((resolve) => {
-            alert(options).then(resolve, resolve);
-        });
-    }
-
-    function deleteItems(apiClient, itemIds) {
-        return new Promise((resolve, reject) => {
-            let msg = globalize.translate('ConfirmDeleteItem');
-            let title = globalize.translate('HeaderDeleteItem');
-
-            if (itemIds.length > 1) {
-                msg = globalize.translate('ConfirmDeleteItems');
-                title = globalize.translate('HeaderDeleteItems');
-            }
-
-            confirm(msg, title).then(() => {
-                const promises = itemIds.map(itemId => apiClient.deleteItem(itemId));
-
-                Promise.all(promises).then(resolve, () => {
-                    alertText(globalize.translate('ErrorDeletingItem')).then(reject, reject);
-                });
-            }, reject);
-        });
-    }
-
-    function showMenuForSelectedItems(e) {
-        const apiClient = ServerConnections.currentApiClient();
-
-        apiClient.getCurrentUser().then(user => {
-            // get first selected item to perform metadata refresh permission check
-            apiClient.getItem(apiClient.getCurrentUserId(), selectedItems[0]).then(firstItem => {
-                const menuItems = [];
-
-                menuItems.push({
-                    name: globalize.translate('SelectAll'),
-                    id: 'selectall',
-                    icon: 'select_all'
-                });
-
-                menuItems.push({
-                    name: globalize.translate('AddToCollection'),
-                    id: 'addtocollection',
-                    icon: 'add'
-                });
-
-                menuItems.push({
-                    name: globalize.translate('AddToPlaylist'),
-                    id: 'playlist',
-                    icon: 'playlist_add'
-                });
-
-                // TODO: Be more dynamic based on what is selected
-                if (user.Policy.EnableContentDeletion) {
-                    menuItems.push({
-                        name: globalize.translate('Delete'),
-                        id: 'delete',
-                        icon: 'delete'
-                    });
+                    touchTarget = card;
+                    touchStartTimeout = setTimeout(onTouchStartTimerFired, 550);
                 }
-
-                if (user.Policy.EnableContentDownloading && appHost.supports('filedownload')) {
-                    // Disabled because there is no callback for this item
-                    /*
-                    menuItems.push({
-                        name: globalize.translate('Download'),
-                        id: 'download',
-                        icon: 'file_download'
-                    });
-                    */
-                }
-
-                if (user.Policy.IsAdministrator) {
-                    menuItems.push({
-                        name: globalize.translate('GroupVersions'),
-                        id: 'groupvideos',
-                        icon: 'call_merge'
-                    });
-                }
-
-                menuItems.push({
-                    name: globalize.translate('MarkPlayed'),
-                    id: 'markplayed',
-                    icon: 'check_box'
-                });
-
-                menuItems.push({
-                    name: globalize.translate('MarkUnplayed'),
-                    id: 'markunplayed',
-                    icon: 'check_box_outline_blank'
-                });
-
-                // this assues that if the user can refresh metadata for the first item
-                // they can refresh metadata for all items
-                if (itemHelper.canRefreshMetadata(firstItem, user)) {
-                    menuItems.push({
-                        name: globalize.translate('RefreshMetadata'),
-                        id: 'refresh',
-                        icon: 'refresh'
-                    });
-                }
-
-                import('../actionSheet/actionSheet').then((actionsheet) => {
-                    actionsheet.show({
-                        items: menuItems,
-                        positionTo: e.target,
-                        callback: function (id) {
-                            const items = selectedItems.slice(0);
-                            const serverId = apiClient.serverInfo().Id;
-
-                            switch (id) {
-                                case 'selectall':
-                                    {
-                                        const elems = document.querySelectorAll('.itemSelectionPanel');
-                                        for (let i = 0, length = elems.length; i < length; i++) {
-                                            const chkItemSelect = elems[i].querySelector('.chkItemSelect');
-
-                                            if (chkItemSelect && !chkItemSelect.classList.contains('checkedInitial') && !chkItemSelect.checked && chkItemSelect.getBoundingClientRect().width != 0) {
-                                                chkItemSelect.checked = true;
-                                                updateItemSelection(chkItemSelect, true);
-                                            }
-                                        }
-                                    }
-                                    break;
-                                case 'addtocollection':
-                                    import('../collectionEditor/collectionEditor').then(({default: collectionEditor}) => {
-                                        new collectionEditor({
-                                            items: items,
-                                            serverId: serverId
-                                        });
-                                    });
-                                    hideSelections();
-                                    dispatchNeedsRefresh();
-                                    break;
-                                case 'playlist':
-                                    new playlistEditor({
-                                        items: items,
-                                        serverId: serverId
-                                    });
-                                    hideSelections();
-                                    dispatchNeedsRefresh();
-                                    break;
-                                case 'delete':
-                                    deleteItems(apiClient, items).then(dispatchNeedsRefresh);
-                                    hideSelections();
-                                    dispatchNeedsRefresh();
-                                    break;
-                                case 'groupvideos':
-                                    combineVersions(apiClient, items);
-                                    break;
-                                case 'markplayed':
-                                    items.forEach(itemId => {
-                                        apiClient.markPlayed(apiClient.getCurrentUserId(), itemId);
-                                    });
-                                    hideSelections();
-                                    dispatchNeedsRefresh();
-                                    break;
-                                case 'markunplayed':
-                                    items.forEach(itemId => {
-                                        apiClient.markUnplayed(apiClient.getCurrentUserId(), itemId);
-                                    });
-                                    hideSelections();
-                                    dispatchNeedsRefresh();
-                                    break;
-                                case 'refresh':
-                                    import('../refreshdialog/refreshdialog').then(({default: refreshDialog}) => {
-                                        new refreshDialog({
-                                            itemIds: items,
-                                            serverId: serverId
-                                        }).show();
-                                    });
-                                    hideSelections();
-                                    dispatchNeedsRefresh();
-                                    break;
-                                default:
-                                    break;
-                            }
-                        }
-                    });
-                });
-            });
-        });
-    }
-
-    function dispatchNeedsRefresh() {
-        const elems = [];
-
-        [].forEach.call(selectedElements, i => {
-            const container = dom.parentWithAttribute(i, 'is', 'emby-itemscontainer');
-
-            if (container && !elems.includes(container)) {
-                elems.push(container);
             }
-        });
-
-        for (let i = 0, length = elems.length; i < length; i++) {
-            elems[i].notifyRefreshNeeded(true);
         }
     }
 
-    function combineVersions(apiClient, selection) {
-        if (selection.length < 2) {
-            alert({
-                text: globalize.translate('PleaseSelectTwoItems')
-            });
+    function onTouchMove(e) {
+        if (touchTarget) {
+            const touch = getTouches(e)[0];
+            let deltaX;
+            let deltaY;
 
+            if (touch) {
+                const touchEndX = touch.clientX || 0;
+                const touchEndY = touch.clientY || 0;
+                deltaX = Math.abs(touchEndX - (touchStartX || 0));
+                deltaY = Math.abs(touchEndY - (touchStartY || 0));
+            } else {
+                deltaX = 100;
+                deltaY = 100;
+            }
+            if (deltaX >= 5 || deltaY >= 5) {
+                onMouseOut();
+            }
+        }
+    }
+
+    function onTouchEnd() {
+        onMouseOut();
+    }
+
+    function onMouseDown(e) {
+        if (touchStartTimeout) {
+            clearTimeout(touchStartTimeout);
+            touchStartTimeout = null;
+        }
+
+        touchTarget = e.target;
+        touchStartTimeout = setTimeout(onTouchStartTimerFired, 550);
+    }
+
+    function onMouseOut() {
+        if (touchStartTimeout) {
+            clearTimeout(touchStartTimeout);
+            touchStartTimeout = null;
+        }
+        touchTarget = null;
+    }
+
+    function onTouchStartTimerFired() {
+        if (!touchTarget) {
             return;
         }
 
-        loading.show();
+        const card = dom.parentWithClass(touchTarget, 'card');
+        touchTarget = null;
 
-        apiClient.ajax({
+        if (card) {
+            showSelections(card);
+        }
+    }
 
-            type: 'POST',
-            url: apiClient.getUrl('Videos/MergeVersions', { Ids: selection.join(',') })
+    function initTapHold(element) {
+        // mobile safari doesn't allow contextmenu override
+        if (browser.touch && !browser.safari) {
+            element.addEventListener('contextmenu', onTapHold);
+        } else {
+            dom.addEventListener(element, 'touchstart', onTouchStart, {
+                passive: true
+            });
+            dom.addEventListener(element, 'touchmove', onTouchMove, {
+                passive: true
+            });
+            dom.addEventListener(element, 'touchend', onTouchEnd, {
+                passive: true
+            });
+            dom.addEventListener(element, 'touchcancel', onTouchEnd, {
+                passive: true
+            });
+            dom.addEventListener(element, 'mousedown', onMouseDown, {
+                passive: true
+            });
+            dom.addEventListener(element, 'mouseleave', onMouseOut, {
+                passive: true
+            });
+            dom.addEventListener(element, 'mouseup', onMouseOut, {
+                passive: true
+            });
+        }
+    }
 
-        }).then(() => {
-            loading.hide();
-            hideSelections();
-            dispatchNeedsRefresh();
+    initTapHold(container);
+
+    if (options.bindOnClick !== false) {
+        container.addEventListener('click', onContainerClick);
+    }
+
+    self.onContainerClick = onContainerClick;
+
+    self.destroy = () => {
+        container.removeEventListener('click', onContainerClick);
+        container.removeEventListener('contextmenu', onTapHold);
+
+        const element = container;
+
+        dom.removeEventListener(element, 'touchstart', onTouchStart, {
+            passive: true
         });
-    }
-
-    function showSelections(initialCard) {
-        import('../../elements/emby-checkbox/emby-checkbox').then(() => {
-            const cards = document.querySelectorAll('.card');
-            for (let i = 0, length = cards.length; i < length; i++) {
-                showSelection(cards[i], initialCard === cards[i]);
-            }
-
-            showSelectionCommands();
-            updateItemSelection(initialCard, true);
+        dom.removeEventListener(element, 'touchmove', onTouchMove, {
+            passive: true
         });
-    }
-
-    function onContainerClick(e) {
-        const target = e.target;
-
-        if (selectedItems.length) {
-            const card = dom.parentWithClass(target, 'card');
-            if (card) {
-                const itemSelectionPanel = card.querySelector('.itemSelectionPanel');
-                if (itemSelectionPanel) {
-                    return onItemSelectionPanelClick(e, itemSelectionPanel);
-                }
-            }
-
-            e.preventDefault();
-            e.stopPropagation();
-            return false;
-        }
-    }
-
-    document.addEventListener('viewbeforehide', hideSelections);
-
-    export default function (options) {
-        const self = this;
-
-        const container = options.container;
-
-        function onTapHold(e) {
-            const card = dom.parentWithClass(e.target, 'card');
-
-            if (card) {
-                showSelections(card);
-            }
-
-            e.preventDefault();
-            // It won't have this if it's a hammer event
-            if (e.stopPropagation) {
-                e.stopPropagation();
-            }
-            return false;
-        }
-
-        function getTouches(e) {
-            return e.changedTouches || e.targetTouches || e.touches;
-        }
-
-        let touchTarget;
-        let touchStartTimeout;
-        let touchStartX;
-        let touchStartY;
-        function onTouchStart(e) {
-            const touch = getTouches(e)[0];
-            touchTarget = null;
-            touchStartX = 0;
-            touchStartY = 0;
-
-            if (touch) {
-                touchStartX = touch.clientX;
-                touchStartY = touch.clientY;
-                const element = touch.target;
-
-                if (element) {
-                    const card = dom.parentWithClass(element, 'card');
-
-                    if (card) {
-                        if (touchStartTimeout) {
-                            clearTimeout(touchStartTimeout);
-                            touchStartTimeout = null;
-                        }
-
-                        touchTarget = card;
-                        touchStartTimeout = setTimeout(onTouchStartTimerFired, 550);
-                    }
-                }
-            }
-        }
-
-        function onTouchMove(e) {
-            if (touchTarget) {
-                const touch = getTouches(e)[0];
-                let deltaX;
-                let deltaY;
-
-                if (touch) {
-                    const touchEndX = touch.clientX || 0;
-                    const touchEndY = touch.clientY || 0;
-                    deltaX = Math.abs(touchEndX - (touchStartX || 0));
-                    deltaY = Math.abs(touchEndY - (touchStartY || 0));
-                } else {
-                    deltaX = 100;
-                    deltaY = 100;
-                }
-                if (deltaX >= 5 || deltaY >= 5) {
-                    onMouseOut();
-                }
-            }
-        }
-
-        function onTouchEnd() {
-            onMouseOut();
-        }
-
-        function onMouseDown(e) {
-            if (touchStartTimeout) {
-                clearTimeout(touchStartTimeout);
-                touchStartTimeout = null;
-            }
-
-            touchTarget = e.target;
-            touchStartTimeout = setTimeout(onTouchStartTimerFired, 550);
-        }
-
-        function onMouseOut() {
-            if (touchStartTimeout) {
-                clearTimeout(touchStartTimeout);
-                touchStartTimeout = null;
-            }
-            touchTarget = null;
-        }
-
-        function onTouchStartTimerFired() {
-            if (!touchTarget) {
-                return;
-            }
-
-            const card = dom.parentWithClass(touchTarget, 'card');
-            touchTarget = null;
-
-            if (card) {
-                showSelections(card);
-            }
-        }
-
-        function initTapHold(element) {
-            // mobile safari doesn't allow contextmenu override
-            if (browser.touch && !browser.safari) {
-                element.addEventListener('contextmenu', onTapHold);
-            } else {
-                dom.addEventListener(element, 'touchstart', onTouchStart, {
-                    passive: true
-                });
-                dom.addEventListener(element, 'touchmove', onTouchMove, {
-                    passive: true
-                });
-                dom.addEventListener(element, 'touchend', onTouchEnd, {
-                    passive: true
-                });
-                dom.addEventListener(element, 'touchcancel', onTouchEnd, {
-                    passive: true
-                });
-                dom.addEventListener(element, 'mousedown', onMouseDown, {
-                    passive: true
-                });
-                dom.addEventListener(element, 'mouseleave', onMouseOut, {
-                    passive: true
-                });
-                dom.addEventListener(element, 'mouseup', onMouseOut, {
-                    passive: true
-                });
-            }
-        }
-
-        initTapHold(container);
-
-        if (options.bindOnClick !== false) {
-            container.addEventListener('click', onContainerClick);
-        }
-
-        self.onContainerClick = onContainerClick;
-
-        self.destroy = () => {
-            container.removeEventListener('click', onContainerClick);
-            container.removeEventListener('contextmenu', onTapHold);
-
-            const element = container;
-
-            dom.removeEventListener(element, 'touchstart', onTouchStart, {
-                passive: true
-            });
-            dom.removeEventListener(element, 'touchmove', onTouchMove, {
-                passive: true
-            });
-            dom.removeEventListener(element, 'touchend', onTouchEnd, {
-                passive: true
-            });
-            dom.removeEventListener(element, 'mousedown', onMouseDown, {
-                passive: true
-            });
-            dom.removeEventListener(element, 'mouseleave', onMouseOut, {
-                passive: true
-            });
-            dom.removeEventListener(element, 'mouseup', onMouseOut, {
-                passive: true
-            });
-        };
-    }
-
-/* eslint-enable indent */
+        dom.removeEventListener(element, 'touchend', onTouchEnd, {
+            passive: true
+        });
+        dom.removeEventListener(element, 'mousedown', onMouseDown, {
+            passive: true
+        });
+        dom.removeEventListener(element, 'mouseleave', onMouseOut, {
+            passive: true
+        });
+        dom.removeEventListener(element, 'mouseup', onMouseOut, {
+            passive: true
+        });
+    };
+}

--- a/src/elements/emby-itemscontainer/emby-itemscontainer.js
+++ b/src/elements/emby-itemscontainer/emby-itemscontainer.js
@@ -19,12 +19,9 @@ import Sortable from 'sortablejs';
 
     function onClick(e) {
         const itemsContainer = this;
-        const multiSelect = itemsContainer.multiSelect;
 
-        if (multiSelect) {
-            if (multiSelect.onContainerClick.call(itemsContainer, e) === false) {
-                return;
-            }
+        if (itemsContainer.multiSelect?.onContainerClick.call(itemsContainer, e) === false) {
+            return;
         }
 
         itemShortcuts.onClick.call(itemsContainer, e);

--- a/src/elements/emby-itemscontainer/emby-itemscontainer.js
+++ b/src/elements/emby-itemscontainer/emby-itemscontainer.js
@@ -74,10 +74,9 @@ import Sortable from 'sortablejs';
         }
 
         const self = this;
-        import('../../components/multiSelect/multiSelect').then(({default: MultiSelect}) => {
+        import('../../components/multiSelect/multiSelect').then(({ default: MultiSelect }) => {
             self.multiSelect = new MultiSelect({
-                container: self,
-                bindOnClick: false
+                container: self
             });
         });
     };


### PR DESCRIPTION
**Changes**
The current implementation operates globally so every item container rendered to the page is being manipulated by each instance of the multiselect "component". This was discovered in https://github.com/jellyfin/jellyfin-web/pull/3296#pullrequestreview-846761881 where we found it was acting on items from hidden tabs and pages still in the dom.

* Fixes indentation
* Rewrites as class
* Only act on items in instance container
* Removes unused bindOnClick option for multiselect
* General cleanup

> Note: Converted this back to a draft because it does not handle cases like the home screen where selecting from multiple containers on a page is a feature.

**Issues**
N/A
