### PR TITLE
add dev-deps label to renovate dev-deps PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,22 +5,31 @@
       "addLabels": ["javascript"]
     },
     {
+      "description": "add label to dev dependency updates",
+      "matchDepTypes": ["devDependencies"],
+      "addLabels": ["dev-deps"]
+    },
+    {
+      "description": "Collects and groups dev dependency updates",
       "matchDepTypes": ["devDependencies"],
       "groupName": "development dependencies",
       "groupSlug": "dev-deps"
     },
     {
+      "description": "Collects and groups npm dependency updates",
       "matchDepTypes": ["dependencies"],
       "groupName": "dependencies",
       "groupSlug": "deps"
     },
     {
+      "description": "Collects and groups GitHub Action dependency updates",
       "matchDepTypes": ["action"],
       "addLabels": ["github_actions"],
       "groupName": "CI dependencies",
       "groupSlug": "ci-deps"
     },
     {
+      "description": "Disables HLS.js major updates",
       "matchPackageNames": ["hls.js"],
       "matchUpdateTypes": "major",
       "enabled": false

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,7 @@
       "addLabels": ["javascript"]
     },
     {
-      "description": "add label to dev dependency updates",
+      "description": "Adds label to dev dependency updates",
       "matchDepTypes": ["devDependencies"],
       "addLabels": ["dev-deps"]
     },


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->
This PR slightly alters the Renovate-Bot config to add a separate label to PRs containing NPM dev dependency updates.


### Changes
<!-- Describe your changes here in 1-5 sentences. -->

* adds some `description` to most of the renovate `packageRules`
* adds `dev-deps` label to single and grouped dev dependency update PRs

### Issues
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
* n/a