### PR TITLE
Fix old streamInfo on stream change

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -1721,17 +1721,17 @@ class PlaybackManager {
         }
 
         function setSrcIntoPlayer(apiClient, player, streamInfo) {
-            return player.play(streamInfo).then(function () {
-                const playerData = getPlayerData(player);
+            const playerData = getPlayerData(player);
 
+            playerData.streamInfo = streamInfo;
+
+            return player.play(streamInfo).then(function () {
                 playerData.isChangingStream = false;
-                playerData.streamInfo = streamInfo;
                 streamInfo.started = true;
                 streamInfo.ended = false;
 
                 sendProgressUpdate(player, 'timeupdate');
             }, function (e) {
-                const playerData = getPlayerData(player);
                 playerData.isChangingStream = false;
 
                 onPlaybackError.call(player, e, {


### PR DESCRIPTION
When the client changes the stream (fail to play) `streamInfo` contains the old play session and the next progress report will update the wrong session. The server then responds with the wrong playback method until the next progress report.

**Changes**
Update `streamInfo` before playback start so that the data is up to date.
_Similar to #3373_

**Issues**
N/A
