### PR TITLE
Fix page reload on return

### DIFF
--- a/src/components/appRouter.js
+++ b/src/components/appRouter.js
@@ -34,15 +34,20 @@ class AppRouter {
 
     constructor() {
         // WebKit fires a popstate event on document load
-        // Skip it using timeout
+        // Skip it using boolean
         // For Tizen 2.x
-        // https://stackoverflow.com/a/12214354
-        window.addEventListener('load', () => {
-            setTimeout(() => {
-                window.addEventListener('popstate', () => {
-                    this.popstateOccurred = true;
-                });
-            }, 0);
+        // See `page` node module
+        let loaded = document.readyState === 'complete';
+        if (!loaded) {
+            window.addEventListener('load', () => {
+                setTimeout(() => {
+                    loaded = true;
+                }, 0);
+            });
+        }
+        window.addEventListener('popstate', () => {
+            if (!loaded) return;
+            this.popstateOccurred = true;
         });
 
         document.addEventListener('viewshow', () => this.onViewShow());


### PR DESCRIPTION
`popstate` event cannot be captured, but we need to process it before `page` node module.

**Changes**
Use boolean to skip `popstate` event on page loading.

**Issues**
Fixes https://github.com/jellyfin/jellyfin-tizen/issues/107
