### PR TITLE
Disable renovate vulnerability PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -36,7 +36,7 @@
     }
   ],
   "vulnerabilityAlerts": {
-    "addLabels": ["security"]
+    "enabled": false
   },
   "dependencyDashboard": false,
   "ignoreDeps": ["npm", "node"],


### PR DESCRIPTION
**Changes**
This disables Renovate from opening PRs for security vulnerabilities. This is already being handled by GitHub/Dependabot by default, so we were getting duplicate PRs.

**Issues**
N/A
