### PR TITLE
Remove functionality from app router

### DIFF
--- a/src/components/ServerConnections.js
+++ b/src/components/ServerConnections.js
@@ -1,19 +1,48 @@
 import { ConnectionManager, Credentials, ApiClient, Events } from 'jellyfin-apiclient';
+
 import { appHost } from './apphost';
 import Dashboard from '../utils/dashboard';
 import { setUserInfo } from '../scripts/settings/userSettings';
+import appSettings from '../scripts/settings/appSettings';
+
+const normalizeImageOptions = options => {
+    if (!options.quality && (options.maxWidth || options.width || options.maxHeight || options.height || options.fillWidth || options.fillHeight)) {
+        options.quality = 90;
+    }
+};
+
+const getMaxBandwidth = () => {
+    /* eslint-disable compat/compat */
+    if (navigator.connection) {
+        let max = navigator.connection.downlinkMax;
+        if (max && max > 0 && max < Number.POSITIVE_INFINITY) {
+            max /= 8;
+            max *= 1000000;
+            max *= 0.7;
+            return parseInt(max, 10);
+        }
+    }
+    /* eslint-enable compat/compat */
+
+    return null;
+};
 
 class ServerConnections extends ConnectionManager {
     constructor() {
         super(...arguments);
         this.localApiClient = null;
 
-        Events.on(this, 'localusersignedout', function (eventName, logoutInfo) {
+        Events.on(this, 'localusersignedout', (_e, logoutInfo) => {
             setUserInfo(null, null);
 
             if (window.NativeShell && typeof window.NativeShell.onLocalUserSignedOut === 'function') {
                 window.NativeShell.onLocalUserSignedOut(logoutInfo);
             }
+        });
+
+        Events.on(this, 'apiclientcreated', (_e, apiClient) => {
+            apiClient.getMaxBandwidth = getMaxBandwidth;
+            apiClient.normalizeImageOptions = normalizeImageOptions;
         });
     }
 
@@ -36,6 +65,13 @@ class ServerConnections extends ConnectionManager {
         this.setLocalApiClient(apiClient);
 
         console.debug('loaded ApiClient singleton');
+    }
+
+    connect(options) {
+        return super.connect({
+            enableAutoLogin: appSettings.enableAutoLogin(),
+            options
+        });
     }
 
     setLocalApiClient(apiClient) {

--- a/src/components/ServerConnections.js
+++ b/src/components/ServerConnections.js
@@ -70,7 +70,7 @@ class ServerConnections extends ConnectionManager {
     connect(options) {
         return super.connect({
             enableAutoLogin: appSettings.enableAutoLogin(),
-            options
+            ...options
         });
     }
 

--- a/src/components/appRouter.js
+++ b/src/components/appRouter.js
@@ -27,7 +27,7 @@ class AppRouter {
     msgTimeout;
     promiseShow;
     resolveOnNextShow;
-    previousRoute;
+    previousRoute = {};
 
     constructor() {
         document.addEventListener('viewshow', () => this.onViewShow());
@@ -482,7 +482,7 @@ class AppRouter {
 
     #getHandler(route) {
         return (ctx, next) => {
-            const ignore = route.dummyRoute === true || this.previousRoute?.dummyRoute === true;
+            const ignore = route.dummyRoute === true || this.previousRoute.dummyRoute === true;
             this.previousRoute = route;
             if (ignore) {
                 // Resolve 'show' promise

--- a/src/components/appRouter.js
+++ b/src/components/appRouter.js
@@ -8,7 +8,6 @@ import globalize from '../scripts/globalize';
 import itemHelper from './itemHelper';
 import loading from './loading/loading';
 import viewManager from './viewManager/viewManager';
-import Dashboard from '../utils/dashboard';
 import ServerConnections from './ServerConnections';
 import alert from './alert';
 import reactControllerFactory from './reactControllerFactory';
@@ -50,26 +49,6 @@ class AppRouter {
             route,
             handler: this.#getHandler(route)
         });
-    }
-
-    showLocalLogin(serverId) {
-        Dashboard.navigate('login.html?serverid=' + serverId);
-    }
-
-    showVideoOsd() {
-        return Dashboard.navigate('video');
-    }
-
-    showSelectServer() {
-        Dashboard.navigate('selectserver.html');
-    }
-
-    showSettings() {
-        Dashboard.navigate('mypreferencesmenu.html');
-    }
-
-    showNowPlaying() {
-        this.show('queue');
     }
 
     beginConnectionWizard() {
@@ -497,7 +476,7 @@ class AppRouter {
                 }).then(data => {
                     if (data !== null && data.StartupWizardCompleted === false) {
                         ServerConnections.setLocalApiClient(firstResult.ApiClient);
-                        Dashboard.navigate('wizardstart.html');
+                        this.show('wizardstart.html');
                     } else {
                         this.handleConnectionResult(firstResult);
                     }
@@ -615,30 +594,6 @@ class AppRouter {
 
             this.handleRoute(ctx, next, route);
         };
-    }
-
-    showGuide() {
-        Dashboard.navigate('livetv.html?tab=1');
-    }
-
-    goHome() {
-        Dashboard.navigate('home.html');
-    }
-
-    showSearch() {
-        Dashboard.navigate('search.html');
-    }
-
-    showLiveTV() {
-        Dashboard.navigate('livetv.html');
-    }
-
-    showRecordedTV() {
-        Dashboard.navigate('livetv.html?tab=3');
-    }
-
-    showFavorites() {
-        Dashboard.navigate('home.html?tab=1');
     }
 
     getRouteUrl(item, options) {
@@ -835,10 +790,53 @@ class AppRouter {
 
         return '#!/details?id=' + id + '&serverId=' + serverId;
     }
+
+    showLocalLogin(serverId) {
+        return this.show('login.html?serverid=' + serverId);
+    }
+
+    showVideoOsd() {
+        return this.show('video');
+    }
+
+    showSelectServer() {
+        return this.show('selectserver.html');
+    }
+
+    showSettings() {
+        return this.show('mypreferencesmenu.html');
+    }
+
+    showNowPlaying() {
+        return this.show('queue');
+    }
+
+    showGuide() {
+        return this.show('livetv.html?tab=1');
+    }
+
+    goHome() {
+        return this.show('home.html');
+    }
+
+    showSearch() {
+        return this.show('search.html');
+    }
+
+    showLiveTV() {
+        return this.show('livetv.html');
+    }
+
+    showRecordedTV() {
+        return this.show('livetv.html?tab=3');
+    }
+
+    showFavorites() {
+        return this.show('home.html?tab=1');
+    }
 }
 
 export const appRouter = new AppRouter();
 
 window.Emby = window.Emby || {};
-
 window.Emby.Page = appRouter;

--- a/src/components/appRouter.js
+++ b/src/components/appRouter.js
@@ -103,19 +103,6 @@ class AppRouter {
         return this.promiseShow;
     }
 
-    // TODO: Unused?
-    async showDirect(path) {
-        if (this.promiseShow) await this.promiseShow;
-
-        this.promiseShow = new Promise((resolve) => {
-            this.resolveOnNextShow = resolve;
-            // Schedule a call to return the promise
-            setTimeout(() => history.push(this.baseUrl() + path), 0);
-        });
-
-        return this.promiseShow;
-    }
-
     #goToRoute({ location, action }) {
         // Strip the leading "!" if present
         const normalizedPath = location.pathname.replace(/^!/, '');
@@ -180,25 +167,6 @@ class AppRouter {
         }
 
         return window.history.length > 1;
-    }
-
-    // TODO: Unused?
-    invokeShortcut(id) {
-        if (id.indexOf('library-') === 0) {
-            id = id.replace('library-', '');
-            id = id.split('_');
-
-            this.showItem(id[0], id[1]);
-        } else if (id.indexOf('item-') === 0) {
-            id = id.replace('item-', '');
-            id = id.split('_');
-            this.showItem(id[0], id[1]);
-        } else {
-            id = id.split('_');
-            this.show(this.getRouteUrl(id[0], {
-                serverId: id[1]
-            }));
-        }
     }
 
     showItem(item, serverId, options) {

--- a/src/components/appRouter.js
+++ b/src/components/appRouter.js
@@ -24,7 +24,6 @@ class AppRouter {
     currentViewLoadRequest;
     firstConnectionResult;
     forcedLogoutMsg;
-    isDummyBackToHome;
     msgTimeout;
     promiseShow;
     resolveOnNextShow;
@@ -227,7 +226,7 @@ class AppRouter {
         }
     }
 
-    #loadContentUrl(ctx, next, route, request) {
+    #loadContentUrl(ctx, _next, route, request) {
         let url;
         if (route.contentPath && typeof (route.contentPath) === 'function') {
             url = route.contentPath(ctx.querystring);
@@ -281,12 +280,6 @@ class AppRouter {
     }
 
     #sendRouteToViewManager(ctx, next, route, controllerFactory) {
-        // TODO: isDummyBackToHome is never true?
-        if (this.isDummyBackToHome && route.type === 'home') {
-            this.isDummyBackToHome = false;
-            return;
-        }
-
         this.#cancelCurrentLoadRequest();
         const isBackNav = ctx.isBack;
 

--- a/src/components/appRouter.js
+++ b/src/components/appRouter.js
@@ -426,7 +426,7 @@ class AppRouter {
             } else if (route.roles) {
                 this.#validateRoles(apiClient, route.roles).then(() => {
                     callback();
-                }, this.#beginConnectionWizard);
+                }, this.#beginConnectionWizard.bind(this));
                 return;
             }
         }

--- a/src/components/appRouter.js
+++ b/src/components/appRouter.js
@@ -202,13 +202,7 @@ class AppRouter {
                 this.goHome();
                 break;
             case 'ServerSignIn':
-                result.ApiClient.getPublicUsers().then((users) => {
-                    if (users.length) {
-                        this.showLocalLogin(result.Servers[0].Id);
-                    } else {
-                        this.showLocalLogin(result.Servers[0].Id, true);
-                    }
-                });
+                this.showLocalLogin(result.ApiClient.serverId());
                 break;
             case 'ServerSelection':
                 this.showSelectServer();

--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -163,6 +163,10 @@ async function onAppReady() {
         import('../assets/css/ios.scss');
     }
 
+    Events.on(appHost, 'resume', () => {
+        ServerConnections.currentApiClient()?.ensureWebSocket();
+    });
+
     appRouter.start();
 
     if (!browser.tv && !browser.xboxOne && !browser.ps4) {


### PR DESCRIPTION
**Changes**
The main point of this was just to do some cleanup of the app router and move as much of the ApiClient initialization code to better places.

* Remove Dashboard.navigate usage in app router
* Limit public methods in app router
* Remove api client setup from app router
* Remove unused methods from app router

**Issues**
N/A
