### PR TITLE
Comics: Add support for .zip & .rar comics

### DIFF
--- a/src/plugins/comicsPlayer/plugin.js
+++ b/src/plugins/comicsPlayer/plugin.js
@@ -233,11 +233,11 @@ export class ComicsPlayer {
     }
 
     canPlayItem(item) {
-        if (item.Path && (item.Path.endsWith('cbz') || item.Path.endsWith('cbr'))) {
-            return true;
-        }
+        const supportedFormats = ['cbz', 'zip', 'cbr', 'rar'];
 
-        return false;
+        const name = item.Path;
+        const index = name.lastIndexOf('.');
+        return index !== -1 && supportedFormats.includes(name.slice(index + 1));
     }
 }
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
As documented in #3446 , the `.cbz` and `.cbr` extensions simply correspond to `.zip` and `.rar` archives respectively.

Presently, comics can only be played by jellyfin if they use one of the "explicit" extensions - a `.cbr` or `.cbz`. This would allow `.zip`s and `.rar`s to be recognized. 

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Resolves #3446

