### PR TITLE
Fix issue #3440 where networking menu can get in a bad state.

### DIFF
--- a/src/controllers/dashboard/networking.html
+++ b/src/controllers/dashboard/networking.html
@@ -87,36 +87,36 @@
                             </label>
                             <div class="fieldDescription checkboxFieldDescription">${AllowRemoteAccessHelp}</div>
                         </div>
-                        <div class="inputContainer fldExternalAddressFilter hide">
+                        <div class="inputContainer fldExternalAddressFilter">
                             <input is="emby-input" type="text" id="txtExternalAddressFilter" label="${LabelAllowedRemoteAddresses}" />
                             <div class="fieldDescription">${AllowedRemoteAddressesHelp}</div>
                         </div>
-                        <div class="selectContainer fldExternalAddressFilterMode hide">
+                        <div class="selectContainer fldExternalAddressFilterMode">
                             <select is="emby-select" id="selectExternalAddressFilterMode" label="${LabelAllowedRemoteAddressesMode}">
                                 <option value="whitelist">${Whitelist}</option>
                                 <option value="blacklist">${Blacklist}</option>
                             </select>
                         </div>
 
-                        <div class="checkboxContainer checkboxContainer-withDescription fldEnableUpnp hide">
+                        <div class="checkboxContainer checkboxContainer-withDescription fldEnableUpnp">
                             <label>
                                 <input type="checkbox" is="emby-checkbox" id="chkEnableUpnp" />
                                 <span>${LabelEnableAutomaticPortMap}</span>
                             </label>
                             <div class="fieldDescription checkboxFieldDescription">${LabelEnableAutomaticPortMapHelp}</div>
                         </div>
-                        <div class="checkboxContainer checkboxContainer-withDescription hide">
+                        <div class="checkboxContainer checkboxContainer-withDescription">
                             <label>
                                 <input type="checkbox" is="emby-checkbox" id="chkCreateHttpPortMap" />
                                 <span>${LabelCreateHttpPortMap}</span>
                             </label>
                             <div class="fieldDescription checkboxFieldDescription">${LabelCreateHttpPortMapHelp}</div>
                         </div>
-                        <div class="inputContainer fldPublicPort hide">
+                        <div class="inputContainer fldPublicPort">
                             <input is="emby-input" type="number" label="${LabelPublicHttpPort}" id="txtPublicPort" pattern="[0-9]*" required="required" min="1" max="65535" />
                             <div class="fieldDescription">${LabelPublicHttpPortHelp}</div>
                         </div>
-                        <div class="inputContainer fldPublicHttpsPort hide">
+                        <div class="inputContainer fldPublicHttpsPort">
                             <input is="emby-input" type="number" id="txtPublicHttpsPort" pattern="[0-9]*" required="required" min="1" max="65535" label="${LabelPublicHttpsPort}" />
                             <div class="fieldDescription">${LabelPublicHttpsPortHelp}</div>
                         </div>
@@ -141,7 +141,7 @@
                     </fieldset>
 
 
-                    <fieldset class='verticalSection verticalSection-extrabottompadding hide'>
+                    <fieldset class='verticalSection verticalSection-extrabottompadding'>
                         <legend><h3>${HeaderAutoDiscovery}</h3></legend>
                         <div class="checkboxContainer checkboxContainer-withDescription">
                             <label>
@@ -159,11 +159,11 @@
                             <input is="emby-input" type="text" id="txtPublishedServer" label="${LabelPublishedServerUri}" />
                             <div class="fieldDescription">${LabelPublishedServerUriHelp}</div>
                         </div>
-                        <div class="inputContainer hide">
+                        <div class="inputContainer">
                             <input is="emby-input" type="text" id="txtUDPPortRange" pattern="[0-9\-]*" label="${LabelUDPPortRange}"  />
                             <div class="fieldDescription">${LabelUDPPortRangeHelp}</div>
                         </div>
-                        <div class="inputContainer hide">
+                        <div class="inputContainer">
                             <input is="emby-input" type="text" id="txtHDHomerunPortRange" pattern="[0-9\-]*" label="${LabelHDHomerunPortRange}" />
                             <div class="fieldDescription">${LabelHDHomerunPortRangeHelp}</div>
                         </div>

--- a/src/controllers/dashboard/networking.js
+++ b/src/controllers/dashboard/networking.js
@@ -165,21 +165,6 @@ import alert from '../../components/alert';
             loading.hide();
         }
 
-        view.querySelector('#chkRemoteAccess').addEventListener('change', function () {
-            if (this.checked) {
-                view.querySelector('.fldExternalAddressFilter').classList.remove('hide');
-                view.querySelector('.fldExternalAddressFilterMode').classList.remove('hide');
-                view.querySelector('.fldPublicPort').classList.remove('hide');
-                view.querySelector('.fldPublicHttpsPort').classList.remove('hide');
-                view.querySelector('.fldEnableUpnp').classList.remove('hide');
-            } else {
-                view.querySelector('.fldExternalAddressFilter').classList.add('hide');
-                view.querySelector('.fldExternalAddressFilterMode').classList.add('hide');
-                view.querySelector('.fldPublicPort').classList.add('hide');
-                view.querySelector('.fldPublicHttpsPort').classList.add('hide');
-                view.querySelector('.fldEnableUpnp').classList.add('hide');
-            }
-        });
         view.querySelector('#btnSelectCertPath').addEventListener('click', function () {
             import('../../components/directorybrowser/directorybrowser').then(({default: DirectoryBrowser}) => {
                 const picker = new DirectoryBrowser();


### PR DESCRIPTION
**Changes**

1. Removed event handler that was hiding part of the menu when a setting was unchecked.
2. Removed "hide" attribute from form items so that they are visible by default.

**Issues**

Fixes #3440