### PR TITLE
Check undefined streamInfo.url

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -3034,7 +3034,7 @@ class PlaybackManager {
 
             const streamInfo = error.streamInfo || getPlayerData(player).streamInfo;
 
-            if (streamInfo) {
+            if (streamInfo?.url) {
                 const currentlyPreventsVideoStreamCopy = streamInfo.url.toLowerCase().indexOf('allowvideostreamcopy=false') !== -1;
                 const currentlyPreventsAudioStreamCopy = streamInfo.url.toLowerCase().indexOf('allowaudiostreamcopy=false') !== -1;
 


### PR DESCRIPTION
When remuxing and transcoding are disabled and the media cannot be played direct, `streamInfo.url` is not set.

Don't get here (`mediaSource.enableDirectPlay: false`): https://github.com/jellyfin/jellyfin-web/blob/43a05129423f76317d2064715d86c92a8c589849/src/components/playback/playbackmanager.js#L2482-L2483

**Changes**
Check undefined streamInfo.url

**Issues**
Access to undefined `streamInfo.url`.
https://github.com/jellyfin/jellyfin-web/blob/c9e2d11c5d33f04faa286894080b62ebf39115e3/src/components/playback/playbackmanager.js#L3038-L3039