### PR TITLE
Sort album tracks by (Parent)IndexNumber, then SortName

### DIFF
--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -1319,7 +1319,9 @@ function renderChildren(page, item) {
         Fields: fields
     };
 
-    if (item.Type !== 'BoxSet') {
+    if (item.Type == 'MusicAlbum') {
+        query.SortBy = 'ParentIndexNumber,IndexNumber,SortName';
+    } else if (item.Type !== 'BoxSet') {
         query.SortBy = 'SortName';
     }
 


### PR DESCRIPTION
Track sorting in albums could previously be incorrect if metadata specified a SortName tag.

Also see: jellyfin/jellyfin#7323, jellyfin/jellyfin#7324
