### PR TITLE
Use text input in Quick Connect page

### DIFF
--- a/src/controllers/user/quickConnect/index.html
+++ b/src/controllers/user/quickConnect/index.html
@@ -5,7 +5,7 @@
             <div>${QuickConnectDescription}</div>
             <br />
             <div class="inputContainer">
-                <input is="emby-input" type="text" inputmode="numeric" pattern="[0-9\s]*" required id="txtQuickConnectCode" label="${LabelQuickConnectCode}" autocomplete="off" />
+                <input is="emby-input" type="text" inputmode="numeric" pattern="[0-9\s]*" minlength="6" required id="txtQuickConnectCode" label="${LabelQuickConnectCode}" autocomplete="off" />
             </div>
             <button id="btnQuickConnectAuthorize" is="emby-button" type="submit" class="raised button-submit block">
                 <span>${Authorize}</span>

--- a/src/controllers/user/quickConnect/index.html
+++ b/src/controllers/user/quickConnect/index.html
@@ -5,7 +5,7 @@
             <div>${QuickConnectDescription}</div>
             <br />
             <div class="inputContainer">
-                <input is="emby-input" type="number" min="0" max="999999" required id="txtQuickConnectCode" label="${LabelQuickConnectCode}" autocomplete="off" />
+                <input is="emby-input" type="text" inputmode="numeric" pattern="[0-9\s]*" required id="txtQuickConnectCode" label="${LabelQuickConnectCode}" autocomplete="off" />
             </div>
             <button id="btnQuickConnectAuthorize" is="emby-button" type="submit" class="raised button-submit block">
                 <span>${Authorize}</span>

--- a/src/controllers/user/quickConnect/index.js
+++ b/src/controllers/user/quickConnect/index.js
@@ -15,7 +15,9 @@ export default function (view) {
                 return;
             }
 
-            authorize(codeElement.value);
+            // Remove spaces from code
+            const normalizedCode = codeElement.value.replace(/\s/g, '');
+            authorize(normalizedCode);
         });
     });
 }


### PR DESCRIPTION
The Android TV app will show Quick Connect codes with a space in the middle. This PR adds support for submitting the code with whitespace and changes the input type. Partially inspired by [this article](https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/).

**Changes**
- Change input type in Quick Connect page to a text input:
  - Now supports Quick Connect codes starting with 0
  - Now supports whitespace (removed out when submitting)
  - Previously it showed a number spinner but the Quick Connect codes are not incremental


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
