### PR TITLE
Fix 'resume' when clicking on item details poster

### DIFF
--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -1926,7 +1926,15 @@ export default function (view, params) {
     }
 
     function onPlayClick() {
-        playCurrentItem(this, this.getAttribute('data-action'));
+        let actionElem = this;
+        let action = actionElem.getAttribute('data-action');
+
+        if (!action) {
+            actionElem = actionElem.querySelector('[data-action]') || actionElem;
+            action = actionElem.getAttribute('data-action');
+        }
+
+        playCurrentItem(actionElem, action);
     }
 
     function onInstantMixClick() {


### PR DESCRIPTION
`detailImageContainer` contains no `data-action`, so action is always `undefined`.

**Changes**
Find the element with 'action'.

**Issues**
Clicking on the poster doesn't resume.
