### PR TITLE
Make now playing bar use cursor pointer

### DIFF
--- a/src/components/nowPlayingBar/nowPlayingBar.scss
+++ b/src/components/nowPlayingBar/nowPlayingBar.scss
@@ -13,6 +13,7 @@
     will-change: transform;
     contain: layout style;
     transition: transform 200ms ease-out;
+    cursor: pointer;
 }
 
 .nowPlayingBar-hidden {
@@ -58,7 +59,6 @@
     font-size: 92%;
     margin-right: 1em;
     margin-left: 0.5em;
-    cursor: pointer;
 }
 
 .nowPlayingBarCenter {

--- a/src/components/nowPlayingBar/nowPlayingBar.scss
+++ b/src/components/nowPlayingBar/nowPlayingBar.scss
@@ -58,6 +58,7 @@
     font-size: 92%;
     margin-right: 1em;
     margin-left: 0.5em;
+    cursor: pointer;
 }
 
 .nowPlayingBarCenter {


### PR DESCRIPTION
### Make clear that nowplayingBar is actually clickable


**Changes**
This is a very tiny change with (hopefully) very big impact.
To me, as a new jellyfin user, it was not intuitive how to show the now playing queue (or if there is one at all) and others seem to have the same struggle, see:
https://www.reddit.com/r/jellyfin/comments/ntj8b3/does_anyone_know_how_to_use_the_music_play_queue/
https://www.reddit.com/r/jellyfin/comments/sdcc0i/where_is_the_queue_thats_used_to_play_my_music/

The first place to look for it, is the nowPlayingBar but there is no button for it.
In reality, you just need to click on it but there is nothing to indicate that.
This change makes that clear through the cursor indicating that the bar is clickable.
