### PR TITLE
Fix webOS OPUS support

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -123,6 +123,11 @@ import browser from './browser';
                 return true;
             }
         } else if (format === 'opus') {
+            if (browser.web0s) {
+                // canPlayType lies about OPUS support
+                return browser.web0sVersion >= 3.5;
+            }
+
             typeString = 'audio/ogg; codecs="opus"';
         } else if (format === 'alac') {
             if (browser.iOS || browser.osx) {


### PR DESCRIPTION
:warning: We can't detect the minor webOS version from the browser version: https://webostv.developer.lge.com/discover/specifications/web-engine/
We need to use `sdkVersion`: https://webostv.developer.lge.com/api/webos-service-api/tv-device-information/?wos_flag=allFlipOpen#getSystemInfo
Or pass the support info in the `options`.

**Changes**
Check webOS version >= 3.5

**Issues**
https://github.com/jellyfin/jellyfin-web/pull/3431#commitcomment-68838072
