### PR TITLE
Append year to title of content in video playback.

### DIFF
--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -210,7 +210,18 @@ import { setBackdropTransparency, TRANSPARENCY_LEVEL } from '../../../components
                 itemName = parentName || '';
             }
 
-            LibraryMenu.setTitle(itemName);
+            // Display the item with its premiere date if it has one
+            let title = itemName;
+            if (item.PremiereDate) {
+                try {
+                    const year = datetime.parseISO8601Date(item.PremiereDate).getFullYear();
+                    title += ` (${year})`;
+                } catch (e) {
+                    console.error(e);
+                }
+            }
+
+            LibraryMenu.setTitle(title);
 
             const documentTitle = parentName || (item ? item.Name : null);
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->


**Changes**
This adds the premiere year to the title in the video player which was requested here: https://features.jellyfin.org/posts/1392/append-the-year-to-the-title-in-the-video-player.

**Issues**
N/A
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
