### PR TITLE
Add error catching when loading home screen tab

### DIFF
--- a/src/controllers/hometab.js
+++ b/src/controllers/hometab.js
@@ -29,15 +29,17 @@ class HomeTab {
         const apiClient = this.apiClient;
         this.destroyHomeSections();
         this.sectionsRendered = true;
-        return apiClient.getCurrentUser().then(function (user) {
-            return homeSections.loadSections(view.querySelector('.sections'), apiClient, user, userSettings).then(function () {
+        return apiClient.getCurrentUser()
+            .then(user => homeSections.loadSections(view.querySelector('.sections'), apiClient, user, userSettings))
+            .then(() => {
                 if (options.autoFocus) {
                     focusManager.autoFocus(view);
                 }
-
+            }).catch(err => {
+                console.error(err);
+            }).finally(() => {
                 loading.hide();
             });
-        });
     }
     onPause() {
         const sectionsContainer = this.sectionsContainer;


### PR DESCRIPTION
**Changes**
This is just a slight refactor of the Promise handling in the `onResume` method of the home tab. The main reasoning is to add error logging when an error occurs since unhandled promise rejections are very hard to track down...

**Issues**
N/A
