### PR TITLE
Add shuffle button to movie collections

### DIFF
--- a/src/controllers/movies/movies.html
+++ b/src/controllers/movies/movies.html
@@ -6,6 +6,7 @@
             <button is="paper-icon-button-light" class="btnSelectView autoSize" title="${ButtonSelectView}"><span class="material-icons view_comfy" aria-hidden="true"></span></button>
             <button is="paper-icon-button-light" class="btnSort autoSize" title="${Sort}"><span class="material-icons sort_by_alpha" aria-hidden="true"></span></button>
             <button is="paper-icon-button-light" class="btnFilter autoSize" title="${Filter}"><span class="material-icons filter_list" aria-hidden="true"></span></button>
+            <button is="paper-icon-button-light" class="btnShuffle autoSize" title="${Shuffle}"><span class="material-icons shuffle" aria-hidden="true"></span></button>
         </div>
 
         <div class="alphaPicker alphaPicker-fixed alphaPicker-vertical">

--- a/src/controllers/movies/movies.html
+++ b/src/controllers/movies/movies.html
@@ -3,7 +3,7 @@
     <div class="pageTabContent" id="moviesTab" data-index="0">
         <div class="flex align-items-center justify-content-center flex-wrap-wrap padded-top padded-left padded-right padded-bottom focuscontainer-x">
             <div class="paging"></div>
-            <button is="paper-icon-button-light" class="btnShuffle autoSize" title="${Shuffle}"><span class="material-icons shuffle" aria-hidden="true"></span></button>
+            <button is="paper-icon-button-light" class="btnShuffle autoSize hide" title="${Shuffle}"><span class="material-icons shuffle" aria-hidden="true"></span></button>
             <button is="paper-icon-button-light" class="btnSelectView autoSize" title="${ButtonSelectView}"><span class="material-icons view_comfy" aria-hidden="true"></span></button>
             <button is="paper-icon-button-light" class="btnSort autoSize" title="${Sort}"><span class="material-icons sort_by_alpha" aria-hidden="true"></span></button>
             <button is="paper-icon-button-light" class="btnFilter autoSize" title="${Filter}"><span class="material-icons filter_list" aria-hidden="true"></span></button>

--- a/src/controllers/movies/movies.html
+++ b/src/controllers/movies/movies.html
@@ -3,10 +3,10 @@
     <div class="pageTabContent" id="moviesTab" data-index="0">
         <div class="flex align-items-center justify-content-center flex-wrap-wrap padded-top padded-left padded-right padded-bottom focuscontainer-x">
             <div class="paging"></div>
+            <button is="paper-icon-button-light" class="btnShuffle autoSize" title="${Shuffle}"><span class="material-icons shuffle" aria-hidden="true"></span></button>
             <button is="paper-icon-button-light" class="btnSelectView autoSize" title="${ButtonSelectView}"><span class="material-icons view_comfy" aria-hidden="true"></span></button>
             <button is="paper-icon-button-light" class="btnSort autoSize" title="${Sort}"><span class="material-icons sort_by_alpha" aria-hidden="true"></span></button>
             <button is="paper-icon-button-light" class="btnFilter autoSize" title="${Filter}"><span class="material-icons filter_list" aria-hidden="true"></span></button>
-            <button is="paper-icon-button-light" class="btnShuffle autoSize" title="${Shuffle}"><span class="material-icons shuffle" aria-hidden="true"></span></button>
         </div>
 
         <div class="alphaPicker alphaPicker-fixed alphaPicker-vertical">

--- a/src/controllers/movies/movies.js
+++ b/src/controllers/movies/movies.js
@@ -6,6 +6,7 @@ import { AlphaPicker } from '../../components/alphaPicker/alphaPicker';
 import listView from '../../components/listview/listview';
 import cardBuilder from '../../components/cardbuilder/cardBuilder';
 import globalize from '../../scripts/globalize';
+import { playbackManager } from '../../components/playback/playbackmanager';
 import '../../elements/emby-itemscontainer/emby-itemscontainer';
 
 /* eslint-disable indent */
@@ -52,6 +53,19 @@ import '../../elements/emby-itemscontainer/emby-itemscontainer';
                 itemsContainer.refreshItems();
             }
 
