### PR TITLE
Fix various issues with SSA subtitle rendering

### DIFF
--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1082,12 +1082,10 @@ function tryRemoveElement(elem) {
                 timeOffset: (this._currentPlayOptions.transcodingOffsetTicks || 0) / 10000000,
 
                 // new octopus options; override all, even defaults
-                renderMode: 'blend',
                 libassMemoryLimit: 40,
                 libassGlyphLimit: 40,
                 targetFps: 24,
-                prescaleTradeoff: 0.8,
-                renderAhead: 90
+                prescaleTradeoff: 0.8
             };
             import('libass-wasm').then(({default: SubtitlesOctopus}) => {
                 apiClient.getNamedConfiguration('encoding').then(config => {

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1083,14 +1083,10 @@ function tryRemoveElement(elem) {
 
                 // new octopus options; override all, even defaults
                 renderMode: 'blend',
-                dropAllAnimations: false,
                 libassMemoryLimit: 40,
                 libassGlyphLimit: 40,
                 targetFps: 24,
                 prescaleTradeoff: 0.8,
-                softHeightLimit: 1080,
-                hardHeightLimit: 2160,
-                resizeVariation: 0.2,
                 renderAhead: 90
             };
             import('libass-wasm').then(({default: SubtitlesOctopus}) => {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
* Removes `renderMode` & `renderAhead` from `SubtitlesOctopusRender`.
* Removes options that are equal to the default for readability from `SubtitlesOctopusRender`.

**Rationale**
This change effectively disables blend rendering in JavascriptSubtitlesOctopus. This rendering mode problematic, which seems to be even more severe in Jellyfin's branch with all of its custom modifications and regressions. For full reference, `jellyfin-vue` exhibits no issues whatsoever and uses `libass-wasm` straight from `npm` (thus https://github.com/libass/JavascriptSubtitlesOctopus) and without using `blend` mode. I would honestly want to see `jellyfin-web` do the same, but I feel that should require some discussion first.

**Issues**
* https://github.com/jellyfin/jellyfin-web/issues/3326
* https://github.com/jellyfin/jellyfin-web/issues/2291
