### PR TITLE
Fix touch events in epub player

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5243,9 +5243,9 @@
       "dev": true
     },
     "epubjs": {
-      "version": "0.3.90",
-      "resolved": "https://registry.npmjs.org/epubjs/-/epubjs-0.3.90.tgz",
-      "integrity": "sha512-8S9Zi9aE3QHvkJbq1mJTfaE1++UysKxgeb2GEv3oR9PEsK+Sx3tzxs3QaRselAVPoTlP5gfLyEgp9BQIyAu8lA==",
+      "version": "0.3.93",
+      "resolved": "https://registry.npmjs.org/epubjs/-/epubjs-0.3.93.tgz",
+      "integrity": "sha512-c06pNSdBxcXv3dZSbXAVLE1/pmleRhOT6mXNZo6INKmvuKpYB65MwU/lO7830czCtjIiK9i+KR+3S+p0wtljrw==",
       "requires": {
         "@types/localforage": "0.0.34",
         "@xmldom/xmldom": "^0.7.5",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "core-js": "3.20.2",
     "date-fns": "2.28.0",
     "dompurify": "2.3.4",
-    "epubjs": "0.3.90",
+    "epubjs": "0.3.93",
     "escape-html": "1.0.3",
     "fast-text-encoding": "1.0.3",
     "flv.js": "1.6.2",

--- a/src/plugins/bookPlayer/plugin.js
+++ b/src/plugins/bookPlayer/plugin.js
@@ -287,7 +287,9 @@ export class BookPlayer {
                     width: '100%',
                     height: renderHeight,
                     // TODO: Add option for scrolled-doc
-                    flow: 'paginated'
+                    flow: 'paginated',
+                    // Scripted content is required to allow touch event passthrough in Safari
+                    allowScriptedContent: true
                 });
 
                 this.currentSrc = downloadHref;


### PR DESCRIPTION
**Changes**
Fixes a regression in 10.8 where touch events do not work in Safari due to iframe content restrictions added in epub.js

**Issues**
Fixes the touch event issue mentioned in #3345 (but not the manga specific issue)
