### PR TITLE
Fix iPadOS icon

### DIFF
--- a/src/scripts/imagehelper.js
+++ b/src/scripts/imagehelper.js
@@ -17,6 +17,7 @@
             case 'Android TV':
                 return baseUrl + 'android.svg';
             case 'Jellyfin Mobile (iOS)':
+            case 'Jellyfin Mobile (iPadOS)':
                 return baseUrl + 'apple.svg';
             case 'Jellyfin Web':
                 switch (device.Name || device.DeviceName) {


### PR DESCRIPTION
**Changes**

Either an Expo or iPadOS update caused the name changed so it is no longer reported as "iOS"

**Issues**
N/A
