### PR TITLE
Collection: Display total duration

### DIFF
--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -1099,7 +1099,7 @@ function renderMiscInfo(page, item) {
             interactive: true
         });
 
-        if (miscInfo.innerHTML && item.Type !== 'SeriesTimer') {
+        if ((miscInfo.innerHTML && item.Type !== 'SeriesTimer') || item.Type === 'BoxSet') {
             miscInfo.classList.remove('hide');
         } else {
             miscInfo.classList.add('hide');
@@ -1707,6 +1707,43 @@ function canPlaySomeItemInCollection(items) {
     return false;
 }
 
+function renderTotalChildrenDuration(children) {
+    let shouldRender = true;
+    let totBoxSetTicks = 0;
+    children.forEach(function (item) {
+        // Avoid rendering if at least one of the children does not have RunTimeTicks (i.e. with boxset in boxset)
+        if (isNaN(item.RunTimeTicks)) return shouldRender = false;
+        totBoxSetTicks += item.RunTimeTicks;
+    });
+
+    if (shouldRender) {
+        const totalDuration = datetime.getDisplayDuration(totBoxSetTicks);
+        const secondaryItemMiscInfo = document.querySelectorAll('.itemMiscInfo-secondary');
+
+        for (const miscInfo of secondaryItemMiscInfo) {
+            if (miscInfo.classList.contains('hide')) miscInfo.classList.remove('hide');
+        }
+
+        const textNode = document.createElement('div');
+        textNode.append(document.createTextNode(totalDuration));
+
+        requestAnimationFrame(function() {
+            textNode.style.transition = 'opacity 0.5s, height 0.2s ease-in';
+            textNode.style.opacity = '0';
+            textNode.style.height = '0px';
+
+            for (const miscInfo of secondaryItemMiscInfo) {
+                miscInfo.appendChild(textNode);
+            }
+
+            requestAnimationFrame(function() {
+                textNode.style.opacity = '1';
+                textNode.style.height = '20.09px';
+            });
+        });
+    }
+}
+
 function renderCollectionItems(page, parentItem, types, items) {
     page.querySelector('.collectionItems').classList.remove('hide');
     page.querySelector('.collectionItems').innerHTML = '';
@@ -1753,6 +1790,8 @@ function renderCollectionItems(page, parentItem, types, items) {
         hideAll(page, 'btnPlay', false);
         hideAll(page, 'btnShuffle', false);
     }
+
+    renderTotalChildrenDuration(items);
 
     // HACK: Call autoFocuser again because btnPlay may be hidden, but focused by reloadFromItem
     // FIXME: Sometimes focus does not move until all (?) sections are loaded


### PR DESCRIPTION
## Edit

The PR has been converted into a Draft as it was agreed that it is better if the total RunTimeTicks of a collection are calculated server-side, so that the frontend only has to convert them to readable format and display them.

### Edit+
I will complete the PR, if necessary (
_working on my [PR](https://github.com/jellyfin/jellyfin/pull/7661) on jellyfin-server seems unnecessary, but I intend to close this draft only when the that one is completed_ :)
) , once the [server side developments](https://github.com/jellyfin/jellyfin/pull/7661) are completed.

-----------

**Changes**

In the **_itemDetails_** page I added the total duration of a BoxSet, obtained from the RunTimeTicks of the children.

When all the children of a BoxSet are retrieved, I execute a new function that deals with:
- Calculate the total ticks of all children
- Get the DisplayDuration
- Add it to the DOM with a transition (in .itemMiscInfo-secondary)

If a collection contains even just one element that does not have a RunTimeTicks, rendering is avoided (e.g. with boxset inside boxset) in order to show the total duration only if it's perfect. 

_I added the transition due to the fact that informations about children are retrieved in a promise, so they come later, otherwise causing an instant unpleasant change of position._

---
_Here are two videos of the animation_


https://user-images.githubusercontent.com/61033694/162517262-e1fb3547-bbaa-4fad-85b3-ef5a2289204e.mp4


https://user-images.githubusercontent.com/61033694/162517390-30692813-a321-467e-826c-78d2179e8712.mp4



**Issues**
I have not found any open issues regarding the total duration of a BoxSet

---
First time working on my jellyfin-web fork!
_If it needs changes / corrections, I am available_