+            function onShuffleClick() {
+                if (isLoading) {
+                    return;
+                }
+
+                ApiClient.getItem(
+                    ApiClient.getCurrentUserId(),
+                    params.topParentId
+                ).then(item => {
+                    playbackManager.shuffle(item);
+                });
+            }
+
             window.scrollTo(0, 0);
             this.alphaPicker?.updateControls(query);
             const pagingHtml = libraryBrowser.getQueryPagingHtml({
@@ -75,6 +89,10 @@ import '../../elements/emby-itemscontainer/emby-itemscontainer';
 
             for (const elem of tabContent.querySelectorAll('.btnPreviousPage')) {
                 elem.addEventListener('click', onPreviousPageClick);
+            }
+
+            for (const elem of tabContent.querySelectorAll('.btnShuffle')) {
+                elem.addEventListener('click', onShuffleClick);
             }
 
             isLoading = false;

--- a/src/controllers/movies/movies.js
+++ b/src/controllers/movies/movies.js
@@ -87,6 +87,8 @@ import '../../elements/emby-itemscontainer/emby-itemscontainer';
                 elem.addEventListener('click', onPreviousPageClick);
             }
 
+            tabContent.querySelector(".btnShuffle").classList.toggle("hide", result.TotalRecordCount < 1);
+
             isLoading = false;
             loading.hide();
 

--- a/src/controllers/movies/movies.js
+++ b/src/controllers/movies/movies.js
@@ -30,6 +30,15 @@ import '../../elements/emby-itemscontainer/emby-itemscontainer';
             return ApiClient.getItems(ApiClient.getCurrentUserId(), query);
         }
 
+        function shuffle() {
+            ApiClient.getItem(
+                ApiClient.getCurrentUserId(),
+                params.topParentId
+            ).then((item) => {
+                playbackManager.shuffle(item);
+            });
+        }
+
         const afterRefresh = (result) => {
             function onNextPageClick() {
                 if (isLoading) {
@@ -51,19 +60,6 @@ import '../../elements/emby-itemscontainer/emby-itemscontainer';
                     query.StartIndex = Math.max(0, query.StartIndex - query.Limit);
                 }
                 itemsContainer.refreshItems();
-            }
-
-            function onShuffleClick() {
-                if (isLoading) {
-                    return;
-                }
-
-                ApiClient.getItem(
-                    ApiClient.getCurrentUserId(),
-                    params.topParentId
-                ).then(item => {
-                    playbackManager.shuffle(item);
-                });
             }
 
             window.scrollTo(0, 0);
@@ -89,10 +85,6 @@ import '../../elements/emby-itemscontainer/emby-itemscontainer';
 
             for (const elem of tabContent.querySelectorAll('.btnPreviousPage')) {
                 elem.addEventListener('click', onPreviousPageClick);
-            }
-
-            for (const elem of tabContent.querySelectorAll('.btnShuffle')) {
-                elem.addEventListener('click', onShuffleClick);
             }
 
             isLoading = false;
@@ -261,6 +253,8 @@ import '../../elements/emby-itemscontainer/emby-itemscontainer';
                 onViewStyleChange();
                 itemsContainer.refreshItems();
             });
+
+            tabContent.querySelector('.btnShuffle').addEventListener('click', shuffle);
         };
 
         let itemsContainer = tabContent.querySelector('.itemsContainer');

--- a/src/controllers/movies/movies.js
+++ b/src/controllers/movies/movies.js
@@ -87,7 +87,7 @@ import '../../elements/emby-itemscontainer/emby-itemscontainer';
                 elem.addEventListener('click', onPreviousPageClick);
             }
 
-            tabContent.querySelector(".btnShuffle").classList.toggle("hide", result.TotalRecordCount < 1);
+            tabContent.querySelector('.btnShuffle').classList.toggle('hide', result.TotalRecordCount < 1);
 
             isLoading = false;
             loading.hide();


### PR DESCRIPTION
**Changes**
Currently shuffling movies (tv shows and music as well) is possible only on desktop by right clicking on collection and then "Shuffle", so mobile apps and tv apps are missing out on this feature. This PR adds a shuffle button for movie collections.
![image](https://user-images.githubusercontent.com/12289537/167715231-6d4ffed6-25b6-4bcb-ab73-e566b309e172.png)

**Issues**
This issue from 2020 is the closest that I could find but for music: #1834
Side note: Stale bot should not be closing issues that have been manually tagged as bugs. 

