### PR TITLE
Change buttons that act as links to anchor tags

### DIFF
--- a/src/components/cardbuilder/card.scss
+++ b/src/components/cardbuilder/card.scss
@@ -327,6 +327,7 @@ button::-moz-focus-inner {
     vertical-align: middle;
     font-family: inherit;
     font-size: inherit;
+    text-decoration: none;
 }
 
 .textActionButton:hover {

--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -22,6 +22,7 @@ import './card.scss';
 import '../../elements/emby-button/paper-icon-button-light';
 import '../guide/programs.scss';
 import ServerConnections from '../ServerConnections';
+import { appRouter } from '../appRouter';
 
         const enableFocusTransform = !browser.slow && !browser.edge;
 
@@ -1038,9 +1039,10 @@ import ServerConnections from '../ServerConnections';
                 return text;
             }
 
-            let html = '<button ' + itemShortcuts.getShortcutAttributesHtml(item, serverId) + ' type="button" class="itemAction textActionButton" title="' + text + '" data-action="link">';
+            const url = appRouter.getRouteUrl(item);
+            let html = '<a href="' + url + '" ' + itemShortcuts.getShortcutAttributesHtml(item, serverId) + ' class="itemAction textActionButton" title="' + text + '" data-action="link">';
             html += text;
-            html += '</button>';
+            html += '</a>';
 
             return html;
         }
@@ -1349,10 +1351,11 @@ import ServerConnections from '../ServerConnections';
             } else {
                 const cardImageContainerAriaLabelAttribute = ` aria-label="${item.Name}"`;
 
+                const url = appRouter.getRouteUrl(item);
                 // Don't use the IMG tag with safari because it puts a white border around it
-                cardImageContainerOpen = imgUrl ? ('<button data-action="' + action + '" class="' + cardImageContainerClass + ' ' + cardContentClass + ' itemAction lazy" data-src="' + imgUrl + '" ' + blurhashAttrib + cardImageContainerAriaLabelAttribute + '>') : ('<button data-action="' + action + '" class="' + cardImageContainerClass + ' ' + cardContentClass + ' itemAction"' + cardImageContainerAriaLabelAttribute + '>');
+                cardImageContainerOpen = imgUrl ? ('<a href="' + url + '" data-action="' + action + '" class="' + cardImageContainerClass + ' ' + cardContentClass + ' itemAction lazy" data-src="' + imgUrl + '" ' + blurhashAttrib + cardImageContainerAriaLabelAttribute + '>') : ('<a href="' + url + '" data-action="' + action + '" class="' + cardImageContainerClass + ' ' + cardContentClass + ' itemAction"' + cardImageContainerAriaLabelAttribute + '>');
 
-                cardImageContainerClose = '</button>';
+                cardImageContainerClose = '</a>';
             }
 
             const cardScalableClass = 'cardScalable';
@@ -1470,6 +1473,8 @@ import ServerConnections from '../ServerConnections';
             let html = '';
 
             html += '<div class="cardOverlayContainer itemAction" data-action="' + action + '">';
+            const url = appRouter.getRouteUrl(item);
+            html += '<a href="' + url + '" class="cardImageContainer"></a>'
 
             const btnCssClass = 'cardOverlayButton cardOverlayButton-hover itemAction paper-icon-button-light';
 

--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -1474,7 +1474,7 @@ import { appRouter } from '../appRouter';
 
             html += '<div class="cardOverlayContainer itemAction" data-action="' + action + '">';
             const url = appRouter.getRouteUrl(item);
-            html += '<a href="' + url + '" class="cardImageContainer"></a>'
+            html += '<a href="' + url + '" class="cardImageContainer"></a>';
 
             const btnCssClass = 'cardOverlayButton cardOverlayButton-hover itemAction paper-icon-button-light';
 

--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -785,7 +785,7 @@ function renderDetailImage(elem, item, imageLoader) {
     imageLoader.lazyChildren(elem);
 
     // Avoid breaking the design by preventing focus of the poster using the keyboard.
-    elem.querySelector('button').tabIndex = -1;
+    elem.querySelector('a').tabIndex = -1;
 }
 
 function renderImage(page, item) {


### PR DESCRIPTION
Buttons (`<button>`) and links (`<a>`) are different and serve different purposes. Links _go somewhere_ while buttons _do something_.

When I click on a movie title to _go to_ the movie page the thing I click should act like a link. If I ctrl+click or middle click it it should still act like a link... by opening in a new tab. It should have a URL. Conversely, if I click a :heart: button it _shouldn't_ take me to a new page; it should _do something_ to the item: by marking it as "hearted".

I often want to open many links in a new tab, especially when initially categorizing/organizing items, but I can't because they aren't links... they are buttons that eventually act like links (they end up changing the URL). There is even CSS to add an underline to the _button text_ on hover like a link :confused:.

There are dozens of other places where buttons are used in places links should be used, and even some cases where buttons act like a link (by changing the URL) only for that URL to not actual route anywhere (like the dialog buttons that open metadata info).

Anyway, let me know if this change is welcomed or not.