### PR TITLE
Add 'Date Episode Added' sort to TV Shows

### DIFF
--- a/src/controllers/shows/tvshows.js
+++ b/src/controllers/shows/tvshows.js
@@ -259,6 +259,9 @@ import '../../elements/emby-itemscontainer/emby-itemscontainer';
                         name: globalize.translate('OptionDateAdded'),
                         id: 'DateCreated,SortName'
                     }, {
+                        name: globalize.translate('OptionDateEpisodeAdded'),
+                        id: 'DateLastContentAdded,SortName'
+                    }, {
                         name: globalize.translate('OptionDatePlayed'),
                         id: 'SeriesDatePlayed,SortName'
                     }, {

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1185,6 +1185,7 @@
     "OptionCustomUsers": "Custom",
     "OptionDaily": "Daily",
     "OptionDateAdded": "Date Added",
+    "OptionDateEpisodeAdded": "Date Episode Added",
     "OptionDateAddedFileTime": "Use file creation date",
     "OptionDateAddedImportTime": "Use date scanned into the library",
     "OptionDatePlayed": "Date Played",

--- a/src/strings/nl.json
+++ b/src/strings/nl.json
@@ -826,6 +826,7 @@
     "OptionCustomUsers": "Aangepast",
     "OptionDaily": "Dagelijks",
     "OptionDateAdded": "Datum toegevoegd",
+    "OptionDateEpisodeAdded": "Datum aflevering toegevoegd",
     "OptionDateAddedFileTime": "Gebruik aanmaak datum bestand",
     "OptionDateAddedImportTime": "Gebruik scan datum",
     "OptionDatePlayed": "Datum afgespeeld",


### PR DESCRIPTION
**Changes**
Adds a 'Date Episode Added' sorter to TV Shows.

**Screenshots:**
![image](https://user-images.githubusercontent.com/198601/164976644-8367dd49-36c6-4352-928a-a64af10ebc9f.png)

**Issues**
* https://github.com/jellyfin/jellyfin-web/issues/3590
