### PR TITLE
Restore missing MessageUnauthorizedUser error message

### DIFF
--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1100,6 +1100,7 @@
     "MessageSyncPlayUserLeft": "{0} has left the group.",
     "MessageTheFollowingLocationWillBeRemovedFromLibrary": "The following media locations will be removed from your library:",
     "MessageUnableToConnectToServer": "We're unable to connect to the selected server right now. Please ensure it is running and try again.",
+    "MessageUnauthorizedUser": "You are not authorized to access the server at this time. Please contact your server administrator for more information.",
     "MessageUnsetContentHelp": "Content will be displayed as plain folders. For best results use the metadata manager to set the content types of sub-folders.",
     "MessageYouHaveVersionInstalled": "You currently have version {0} installed.",
     "Metadata": "Metadata",


### PR DESCRIPTION
**Changes**
Restores an error message displayed when a user cannot login due to parental controls that was mistakenly removed in https://github.com/jellyfin/jellyfin-web/commit/b9317ff0627e20b233c7184ee4fb73e883ab7f41

**Issues**
N/A
