### PR TITLE
Restore external links on mobile

### DIFF
--- a/src/assets/css/librarybrowser.scss
+++ b/src/assets/css/librarybrowser.scss
@@ -523,10 +523,6 @@
     margin: -0.25em 0 0.25em;
 }
 
-.layout-mobile .itemExternalLinks {
-    display: none;
-}
-
 .mainDetailButtons {
     display: flex;
     align-items: center;


### PR DESCRIPTION
**Changes**
The external links were hidden on mobile as part of #1206. I don't see any reason for the change listed there, and I don't think it makes sense for us in general to remove information on mobile.

**Issues**
[Reported on Reddit](https://old.reddit.com/r/jellyfin/comments/ullimy/imdb_trakt_themobiedb_links_for_movies_tv_shows/)
