### PR TITLE
Fix remote control translation

### DIFF
--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -423,7 +423,7 @@
     "HeaderRecordingOptions": "Recording Options",
     "HeaderRecordingPostProcessing": "Recording Post Processing",
     "HeaderRemoteAccessSettings": "Remote Access Settings",
-    "HeaderRemoteControl": "Remote control:",
+    "HeaderRemoteControl": "Remote Control",
     "HeaderRemoveMediaFolder": "Remove Media Folder",
     "HeaderRemoveMediaLocation": "Remove Media Location",
     "HeaderResponseProfile": "Response Profile",


### PR DESCRIPTION
**Changes**
Fixes the remote control translation to remove the colon. On a related note we should probably remove colons from all the translations. If one is needed somewhere it can be added in code.

![Screenshot 2022-02-25 at 01-58-38 Jellyfin](https://user-images.githubusercontent.com/3450688/155669643-ab3f0efa-c504-4540-8bc5-acf7eee98534.png)

**Issues**
N/A
