### PR TITLE
Fix backdrop being used on large screens in mobile layout

### DIFF
--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -509,7 +509,7 @@ function setTrailerButtonVisibility(page, item) {
 }
 
 function renderBackdrop(item) {
-    if (dom.getWindowSize().innerWidth >= 1000) {
+    if (!layoutManager.mobile && dom.getWindowSize().innerWidth >= 1000) {
         backdrop.setBackdrops([item]);
     } else {
         backdrop.clearBackdrop();


### PR DESCRIPTION
**Changes**
This fixes an issue where the backdrop was enabled on the item details screen on large devices (tablets) that use the mobile layout. The backdrops are not compatible with the header styling used for the mobile layout.

**Issues**
As you can see in the following screenshot, the header image and backdrop are not aligned. The header image also scrolls with the page while the backdrop remains fixed in the mobile layout.

![4B35AF34-44F1-4C56-9D91-97A3B241F52D](https://user-images.githubusercontent.com/3450688/166949301-37bab9e5-1a38-48c3-922a-357cd13dd6ed.png)
