### PR TITLE
Move utility files

### DIFF
--- a/src/components/ServerConnections.js
+++ b/src/components/ServerConnections.js
@@ -1,6 +1,6 @@
 import { ConnectionManager, Credentials, ApiClient, Events } from 'jellyfin-apiclient';
 import { appHost } from './apphost';
-import Dashboard from '../scripts/clientUtils';
+import Dashboard from '../utils/dashboard';
 import { setUserInfo } from '../scripts/settings/userSettings';
 
 class ServerConnections extends ConnectionManager {

--- a/src/components/appRouter.js
+++ b/src/components/appRouter.js
@@ -8,7 +8,7 @@ import itemHelper from './itemHelper';
 import loading from './loading/loading';
 import page from 'page';
 import viewManager from './viewManager/viewManager';
-import Dashboard from '../scripts/clientUtils';
+import Dashboard from '../utils/dashboard';
 import ServerConnections from './ServerConnections';
 import alert from './alert';
 import reactControllerFactory from './reactControllerFactory';

--- a/src/components/dashboard/users/UserPasswordForm.tsx
+++ b/src/components/dashboard/users/UserPasswordForm.tsx
@@ -1,6 +1,6 @@
 import { UserDto } from '@thornbill/jellyfin-sdk/dist/generated-client';
 import React, { FunctionComponent, useCallback, useEffect, useRef } from 'react';
-import Dashboard from '../../../scripts/clientUtils';
+import Dashboard from '../../../utils/dashboard';
 import globalize from '../../../scripts/globalize';
 import LibraryMenu from '../../../scripts/libraryMenu';
 import confirm from '../../confirm/confirm';

--- a/src/components/groupedcards.js
+++ b/src/components/groupedcards.js
@@ -2,7 +2,7 @@
 
 import dom from '../scripts/dom';
 import { appRouter } from './appRouter';
-import Dashboard from '../scripts/clientUtils';
+import Dashboard from '../utils/dashboard';
 import ServerConnections from './ServerConnections';
 
     function onGroupedCardClick(e, card) {

--- a/src/components/homesections/homesections.js
+++ b/src/components/homesections/homesections.js
@@ -11,7 +11,7 @@ import '../../elements/emby-itemscontainer/emby-itemscontainer';
 import '../../elements/emby-scroller/emby-scroller';
 import '../../elements/emby-button/emby-button';
 import './homesections.scss';
-import Dashboard from '../../scripts/clientUtils';
+import Dashboard from '../../utils/dashboard';
 import ServerConnections from '../ServerConnections';
 
 /* eslint-disable indent */

--- a/src/components/pages/NewUserPage.tsx
+++ b/src/components/pages/NewUserPage.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent, useCallback, useEffect, useState, useRef } from 'react';
 
-import Dashboard from '../../scripts/clientUtils';
+import Dashboard from '../../utils/dashboard';
 import globalize from '../../scripts/globalize';
 import loading from '../loading/loading';
 import toast from '../toast/toast';

--- a/src/components/pages/UserEditPage.tsx
+++ b/src/components/pages/UserEditPage.tsx
@@ -1,6 +1,6 @@
 import { SyncPlayUserAccessType, UserDto } from '@thornbill/jellyfin-sdk/dist/generated-client';
 import React, { FunctionComponent, useCallback, useEffect, useState, useRef } from 'react';
-import Dashboard from '../../scripts/clientUtils';
+import Dashboard from '../../utils/dashboard';
 import globalize from '../../scripts/globalize';
 import LibraryMenu from '../../scripts/libraryMenu';
 import { appRouter } from '../appRouter';

--- a/src/components/pages/UserProfilePage.tsx
+++ b/src/components/pages/UserProfilePage.tsx
@@ -1,7 +1,7 @@
 import { ImageType, UserDto } from '@thornbill/jellyfin-sdk/dist/generated-client';
 import React, { FunctionComponent, useEffect, useState, useRef, useCallback } from 'react';
 
-import Dashboard from '../../scripts/clientUtils';
+import Dashboard from '../../utils/dashboard';
 import globalize from '../../scripts/globalize';
 import LibraryMenu from '../../scripts/libraryMenu';
 import { appHost } from '../apphost';

--- a/src/components/pages/UserProfilesPage.tsx
+++ b/src/components/pages/UserProfilesPage.tsx
@@ -1,6 +1,6 @@
 import { UserDto } from '@thornbill/jellyfin-sdk/dist/generated-client';
 import React, {FunctionComponent, useEffect, useState, useRef} from 'react';
-import Dashboard from '../../scripts/clientUtils';
+import Dashboard from '../../utils/dashboard';
 import globalize from '../../scripts/globalize';
 import loading from '../loading/loading';
 import dom from '../../scripts/dom';

--- a/src/components/syncPlay/core/PlaybackCore.js
+++ b/src/components/syncPlay/core/PlaybackCore.js
@@ -5,7 +5,7 @@
 import { Events } from 'jellyfin-apiclient';
 
 import browser from '../../../scripts/browser';
-import { toBoolean, toFloat } from '../../../scripts/stringUtils';
+import { toBoolean, toFloat } from '../../../utils/string.ts';
 import * as Helper from './Helper';
 import { getSetting } from './Settings';
 

--- a/src/components/syncPlay/core/timeSync/TimeSyncCore.js
+++ b/src/components/syncPlay/core/timeSync/TimeSyncCore.js
@@ -5,7 +5,7 @@
 
 import { Events } from 'jellyfin-apiclient';
 import appSettings from '../../../../scripts/settings/appSettings';
-import { toFloat } from '../../../../scripts/stringUtils';
+import { toFloat } from '../../../../utils/string.ts';
 import { getSetting } from '../Settings';
 import TimeSyncServer from './TimeSyncServer';
 

--- a/src/components/tvproviders/schedulesdirect.js
+++ b/src/components/tvproviders/schedulesdirect.js
@@ -8,7 +8,7 @@ import '../../elements/emby-button/paper-icon-button-light';
 import '../../elements/emby-select/emby-select';
 import '../../elements/emby-button/emby-button';
 import '../../assets/css/flexstyles.scss';
-import Dashboard from '../../scripts/clientUtils';
+import Dashboard from '../../utils/dashboard';
 import { Events } from 'jellyfin-apiclient';
 
 export default function (page, providerId, options) {

--- a/src/components/tvproviders/xmltv.js
+++ b/src/components/tvproviders/xmltv.js
@@ -5,7 +5,7 @@ import '../../elements/emby-checkbox/emby-checkbox';
 import '../../elements/emby-input/emby-input';
 import '../listview/listview.scss';
 import '../../elements/emby-button/paper-icon-button-light';
-import Dashboard from '../../scripts/clientUtils';
+import Dashboard from '../../utils/dashboard';
 import { Events } from 'jellyfin-apiclient';
 
 export default function (page, providerId, options) {

--- a/src/components/viewContainer.js
+++ b/src/components/viewContainer.js
@@ -1,6 +1,6 @@
 import { importModule } from '@uupaa/dynamic-import-polyfill';
 import './viewManager/viewContainer.scss';
-import Dashboard from '../scripts/clientUtils';
+import Dashboard from '../utils/dashboard';
 
 /* eslint-disable indent */
 

--- a/src/controllers/dashboard/apikeys.js
+++ b/src/controllers/dashboard/apikeys.js
@@ -4,7 +4,7 @@ import dom from '../../scripts/dom';
 import globalize from '../../scripts/globalize';
 import '../../elements/emby-button/emby-button';
 import confirm from '../../components/confirm/confirm';
-import { pageIdOn } from '../../scripts/clientUtils';
+import { pageIdOn } from '../../utils/dashboard';
 
 /* eslint-disable indent */
 

--- a/src/controllers/dashboard/dashboard.js
+++ b/src/controllers/dashboard/dashboard.js
@@ -19,7 +19,7 @@ import '../../elements/emby-button/emby-button';
 import '../../assets/css/flexstyles.scss';
 import '../../elements/emby-itemscontainer/emby-itemscontainer';
 import taskButton from '../../scripts/taskbutton';
-import Dashboard from '../../scripts/clientUtils';
+import Dashboard from '../../utils/dashboard';
 import ServerConnections from '../../components/ServerConnections';
 import alert from '../../components/alert';
 import confirm from '../../components/confirm/confirm';

--- a/src/controllers/dashboard/devices/device.js
+++ b/src/controllers/dashboard/devices/device.js
@@ -2,7 +2,7 @@ import loading from '../../../components/loading/loading';
 import dom from '../../../scripts/dom';
 import '../../../elements/emby-input/emby-input';
 import '../../../elements/emby-button/emby-button';
-import Dashboard from '../../../scripts/clientUtils';
+import Dashboard from '../../../utils/dashboard';
 import { getParameterByName } from '../../../utils/url.ts';
 
 /* eslint-disable indent */

--- a/src/controllers/dashboard/devices/devices.js
+++ b/src/controllers/dashboard/devices/devices.js
@@ -9,7 +9,7 @@ import { localeWithSuffix } from '../../../scripts/dfnshelper';
 import '../../../elements/emby-button/emby-button';
 import '../../../elements/emby-itemscontainer/emby-itemscontainer';
 import '../../../components/cardbuilder/card.scss';
-import Dashboard from '../../../scripts/clientUtils';
+import Dashboard from '../../../utils/dashboard';
 import confirm from '../../../components/confirm/confirm';
 
 /* eslint-disable indent */

--- a/src/controllers/dashboard/dlna/profile.js
+++ b/src/controllers/dashboard/dlna/profile.js
@@ -7,7 +7,7 @@ import '../../../elements/emby-button/emby-button';
 import '../../../elements/emby-input/emby-input';
 import '../../../elements/emby-checkbox/emby-checkbox';
 import '../../../components/listview/listview.scss';
-import Dashboard from '../../../scripts/clientUtils';
+import Dashboard from '../../../utils/dashboard';
 import toast from '../../../components/toast/toast';
 import { getParameterByName } from '../../../utils/url.ts';
 

--- a/src/controllers/dashboard/dlna/settings.js
+++ b/src/controllers/dashboard/dlna/settings.js
@@ -3,7 +3,7 @@ import 'jquery';
 import loading from '../../../components/loading/loading';
 import libraryMenu from '../../../scripts/libraryMenu';
 import globalize from '../../../scripts/globalize';
-import Dashboard from '../../../scripts/clientUtils';
+import Dashboard from '../../../utils/dashboard';
 
 /* eslint-disable indent */
 

--- a/src/controllers/dashboard/encodingsettings.js
+++ b/src/controllers/dashboard/encodingsettings.js
@@ -3,7 +3,7 @@ import loading from '../../components/loading/loading';
 import globalize from '../../scripts/globalize';
 import dom from '../../scripts/dom';
 import libraryMenu from '../../scripts/libraryMenu';
-import Dashboard from '../../scripts/clientUtils';
+import Dashboard from '../../utils/dashboard';
 import alert from '../../components/alert';
 
 /* eslint-disable indent */

--- a/src/controllers/dashboard/general.js
+++ b/src/controllers/dashboard/general.js
@@ -6,7 +6,7 @@ import '../../elements/emby-textarea/emby-textarea';
 import '../../elements/emby-input/emby-input';
 import '../../elements/emby-select/emby-select';
 import '../../elements/emby-button/emby-button';
-import Dashboard from '../../scripts/clientUtils';
+import Dashboard from '../../utils/dashboard';
 import alert from '../../components/alert';
 
 /* eslint-disable indent */

--- a/src/controllers/dashboard/library.js
+++ b/src/controllers/dashboard/library.js
@@ -8,7 +8,7 @@ import dom from '../../scripts/dom';
 import imageHelper from '../../scripts/imagehelper';
 import '../../components/cardbuilder/card.scss';
 import '../../elements/emby-itemrefreshindicator/emby-itemrefreshindicator';
-import Dashboard, { pageClassOn, pageIdOn } from '../../scripts/clientUtils';
+import Dashboard, { pageClassOn, pageIdOn } from '../../utils/dashboard';
 import confirm from '../../components/confirm/confirm';
 import cardBuilder from '../../components/cardbuilder/cardBuilder';
 

--- a/src/controllers/dashboard/librarydisplay.js
+++ b/src/controllers/dashboard/librarydisplay.js
@@ -3,7 +3,7 @@ import loading from '../../components/loading/loading';
 import libraryMenu from '../../scripts/libraryMenu';
 import '../../elements/emby-checkbox/emby-checkbox';
 import '../../elements/emby-button/emby-button';
-import Dashboard from '../../scripts/clientUtils';
+import Dashboard from '../../utils/dashboard';
 
 /* eslint-disable indent */
 

--- a/src/controllers/dashboard/logs.js
+++ b/src/controllers/dashboard/logs.js
@@ -4,7 +4,7 @@ import globalize from '../../scripts/globalize';
 import '../../elements/emby-button/emby-button';
 import '../../components/listview/listview.scss';
 import '../../assets/css/flexstyles.scss';
-import Dashboard from '../../scripts/clientUtils';
+import Dashboard from '../../utils/dashboard';
 import alert from '../../components/alert';
 
 /* eslint-disable indent */

--- a/src/controllers/dashboard/metadataImages.js
+++ b/src/controllers/dashboard/metadataImages.js
@@ -3,7 +3,7 @@ import loading from '../../components/loading/loading';
 import libraryMenu from '../../scripts/libraryMenu';
 import globalize from '../../scripts/globalize';
 import '../../components/listview/listview.scss';
-import Dashboard from '../../scripts/clientUtils';
+import Dashboard from '../../utils/dashboard';
 
 /* eslint-disable indent */
 

--- a/src/controllers/dashboard/metadatanfo.js
+++ b/src/controllers/dashboard/metadatanfo.js
@@ -3,7 +3,7 @@ import 'jquery';
 import loading from '../../components/loading/loading';
 import libraryMenu from '../../scripts/libraryMenu';
 import globalize from '../../scripts/globalize';
-import Dashboard from '../../scripts/clientUtils';
+import Dashboard from '../../utils/dashboard';
 import alert from '../../components/alert';
 
 /* eslint-disable indent */

--- a/src/controllers/dashboard/networking.js
+++ b/src/controllers/dashboard/networking.js
@@ -2,7 +2,7 @@ import loading from '../../components/loading/loading';
 import globalize from '../../scripts/globalize';
 import '../../elements/emby-checkbox/emby-checkbox';
 import '../../elements/emby-select/emby-select';
-import Dashboard from '../../scripts/clientUtils';
+import Dashboard from '../../utils/dashboard';
 import alert from '../../components/alert';
 
 /* eslint-disable indent */

--- a/src/controllers/dashboard/notifications/notification/index.js
+++ b/src/controllers/dashboard/notifications/notification/index.js
@@ -1,7 +1,7 @@
 import escapeHtml from 'escape-html';
 import 'jquery';
 import '../../../../elements/emby-checkbox/emby-checkbox';
-import Dashboard from '../../../../scripts/clientUtils';
+import Dashboard from '../../../../utils/dashboard';
 import { getParameterByName } from '../../../../utils/url.ts';
 
 function fillItems(elem, items, cssClass, idPrefix, currentList, isEnabledList) {

--- a/src/controllers/dashboard/playback.js
+++ b/src/controllers/dashboard/playback.js
@@ -2,7 +2,7 @@ import 'jquery';
 import loading from '../../components/loading/loading';
 import libraryMenu from '../../scripts/libraryMenu';
 import globalize from '../../scripts/globalize';
-import Dashboard from '../../scripts/clientUtils';
+import Dashboard from '../../utils/dashboard';
 
 /* eslint-disable indent */
 

--- a/src/controllers/dashboard/plugins/add/index.js
+++ b/src/controllers/dashboard/plugins/add/index.js
@@ -4,7 +4,7 @@ import DOMPurify from 'dompurify';
 import loading from '../../../../components/loading/loading';
 import globalize from '../../../../scripts/globalize';
 import '../../../../elements/emby-button/emby-button';
-import Dashboard from '../../../../scripts/clientUtils';
+import Dashboard from '../../../../utils/dashboard';
 import alert from '../../../../components/alert';
 import confirm from '../../../../components/confirm/confirm';
 

--- a/src/controllers/dashboard/plugins/installed/index.js
+++ b/src/controllers/dashboard/plugins/installed/index.js
@@ -5,7 +5,7 @@ import globalize from '../../../../scripts/globalize';
 import * as cardBuilder from '../../../../components/cardbuilder/cardBuilder.js';
 import '../../../../components/cardbuilder/card.scss';
 import '../../../../elements/emby-button/emby-button';
-import Dashboard, { pageIdOn } from '../../../../scripts/clientUtils';
+import Dashboard, { pageIdOn } from '../../../../utils/dashboard';
 import confirm from '../../../../components/confirm/confirm';
 
 function deletePlugin(page, uniqueid, version, name) {

--- a/src/controllers/dashboard/streaming.js
+++ b/src/controllers/dashboard/streaming.js
@@ -2,7 +2,7 @@ import 'jquery';
 import libraryMenu from '../../scripts/libraryMenu';
 import loading from '../../components/loading/loading';
 import globalize from '../../scripts/globalize';
-import Dashboard from '../../scripts/clientUtils';
+import Dashboard from '../../utils/dashboard';
 
 /* eslint-disable indent */
 

--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -29,7 +29,7 @@ import '../../elements/emby-ratingbutton/emby-ratingbutton';
 import '../../elements/emby-scroller/emby-scroller';
 import '../../elements/emby-select/emby-select';
 import itemShortcuts from '../../components/shortcuts';
-import Dashboard from '../../scripts/clientUtils';
+import Dashboard from '../../utils/dashboard';
 import ServerConnections from '../../components/ServerConnections';
 import confirm from '../../components/confirm/confirm';
 import { download } from '../../scripts/fileDownloader';

--- a/src/controllers/livetv/livetvrecordings.js
+++ b/src/controllers/livetv/livetvrecordings.js
@@ -4,7 +4,7 @@ import imageLoader from '../../components/images/imageLoader';
 import '../../scripts/livetvcomponents';
 import '../../components/listview/listview.scss';
 import '../../elements/emby-itemscontainer/emby-itemscontainer';
-import Dashboard from '../../scripts/clientUtils';
+import Dashboard from '../../utils/dashboard';
 
 function renderRecordings(elem, recordings, cardOptions, scrollX) {
     if (!elem) {

--- a/src/controllers/livetv/livetvschedule.js
+++ b/src/controllers/livetv/livetvschedule.js
@@ -5,7 +5,7 @@ import loading from '../../components/loading/loading';
 import '../../scripts/livetvcomponents';
 import '../../elements/emby-button/emby-button';
 import '../../elements/emby-itemscontainer/emby-itemscontainer';
-import Dashboard from '../../scripts/clientUtils';
+import Dashboard from '../../utils/dashboard';
 
 function enableScrollX() {
     return !layoutManager.desktop;

--- a/src/controllers/livetv/livetvsuggested.js
+++ b/src/controllers/livetv/livetvsuggested.js
@@ -10,7 +10,7 @@ import '../../assets/css/scrollstyles.scss';
 import '../../elements/emby-itemscontainer/emby-itemscontainer';
 import '../../elements/emby-tabs/emby-tabs';
 import '../../elements/emby-button/emby-button';
-import Dashboard from '../../scripts/clientUtils';
+import Dashboard from '../../utils/dashboard';
 
 function enableScrollX() {
     return !layoutManager.desktop;

--- a/src/controllers/livetvguideprovider.js
+++ b/src/controllers/livetvguideprovider.js
@@ -1,7 +1,7 @@
 import { Events } from 'jellyfin-apiclient';
 import loading from '../components/loading/loading';
 import globalize from '../scripts/globalize';
-import Dashboard, { pageIdOn } from '../scripts/clientUtils';
+import Dashboard, { pageIdOn } from '../utils/dashboard';
 import { getParameterByName } from '../utils/url.ts';
 
 function onListingsSubmitted() {

--- a/src/controllers/livetvsettings.js
+++ b/src/controllers/livetvsettings.js
@@ -2,7 +2,7 @@ import 'jquery';
 import loading from '../components/loading/loading';
 import globalize from '../scripts/globalize';
 import '../elements/emby-button/emby-button';
-import Dashboard from '../scripts/clientUtils';
+import Dashboard from '../utils/dashboard';
 import alert from '../components/alert';
 
 function loadPage(page, config) {

--- a/src/controllers/livetvstatus.js
+++ b/src/controllers/livetvstatus.js
@@ -12,7 +12,7 @@ import '../elements/emby-itemscontainer/emby-itemscontainer';
 import '../components/cardbuilder/card.scss';
 import 'material-design-icons-iconfont';
 import '../elements/emby-button/emby-button';
-import Dashboard from '../scripts/clientUtils';
+import Dashboard from '../utils/dashboard';
 import confirm from '../components/confirm/confirm';
 
 const enableFocusTransform = !browser.slow && !browser.edge;

--- a/src/controllers/livetvtuner.js
+++ b/src/controllers/livetvtuner.js
@@ -5,7 +5,7 @@ import '../elements/emby-input/emby-input';
 import '../elements/emby-button/emby-button';
 import '../elements/emby-checkbox/emby-checkbox';
 import '../elements/emby-select/emby-select';
-import Dashboard from '../scripts/clientUtils';
+import Dashboard from '../utils/dashboard';
 import { getParameterByName } from '../utils/url.ts';
 
 function isM3uVariant(type) {

--- a/src/controllers/movies/moviesrecommended.js
+++ b/src/controllers/movies/moviesrecommended.js
@@ -14,7 +14,7 @@ import '../../elements/emby-scroller/emby-scroller';
 import '../../elements/emby-itemscontainer/emby-itemscontainer';
 import '../../elements/emby-tabs/emby-tabs';
 import '../../elements/emby-button/emby-button';
-import Dashboard from '../../scripts/clientUtils';
+import Dashboard from '../../utils/dashboard';
 
 /* eslint-disable indent */
 

--- a/src/controllers/music/musicrecommended.js
+++ b/src/controllers/music/musicrecommended.js
@@ -14,7 +14,7 @@ import '../../elements/emby-itemscontainer/emby-itemscontainer';
 import '../../elements/emby-tabs/emby-tabs';
 import '../../elements/emby-button/emby-button';
 import '../../assets/css/flexstyles.scss';
-import Dashboard from '../../scripts/clientUtils';
+import Dashboard from '../../utils/dashboard';
 
 /* eslint-disable indent */
 

--- a/src/controllers/music/songs.js
+++ b/src/controllers/music/songs.js
@@ -7,7 +7,7 @@ import loading from '../../components/loading/loading';
 import * as userSettings from '../../scripts/settings/userSettings';
 import globalize from '../../scripts/globalize';
 import '../../elements/emby-itemscontainer/emby-itemscontainer';
-import Dashboard from '../../scripts/clientUtils';
+import Dashboard from '../../utils/dashboard';
 
 /* eslint-disable indent */
 

--- a/src/controllers/session/addServer/index.js
+++ b/src/controllers/session/addServer/index.js
@@ -2,7 +2,7 @@ import appSettings from '../../../scripts/settings/appSettings';
 import loading from '../../../components/loading/loading';
 import globalize from '../../../scripts/globalize';
 import '../../../elements/emby-button/emby-button';
-import Dashboard from '../../../scripts/clientUtils';
+import Dashboard from '../../../utils/dashboard';
 import ServerConnections from '../../../components/ServerConnections';
 
 /* eslint-disable indent */

--- a/src/controllers/session/forgotPassword/index.js
+++ b/src/controllers/session/forgotPassword/index.js
@@ -1,5 +1,5 @@
 import globalize from '../../../scripts/globalize';
-import Dashboard from '../../../scripts/clientUtils';
+import Dashboard from '../../../utils/dashboard';
 
 /* eslint-disable indent */
 

--- a/src/controllers/session/login/index.js
+++ b/src/controllers/session/login/index.js
@@ -10,7 +10,7 @@ import browser from '../../../scripts/browser';
 import globalize from '../../../scripts/globalize';
 import '../../../components/cardbuilder/card.scss';
 import '../../../elements/emby-checkbox/emby-checkbox';
-import Dashboard from '../../../scripts/clientUtils';
+import Dashboard from '../../../utils/dashboard';
 import ServerConnections from '../../../components/ServerConnections';
 import toast from '../../../components/toast/toast';
 import dialogHelper from '../../../components/dialogHelper/dialogHelper';

--- a/src/controllers/session/resetPassword/index.js
+++ b/src/controllers/session/resetPassword/index.js
@@ -1,5 +1,5 @@
 import globalize from '../../../scripts/globalize';
-import Dashboard from '../../../scripts/clientUtils';
+import Dashboard from '../../../utils/dashboard';
 
 /* eslint-disable indent */
 

--- a/src/controllers/session/selectServer/index.js
+++ b/src/controllers/session/selectServer/index.js
@@ -15,7 +15,7 @@ import '../../../elements/emby-scroller/emby-scroller';
 import '../../../elements/emby-itemscontainer/emby-itemscontainer';
 import '../../../components/cardbuilder/card.scss';
 import '../../../elements/emby-button/emby-button';
-import Dashboard from '../../../scripts/clientUtils';
+import Dashboard from '../../../utils/dashboard';
 import ServerConnections from '../../../components/ServerConnections';
 import alert from '../../../components/alert';
 import cardBuilder from '../../../components/cardbuilder/cardBuilder';

--- a/src/controllers/shows/episodes.js
+++ b/src/controllers/shows/episodes.js
@@ -7,7 +7,7 @@ import cardBuilder from '../../components/cardbuilder/cardBuilder';
 import * as userSettings from '../../scripts/settings/userSettings';
 import globalize from '../../scripts/globalize';
 import '../../elements/emby-itemscontainer/emby-itemscontainer';
-import Dashboard from '../../scripts/clientUtils';
+import Dashboard from '../../utils/dashboard';
 
 /* eslint-disable indent */
 

--- a/src/controllers/shows/tvrecommended.js
+++ b/src/controllers/shows/tvrecommended.js
@@ -13,7 +13,7 @@ import globalize from '../../scripts/globalize';
 import '../../assets/css/scrollstyles.scss';
 import '../../elements/emby-itemscontainer/emby-itemscontainer';
 import '../../elements/emby-button/emby-button';
-import Dashboard from '../../scripts/clientUtils';
+import Dashboard from '../../utils/dashboard';
 import autoFocuser from '../../components/autoFocuser';
 
 /* eslint-disable indent */

--- a/src/controllers/user/menu/index.js
+++ b/src/controllers/user/menu/index.js
@@ -2,7 +2,7 @@ import { appHost } from '../../../components/apphost';
 import '../../../components/listview/listview.scss';
 import '../../../elements/emby-button/emby-button';
 import layoutManager from '../../../components/layoutManager';
-import Dashboard from '../../../scripts/clientUtils';
+import Dashboard from '../../../utils/dashboard';
 
 export default function (view, params) {
     view.querySelector('.btnLogout').addEventListener('click', function () {

--- a/src/controllers/wizard/remote/index.js
+++ b/src/controllers/wizard/remote/index.js
@@ -2,7 +2,7 @@ import loading from '../../../components/loading/loading';
 import '../../../elements/emby-checkbox/emby-checkbox';
 import '../../../elements/emby-button/emby-button';
 import '../../../elements/emby-select/emby-select';
-import Dashboard from '../../../scripts/clientUtils';
+import Dashboard from '../../../utils/dashboard';
 
 function save(page) {
     loading.show();

--- a/src/controllers/wizard/settings/index.js
+++ b/src/controllers/wizard/settings/index.js
@@ -2,7 +2,7 @@ import loading from '../../../components/loading/loading';
 import '../../../elements/emby-checkbox/emby-checkbox';
 import '../../../elements/emby-button/emby-button';
 import '../../../elements/emby-select/emby-select';
-import Dashboard from '../../../scripts/clientUtils';
+import Dashboard from '../../../utils/dashboard';
 
 function save(page) {
     loading.show();

--- a/src/controllers/wizard/start/index.js
+++ b/src/controllers/wizard/start/index.js
@@ -2,7 +2,7 @@ import 'jquery';
 import loading from '../../../components/loading/loading';
 import '../../../elements/emby-button/emby-button';
 import '../../../elements/emby-select/emby-select';
-import Dashboard from '../../../scripts/clientUtils';
+import Dashboard from '../../../utils/dashboard';
 
 function loadPage(page, config, languageOptions) {
     $('#selectLocalizationLanguage', page).html(languageOptions.map(function (l) {

--- a/src/controllers/wizard/user/index.js
+++ b/src/controllers/wizard/user/index.js
@@ -3,7 +3,7 @@ import globalize from '../../../scripts/globalize';
 import '../../../assets/css/dashboard.scss';
 import '../../../elements/emby-input/emby-input';
 import '../../../elements/emby-button/emby-button';
-import Dashboard from '../../../scripts/clientUtils';
+import Dashboard from '../../../utils/dashboard';
 import toast from '../../../components/toast/toast';
 
 function getApiClient() {

--- a/src/scripts/autoBackdrops.js
+++ b/src/scripts/autoBackdrops.js
@@ -1,7 +1,7 @@
 import backdrop from '../components/backdrop/backdrop';
 import * as userSettings from './settings/userSettings';
 import libraryMenu from './libraryMenu';
-import { pageClassOn } from './clientUtils';
+import { pageClassOn } from '../utils/dashboard';
 
 const cache = {};
 

--- a/src/scripts/autoThemes.js
+++ b/src/scripts/autoThemes.js
@@ -2,7 +2,7 @@ import * as userSettings from './settings/userSettings';
 import skinManager from './themeManager';
 import { Events } from 'jellyfin-apiclient';
 import ServerConnections from '../components/ServerConnections';
-import { pageClassOn } from '../scripts/clientUtils';
+import { pageClassOn } from '../utils/dashboard';
 
 // Set the default theme when loading
 skinManager.setTheme(userSettings.theme())

--- a/src/scripts/editorsidebar.js
+++ b/src/scripts/editorsidebar.js
@@ -2,7 +2,7 @@ import escapeHtml from 'escape-html';
 import 'jquery';
 import globalize from './globalize';
 import 'material-design-icons-iconfont';
-import Dashboard from './clientUtils';
+import Dashboard from '../utils/dashboard';
 import { getParameterByName } from '../utils/url.ts';
 
 /* eslint-disable indent */

--- a/src/scripts/libraryMenu.js
+++ b/src/scripts/libraryMenu.js
@@ -16,7 +16,7 @@ import '../elements/emby-button/paper-icon-button-light';
 import 'material-design-icons-iconfont';
 import '../assets/css/scrollstyles.scss';
 import '../assets/css/flexstyles.scss';
-import Dashboard, { pageClassOn } from './clientUtils';
+import Dashboard, { pageClassOn } from '../utils/dashboard';
 import ServerConnections from '../components/ServerConnections';
 import Headroom from 'headroom.js';
 import { getParameterByName } from '../utils/url.ts';

--- a/src/scripts/playlists.js
+++ b/src/scripts/playlists.js
@@ -6,7 +6,7 @@ import libraryBrowser from './libraryBrowser';
 import imageLoader from '../components/images/imageLoader';
 import * as userSettings from './settings/userSettings';
 import '../elements/emby-itemscontainer/emby-itemscontainer';
-import Dashboard from './clientUtils';
+import Dashboard from '../utils/dashboard';
 
 export default function (view) {
     function getPageData(context) {

--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -25,7 +25,7 @@ import './libraryMenu';
 import './routes';
 import '../components/themeMediaPlayer';
 import './autoBackdrops';
-import { pageClassOn, serverAddress } from './clientUtils';
+import { pageClassOn, serverAddress } from '../utils/dashboard';
 import './screensavermanager';
 import './serverNotifications';
 import '../components/playback/playerSelectionMenu';

--- a/src/utils/dashboard.js
+++ b/src/utils/dashboard.js
@@ -5,12 +5,12 @@ import { appRouter } from '../components/appRouter';
 import baseAlert from '../components/alert';
 import baseConfirm from '../components/confirm/confirm';
 import globalize from '../scripts/globalize';
-import * as webSettings from './settings/webSettings';
+import * as webSettings from '../scripts/settings/webSettings';
 import datetime from '../scripts/datetime';
 import DirectoryBrowser from '../components/directorybrowser/directorybrowser';
 import dialogHelper from '../components/dialogHelper/dialogHelper';
 import itemIdentifier from '../components/itemidentifier/itemidentifier';
-import { getLocationSearch } from '../utils/url.ts';
+import { getLocationSearch } from './url.ts';
 
 export function getCurrentUser() {
     return window.ApiClient.getCurrentUser(false);

--- a/src/utils/dashboard.js
+++ b/src/utils/dashboard.js
@@ -86,7 +86,7 @@ export function getCurrentUserId() {
     return null;
 }
 
-export function onServerChanged(userId, accessToken, apiClient) {
+export function onServerChanged(_userId, _accessToken, apiClient) {
     ServerConnections.setLocalApiClient(apiClient);
 }
 

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -4,7 +4,7 @@
  * @param {boolean} defaultValue The default value if the string is invalid.
  * @returns {boolean} The value.
  */
-export function toBoolean(value, defaultValue = false) {
+export function toBoolean(value: string | undefined | null, defaultValue = false) {
     if (value !== 'true' && value !== 'false') {
         return defaultValue;
     } else {
@@ -18,8 +18,8 @@ export function toBoolean(value, defaultValue = false) {
  * @param {number} defaultValue The default value if the string is invalid.
  * @returns {number} The value.
  */
-export function toFloat(value, defaultValue = 0) {
-    if (value === null || value === '' || isNaN(value)) {
+export function toFloat(value: string | null | undefined, defaultValue = 0) {
+    if (!value || isNaN(value as never)) {
         return defaultValue;
     } else {
         return parseFloat(value);


### PR DESCRIPTION
**Changes**
* Moves the `stringUtils` file to the new `utils` directory and migrates the file to typescript
* Moves the `clientUtils` file to the new `utils` directory and renames it to `dashboard` to match the default export (I'm not a fan of the name, but it's attached to the window scope and used in some plugins I believe)

**Issues**
N/A
