### PR TITLE
Few refactors of remotecontrol

### DIFF
--- a/src/components/cardbuilder/card.scss
+++ b/src/components/cardbuilder/card.scss
@@ -389,6 +389,10 @@ button::-moz-focus-inner {
     transform: translate(-50%, -50%);
 }
 
+.cardImageContainer .cardImageIcon {
+    margin: auto; /* 'justify-content: center' doesn't work in Safari 10 */
+}
+
 .cardIndicators {
     right: 0.225em;
     top: 0.225em;

--- a/src/components/remotecontrol/remotecontrol.scss
+++ b/src/components/remotecontrol/remotecontrol.scss
@@ -273,9 +273,7 @@
     .remoteControlContent {
         padding-left: 7.3% !important;
         padding-right: 7.3% !important;
-        display: flex;
         height: 100%;
-        flex-direction: column;
     }
 
     .layout-desktop .nowPlayingPageUserDataButtons {

--- a/src/components/remotecontrol/remotecontrol.scss
+++ b/src/components/remotecontrol/remotecontrol.scss
@@ -81,8 +81,6 @@
     -webkit-box-align: center;
     -webkit-align-items: center;
     align-items: center;
-    -webkit-flex-wrap: wrap;
-    flex-wrap: wrap;
     -webkit-flex-shrink: 0;
     flex-shrink: 0;
 }
@@ -321,6 +319,8 @@
         -webkit-justify-content: center;
         justify-content: center;
         font-size: 1.5em;
+        margin-left: -0.5em;
+        margin-right: -0.5em;
     }
 
     .nowPlayingPageImageContainer {
@@ -372,19 +372,15 @@
 
     .nowPlayingInfoButtons .btnRepeat,
     .nowPlayingInfoButtons .btnRewind {
-        position: absolute;
-        left: 0;
         margin-left: 0;
-        padding-left: 7.3%;
+        margin-right: auto;
         font-size: smaller;
     }
 
     .nowPlayingInfoButtons .btnShuffleQueue,
     .nowPlayingInfoButtons .btnFastForward {
-        position: absolute;
-        right: 0;
+        margin-left: auto;
         margin-right: 0;
-        padding-right: 7.3%;
         font-size: smaller;
     }
 

--- a/src/components/remotecontrol/remotecontrol.scss
+++ b/src/components/remotecontrol/remotecontrol.scss
@@ -410,7 +410,6 @@
 
     .nowPlayingButtonsContainer {
         display: flex;
-        height: 100%;
         flex-direction: column;
     }
 }


### PR DESCRIPTION
**Changes**
- Fix vertical button alignment in Safari 10
- Remove unnecessary flexbox.
- Center card icon in Safari 10 (in all cards)
- Remove unnecessary `height`

**Issues**
N/A

**Screenshots**
_The colors are just to distinguish the elements._

Old
_Using `position: absolute` breaks Flexbox._ https://github.com/jellyfin/jellyfin-web/pull/3018#issuecomment-1048455506
<img width="25%" src="https://user-images.githubusercontent.com/56478732/155401177-35420930-aaa7-4349-a8ad-c20bd3c8f4d8.png">
New
<img width="25%" src="https://user-images.githubusercontent.com/56478732/155400886-d5ca82e6-ad04-4c5d-bc1b-c85b3ed550f7.png">

**Unresolved problem**
Still can't find a proper fix for Safari 10 not being able to shrink poster.
Adding `min-height: 0` makes the poster shrinkable, but without respecting the aspect ratio.
https://github.com/jellyfin/jellyfin-web/blob/bce24b26ba33a02b635797b36df2852b445b6e53/src/components/remotecontrol/remotecontrol.scss#L395-L400

Another approach is to limit the size of `nowPlayingPageImageContainer`:
```css
max-height: 50%; // or calc(100% - ??em);
```
But it is not universal.