### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -657,12 +657,12 @@ import { appRouter } from '../appRouter';
 
             if (str) {
                 const charIndex = Math.floor(str.length / 2);
-                const character = String(str.substr(charIndex, 1).charCodeAt());
+                const character = String(str.slice(charIndex, charIndex + 1).charCodeAt());
                 let sum = 0;
                 for (let i = 0; i < character.length; i++) {
                     sum += parseInt(character.charAt(i));
                 }
-                const index = String(sum).substr(-1);
+                const index = String(sum).slice(-1);
 
                 return (index % numRandomColors) + 1;
             } else {

--- a/src/plugins/bookPlayer/tableOfContents.js
+++ b/src/plugins/bookPlayer/tableOfContents.js
@@ -70,7 +70,7 @@ export default class TableOfContents {
             tocHtml += '<li>';
 
             // remove parent directory reference from href to fix certain books
-            const link = chapter.href.startsWith('../') ? chapter.href.substr(3) : chapter.href;
+            const link = chapter.href.startsWith('../') ? chapter.href.slice(3) : chapter.href;
             tocHtml += `<a href="${rendition.book.path.directory + link}">${chapter.label}</a>`;
             tocHtml += '</li>';
         });

--- a/src/plugins/pdfPlayer/plugin.js
+++ b/src/plugins/pdfPlayer/plugin.js
@@ -263,7 +263,7 @@ export class PdfPlayer {
         for (const page of pages) {
             if (!this.pages[page]) {
                 this.pages[page] = document.createElement('canvas');
-                this.renderPage(this.pages[page], parseInt(page.substr(4)));
+                this.renderPage(this.pages[page], parseInt(page.slice(4)));
             }
         }
 


### PR DESCRIPTION
**Changes**

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

