### PR TITLE
Remove duplicate appRouter.param function

### DIFF
--- a/src/components/appRouter.js
+++ b/src/components/appRouter.js
@@ -12,7 +12,6 @@ import Dashboard from '../scripts/clientUtils';
 import ServerConnections from './ServerConnections';
 import alert from './alert';
 import reactControllerFactory from './reactControllerFactory';
-import { getLocationSearch } from '../utils/url.ts';
 
 class AppRouter {
     allRoutes = [];
@@ -114,19 +113,6 @@ class AppRouter {
         }).then((result) => {
             this.handleConnectionResult(result);
         });
-    }
-
-    param(name, url) {
-        name = name.replace(/[[]/, '\\[').replace(/[\]]/, '\\]');
-        const regexS = '[\\?&]' + name + '=([^&#]*)';
-        const regex = new RegExp(regexS, 'i');
-
-        const results = regex.exec(url || getLocationSearch());
-        if (results == null) {
-            return '';
-        } else {
-            return decodeURIComponent(results[1].replace(/\+/g, ' '));
-        }
     }
 
     ready() {

--- a/src/components/pages/UserEditPage.tsx
+++ b/src/components/pages/UserEditPage.tsx
@@ -3,7 +3,6 @@ import React, { FunctionComponent, useCallback, useEffect, useState, useRef } fr
 import Dashboard from '../../scripts/clientUtils';
 import globalize from '../../scripts/globalize';
 import LibraryMenu from '../../scripts/libraryMenu';
-import { appRouter } from '../appRouter';
 import ButtonElement from '../dashboard/users/ButtonElement';
 import CheckBoxElement from '../dashboard/users/CheckBoxElement';
 import CheckBoxListItem from '../dashboard/users/CheckBoxListItem';
@@ -15,6 +14,7 @@ import SelectSyncPlayAccessElement from '../dashboard/users/SelectSyncPlayAccess
 import SectionTabs from '../dashboard/users/SectionTabs';
 import loading from '../loading/loading';
 import toast from '../toast/toast';
+import { getParameterByName } from '../../utils/url';
 
 type ItemsArr = {
     Name?: string;
@@ -40,7 +40,7 @@ const UserEditPage: FunctionComponent = () => {
     };
 
     const getUser = () => {
-        const userId = appRouter.param('userId');
+        const userId = getParameterByName('userId');
         return window.ApiClient.getUser(userId);
     };
 

--- a/src/components/pages/UserLibraryAccessPage.tsx
+++ b/src/components/pages/UserLibraryAccessPage.tsx
@@ -5,12 +5,12 @@ import loading from '../loading/loading';
 import libraryMenu from '../../scripts/libraryMenu';
 import globalize from '../../scripts/globalize';
 import toast from '../toast/toast';
-import { appRouter } from '../appRouter';
 import SectionTitleLinkElement from '../dashboard/users/SectionTitleLinkElement';
 import SectionTabs from '../dashboard/users/SectionTabs';
 import CheckBoxElement from '../dashboard/users/CheckBoxElement';
 import CheckBoxListItem from '../dashboard/users/CheckBoxListItem';
 import ButtonElement from '../dashboard/users/ButtonElement';
+import { getParameterByName } from '../../utils/url';
 
 type ItemsArr = {
     Name?: string;
@@ -138,7 +138,7 @@ const UserLibraryAccessPage: FunctionComponent = () => {
 
     const loadData = useCallback(() => {
         loading.show();
-        const userId = appRouter.param('userId');
+        const userId = getParameterByName('userId');
         const promise1 = userId ? window.ApiClient.getUser(userId) : Promise.resolve({ Configuration: {} });
         const promise2 = window.ApiClient.getJSON(window.ApiClient.getUrl('Library/MediaFolders', {
             IsHidden: false
@@ -162,7 +162,7 @@ const UserLibraryAccessPage: FunctionComponent = () => {
 
         const onSubmit = (e: Event) => {
             loading.show();
-            const userId = appRouter.param('userId');
+            const userId = getParameterByName('userId');
             window.ApiClient.getUser(userId).then(function (result) {
                 saveUser(result);
             });

--- a/src/components/pages/UserParentalControl.tsx
+++ b/src/components/pages/UserParentalControl.tsx
@@ -2,7 +2,6 @@ import { AccessSchedule, DynamicDayOfWeek, UserDto } from '@thornbill/jellyfin-s
 import React, { FunctionComponent, useCallback, useEffect, useState, useRef } from 'react';
 import globalize from '../../scripts/globalize';
 import LibraryMenu from '../../scripts/libraryMenu';
-import { appRouter } from '../appRouter';
 import AccessScheduleList from '../dashboard/users/AccessScheduleList';
 import BlockedTagList from '../dashboard/users/BlockedTagList';
 import ButtonElement from '../dashboard/users/ButtonElement';
@@ -13,6 +12,7 @@ import SelectMaxParentalRating from '../dashboard/users/SelectMaxParentalRating'
 import SectionTabs from '../dashboard/users/SectionTabs';
 import loading from '../loading/loading';
 import toast from '../toast/toast';
+import { getParameterByName } from '../../utils/url';
 
 type RatingsArr = {
     Name: string;
@@ -194,7 +194,7 @@ const UserParentalControl: FunctionComponent = () => {
 
     const loadData = useCallback(() => {
         loading.show();
-        const userId = appRouter.param('userId');
+        const userId = getParameterByName('userId');
         const promise1 = window.ApiClient.getUser(userId);
         const promise2 = window.ApiClient.getParentalRatings();
         Promise.all([promise1, promise2]).then(function (responses) {
@@ -290,7 +290,7 @@ const UserParentalControl: FunctionComponent = () => {
 
         const onSubmit = (e: Event) => {
             loading.show();
-            const userId = appRouter.param('userId');
+            const userId = getParameterByName('userId');
             window.ApiClient.getUser(userId).then(function (result) {
                 saveUser(result);
             });

--- a/src/components/pages/UserPasswordPage.tsx
+++ b/src/components/pages/UserPasswordPage.tsx
@@ -1,11 +1,11 @@
 import React, { FunctionComponent, useCallback, useEffect, useState } from 'react';
-import { appRouter } from '../appRouter';
 import SectionTitleLinkElement from '../dashboard/users/SectionTitleLinkElement';
 import SectionTabs from '../dashboard/users/SectionTabs';
 import UserPasswordForm from '../dashboard/users/UserPasswordForm';
+import { getParameterByName } from '../../utils/url';
 
 const UserPasswordPage: FunctionComponent = () => {
-    const userId = appRouter.param('userId');
+    const userId = getParameterByName('userId');
     const [ userName, setUserName ] = useState('');
 
     const loadUser = useCallback(() => {


### PR DESCRIPTION
**Changes**
Removes `appRouter.param` function that is functionally a duplicate of the `getParameterByName` function in url utils.

I did a search and nothing seems to be using this function via the window global, so it should be safe to remove entirely.

**Issues**
N/A
