### PR TITLE
Fix underline in card images

### DIFF
--- a/src/components/cardbuilder/card.scss
+++ b/src/components/cardbuilder/card.scss
@@ -171,6 +171,7 @@ button::-moz-focus-inner {
     position: relative;
     background-clip: content-box !important;
     color: inherit;
+    text-decoration: none;
 }
 
 .cardContent.cardImageContainer {


### PR DESCRIPTION
**Changes**
Fixes a minor regression from #3479 that I missed in my initial testing where the icon placeholders are underlined.

![Screenshot 2022-04-19 at 16-55-25 Jellyfin](https://user-images.githubusercontent.com/3450688/164094164-962738d2-2a1a-4199-88c4-29a791c554f1.png)

**Issues**
N/A
