### PR TITLE
Update dialog history handling

### DIFF
--- a/src/components/appRouter.js
+++ b/src/components/appRouter.js
@@ -11,7 +11,7 @@ import ServerConnections from './ServerConnections';
 import alert from './alert';
 import reactControllerFactory from './reactControllerFactory';
 
-const history = createHashHistory();
+export const history = createHashHistory();
 
 /**
  * Page types of "no return" (when "Go back" should behave differently, probably quitting the application).
@@ -20,14 +20,13 @@ const START_PAGE_TYPES = ['home', 'login', 'selectserver'];
 
 class AppRouter {
     allRoutes = new Map();
-    currentRouteInfo;
+    currentRouteInfo = { route: {} };
     currentViewLoadRequest;
     firstConnectionResult;
     forcedLogoutMsg;
     msgTimeout;
     promiseShow;
     resolveOnNextShow;
-    previousRoute = {};
 
     constructor() {
         document.addEventListener('viewshow', () => this.onViewShow());
@@ -482,9 +481,9 @@ class AppRouter {
 
     #getHandler(route) {
         return (ctx, next) => {
-            const ignore = route.dummyRoute === true || this.previousRoute.dummyRoute === true;
-            this.previousRoute = route;
+            const ignore = ctx.path === this.currentRouteInfo.path;
             if (ignore) {
+                console.debug('[appRouter] path did not change, ignoring route change');
                 // Resolve 'show' promise
                 this.onViewShow();
                 return;

--- a/src/scripts/routes.js
+++ b/src/scripts/routes.js
@@ -561,11 +561,6 @@ import { appRouter } from '../components/appRouter';
     });
 
     defineRoute({
-        path: '/dialog',
-        dummyRoute: true
-    });
-
-    defineRoute({
         path: '/',
         autoFocus: false,
         isDefaultRoute: true


### PR DESCRIPTION
**Changes**
This updates our dialog handling to use history state instead of path changes. This fixes the issue where refreshing the page when a dialog is open breaks the app and makes our dialogs compatible with React Router.

**Issues**
N/A?
