### PR TITLE
Fix transcode reasons listing

### DIFF
--- a/src/components/playerstats/playerstats.js
+++ b/src/components/playerstats/playerstats.js
@@ -167,10 +167,10 @@ import ServerConnections from '../ServerConnections';
                     value: session.TranscodingInfo.Framerate + ' fps'
                 });
             }
-            if (session.TranscodingInfo.TranscodeReasons && session.TranscodingInfo.TranscodeReasons.length) {
+            if (session.TranscodingInfo.TranscodeReason?.length) {
                 sessionStats.push({
                     label: globalize.translate('LabelReasonForTranscoding'),
-                    value: session.TranscodingInfo.TranscodeReasons.map(translateReason).join('<br/>')
+                    value: session.TranscodingInfo.TranscodeReason.map(translateReason).join('<br/>')
                 });
             }
             if (session.TranscodingInfo.HardwareAccelerationType) {

--- a/src/controllers/dashboard/dashboard.js
+++ b/src/controllers/dashboard/dashboard.js
@@ -49,10 +49,10 @@ import confirm from '../../components/confirm/confirm';
             text.push(globalize.translate('MediaIsBeingConverted'));
             text.push(DashboardPage.getSessionNowPlayingStreamInfo(session));
 
-            if (session.TranscodingInfo && session.TranscodingInfo.TranscodeReasons && session.TranscodingInfo.TranscodeReasons.length) {
+            if (session.TranscodingInfo?.TranscodeReason?.length) {
                 text.push('<br/>');
                 text.push(globalize.translate('LabelReasonForTranscoding'));
-                session.TranscodingInfo.TranscodeReasons.forEach(function (transcodeReason) {
+                session.TranscodingInfo.TranscodeReason.forEach(function (transcodeReason) {
                     text.push(globalize.translate(transcodeReason));
                 });
             }
@@ -92,7 +92,7 @@ import confirm from '../../components/confirm/confirm';
                 });
             }
 
-            if (session.TranscodingInfo && session.TranscodingInfo.TranscodeReasons && session.TranscodingInfo.TranscodeReasons.length) {
+            if (session.TranscodingInfo?.TranscodeReason?.length) {
                 menuItems.push({
                     name: globalize.translate('ViewPlaybackInfo'),
                     id: 'transcodinginfo'


### PR DESCRIPTION
In https://github.com/jellyfin/jellyfin/pull/7325 `TranscodeReasons` was changed to `TranscodeReason`.

**Changes**
Use `TranscodeReason` and beautfy the code.

**Issues**
No transcode reasons in stats and Dashboard.
