### PR TITLE
Change CSS font-family by language preference

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -51,6 +51,7 @@
  - [GodTamIt](https://github.com/GodTamIt)
  - [MinecraftPlaye](https://github.com/MinecraftPlaye)
  - [Matthew Jones](https://github.com/matthew-jones-uk)
+ - [taku0](https://github.com/taku0)
 
 # Emby Contributors
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2450,6 +2450,11 @@
       "resolved": "https://registry.npmjs.org/@fontsource/noto-sans-sc/-/noto-sans-sc-4.5.2.tgz",
       "integrity": "sha512-q9a61ND72RZdb4S1SG3w0c8POLS7s7QtfMMbfFG/jlsKxidsBnUS66jAE+h+OhaQCl8FeQrY8yMnHOff/4paFw=="
     },
+    "@fontsource/noto-sans-tc": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@fontsource/noto-sans-tc/-/noto-sans-tc-4.5.2.tgz",
+      "integrity": "sha512-K7c/1Uh7SlBdxRBNsYONtC/oPG/6wJ4xsbnYY4Q+XqpwggJkKYB9dmAgdC1XTDHcY9dZX8AO+oH+wyB4rvdI/w=="
+    },
     "@humanwhocodes/config-array": {
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@fontsource/noto-sans-jp": "4.5.2",
     "@fontsource/noto-sans-kr": "4.5.2",
     "@fontsource/noto-sans-sc": "4.5.2",
+    "@fontsource/noto-sans-tc": "4.5.2",
     "blurhash": "1.1.4",
     "classlist.js": "https://github.com/eligrey/classList.js/archive/1.2.20180112.tar.gz",
     "classnames": "2.3.1",

--- a/src/assets/css/fonts.scss
+++ b/src/assets/css/fonts.scss
@@ -1,16 +1,36 @@
 @import "../../styles/noto-sans/index.scss";
 
 @mixin font($weight: null, $size: null) {
-    font-family: "Noto Sans", "Noto Sans HK", "Noto Sans JP", "Noto Sans KR", "Noto Sans SC", sans-serif;
     font-weight: $weight;
     font-size: $size;
 }
 
 html {
     @include font($size: 93%);
+    font-family: "Noto Sans", "Noto Sans HK", "Noto Sans JP", "Noto Sans KR", "Noto Sans SC", "Noto Sans TC", sans-serif;
     text-size-adjust: 100%;
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
+}
+
+html[lang|="ja"] {
+    font-family: "Noto Sans", "Noto Sans JP", "Noto Sans HK", "Noto Sans KR", "Noto Sans SC", "Noto Sans TC", sans-serif;
+}
+
+html[lang|="ko"] {
+    font-family: "Noto Sans", "Noto Sans KR", "Noto Sans HK", "Noto Sans JP", "Noto Sans SC", "Noto Sans TC", sans-serif;
+}
+
+html[lang|="zh-CN"] {
+    font-family: "Noto Sans", "Noto Sans SC", "Noto Sans HK", "Noto Sans JP", "Noto Sans KR", "Noto Sans TC", sans-serif;
+}
+
+html[lang|="zh-TW"] {
+    font-family: "Noto Sans", "Noto Sans TC", "Noto Sans HK", "Noto Sans JP", "Noto Sans KR", "Noto Sans SC", sans-serif;
+}
+
+html[lang|="zh-HK"] {
+    font-family: "Noto Sans", "Noto Sans HK", "Noto Sans JP", "Noto Sans KR", "Noto Sans SC", "Noto Sans TC", sans-serif;
 }
 
 h1 {

--- a/src/scripts/globalize.js
+++ b/src/scripts/globalize.js
@@ -1,7 +1,7 @@
 import { Events } from 'jellyfin-apiclient';
 import isEmpty from 'lodash-es/isEmpty';
 
-import * as userSettings from './settings/userSettings';
+import { currentSettings as userSettings } from './settings/userSettings';
 
 /* eslint-disable indent */
 

--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -274,11 +274,24 @@ async function onAppReady() {
             }
         };
 
-        Events.on(ServerConnections, 'localusersignedin', handleStyleChange);
-        Events.on(ServerConnections, 'localusersignedout', handleStyleChange);
+        const handleLanguageChange = () => {
+            const locale = globalize.getCurrentLocale();
+
+            document.documentElement.setAttribute('lang', locale);
+        };
+
+        const handleUserChange = () => {
+            handleStyleChange();
+            handleLanguageChange();
+        };
+
+        Events.on(ServerConnections, 'localusersignedin', handleUserChange);
+        Events.on(ServerConnections, 'localusersignedout', handleUserChange);
         Events.on(currentSettings, 'change', (e, prop) => {
             if (prop == 'disableCustomCss' || prop == 'customCss') {
                 handleStyleChange();
+            } else if (prop == 'language') {
+                handleLanguageChange();
             }
         });
 

--- a/src/styles/noto-sans/index.scss
+++ b/src/styles/noto-sans/index.scss
@@ -28,3 +28,6 @@ $weight-names: (100: "Thin", 200: "ExtraLight", 300: "Light", 400: "Regular", 50
 // SC character set
 @import "./sc-400-normal";
 @import "./sc-700-normal";
+// TC character set
+@import "./tc-400-normal";
+@import "./tc-700-normal";

--- a/src/styles/noto-sans/tc-400-normal.scss
+++ b/src/styles/noto-sans/tc-400-normal.scss
@@ -1,0 +1,708 @@
+$tcFamily: "Noto Sans TC";
+
+/* noto-sans-tc-[0]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-0-400-normal.woff2",
+    $range: (U+1f921-1f930, U+1f932-1f935, U+1f937-1f939, U+1f940-1f944, U+1f947-1f94a, U+1f950-1f95f, U+1f962-1f967, U+1f969-1f96a, U+1f980-1f981, U+1f984-1f98d, U+1f990-1f992, U+1f994-1f996, U+1f9c0, U+1f9d0, U+1f9d2, U+1f9d4, U+1f9d6, U+1f9d8, U+1f9da, U+1f9dc-1f9dd, U+1f9df-1f9e2, U+1f9e5-1f9e6, U+20024, U+20487, U+20779, U+20c41, U+20c78, U+20d71, U+20e98, U+20ef9, U+2107b, U+210c1, U+22c51, U+233b4, U+24a12, U+2512b, U+2546e, U+25683, U+267cc, U+269f2, U+27657, U+282e2, U+2898d, U+29d5a, U+f0001-f0005, U+f0019, U+f009b, U+f0101-f0104, U+f012b, U+f01ba, U+f01d6, U+f0209, U+f0217, U+f0223-f0224, U+fc355, U+fe327, U+fe517, U+feb97, U+fffb4)
+);
+
+/* noto-sans-tc-[6]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-6-400-normal.woff2",
+    $range: (U+ff78-ff7e, U+ff80-ff86, U+ff89-ff94, U+ff97-ff9e, U+ffb9, U+ffe0-ffe3, U+ffe9, U+ffeb, U+ffed, U+fffc, U+1d7c7, U+1f004, U+1f0cf, U+1f141-1f142, U+1f150, U+1f154, U+1f158, U+1f15b, U+1f15d-1f15e, U+1f162-1f163, U+1f170-1f171, U+1f174, U+1f177-1f178, U+1f17d-1f17f, U+1f192-1f195, U+1f197-1f19a, U+1f1e6-1f1f5, U+1f1f7-1f1ff, U+1f21a, U+1f22f, U+1f232-1f237, U+1f239-1f23a, U+1f250-1f251, U+1f300, U+1f302-1f319)
+);
+
+/* noto-sans-tc-[7]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-7-400-normal.woff2",
+    $range: (U+fa0a, U+fa0c, U+fa11, U+fa17, U+fa19, U+fa1b, U+fa1d, U+fa26, U+fa2c, U+fb01, U+fdfc, U+fe0e, U+fe33-fe36, U+fe38-fe44, U+fe49-fe51, U+fe54, U+fe56-fe57, U+fe59-fe5c, U+fe5f-fe6a, U+fe8e, U+fe92-fe93, U+feae, U+fecb-fecc, U+fee0, U+feec, U+fef3, U+ff04, U+ff07, U+ff26-ff2c, U+ff31-ff32, U+ff35-ff37, U+ff39-ff3a, U+ff3c, U+ff3e-ff5b, U+ff5d, U+ff61-ff65, U+ff67-ff68, U+ff6a, U+ff6c-ff77)
+);
+
+/* noto-sans-tc-[8]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-8-400-normal.woff2",
+    $range: (U+f78a-f78c, U+f78e, U+f792-f796, U+f798, U+f79c, U+f7f5, U+f812, U+f815, U+f876, U+f8f5, U+f8f8, U+f8ff, U+f901-f902, U+f904, U+f906, U+f909-f90a, U+f90f, U+f914, U+f918-f919, U+f91b, U+f91d, U+f91f, U+f923, U+f925, U+f92d-f92f, U+f934, U+f937-f938, U+f93d, U+f93f, U+f941, U+f949, U+f94c, U+f94e-f94f, U+f95a, U+f95d-f95e, U+f961-f963, U+f965-f970, U+f974, U+f976-f97a, U+f97c, U+f97e-f97f, U+f981, U+f983, U+f988, U+f98a, U+f98c, U+f98e, U+f996-f997, U+f999-f99a, U+f99c, U+f99f-f9a0, U+f9a3, U+f9a8, U+f9ad, U+f9b2-f9b6, U+f9b9-f9ba, U+f9bd-f9be, U+f9c1, U+f9c4, U+f9c7, U+f9ca, U+f9cd, U+f9d0-f9d1, U+f9d3-f9d4, U+f9d7-f9d8, U+f9dc-f9dd, U+f9df-f9e1, U+f9e4, U+f9e8-f9ea, U+f9f4, U+f9f6-f9f7, U+f9f9-f9fa, U+f9fc-fa01, U+fa03-fa04, U+fa06, U+fa08-fa09)
+);
+
+/* noto-sans-tc-[19]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-19-400-normal.woff2",
+    $range: (U+9eb9-9eba, U+9ebe-9ebf, U+9ecc-9ecd, U+9ed0, U+9ed2, U+9ed4, U+9ed9-9eda, U+9edc-9edd, U+9edf-9ee0, U+9ee2, U+9ee5, U+9ee7, U+9eee, U+9ef3-9ef4, U+9ef6-9ef7, U+9ef9, U+9efb-9efd, U+9eff, U+9f07-9f09, U+9f10, U+9f14-9f15, U+9f19, U+9f22, U+9f29, U+9f2c, U+9f2f, U+9f31, U+9f34, U+9f37, U+9f39, U+9f3d-9f3e, U+9f41, U+9f4c-9f50, U+9f54, U+9f57, U+9f59, U+9f5c, U+9f5f-9f60, U+9f62-9f63, U+9f66-9f67, U+9f6a, U+9f6c, U+9f72, U+9f76-9f77, U+9f7f, U+9f84-9f85, U+9f88, U+9f8e, U+9f91, U+9f94-9f96, U+9f98, U+9f9a-9f9b, U+9f9f-9fa0, U+9fa2, U+9fa4, U+a1f4, U+a4b0-a4b1, U+a4b3, U+a9c1-a9c2, U+aa31, U+ab34, U+ac00-ac01, U+ac04, U+ac08, U+ac10-ac11, U+ac13-ac16, U+ac19, U+ac1c-ac1d, U+ac24, U+ac70-ac71, U+ac74, U+ac77-ac78, U+ac80-ac81, U+ac83, U+ac8c, U+ac90, U+aca0, U+aca8-aca9, U+acac, U+acb0, U+acb8-acb9, U+acbc-acbd, U+acc1, U+acc4, U+ace0-ace1, U+ace4, U+ace8, U+acf0-acf1, U+acf3, U+acf5, U+acfc)
+);
+
+/* noto-sans-tc-[20]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-20-400-normal.woff2",
+    $range: (U+9d34, U+9d37, U+9d3d, U+9d42, U+9d50, U+9d52-9d53, U+9d59, U+9d5c, U+9d5e-9d61, U+9d6a, U+9d6f-9d70, U+9d77, U+9d7a, U+9d7e, U+9d87, U+9d89, U+9d8f, U+9d91-9d93, U+9d96, U+9d98, U+9d9a, U+9da1-9da2, U+9da5, U+9da9, U+9dab-9dac, U+9db1-9db2, U+9db5, U+9db9-9dbc, U+9dbf-9dc2, U+9dc4, U+9dc7-9dc9, U+9dd3, U+9dd6, U+9dd9-9dda, U+9dde-9ddf, U+9de2, U+9de5-9de6, U+9de8, U+9def-9df0, U+9df2-9df4, U+9df8, U+9dfa, U+9dfd, U+9dff, U+9e02, U+9e07, U+9e0a, U+9e11, U+9e15, U+9e18, U+9e1a-9e1b, U+9e1d-9e1e, U+9e20-9e23, U+9e25-9e26, U+9e2d, U+9e2f, U+9e33, U+9e35, U+9e3d-9e3f, U+9e42-9e43, U+9e45, U+9e48-9e4a, U+9e4c, U+9e4f, U+9e51, U+9e55, U+9e64, U+9e66, U+9e6b, U+9e6d-9e6e, U+9e70, U+9e73, U+9e75, U+9e78, U+9e80-9e83, U+9e87-9e88, U+9e8b-9e8c, U+9e90-9e91, U+9e93, U+9e96, U+9e9d, U+9ea1, U+9ea4, U+9ea6, U+9ea9-9eab, U+9ead, U+9eaf, U+9eb4, U+9eb7-9eb8)
+);
+
+/* noto-sans-tc-[21]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-21-400-normal.woff2",
+    $range: (U+9bd3-9bd7, U+9bd9, U+9bdb, U+9bdd, U+9be1-9be2, U+9be4-9be5, U+9be7, U+9bea, U+9bed-9bee, U+9bf0-9bf1, U+9bf5, U+9bf7, U+9bf9, U+9bfd, U+9bff, U+9c02, U+9c06, U+9c08-9c0a, U+9c0d, U+9c10, U+9c12-9c13, U+9c15, U+9c1c, U+9c1f, U+9c21, U+9c23-9c25, U+9c28-9c29, U+9c2d-9c2e, U+9c31-9c33, U+9c35-9c37, U+9c39-9c3b, U+9c3d-9c3e, U+9c40, U+9c42, U+9c45-9c49, U+9c52, U+9c54, U+9c56, U+9c58-9c5a, U+9c5d, U+9c5f-9c60, U+9c63, U+9c67-9c68, U+9c72, U+9c75, U+9c78, U+9c7a-9c7c, U+9c7f-9c81, U+9c87-9c88, U+9c8d, U+9c91, U+9c94, U+9c97, U+9c9b, U+9ca4, U+9ca8, U+9cab, U+9cad, U+9cb1-9cb3, U+9cb6-9cb8, U+9cc4-9cc5, U+9ccc-9ccd, U+9cd5-9cd7, U+9cdd-9cdf, U+9ce7, U+9ce9, U+9cee-9cf0, U+9cf2, U+9cfc-9cfe, U+9d03, U+9d06-9d08, U+9d0e, U+9d10, U+9d12, U+9d15, U+9d17, U+9d1d-9d1f, U+9d23, U+9d2b, U+9d2f-9d30)
+);
+
+/* noto-sans-tc-[22]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-22-400-normal.woff2",
+    $range: (U+9a6f-9a71, U+9a73-9a74, U+9a76, U+9a78-9a79, U+9a7b-9a7c, U+9a7e-9a7f, U+9a81-9a82, U+9a84-9a87, U+9a8a-9a8b, U+9a8f-9a91, U+9a97, U+9a9a, U+9a9e, U+9aa0-9aa1, U+9aa4-9aa5, U+9aaf-9ab1, U+9ab6, U+9ab9-9aba, U+9abe, U+9ac0-9ac5, U+9ac8, U+9acb-9acc, U+9ace-9acf, U+9ad1, U+9ad5-9ad7, U+9ad9, U+9adf, U+9ae1, U+9ae3, U+9aea-9aeb, U+9aed, U+9aef, U+9af2, U+9af4, U+9af9, U+9afb, U+9afd, U+9b03-9b04, U+9b08, U+9b13, U+9b18, U+9b1f, U+9b22-9b23, U+9b28-9b2a, U+9b2c-9b30, U+9b32, U+9b3b, U+9b43, U+9b46-9b49, U+9b4b-9b4e, U+9b51, U+9b55, U+9b58, U+9b5b, U+9b5e-9b60, U+9b63, U+9b68-9b69, U+9b74, U+9b7d, U+9b80-9b81, U+9b83-9b84, U+9b87-9b88, U+9b8a-9b8b, U+9b8d-9b8e, U+9b90, U+9b92-9b95, U+9b97, U+9b9f-9ba0, U+9ba2-9ba3, U+9ba8, U+9bab, U+9bb0, U+9bb8, U+9bc0-9bc1, U+9bc3, U+9bc6-9bc8)
+);
+
+/* noto-sans-tc-[23]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-23-400-normal.woff2",
+    $range: (U+9912, U+9914, U+9916-9917, U+991b-991c, U+991e, U+9920, U+9927, U+992b-992c, U+992e, U+9931-9933, U+9938, U+993a, U+993c-9940, U+9943-9944, U+9948-994a, U+994c-994e, U+9951, U+9954, U+995c, U+995e-995f, U+9961-9962, U+9965, U+9968, U+996a, U+996d-9972, U+9975-9976, U+997a, U+997c, U+997f-9980, U+9984-9985, U+9988, U+998b, U+998d, U+998f, U+9992, U+9994-9995, U+9997-9998, U+999c, U+999e, U+99a0-99a1, U+99ab, U+99af, U+99b1, U+99b4, U+99b9, U+99c4-99c6, U+99cf, U+99d1-99d2, U+99d4, U+99d6, U+99d8-99d9, U+99df, U+99e1-99e2, U+99e9, U+99ee, U+99f0, U+99f8, U+99fb, U+9a01-9a05, U+9a0c, U+9a0f-9a13, U+9a16, U+9a1b-9a1c, U+9a20, U+9a24, U+9a28, U+9a2b, U+9a2d-9a2e, U+9a34-9a36, U+9a38, U+9a3e, U+9a40-9a44, U+9a4a, U+9a4c-9a4e, U+9a52, U+9a56, U+9a62-9a65, U+9a69-9a6b, U+9a6d)
+);
+
+/* noto-sans-tc-[24]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-24-400-normal.woff2",
+    $range: (U+97c6, U+97c9, U+97cd, U+97d6, U+97d8-97d9, U+97dc-97de, U+97e1, U+97e6-97e7, U+97ec-97ee, U+97f0-97f1, U+97f5, U+97f9-97fa, U+97fe, U+9804, U+9807, U+980a, U+980e-980f, U+9814, U+9816, U+981a, U+981c, U+981e, U+9820-9821, U+9823, U+9826, U+9828, U+982a-982c, U+9832, U+9834-9835, U+9837, U+9839, U+983c-983d, U+9845, U+9848-9849, U+984e, U+9852-9857, U+9859-985a, U+9862-9863, U+9865, U+9870-9871, U+9873-9874, U+9877, U+987a-987f, U+9881-9882, U+9885, U+9887-988a, U+988c-988d, U+9890, U+9893, U+9896-9897, U+989a, U+989c-989e, U+98a0, U+98a4, U+98a6-98a7, U+98a9, U+98ae-98af, U+98b2-98b3, U+98b6-98b8, U+98ba-98bd, U+98bf, U+98c7-98c8, U+98ca, U+98d2-98d3, U+98d8-98da, U+98dc, U+98de, U+98e0-98e1, U+98e3, U+98e5, U+98e7-98e9, U+98eb-98ee, U+98f1, U+98f4, U+9901, U+9908-9909, U+990c, U+9911)
+);
+
+/* noto-sans-tc-[25]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-25-400-normal.woff2",
+    $range: (U+964e-964f, U+9651, U+9653-9655, U+9658, U+965b-965f, U+9661, U+9665, U+9668-9669, U+966c, U+9672, U+9674, U+967a, U+9682-9685, U+9688-9689, U+968b, U+968d, U+9695, U+9697-9698, U+969e, U+96a0-96a4, U+96a9, U+96ac, U+96ae, U+96b0, U+96b2-96b4, U+96b6-96b7, U+96b9, U+96bc-96be, U+96c3, U+96c9-96cb, U+96ce-96cf, U+96d1-96d2, U+96d8, U+96dd, U+96e9, U+96eb, U+96f0-96f1, U+96f3-96f4, U+96f9, U+96fe-96ff, U+9701-9702, U+9705, U+9708, U+970a, U+970e-9711, U+9719, U+971d, U+971f-9720, U+9728, U+972a, U+972d, U+9730, U+9733, U+973a, U+973d, U+9744, U+9746-9747, U+9749, U+9750-9751, U+9753, U+9758-9759, U+975b, U+975d, U+9763, U+9765-9766, U+9768, U+976c-976d, U+9771, U+9773, U+9776, U+977a, U+977c, U+9780, U+9784-9786, U+9788, U+978e-978f, U+9798, U+979d-979e, U+97a3, U+97a5-97a6, U+97a8, U+97ab-97ac, U+97ae, U+97b6-97b7, U+97b9, U+97bf, U+97c1, U+97c3)
+);
+
+/* noto-sans-tc-[26]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-26-400-normal.woff2",
+    $range: (U+950c, U+950f-9510, U+9519-951b, U+951d, U+951f, U+9521-9526, U+952d-9530, U+9535, U+953a-953b, U+9540-9542, U+9547, U+9549-954a, U+954d, U+9550-9551, U+9554-9556, U+955c, U+956c-956d, U+956f-9570, U+9573, U+9576, U+9578, U+9582, U+9586, U+9588, U+958e-958f, U+9599, U+959c, U+959e-959f, U+95a1-95a2, U+95a4, U+95a6-95a7, U+95aa-95ae, U+95b0, U+95b2, U+95b6, U+95b9-95bf, U+95c2-95c4, U+95c7-95c9, U+95cb-95cd, U+95d0, U+95d3-95d5, U+95d7-95d8, U+95da, U+95de, U+95e0-95e1, U+95e4-95e5, U+95ea-95eb, U+95ef-95f0, U+95f2-95f3, U+95f5, U+95f7-95fa, U+95fd, U+9600-9602, U+9607-9609, U+960e, U+9610-9611, U+9614, U+9616, U+9619-961a, U+961c-961d, U+961f, U+9621, U+9624, U+9628, U+962f, U+9633-9636, U+963c, U+9641-9643, U+9645, U+9647-9648)
+);
+
+/* noto-sans-tc-[27]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-27-400-normal.woff2",
+    $range: (U+93e4, U+93e8, U+93ee, U+93f0, U+93f5, U+93f7-93f9, U+93fb, U+9403, U+9407, U+940f-9410, U+9413-9414, U+9417, U+9419-941a, U+941c, U+941e, U+9420-9425, U+9427-942b, U+942e, U+9432-9433, U+9436, U+9438, U+943a, U+943d, U+943f-9440, U+9445, U+944a, U+944c, U+9454-9455, U+945a-945b, U+945e, U+9460, U+9462-9463, U+9468, U+946a, U+946d, U+946f, U+9471, U+9474-9477, U+9479, U+947e-9481, U+9488-948a, U+948e, U+9492-9493, U+9497, U+9499, U+949b-94a3, U+94a5-94a9, U+94ac, U+94ae-94b1, U+94b3-94b5, U+94bb-94bc, U+94be-94c3, U+94c5-94c6, U+94c9, U+94ce-94d0, U+94db-94dd, U+94e0, U+94e2-94e3, U+94e8, U+94ec-94ee, U+94f0, U+94f2, U+94f5-94f6, U+94f8, U+94fa, U+94ff-9502, U+9504-9506, U+9508, U+950b)
+);
+
+/* noto-sans-tc-[28]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-28-400-normal.woff2",
+    $range: (U+92e5-92e6, U+92e8-92e9, U+92ed-92ef, U+92f1-92f3, U+92f6, U+92f9, U+92fb, U+9300-9302, U+9306, U+930b, U+930f, U+9312, U+9315, U+9319-931b, U+931d-931f, U+9321, U+9323-9325, U+9327-932a, U+932c-932e, U+9331-9333, U+9335, U+9338, U+933c, U+9340-9341, U+9345-9349, U+934f-9352, U+9354, U+9356-935a, U+935c-9360, U+9363-9367, U+9369-936a, U+936c, U+936e, U+9370-9371, U+9373, U+9376, U+9379-937a, U+937c, U+9385, U+9387, U+938c, U+938f, U+9394, U+9397-9398, U+939a-939b, U+939d-939e, U+93a1-93a3, U+93a6-93a7, U+93a9-93aa, U+93ac-93ad, U+93af-93b0, U+93b3-93bb, U+93bd-93be, U+93c0-93c4, U+93c7, U+93ca-93cd, U+93d0-93d1, U+93d6-93d8, U+93dc-93de, U+93e0)
+);
+
+/* noto-sans-tc-[29]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-29-400-normal.woff2",
+    $range: (U+91f0-91f1, U+91f5-91fa, U+91fd, U+91ff-9201, U+9203-920a, U+920d-920e, U+9210-9211, U+9217, U+9219, U+921c, U+9221, U+9224-9225, U+9227, U+922a, U+922d-922e, U+9230-9231, U+9233, U+9235-9239, U+923b, U+923d-9241, U+9244, U+9246, U+9248-9249, U+924b-9251, U+9253, U+925a, U+925d-925e, U+9262, U+9265-9267, U+926b-926d, U+926f, U+9271-9272, U+9274, U+9276, U+9278, U+927a-927c, U+927e-927f, U+9282-9283, U+9286, U+9288, U+928a, U+928d-928e, U+9291, U+9295-9296, U+9299-929b, U+929d, U+92a0-92ae, U+92b2, U+92b5-92b6, U+92bb-92bc, U+92c2-92c3, U+92c6-92cd, U+92cf-92d1, U+92d5, U+92d7, U+92d9, U+92dd, U+92df, U+92e4)
+);
+
+/* noto-sans-tc-[30]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-30-400-normal.woff2",
+    $range: (U+90bb, U+90bd-90be, U+90c3-90c5, U+90c7, U+90d1, U+90d4-90d5, U+90d7, U+90db-90df, U+90e2-90e4, U+90ea-90eb, U+90ef, U+90f4, U+90f7-90f8, U+90fc, U+90fe-9100, U+9102, U+9104, U+9106, U+9112, U+9114-911a, U+911c, U+911e, U+9120, U+9122-9123, U+9129, U+912b, U+912f, U+9131-9132, U+9134, U+9136, U+9139-913a, U+9143, U+9146, U+9148-914a, U+914e-9150, U+9154, U+9156-9157, U+9159-915a, U+915d-915e, U+9161-9164, U+916b, U+916e, U+9170-9172, U+9174, U+9176, U+9179-917a, U+917f, U+9181-9182, U+9184-9186, U+918c-918e, U+9190-9191, U+9196, U+919a-919b, U+919e, U+91a1-91a4, U+91a7, U+91aa, U+91ae-91b2, U+91b4-91b5, U+91b8, U+91bd-91be, U+91c1, U+91c3, U+91c5-91c6, U+91c8-91ca, U+91d2-91d5, U+91d7, U+91d9, U+91e1, U+91e4, U+91e6-91e9, U+91ec-91ed)
+);
+
+/* noto-sans-tc-[31]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-31-400-normal.woff2",
+    $range: (U+8f68-8f69, U+8f6d-8f72, U+8f74, U+8f76, U+8f7b-8f7c, U+8f7f, U+8f83-8f86, U+8f88-8f8a, U+8f8d, U+8f90, U+8f93, U+8f95-8f97, U+8f99, U+8f9e-8f9f, U+8fa2, U+8fa7, U+8fa9, U+8fab, U+8fae, U+8fb3, U+8fb5-8fb6, U+8fba-8fbd, U+8fbf, U+8fc1-8fc2, U+8fc6, U+8fc8, U+8fcc-8fcd, U+8fd2-8fd3, U+8fd5, U+8fdc-8fdd, U+8fdf, U+8fe2-8fe5, U+8fe8-8fe9, U+8fed-8fee, U+8ff3, U+8ff5, U+8ff8, U+8ffa-8ffc, U+8ffe, U+9002, U+9004, U+9008, U+900a-900b, U+9011-9013, U+9016, U+901e, U+9021, U+9024, U+902d, U+902f-9030, U+9034-9036, U+9039-903b, U+9041, U+9044-9045, U+904f-9052, U+9057-9058, U+905b, U+905d, U+9061-9062, U+9065, U+9068, U+906f, U+9074, U+9079, U+907d, U+9083, U+9085, U+9087-9089, U+908b, U+9090, U+9093, U+9095, U+9097, U+9099, U+909b, U+909d-909e, U+90a0-90a2, U+90ac, U+90af-90b0, U+90b2-90b4, U+90b6, U+90b9)
+);
+
+/* noto-sans-tc-[32]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-32-400-normal.woff2",
+    $range: (U+8e18, U+8e1d-8e21, U+8e23, U+8e26-8e28, U+8e2a-8e2b, U+8e2d-8e2e, U+8e30-8e31, U+8e35, U+8e39, U+8e3c-8e3d, U+8e40-8e42, U+8e47, U+8e49-8e4e, U+8e50, U+8e53-8e55, U+8e59-8e5b, U+8e60, U+8e62-8e63, U+8e67, U+8e69, U+8e6c-8e6d, U+8e6f, U+8e74, U+8e76, U+8e7a-8e7c, U+8e82, U+8e84-8e85, U+8e87, U+8e89-8e8b, U+8e8f-8e95, U+8e99-8e9a, U+8e9d-8e9e, U+8ea1, U+8ea3, U+8ea5-8ea6, U+8eaa, U+8eac-8ead, U+8eaf-8eb1, U+8eb9, U+8ebc, U+8ebe, U+8ec6, U+8ecb, U+8ecf, U+8ed1, U+8ed4, U+8ed7, U+8eda-8edb, U+8ee2, U+8ee8, U+8eeb, U+8ef2, U+8ef9-8efe, U+8f05, U+8f07-8f08, U+8f0a-8f0c, U+8f12-8f13, U+8f17, U+8f19-8f1a, U+8f1c, U+8f1e-8f1f, U+8f25-8f26, U+8f2d, U+8f30, U+8f33, U+8f36, U+8f3e, U+8f40-8f42, U+8f45-8f47, U+8f4d, U+8f54-8f55, U+8f5d, U+8f61-8f62, U+8f64, U+8f67)
+);
+
+/* noto-sans-tc-[33]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-33-400-normal.woff2",
+    $range: (U+8cc1-8cc2, U+8cc4-8cc5, U+8ccf-8cd2, U+8cd4-8cd5, U+8cd9-8cdb, U+8ce1, U+8ce8, U+8ceb, U+8cf0, U+8cf8, U+8cfb, U+8cfe, U+8d04, U+8d07, U+8d0b, U+8d0d, U+8d10, U+8d12-8d14, U+8d17, U+8d1b-8d1f, U+8d21-8d26, U+8d29-8d2c, U+8d2e-8d32, U+8d34-8d35, U+8d37-8d38, U+8d3a-8d3c, U+8d3e-8d3f, U+8d41-8d43, U+8d48, U+8d4b-8d4c, U+8d4e-8d50, U+8d54, U+8d56, U+8d58, U+8d5a-8d5b, U+8d5f-8d60, U+8d62-8d63, U+8d66-8d69, U+8d6c-8d6e, U+8d73, U+8d75-8d76, U+8d7b, U+8d7d, U+8d84, U+8d8b, U+8d90-8d91, U+8d94, U+8d96, U+8d9c, U+8dab, U+8daf, U+8db2, U+8db5, U+8db7, U+8dba, U+8dbc, U+8dbf, U+8dc2-8dc3, U+8dc6, U+8dcb, U+8dce-8dd0, U+8dd6-8dd7, U+8dda-8ddb, U+8de3-8de4, U+8de9, U+8deb-8dec, U+8df1, U+8df5-8df7, U+8dfa-8dfd, U+8e05, U+8e08-8e0a, U+8e0e, U+8e14, U+8e16)
+);
+
+/* noto-sans-tc-[34]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-34-400-normal.woff2",
+    $range: (U+8b6c-8b6d, U+8b72, U+8b7e, U+8b83, U+8b89, U+8b8c, U+8b8e, U+8b90, U+8b92, U+8b95-8b96, U+8b99, U+8b9c, U+8b9e-8b9f, U+8ba3, U+8ba5, U+8ba7, U+8baa, U+8bad, U+8bb2-8bb4, U+8bb6-8bb9, U+8bbc-8bbd, U+8bbf-8bc0, U+8bc3, U+8bc5, U+8bc8-8bcb, U+8bcf, U+8bd1, U+8bd7-8bdc, U+8bde-8be1, U+8be3, U+8be7, U+8be9, U+8beb-8bec, U+8bef, U+8bf1-8bf2, U+8bf5-8bf6, U+8bf8, U+8bfa, U+8bfd-8bfe, U+8c01-8c02, U+8c05, U+8c08, U+8c0a-8c11, U+8c13-8c15, U+8c18-8c1c, U+8c1f, U+8c23-8c29, U+8c2c-8c2d, U+8c31, U+8c34, U+8c36, U+8c39, U+8c3f, U+8c47, U+8c49-8c4c, U+8c4f, U+8c51, U+8c55, U+8c62, U+8c68, U+8c73, U+8c78, U+8c7a-8c7c, U+8c82, U+8c85, U+8c89-8c8a, U+8c8d-8c8e, U+8c90, U+8c94, U+8c98-8c99, U+8ca3-8ca4, U+8cad-8cb0, U+8cb2, U+8cb9-8cba, U+8cbd)
+);
+
+/* noto-sans-tc-[35]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-35-400-normal.woff2",
+    $range: (U+89f6, U+89ff, U+8a01, U+8a03, U+8a07, U+8a09, U+8a0c, U+8a0f-8a12, U+8a16, U+8a1b, U+8a22, U+8a25, U+8a27, U+8a2b, U+8a33, U+8a36, U+8a38, U+8a3d-8a3e, U+8a41, U+8a45-8a46, U+8a48, U+8a4e, U+8a51-8a52, U+8a54, U+8a56-8a58, U+8a5b, U+8a5d, U+8a61, U+8a63, U+8a67, U+8a6a-8a6c, U+8a70, U+8a74-8a76, U+8a7a-8a7c, U+8a82, U+8a84-8a86, U+8a89, U+8a8f-8a92, U+8a94, U+8a9a, U+8aa1, U+8aa3, U+8aa5, U+8aa7-8aa8, U+8aad, U+8ab1, U+8ab6, U+8abe, U+8ac2, U+8ac4, U+8ac6, U+8ac9, U+8acc-8acf, U+8ad1, U+8adb, U+8add-8ae2, U+8ae4, U+8ae6, U+8aea-8aeb, U+8aed, U+8af1-8af6, U+8afa, U+8afc, U+8b01, U+8b04-8b05, U+8b07, U+8b0b-8b0d, U+8b0f-8b10, U+8b13-8b14, U+8b16, U+8b1a, U+8b1c, U+8b21-8b22, U+8b26, U+8b28, U+8b2b, U+8b2e, U+8b33, U+8b41, U+8b46, U+8b4c-8b4f, U+8b53-8b54, U+8b56, U+8b59, U+8b5e-8b60, U+8b64, U+8b6a-8b6b)
+);
+
+/* noto-sans-tc-[36]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-36-400-normal.woff2",
+    $range: (U+889b-889c, U+889e, U+88a2, U+88a4, U+88a8, U+88aa, U+88ad-88ae, U+88b1, U+88b4, U+88b7-88b8, U+88bc-88be, U+88c0, U+88c4, U+88c6-88c7, U+88c9-88cc, U+88ce, U+88d2, U+88d6, U+88d8, U+88db, U+88df, U+88e4, U+88e8-88e9, U+88ec, U+88ef-88f1, U+88f3-88f5, U+88fc, U+88fe, U+8900, U+8902, U+8906, U+890a-890c, U+8912-8915, U+8918-891a, U+891f, U+8921, U+8923, U+8925, U+892a-892b, U+892d, U+8930, U+8933, U+8935-8936, U+8938, U+893d, U+8941-8943, U+8946-8947, U+8949, U+894c-894d, U+8956-8957, U+8959, U+895c, U+895e-8960, U+8964, U+8966, U+896c, U+8971, U+8974, U+897b, U+897e, U+8980, U+8982-8983, U+8987-8988, U+898a, U+898c, U+8991, U+8994-8995, U+8997-8998, U+899a, U+899c, U+89a1, U+89a4-89a7, U+89a9, U+89ac, U+89af, U+89b2-89b3, U+89b7, U+89bb, U+89bf, U+89c5, U+89c9-89ca, U+89d1, U+89d4-89d5, U+89da, U+89dc-89de, U+89e5-89e7, U+89ed, U+89f1, U+89f3-89f4)
+);
+
+/* noto-sans-tc-[37]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-37-400-normal.woff2",
+    $range: (U+874c, U+874e-874f, U+8753, U+8757-8758, U+875d, U+875f, U+8761-8765, U+8768, U+876a, U+876c-8770, U+8772, U+8777, U+877a-877b, U+877d, U+8781, U+8784-8785, U+8788, U+878b, U+8793, U+8797-8798, U+879f, U+87a3, U+87a8, U+87ab-87ad, U+87af, U+87b3, U+87b5, U+87b9, U+87bb, U+87bd-87c0, U+87c4-87c8, U+87ca-87cc, U+87ce, U+87d2, U+87db-87dc, U+87e0-87e1, U+87e3, U+87e5, U+87e7, U+87ea-87eb, U+87ee-87ef, U+87f3-87f4, U+87f6-87f7, U+87fe, U+8802-8806, U+880a-880b, U+880e, U+8810-8811, U+8813, U+8815-8816, U+881b, U+8821, U+8823, U+8827, U+8831-8832, U+8835, U+8839-883a, U+883c, U+8844-8846, U+884a, U+884e, U+8852, U+8854-8856, U+8859-885a, U+885e, U+8862, U+8864-8865, U+8869-886a, U+886c-886e, U+8871-8872, U+8875, U+8879, U+887d-887f, U+8882, U+8884-8885, U+8888, U+8890, U+8892-8893, U+8897-8898, U+889a)
+);
+
+/* noto-sans-tc-[38]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-38-400-normal.woff2",
+    $range: (U+8602, U+8604-8605, U+8610, U+8616-8618, U+861a, U+861e, U+8621-8622, U+8627, U+8629-862a, U+8634-8636, U+8638, U+863a, U+863c, U+8640, U+8642, U+8646, U+864c-864d, U+864f, U+8651-8654, U+8657, U+8659-865a, U+865c, U+8662, U+866b-866c, U+866f-8671, U+8673, U+8677, U+867a-867b, U+867d-867e, U+8680-8682, U+868b-868d, U+8693-8696, U+869a, U+869c-869d, U+86a1, U+86a3-86a4, U+86a7-86aa, U+86af-86b1, U+86b3-86b4, U+86b6, U+86b9-86ba, U+86c0-86c2, U+86c4, U+86c6, U+86c9-86ca, U+86cc-86ce, U+86d0, U+86d3-86d4, U+86de-86df, U+86e9, U+86ed-86f0, U+86f3, U+86f8-86fc, U+86fe, U+8703, U+8706-870a, U+870d-870e, U+8711-8712, U+8715, U+8717, U+8719-871a, U+871e, U+8721-8723, U+8725, U+8728-8729, U+872e, U+8731, U+8734, U+8737, U+873a, U+873e-8740, U+8742, U+8747, U+8749, U+874b)
+);
+
+/* noto-sans-tc-[39]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-39-400-normal.woff2",
+    $range: (U+84b1, U+84b4, U+84b9-84bb, U+84bd-84c0, U+84c2, U+84c6-84c7, U+84ca, U+84cd-84d2, U+84d6, U+84dd, U+84df, U+84e2, U+84e6-84e8, U+84ea, U+84ef-84f0, U+84f3-84f4, U+84f7, U+84fa, U+84fc-84fd, U+84ff-8500, U+8506, U+850c, U+8511, U+8515, U+8517, U+851d-851f, U+8524, U+852b, U+852f, U+8532, U+8534-8535, U+8537-8538, U+853a, U+853c, U+853e, U+8541-8542, U+8545, U+8548, U+854b, U+854d-854e, U+8552-8553, U+8555-8558, U+855a, U+855e, U+8561-8565, U+8568, U+856a-856c, U+856f, U+8574, U+8577-857b, U+8580-8581, U+8585-8586, U+858a, U+858c, U+858f-8590, U+8594, U+8597-8599, U+859c, U+859f, U+85a1-85a2, U+85a4, U+85a8, U+85ab-85ac, U+85ae, U+85b3-85b4, U+85b7, U+85b9-85ba, U+85bd-85be, U+85c1-85c2, U+85cb, U+85ce, U+85d0, U+85d3, U+85d5, U+85dc, U+85e0, U+85e6, U+85e8, U+85ea, U+85ed, U+85f4, U+85f6-85f7, U+85f9-85fa, U+85ff)
+);
+
+/* noto-sans-tc-[40]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-40-400-normal.woff2",
+    $range: (U+8378, U+837a-8380, U+8383, U+8385-8386, U+8392, U+8394-8395, U+8398-8399, U+839b-839c, U+83a0, U+83a2, U+83a4, U+83a7-83aa, U+83af-83b5, U+83b7, U+83b9-83ba, U+83bc-83c0, U+83c2, U+83c4-83c5, U+83c8-83c9, U+83cb, U+83ce-83cf, U+83d1, U+83d4-83d6, U+83d8, U+83dd, U+83df, U+83e1-83e2, U+83e5, U+83ea-83eb, U+83f0, U+83f3-83f4, U+83f9, U+83fb-83fe, U+8406-8407, U+840b, U+840f, U+8411, U+8413, U+8418, U+841b-841d, U+8420-8421, U+8423-8424, U+8426-8429, U+842b, U+842d-842e, U+8432-8433, U+8435, U+8437-8439, U+843b-843c, U+843e, U+8445-8447, U+844e, U+8451-8452, U+8456, U+8459-845a, U+845c, U+845f, U+8462, U+8466-8467, U+846d, U+846f-8471, U+8473-8474, U+8476-8478, U+847a, U+8484, U+848b, U+848d-848e, U+8493-8494, U+8497, U+849d, U+849f, U+84a1, U+84a8, U+84af)
+);
+
+/* noto-sans-tc-[41]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-41-400-normal.woff2",
+    $range: (U+826e, U+8270, U+8273, U+8276, U+8278-8279, U+827d, U+827f, U+8283-8284, U+8288-828a, U+828d-8291, U+8293-8294, U+8298, U+829a-829c, U+829e-82a4, U+82a6-82ab, U+82ae, U+82b0, U+82b4, U+82b6, U+82ba-82bc, U+82be, U+82c1, U+82c4-82c5, U+82c7, U+82cb, U+82cd, U+82cf-82d0, U+82d2, U+82d5-82d6, U+82d9, U+82db-82dc, U+82de-82e1, U+82e3-82e4, U+82e7, U+82ea-82eb, U+82ef-82f0, U+82f3-82f4, U+82f6-82f7, U+82f9-82fc, U+82fe-8301, U+8306-8308, U+830b-830e, U+8316, U+8318, U+831a-831b, U+831d-831e, U+8327, U+832a, U+832c-832d, U+832f, U+8331, U+8333-8334, U+8337, U+833a-833c, U+833f-8340, U+8342, U+8344-8347, U+834b-834c, U+834f, U+8351, U+8356-8358, U+835a, U+835e-8361, U+8363-8364, U+8367-8368, U+836b, U+836f, U+8373, U+8375)
+);
+
+/* noto-sans-tc-[42]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-42-400-normal.woff2",
+    $range: (U+8113, U+8115, U+8117-8118, U+811a-811b, U+811e, U+8121-8127, U+8129, U+812c, U+812f-8134, U+8137-8138, U+813a, U+813d, U+8144, U+8146, U+8148, U+814a, U+814c-814d, U+8151, U+8153, U+8156, U+8158, U+815a, U+8160, U+8167, U+8169, U+816d, U+816f, U+8171, U+8174, U+817b-817c, U+817e, U+8182, U+8188, U+818a, U+8194-8195, U+8198, U+819b, U+819e, U+81a3, U+81a6-81a7, U+81ab, U+81af-81b0, U+81b5-81b6, U+81b8, U+81ba-81bb, U+81be-81bf, U+81c3, U+81c6, U+81ca, U+81cc, U+81cf, U+81d1-81d3, U+81d6-81d7, U+81d9-81da, U+81dd-81de, U+81e0-81e2, U+81e7, U+81ec, U+81ef, U+81fc, U+81fe, U+8200-8202, U+8204-8206, U+820b, U+820e, U+8210, U+8215, U+8217-8218, U+821b, U+821d, U+8221-8222, U+8224, U+8228-8229, U+822b, U+822f-8234, U+8236-8238, U+823a, U+823e, U+8240, U+8244-8245, U+8249, U+824b, U+824e-824f, U+8257, U+825a, U+825f, U+8264, U+8268, U+826b)
+);
+
+/* noto-sans-tc-[43]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-43-400-normal.woff2",
+    $range: (U+7fb1-7fb2, U+7fb4, U+7fb6, U+7fb8, U+7fbc, U+7fbf-7fc0, U+7fc3, U+7fcb-7fcc, U+7fce-7fcf, U+7fd1, U+7fd5, U+7fd8, U+7fdb, U+7fde-7fdf, U+7fe5-7fe6, U+7fe9, U+7feb-7fec, U+7fee, U+7ff2-7ff3, U+7ffa, U+7ffd-7ffe, U+8002, U+8004, U+8006, U+800b, U+800e, U+8011-8012, U+8014, U+8016, U+8018-8019, U+801c, U+8024, U+8026, U+8028, U+802c, U+8030, U+8035, U+8037-8039, U+803b, U+8042-8043, U+804b-804c, U+8052, U+8061, U+8068, U+806a, U+806e, U+8071, U+8073-8076, U+8079, U+807c, U+807e-807f, U+8083-8084, U+808f, U+8093, U+8095, U+8098, U+809c, U+809f-80a0, U+80a4, U+80a7, U+80ab, U+80ad-80ae, U+80b0-80b1, U+80b4-80b6, U+80b8, U+80bc-80c2, U+80c4, U+80c6-80c7, U+80cb, U+80cd, U+80cf, U+80d4, U+80d7, U+80d9, U+80db-80dd, U+80e0, U+80e3-80e5, U+80e7, U+80eb-80ed, U+80ef-80f1, U+80f3-80f4, U+80f6-80f7, U+80fc, U+80fe-80ff, U+8101, U+8107, U+8109, U+810f-8112)
+);
+
+/* noto-sans-tc-[44]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-44-400-normal.woff2",
+    $range: (U+7eaf, U+7eb1-7eb3, U+7eb5-7eba, U+7ebd-7ebe, U+7ec0-7ec1, U+7ec3, U+7ec5, U+7ec7-7eca, U+7ecd-7ece, U+7ed1-7ed2, U+7ed4-7ed5, U+7ed7-7ed8, U+7eda-7edb, U+7edd-7ede, U+7ee2-7ee3, U+7ee5, U+7ee7, U+7ee9-7eeb, U+7eee-7ef0, U+7ef3, U+7ef5, U+7ef7-7ef8, U+7efd-7f01, U+7f03, U+7f05-7f09, U+7f0e, U+7f10, U+7f13-7f15, U+7f18-7f1a, U+7f1c-7f1d, U+7f20, U+7f24-7f25, U+7f28-7f2a, U+7f2d-7f2e, U+7f30, U+7f34, U+7f36-7f37, U+7f3d, U+7f42-7f45, U+7f47-7f4e, U+7f52, U+7f54, U+7f58, U+7f5a, U+7f5d, U+7f5f-7f63, U+7f65, U+7f68, U+7f6b, U+7f78, U+7f7d-7f7e, U+7f81-7f83, U+7f86-7f87, U+7f8b-7f8d, U+7f91, U+7f93-7f95, U+7f97, U+7f99-7f9a, U+7f9d, U+7f9f, U+7fa1-7fa3, U+7fa5, U+7fa7, U+7fad-7fb0)
+);
+
+/* noto-sans-tc-[45]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-45-400-normal.woff2",
+    $range: (U+7d89, U+7d8b-7d8f, U+7d91, U+7d95-7d96, U+7d98-7d9a, U+7d9d-7d9e, U+7da2-7da3, U+7da6, U+7daa, U+7dac, U+7dae-7db0, U+7db3, U+7db5, U+7db7, U+7db9, U+7dbd, U+7dc1, U+7dc3-7dc7, U+7dcc-7dcf, U+7dd1, U+7dd6-7dd9, U+7ddb-7ddc, U+7de1-7de2, U+7de6, U+7df0-7df3, U+7df6, U+7dfe, U+7e01-7e02, U+7e04, U+7e08-7e0b, U+7e10-7e11, U+7e13, U+7e15, U+7e1d-7e20, U+7e22, U+7e25-7e27, U+7e29, U+7e2d, U+7e2f-7e30, U+7e32-7e37, U+7e39, U+7e3b, U+7e44-7e45, U+7e47-7e48, U+7e4a-7e4b, U+7e4d, U+7e50-7e52, U+7e56, U+7e58-7e5b, U+7e62, U+7e68, U+7e6d-7e70, U+7e76, U+7e78, U+7e7b, U+7e7e, U+7e81-7e82, U+7e86-7e88, U+7e8a, U+7e8d-7e8e, U+7e92-7e94, U+7e98-7e9b, U+7e9e, U+7ea0, U+7ea3-7ea4, U+7ea8, U+7eaa-7eae)
+);
+
+/* noto-sans-tc-[46]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-46-400-normal.woff2",
+    $range: (U+7c20, U+7c23, U+7c25-7c26, U+7c2a-7c2b, U+7c37-7c39, U+7c40-7c41, U+7c48-7c49, U+7c50, U+7c53-7c54, U+7c56-7c57, U+7c59-7c5c, U+7c5f, U+7c63, U+7c65, U+7c69, U+7c6c-7c6e, U+7c74-7c75, U+7c79, U+7c7c, U+7c7e, U+7c84, U+7c8b, U+7c8d, U+7c91, U+7c94-7c95, U+7c9b, U+7c9f, U+7ca2, U+7ca4, U+7ca6, U+7ca8-7caa, U+7cae, U+7cb1-7cb3, U+7cba, U+7cbc, U+7cbf-7cc0, U+7cc5, U+7cc8-7cc9, U+7ccc-7cce, U+7cd7, U+7cdc-7cdd, U+7ce0, U+7ce2, U+7ce8, U+7cea, U+7ced, U+7cf2, U+7cf4, U+7cf6, U+7cf8-7cfa, U+7cfc, U+7d02, U+7d06-7d0a, U+7d0f, U+7d11-7d12, U+7d15, U+7d18, U+7d1c-7d1e, U+7d25, U+7d27, U+7d29, U+7d2c, U+7d31-7d32, U+7d35, U+7d38, U+7d3a, U+7d3c, U+7d3e-7d41, U+7d43, U+7d45, U+7d4c, U+7d4e-7d4f, U+7d53-7d54, U+7d56, U+7d5b-7d5d, U+7d5f, U+7d63, U+7d67, U+7d6a, U+7d6d, U+7d70, U+7d73, U+7d75, U+7d79-7d7b, U+7d7d, U+7d80, U+7d83-7d84, U+7d86-7d88)
+);
+
+/* noto-sans-tc-[47]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-47-400-normal.woff2",
+    $range: (U+7afb, U+7afd-7afe, U+7b01-7b06, U+7b09-7b0b, U+7b0e-7b10, U+7b14, U+7b18, U+7b1a, U+7b1e-7b1f, U+7b22-7b25, U+7b29-7b2b, U+7b2d-7b2e, U+7b31-7b35, U+7b38-7b3c, U+7b45, U+7b47-7b48, U+7b4a, U+7b4c, U+7b4e-7b50, U+7b58, U+7b5b, U+7b5d, U+7b60, U+7b62, U+7b65-7b67, U+7b69, U+7b6d-7b6f, U+7b72-7b76, U+7b79, U+7b7e, U+7b82, U+7b84-7b85, U+7b87, U+7b8b, U+7b8d-7b93, U+7b95-7b96, U+7b98, U+7b9c-7b9d, U+7ba0, U+7ba7, U+7ba9-7bac, U+7bb0, U+7bb4, U+7bb6, U+7bb8-7bb9, U+7bc1, U+7bc3, U+7bc6, U+7bcb-7bcc, U+7bcf, U+7bd4, U+7bd9-7bdb, U+7bdd, U+7be0-7be1, U+7be5-7be6, U+7bea, U+7bed-7bee, U+7bf1-7bf3, U+7bf8-7bf9, U+7bfc-7c01, U+7c03, U+7c07, U+7c0a-7c0d, U+7c0f, U+7c11-7c12, U+7c15, U+7c1e-7c1f)
+);
+
+/* noto-sans-tc-[48]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-48-400-normal.woff2",
+    $range: (U+7988, U+798a-798b, U+7991, U+7993-7996, U+7998, U+799a-799b, U+799f-79a2, U+79a4, U+79a8-79a9, U+79af-79b0, U+79b3, U+79b5, U+79b8, U+79ba, U+79c3, U+79c6, U+79c8, U+79cf, U+79d5-79d6, U+79dc-79de, U+79e3, U+79e7, U+79ea-79ed, U+79ef-79f0, U+79f4, U+79f6-79f8, U+79fd, U+7a02-7a03, U+7a08-7a0a, U+7a0c, U+7a0e, U+7a10-7a11, U+7a14, U+7a17-7a19, U+7a1c, U+7a1e-7a1f, U+7a23, U+7a26, U+7a2d, U+7a32-7a33, U+7a37, U+7a39, U+7a3c, U+7a42, U+7a45, U+7a49, U+7a4f, U+7a56, U+7a5a, U+7a5c, U+7a60-7a61, U+7a63, U+7a68, U+7a6d-7a6e, U+7a70-7a71, U+7a77-7a79, U+7a80, U+7a83, U+7a85-7a86, U+7a88, U+7a8d, U+7a90-7a91, U+7a93-7a96, U+7a98, U+7a9c-7a9d, U+7aa0, U+7aa3, U+7aa5-7aa6, U+7aa8, U+7aaa, U+7aac, U+7ab0, U+7ab3, U+7ab6, U+7ab8, U+7abb, U+7abe-7abf, U+7ac2, U+7ac8-7ac9, U+7ad1-7ad2, U+7ad6, U+7ada, U+7adc-7ade, U+7ae4, U+7ae6, U+7ae9-7aeb, U+7af4, U+7af8, U+7afa)
+);
+
+/* noto-sans-tc-[49]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-49-400-normal.woff2",
+    $range: (U+7840, U+7842-7843, U+7845, U+7847, U+784a, U+784c-7850, U+7852-7853, U+7855, U+7858, U+785a, U+785c-785d, U+7864, U+7866, U+7868, U+786a, U+786f, U+7874, U+7876, U+787c, U+787f, U+7886-7887, U+7889, U+788d, U+788f, U+7893, U+7895-7896, U+7898, U+789a, U+789e, U+78a1, U+78a3, U+78a5, U+78aa, U+78ad, U+78b1-78b2, U+78b4, U+78b6, U+78b8, U+78be, U+78c8-78c9, U+78cb, U+78ce, U+78d0-78d1, U+78d4-78d5, U+78d7-78d8, U+78de, U+78e3, U+78e6-78e7, U+78ea, U+78ec, U+78f2-78f4, U+78fa-78fb, U+78fd-7900, U+7904-7906, U+790a, U+790c, U+7910-7912, U+791c, U+791e, U+7920-7921, U+792a-792c, U+792e, U+7931, U+7934, U+7938, U+793b, U+793d, U+793f, U+7941-7942, U+7945-7947, U+7949, U+794c, U+794e, U+7953-7954, U+7957-795c, U+795f, U+7961-7962, U+7964, U+7967, U+7969, U+796b-796c, U+796f, U+7972-7973, U+7977-7979, U+797b-797c, U+797e, U+7980, U+7982, U+7984-7987)
+);
+
+/* noto-sans-tc-[50]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-50-400-normal.woff2",
+    $range: (U+7705, U+7707-7708, U+770a, U+770c, U+770f, U+7715, U+7719-771b, U+771d-771e, U+7722, U+7725-7726, U+7728, U+772d, U+772f, U+7733-7736, U+7738, U+773b, U+773d, U+7741, U+7744, U+7746, U+774c, U+774e-7752, U+7755, U+7759-775a, U+775f-7760, U+7762, U+7765-7766, U+7768-776a, U+776c-776e, U+7771, U+7778, U+777a, U+777d-777e, U+7780, U+7785, U+7787, U+7789, U+778b-778d, U+7791-7793, U+779c, U+779f-77a0, U+77a2, U+77a5, U+77a9, U+77b0-77b1, U+77b4, U+77b6-77b7, U+77b9, U+77bc-77bf, U+77c5, U+77c7, U+77cc-77cd, U+77d3, U+77d6-77d7, U+77dc, U+77de, U+77e3, U+77e7, U+77eb-77ec, U+77f0, U+77f2, U+77f6, U+77f8, U+77fa-77fc, U+77fe-7800, U+7803, U+7805-7806, U+7809, U+7810-7812, U+7815-7816, U+781a, U+781c-781d, U+781f-7823, U+7825-7827, U+7829, U+782c-7830, U+7833, U+7835, U+7837, U+7839-783a, U+783c, U+783e)
+);
+
+/* noto-sans-tc-[51]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-51-400-normal.woff2",
+    $range: (U+75cc-75cd, U+75d2, U+75d4, U+75d9, U+75df, U+75e2-75e4, U+75e6-75e7, U+75e9-75ec, U+75f0-75f3, U+75f7, U+75f9-75fa, U+75fc, U+75fe-7602, U+7608-760a, U+760c-760d, U+7610, U+7615-7616, U+7618-7620, U+7622-7623, U+7625, U+7627, U+7629, U+762b, U+762e, U+7630, U+7632-7635, U+7638, U+763a-763c, U+763e, U+7640, U+7643, U+7646, U+7648-7649, U+764d-764e, U+7654, U+7658, U+765c, U+765f, U+7663-7667, U+7669, U+766b-766d, U+766f-7670, U+7676, U+7678-767a, U+767f-7681, U+7683, U+7688, U+768a-768b, U+768e, U+7690, U+7695-7696, U+769a-769e, U+76a3-76a4, U+76aa, U+76b0-76b1, U+76b4, U+76b7-76b8, U+76c2, U+76c5, U+76c9, U+76cc-76cd, U+76cf-76d1, U+76d6-76d8, U+76e5-76e6, U+76e9, U+76ec, U+76f1, U+76f7, U+76f9-76fb, U+76ff-7700, U+7704)
+);
+
+/* noto-sans-tc-[52]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-52-400-normal.woff2",
+    $range: (U+749a, U+749c-74a1, U+74a3, U+74a5-74a7, U+74a9-74ab, U+74ae, U+74b1-74b2, U+74b5, U+74b8, U+74ba, U+74bf, U+74c5, U+74c8, U+74cc-74cd, U+74d2, U+74d4, U+74d6, U+74d8, U+74da, U+74de-74e0, U+74e2, U+74e4, U+74e8-74e9, U+74ee-74ef, U+74f4, U+74f9, U+74fb, U+74ff-7501, U+7503, U+7507, U+750c-750d, U+7511, U+7513, U+7515-7517, U+7519, U+751e, U+7521, U+7525, U+752a, U+752c-752f, U+7534, U+753e, U+7542, U+7545, U+7547-7548, U+754a-754b, U+754e, U+7551, U+755a-755b, U+755d, U+7560, U+7563-7564, U+7566-7568, U+756c-756f, U+7572-7575, U+7577-757a, U+757c, U+757e-757f, U+7583-7584, U+7587, U+7589, U+758b-758e, U+7590, U+7592, U+7594-7595, U+7597, U+7599-759a, U+759d, U+759f, U+75a1-75a3, U+75a5, U+75a7, U+75aa, U+75ac, U+75ae-75b1, U+75b3-75b4, U+75b8, U+75bd, U+75c0, U+75c2-75c4, U+75c9-75ca)
+);
+
+/* noto-sans-tc-[53]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-53-400-normal.woff2",
+    $range: (U+73b3-73ba, U+73bc, U+73bf, U+73c2, U+73c4-73c6, U+73c9, U+73cb-73cc, U+73ce-73d2, U+73d6-73d7, U+73d9, U+73db-73de, U+73e3, U+73e5-73eb, U+73ef, U+73f5-73f7, U+73f9-73fa, U+73fc-73fd, U+7400-7401, U+7404-7405, U+7407-7408, U+740a-740d, U+740f-7410, U+7416, U+741a-741b, U+741d-741e, U+7420-7425, U+7428-7429, U+742c-7432, U+7435-7436, U+7438-743a, U+743c-7442, U+7445-7446, U+7448-744a, U+7451-7452, U+7454, U+7457, U+7459, U+745d, U+7460-7462, U+7465, U+7467-7468, U+746c-746e, U+7471-7477, U+7479-747a, U+747c-747f, U+7481-7482, U+7484-7486, U+7488-748a, U+748e-7490, U+7492, U+7498)
+);
+
+/* noto-sans-tc-[54]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-54-400-normal.woff2",
+    $range: (U+727f, U+7281-7282, U+7284, U+7287, U+728a, U+728d, U+7292, U+7296, U+7298, U+729b, U+729f-72a2, U+72ad-72ae, U+72b0-72b5, U+72b8-72b9, U+72bc-72bd, U+72c1, U+72c3, U+72c5-72c6, U+72c8, U+72cc-72ce, U+72d2, U+72d4, U+72db, U+72dd, U+72df, U+72e1, U+72e8, U+72ec-72ee, U+72f1, U+72f3-72f4, U+72f7, U+72fa-72fb, U+72fd, U+7300-7301, U+7304, U+7307, U+730a-730b, U+730e, U+7313, U+7315-7317, U+7319, U+731e-731f, U+7322, U+7328-732e, U+7330-7331, U+7337, U+733a-733c, U+733e, U+7340-7341, U+7343, U+734c-734d, U+734f-7350, U+7352, U+7355, U+7357, U+7359-735a, U+7360-7363, U+7365, U+7369-7370, U+7373-7374, U+7377, U+737a, U+737c, U+737e, U+7380, U+7385-7386, U+738a, U+738e-738f, U+7391-7395, U+7397-7398, U+739b, U+73a0-73a2, U+73a5-73a8, U+73ad-73ae)
+);
+
+/* noto-sans-tc-[55]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-55-400-normal.woff2",
+    $range: (U+7113-7116, U+7118, U+711c, U+711e, U+7120, U+7122, U+712e-712f, U+7131, U+7134, U+713c, U+713f, U+7143, U+7145-7147, U+714a-714b, U+7150-7153, U+7155-7156, U+715a, U+7160, U+7162, U+7166, U+7168, U+716c, U+7171, U+7173, U+7178, U+717a-717b, U+717d, U+7180-7181, U+7185, U+7187-7188, U+718b, U+718f-7190, U+7192, U+7196-7198, U+719a-719c, U+71a0, U+71a4, U+71a8, U+71af, U+71b2-71b3, U+71b5, U+71b7-71ba, U+71be, U+71c1, U+71c4, U+71ca-71cb, U+71ce-71d0, U+71d4, U+71d7-71d8, U+71da, U+71dc, U+71e0-71e1, U+71e7, U+71ec, U+71f4-71f6, U+71f9, U+71fc, U+71fe-7201, U+7203, U+7207, U+7209, U+720c, U+7213-7215, U+7217, U+721a, U+721d, U+7222-7223, U+7228, U+722b, U+7230, U+7237, U+723b, U+723f-7242, U+724b, U+724d, U+7252-7253, U+7256, U+7258, U+725d, U+7263-7266, U+726a-726b, U+726e-7270, U+7273-7275, U+7277, U+727a-727b, U+727e)
+);
+
+/* noto-sans-tc-[56]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-56-400-normal.woff2",
+    $range: (U+6fe8-6fe9, U+6fec, U+6fee, U+6ff0, U+6ff3, U+6ff5-6ff6, U+6ffa, U+6ffc, U+6fff-7001, U+7003, U+7005-7007, U+700b, U+700d, U+7015, U+7018, U+701b, U+701e, U+7020-7021, U+7023, U+7026-7027, U+702c, U+702f-7032, U+7034-7035, U+7037-703c, U+7040, U+7042-7044, U+7046, U+7049, U+704b, U+704f, U+7052, U+7054-7055, U+705c-7061, U+7064-7069, U+706c-706d, U+706f, U+7073-7075, U+7078, U+707a, U+707e-7081, U+7085-7086, U+7089, U+7090-7091, U+7094-7096, U+7098, U+709c, U+709f, U+70a1, U+70a4, U+70a9, U+70ac, U+70af-70b2, U+70b4-70b5, U+70b7, U+70bb-70be, U+70c0-70c3, U+70ca-70cb, U+70d2, U+70d4-70d5, U+70d9-70dd, U+70df, U+70e6-70e9, U+70eb-70ec, U+70ef, U+70f1, U+70f4, U+70f7, U+70fa, U+70fd, U+70ff, U+7104, U+7106, U+7109, U+710c, U+7110)
+);
+
+/* noto-sans-tc-[57]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-57-400-normal.woff2",
+    $range: (U+6ed6, U+6ed8, U+6eda-6edb, U+6edd-6ede, U+6ee2, U+6ee4-6ee5, U+6ee8-6ee9, U+6eeb, U+6eee, U+6ef3, U+6ef8-6efb, U+6f00, U+6f08-6f0a, U+6f0d-6f0e, U+6f11-6f13, U+6f15, U+6f19-6f1a, U+6f23, U+6f25-6f2a, U+6f2d-6f31, U+6f33-6f36, U+6f3a-6f3c, U+6f40-6f41, U+6f43-6f44, U+6f47, U+6f4d-6f4f, U+6f53, U+6f57, U+6f59-6f5a, U+6f5c, U+6f5e-6f61, U+6f63, U+6f66-6f67, U+6f69-6f6c, U+6f6f, U+6f72-6f78, U+6f7a-6f7f, U+6f81-6f82, U+6f87, U+6f89, U+6f8b-6f8d, U+6f90, U+6f92, U+6f94-6f97, U+6f9c, U+6f9f-6fa0, U+6fa2-6fa3, U+6fa5-6fa8, U+6faa-6fab, U+6fae-6faf, U+6fb4, U+6fb6, U+6fb9-6fba, U+6fbc, U+6fc2, U+6fc6-6fcb, U+6fce, U+6fd1-6fd2, U+6fd4, U+6fd8, U+6fda, U+6fde, U+6fe0-6fe2)
+);
+
+/* noto-sans-tc-[58]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-58-400-normal.woff2",
+    $range: (U+6dd3, U+6dd5-6dd6, U+6dd9, U+6ddb-6de0, U+6de2-6de6, U+6de9, U+6dec, U+6def-6df0, U+6df2, U+6df4, U+6df6, U+6df8, U+6dfc-6dfd, U+6e00, U+6e02-6e03, U+6e07-6e0b, U+6e0d-6e0e, U+6e10, U+6e13-6e15, U+6e17, U+6e19-6e1a, U+6e1d, U+6e1f, U+6e22, U+6e24-6e25, U+6e27, U+6e2b, U+6e2d-6e2e, U+6e30-6e31, U+6e36, U+6e39-6e3a, U+6e3c-6e3d, U+6e40-6e41, U+6e44-6e45, U+6e47, U+6e49, U+6e4b, U+6e4d-6e4f, U+6e51, U+6e53-6e54, U+6e59, U+6e5c, U+6e5e-6e61, U+6e63-6e66, U+6e69-6e6b, U+6e6e, U+6e70-6e76, U+6e78, U+6e7c, U+6e7f-6e80, U+6e83, U+6e85-6e86, U+6e88-6e89, U+6e8b, U+6e8d-6e8f, U+6e93, U+6e98-6e9a, U+6e9f, U+6ea1, U+6ea4-6ea7, U+6eae, U+6eb1-6eb2, U+6eb4-6eb5, U+6eb7, U+6ebd, U+6ec1-6ec3, U+6ec7-6ec9, U+6ecd-6ed0, U+6ed3-6ed5)
+);
+
+/* noto-sans-tc-[59]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-59-400-normal.woff2",
+    $range: (U+6cda, U+6cdc-6cde, U+6ce0, U+6ce7, U+6ce9-6cec, U+6cee-6cef, U+6cf1, U+6cf7-6cf8, U+6cfb-6cfe, U+6d00-6d02, U+6d04, U+6d06-6d07, U+6d09-6d0a, U+6d0c, U+6d0e-6d12, U+6d18-6d1a, U+6d1f, U+6d22-6d24, U+6d27-6d28, U+6d2b, U+6d2d-6d31, U+6d33-6d3a, U+6d3c, U+6d3f, U+6d43-6d47, U+6d4a-6d4b, U+6d4e-6d4f, U+6d51-6d53, U+6d57-6d58, U+6d5a, U+6d5c, U+6d5e-6d65, U+6d67, U+6d6c-6d6d, U+6d6f-6d70, U+6d72, U+6d75, U+6d79, U+6d7c, U+6d7f, U+6d82, U+6d85, U+6d87, U+6d8e-6d8f, U+6d91-6d95, U+6d97-6d99, U+6d9b, U+6d9d, U+6d9f, U+6da1, U+6da4, U+6da6-6dac, U+6db3-6db4, U+6db7-6db8, U+6dbe-6dc0, U+6dc2, U+6dc4-6dc5, U+6dc8-6dca, U+6dcc-6dcd, U+6dcf-6dd0, U+6dd2)
+);
+
+/* noto-sans-tc-[60]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-60-400-normal.woff2",
+    $range: (U+6bbb, U+6bbd, U+6bc1-6bc2, U+6bcc, U+6bce, U+6bd0-6bd1, U+6bd5-6bd9, U+6bde, U+6be1, U+6bec, U+6bf3, U+6bf9, U+6bfd, U+6bff-6c00, U+6c02, U+6c05-6c06, U+6c0a, U+6c0c-6c0d, U+6c10, U+6c13, U+6c16, U+6c18-6c1a, U+6c1f, U+6c21-6c22, U+6c24, U+6c26, U+6c28-6c2a, U+6c2c, U+6c2e-6c33, U+6c35-6c37, U+6c39-6c3a, U+6c3d-6c3f, U+6c43, U+6c46, U+6c49-6c4f, U+6c54-6c55, U+6c58, U+6c5a-6c5c, U+6c5e, U+6c64-6c69, U+6c6b-6c6f, U+6c71-6c75, U+6c78-6c79, U+6c7c, U+6c7e, U+6c82, U+6c84-6c87, U+6c8c-6c8d, U+6c8f, U+6c93-6c94, U+6c98, U+6c9a, U+6c9d, U+6c9f, U+6ca2, U+6ca5-6ca8, U+6caa, U+6cac-6cb2, U+6cb4-6cb5, U+6cba, U+6cbc, U+6cc2-6cc3, U+6cc5-6cc7, U+6cd0-6cd2, U+6cd4, U+6cd6-6cd7, U+6cd9)
+);
+
+/* noto-sans-tc-[61]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-61-400-normal.woff2",
+    $range: (U+6a31-6a32, U+6a35, U+6a3b, U+6a3e-6a40, U+6a47-6a48, U+6a50, U+6a52, U+6a55-6a57, U+6a5a-6a5b, U+6a5e, U+6a62, U+6a66, U+6a6a, U+6a71, U+6a79, U+6a7c, U+6a7e-6a81, U+6a84, U+6a87, U+6a89, U+6a8d-6a8e, U+6a90-6a92, U+6a97, U+6a9c, U+6a9e-6aa1, U+6aa3-6aa5, U+6aa8, U+6aab, U+6aae, U+6ab5, U+6aba, U+6abe, U+6ac2, U+6ac5-6ac6, U+6ac8-6ac9, U+6acc, U+6ad3, U+6ada-6adb, U+6add-6adf, U+6ae3, U+6ae7-6ae8, U+6aea-6aec, U+6af1, U+6af3, U+6af8, U+6afa, U+6afc, U+6b05, U+6b09, U+6b0e-6b13, U+6b17, U+6b1d-6b1e, U+6b25, U+6b2c, U+6b31, U+6b35-6b37, U+6b39, U+6b3b, U+6b40, U+6b43, U+6b46, U+6b48, U+6b53-6b55, U+6b59, U+6b5b, U+6b5f-6b60, U+6b68-6b69, U+6b6f, U+6b74, U+6b7a, U+6b7c, U+6b7f-6b84, U+6b86-6b87, U+6b89, U+6b8b, U+6b8d, U+6b91-6b93, U+6b9b, U+6b9e, U+6ba1-6ba2, U+6ba4, U+6baa-6bab, U+6bad-6bae, U+6bb2-6bb4)
+);
+
+/* noto-sans-tc-[62]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-62-400-normal.woff2",
+    $range: (U+6900, U+6902, U+6904, U+6906-6907, U+6909, U+690b, U+690f-6910, U+6917, U+691a-691c, U+6925, U+692a, U+692c-692d, U+6932, U+6934, U+6939, U+693c-6940, U+6942, U+6949, U+6952, U+6954-6957, U+6959, U+695b-695f, U+6961-696c, U+696e-6970, U+6973-6974, U+6976, U+6978-697a, U+697c, U+6980, U+6984-6986, U+6988-698a, U+698d-698e, U+6990-6991, U+6994, U+6996-699b, U+699e, U+69a3-69a7, U+69ab, U+69ad, U+69af, U+69b1, U+69b3, U+69b6-69b7, U+69bb-69bc, U+69bf, U+69c1, U+69c3-69c5, U+69c7, U+69ca, U+69cc, U+69ce, U+69d0-69d1, U+69d4, U+69d8-69d9, U+69db, U+69df, U+69e4, U+69e8-69ea, U+69ed-69ee, U+69f1-69f4, U+69f6, U+69f8, U+69fa-69fb, U+69ff-6a00, U+6a05, U+6a0a-6a0b, U+6a17-6a18, U+6a1b, U+6a28-6a2b)
+);
+
+/* noto-sans-tc-[63]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-63-400-normal.woff2",
+    $range: (U+67d9, U+67db-67e0, U+67e2, U+67e4, U+67e9-67ea, U+67f0, U+67f2, U+67f6-67f8, U+67fa-67fb, U+67fe, U+6800-6805, U+6808-6809, U+680b, U+680e-680f, U+6811-6812, U+6814, U+6816, U+6818, U+681c-681e, U+6820, U+6822, U+6825, U+6827-6829, U+682b, U+682e-682f, U+6831-6834, U+683a-683b, U+683e, U+6840-6841, U+6844-6845, U+6849, U+684e, U+6853, U+6855-6856, U+685c-685d, U+685f, U+6861-6863, U+6865-6869, U+686b, U+686d, U+686f, U+6871-6872, U+6874-6875, U+6877, U+6879, U+687b-687c, U+687e, U+6880, U+6882-6883, U+6886, U+688f, U+6891-6892, U+6894, U+6896, U+6898, U+689b-689c, U+689f-68a0, U+68a2-68a3, U+68a6, U+68a9, U+68b1-68b2, U+68b4, U+68b6, U+68c0, U+68c3, U+68c6, U+68c8, U+68ca, U+68d0-68d1, U+68d3, U+68d6, U+68e1, U+68e3, U+68e6, U+68e8-68ec, U+68ef-68f1, U+68f3, U+68f6-68f7, U+68f9, U+68fb-68fd)
+);
+
+/* noto-sans-tc-[64]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-64-400-normal.woff2",
+    $range: (U+66a7, U+66aa, U+66b2-66b3, U+66b5, U+66b8-66bc, U+66be, U+66c1, U+66c4, U+66c7-66c8, U+66cc, U+66cf, U+66d5, U+66d8-66db, U+66df, U+66e1-66e2, U+66e8-66e9, U+66ef, U+66f1, U+66f5, U+66f7, U+66fa, U+66fd, U+6705, U+670a, U+670f-6710, U+6713-6715, U+6718-6719, U+6720, U+6722-6727, U+6729, U+672e, U+6733, U+6736, U+6738-6739, U+673f-6740, U+6742, U+6745, U+6747-6748, U+674b-674d, U+6753, U+6755, U+6759, U+675d-675e, U+6760, U+6762-6763, U+6767-676a, U+676c, U+676e, U+6772-6777, U+677a-677c, U+6782, U+6786-6787, U+678a-678c, U+678e-678f, U+6791-6793, U+6796, U+6798-6799, U+679f-67a3, U+67a5, U+67aa-67ae, U+67b0, U+67b2-67b5, U+67b7-67bc, U+67c0-67c3, U+67c5-67c6, U+67c8-67ca, U+67ce, U+67d2, U+67d8)
+);
+
+/* noto-sans-tc-[65]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-65-400-normal.woff2",
+    $range: (U+655d, U+6561, U+6564-6565, U+6567, U+656b, U+656d-656e, U+6573, U+6576, U+6579-657b, U+6581, U+6586, U+6588-6589, U+658b, U+658e, U+6593, U+6595, U+659b, U+659d, U+659f-65a1, U+65a9, U+65ab, U+65ad, U+65b2-65b3, U+65b5, U+65bb, U+65be-65bf, U+65c2-65c4, U+65c6, U+65cc, U+65ce, U+65d2, U+65d6, U+65db, U+65e1, U+65e3, U+65e7, U+65ee-65f0, U+65f2-65f4, U+65f7-65f8, U+65fc-65fd, U+6600, U+6603-6605, U+6609, U+660d, U+6610-6611, U+6619, U+661c-661e, U+6621-6622, U+6624, U+6626, U+6629, U+662b, U+6630, U+6633-6636, U+6639-663d, U+6640-6641, U+6644-6645, U+664a-664c, U+6653-6657, U+6659, U+665b, U+665d-665e, U+6661-6667, U+6669, U+666c, U+6672-6673, U+6677-6679, U+667b-667e, U+6681-6684, U+668b-6690, U+6692, U+6698, U+669d, U+669f-66a0, U+66a6)
+);
+
+/* noto-sans-tc-[66]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-66-400-normal.woff2",
+    $range: (U+6427-6428, U+642a-642b, U+642f-6430, U+6432, U+6434, U+6437, U+643a, U+643d-6444, U+6446-6447, U+644a-644b, U+644e, U+6450-6453, U+6456, U+6459, U+645b-645c, U+645e, U+6460-6461, U+6463-6465, U+6468, U+646c-646e, U+6470, U+6472-6477, U+6479, U+647b, U+647d, U+6480, U+6482, U+6485, U+648b-648c, U+6491, U+6493, U+6496-649a, U+649d, U+649f-64a0, U+64a2-64a3, U+64ac, U+64b1, U+64b3-64b4, U+64b7-64b9, U+64bb, U+64be, U+64c0, U+64c3-64c4, U+64d0, U+64d2, U+64d5, U+64d7-64d8, U+64e1-64e4, U+64e7, U+64e9, U+64ed, U+64ef-64f0, U+64f3, U+64f8, U+64fb-64fc, U+64ff, U+6504-6506, U+6509, U+6511-6512, U+6516, U+6518-6519, U+651b, U+6520-6523, U+6525-6526, U+6529, U+652b, U+652e, U+6530, U+6532, U+6534-6535, U+6537-6538, U+653a, U+653d, U+6542-6543, U+6549, U+654c-654e, U+6554-6555, U+655b)
+);
+
+/* noto-sans-tc-[67]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-67-400-normal.woff2",
+    $range: (U+630d-630e, U+6310, U+6312-6313, U+6319-631b, U+631d-6321, U+6323-6325, U+632d-632e, U+6332, U+6334-6339, U+633b-633c, U+633e-6340, U+6342-6346, U+634b-634c, U+634e, U+6352, U+6357, U+635a, U+635c, U+635e-635f, U+6361, U+6363, U+6365, U+6369, U+636b-636d, U+636f-6370, U+6373, U+6375-6376, U+637a-637b, U+637d, U+6381, U+6384, U+6387, U+638a, U+638d-638e, U+6390, U+6394-6397, U+639e-639f, U+63a3-63a4, U+63a6, U+63ac-63af, U+63b1-63b4, U+63b7, U+63b9-63bb, U+63bd-63be, U+63c3-63c4, U+63c8, U+63cd-63ce, U+63d1, U+63d6, U+63dc, U+63de, U+63e0, U+63e3-63e4, U+63e6, U+63e9, U+63f0, U+63f2-63f3, U+63f5-63f8, U+63fa, U+63fc-63fe, U+6400-6402, U+6405-6406, U+6409-640c, U+6410, U+6414-6415, U+6418, U+641b, U+641f-6423, U+6425-6426)
+);
+
+/* noto-sans-tc-[68]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-68-400-normal.woff2",
+    $range: (U+61c6, U+61ca-61cd, U+61d0, U+61d2, U+61de-61e0, U+61e3, U+61e6, U+61e8, U+61ed-61ee, U+61f5, U+61f9-61fa, U+61fd-61fe, U+6207, U+6209, U+620d-620e, U+6213-6215, U+6219, U+621b, U+621d-6223, U+6225-6227, U+6229, U+622b-622c, U+622e-622f, U+6231, U+6238, U+623b, U+623d-623e, U+6242-6243, U+6246, U+6248-6249, U+624c, U+6251, U+6255, U+6259-625a, U+625e, U+6260-6262, U+6265-6267, U+6269, U+626b-626c, U+6270-6273, U+6275, U+627a-627d, U+6283, U+6285-6286, U+6289, U+628c, U+628e, U+6294, U+629a-629e, U+62a0, U+62a2, U+62a6, U+62a8, U+62af, U+62b3, U+62b6, U+62ba-62bb, U+62be-62bf, U+62c2, U+62c4-62c5, U+62c8, U+62ca, U+62cf, U+62d1, U+62d5, U+62d7, U+62d9, U+62dd, U+62df-62e3, U+62e5-62e8, U+62ee, U+62f4-62fb, U+62fd, U+6300, U+6302, U+6308, U+630c)
+);
+
+/* noto-sans-tc-[69]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-69-400-normal.woff2",
+    $range: (U+60ac-60ad, U+60af-60b1, U+60b3-60b5, U+60b8, U+60bb, U+60bd-60be, U+60c0, U+60c6-60c7, U+60ca-60cb, U+60d3-60d5, U+60d7-60db, U+60dd, U+60e2-60e3, U+60e6-60f0, U+60f2, U+60f4, U+60f6, U+60fa-60fb, U+60ff-6100, U+6103, U+6106, U+610a-610b, U+610d-610e, U+6110, U+6112-6116, U+6120, U+6123-6124, U+6128-6130, U+6134, U+6136, U+613c-613f, U+6144, U+6146-6147, U+6149-614a, U+614d, U+6151-6153, U+6159-615a, U+615c-615f, U+6164-6165, U+6169-616d, U+616f, U+6171-6175, U+6177, U+617a, U+617c, U+617f-6180, U+6187, U+618a-618e, U+6192-6194, U+6199-619b, U+619f, U+61a1, U+61a7-61a8, U+61aa-61af, U+61b8, U+61ba, U+61bf, U+61c3)
+);
+
+/* noto-sans-tc-[70]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-70-400-normal.woff2",
+    $range: (U+5f78, U+5f7b, U+5f7d, U+5f82-5f84, U+5f87, U+5f89-5f8a, U+5f8d, U+5f93, U+5f95, U+5f98-5f99, U+5f9b-5f9c, U+5fa0, U+5fa4, U+5fa6-5fa8, U+5fab-5fad, U+5fb3-5fb4, U+5fbc, U+5fc4, U+5fc6, U+5fc9, U+5fcb, U+5fce-5fd6, U+5fdc-5fdf, U+5fe1, U+5fe4, U+5fe7, U+5fea, U+5fec-5fee, U+5ff1, U+5ff3, U+5ff8, U+5ffa-5ffc, U+5fff-6000, U+6002, U+6005, U+600a, U+600d, U+600f-6010, U+6014, U+6017, U+6019-601c, U+601e, U+6020, U+6022, U+6026, U+6029, U+602b-602c, U+602e-602f, U+6031, U+6033-6035, U+6039, U+603c, U+6040-6043, U+6045, U+6047, U+604a-604c, U+604f, U+6053, U+6059-605b, U+605d, U+6060, U+6063, U+6067, U+606a-606b, U+606e, U+6072-6076, U+6078, U+607a, U+607c, U+607f-6081, U+6083, U+6086, U+608a, U+608c, U+608e, U+6092-6093, U+6095-6097, U+609b, U+609d, U+60a2, U+60a6-60a7, U+60a9-60aa)
+);
+
+/* noto-sans-tc-[71]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-71-400-normal.woff2",
+    $range: (U+5e34, U+5e37, U+5e3a, U+5e3c, U+5e40, U+5e42-5e44, U+5e47, U+5e54, U+5e57-5e5b, U+5e5e-5e5f, U+5e61-5e62, U+5e64, U+5e6a, U+5e6c, U+5e6e, U+5e75, U+5e77, U+5e7a, U+5e80-5e81, U+5e83, U+5e86, U+5e88, U+5e8b, U+5e90, U+5e92, U+5e96, U+5e99, U+5e9b, U+5e9d-5ea2, U+5ea4-5ea5, U+5eb3-5eb6, U+5eb9, U+5ebe, U+5ec3-5ec4, U+5ec6, U+5ecb-5ecd, U+5ed0-5ed2, U+5ed4-5ed5, U+5ed8-5ed9, U+5edb, U+5edd, U+5ee1, U+5ee8-5ee9, U+5eec, U+5eef-5ef0, U+5ef4-5ef5, U+5ef8, U+5efb-5efc, U+5efe, U+5f01-5f03, U+5f05, U+5f07-5f09, U+5f0b-5f0e, U+5f10-5f12, U+5f14, U+5f16, U+5f1b, U+5f1d, U+5f22, U+5f25, U+5f28-5f29, U+5f2d, U+5f2f-5f30, U+5f36, U+5f38-5f39, U+5f3c, U+5f3e, U+5f40-5f42, U+5f45-5f46, U+5f4a, U+5f50-5f52, U+5f54, U+5f56-5f58, U+5f5a-5f5e, U+5f61, U+5f63, U+5f66-5f67, U+5f6b, U+5f72-5f74, U+5f76)
+);
+
+/* noto-sans-tc-[72]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-72-400-normal.woff2",
+    $range: (U+5ce0-5ce1, U+5ce5-5ce6, U+5ce8-5cea, U+5ced-5cee, U+5cf1, U+5cf4-5cf5, U+5cf8, U+5cfe-5d00, U+5d06, U+5d08, U+5d0a-5d0d, U+5d15, U+5d18, U+5d1a, U+5d1d, U+5d1f-5d22, U+5d24, U+5d26-5d28, U+5d2c-5d2e, U+5d33-5d35, U+5d3d, U+5d3f, U+5d42-5d43, U+5d46-5d47, U+5d49-5d4b, U+5d4e, U+5d52-5d53, U+5d57-5d59, U+5d5b-5d5c, U+5d65, U+5d68-5d69, U+5d6b-5d6c, U+5d6f, U+5d74-5d75, U+5d7e-5d7f, U+5d81-5d82, U+5d85-5d88, U+5d8b-5d8c, U+5d92, U+5d94, U+5d97, U+5d99, U+5d9d, U+5da0-5da2, U+5da7, U+5da9-5daa, U+5dae, U+5db2, U+5db4, U+5db7-5db8, U+5dbd, U+5dc2-5dc5, U+5dc9, U+5dcb-5dcd, U+5dd2, U+5dd6, U+5dd8, U+5ddb-5ddc, U+5de0, U+5de3, U+5de9, U+5df0, U+5df3, U+5df5, U+5df9, U+5dfb-5dfd, U+5e00-5e01, U+5e04-5e05, U+5e0a, U+5e11, U+5e14, U+5e18-5e1c, U+5e1f-5e22, U+5e27-5e28, U+5e2f-5e30)
+);
+
+/* noto-sans-tc-[73]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-73-400-normal.woff2",
+    $range: (U+5b80-5b82, U+5b84, U+5b8d, U+5b92-5b93, U+5b95-5b96, U+5b9f-5ba1, U+5ba6-5ba8, U+5baa-5bad, U+5bbd-5bbe, U+5bc0-5bc1, U+5bc3, U+5bd0-5bd1, U+5bd4-5bd8, U+5bdb-5bdd, U+5be4-5be5, U+5bef, U+5bf3, U+5bfb, U+5bfe-5bff, U+5c02-5c03, U+5c05, U+5c09, U+5c0c, U+5c10, U+5c12-5c13, U+5c15, U+5c18-5c19, U+5c1b, U+5c1d-5c1f, U+5c22, U+5c25, U+5c27-5c28, U+5c2a-5c2b, U+5c34, U+5c38, U+5c3d, U+5c42, U+5c44, U+5c47, U+5c49-5c4a, U+5c50, U+5c53, U+5c58-5c59, U+5c5b, U+5c5d, U+5c61, U+5c63, U+5c68, U+5c6d-5c6e, U+5c74, U+5c79-5c84, U+5c86, U+5c88, U+5c8a-5c8d, U+5c92-5c9c, U+5ca0, U+5ca2-5ca3, U+5ca5-5ca7, U+5cab-5cad, U+5cb5, U+5cb7, U+5cba-5cbb, U+5cc1, U+5cc8, U+5cca-5ccb, U+5cce, U+5cd2, U+5cd6, U+5cd8-5cda, U+5cdf)
+);
+
+/* noto-sans-tc-[74]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-74-400-normal.woff2",
+    $range: (U+5a51, U+5a53, U+5a56-5a57, U+5a5d-5a5e, U+5a60-5a62, U+5a65, U+5a67, U+5a6a, U+5a6c-5a6d, U+5a73-5a76, U+5a7a-5a7c, U+5a81-5a84, U+5a8c, U+5a90, U+5a93, U+5a96-5a97, U+5a9c, U+5a9e-5aa0, U+5aa4, U+5aa7, U+5aab-5aac, U+5aae-5aaf, U+5ab1, U+5ab4-5ab5, U+5ab8, U+5aba-5abc, U+5abe-5abf, U+5ac3-5ac4, U+5ac6-5acb, U+5acf-5ad2, U+5ad4-5adc, U+5ae0-5ae1, U+5ae3, U+5ae5-5ae6, U+5ae8, U+5aea-5aeb, U+5aee, U+5af0, U+5af2, U+5af5, U+5afa, U+5aff, U+5b01, U+5b05, U+5b08, U+5b0b, U+5b11, U+5b16-5b17, U+5b19, U+5b1b, U+5b1d, U+5b21-5b23, U+5b28, U+5b2a-5b2d, U+5b32, U+5b34, U+5b36-5b38, U+5b3e-5b40, U+5b43-5b46, U+5b4b-5b4c, U+5b51, U+5b53, U+5b59, U+5b5b-5b5c, U+5b62, U+5b65, U+5b6c-5b6e, U+5b70-5b73, U+5b75, U+5b7a-5b7b, U+5b7d, U+5b7f)
+);
+
+/* noto-sans-tc-[75]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-75-400-normal.woff2",
+    $range: (U+590b-590c, U+590e, U+5910-5911, U+5914, U+5919, U+591b, U+591f, U+5923-5924, U+592c, U+5932, U+5938-593a, U+5940, U+5942, U+5944, U+594b-594c, U+594e, U+5950, U+5953, U+5956, U+5958, U+595a, U+5961, U+5966, U+5968-5969, U+596c-596d, U+5975, U+5977, U+597b-597c, U+597e, U+5980-5981, U+5986-5988, U+598a, U+598f, U+5997-5998, U+599f-59a3, U+59a6-59a7, U+59a9, U+59ab-59ac, U+59af, U+59b1-59b2, U+59b6, U+59b8, U+59ba, U+59be, U+59c1, U+59c3, U+59c7-59c9, U+59cd-59ce, U+59d2, U+59d6-59d9, U+59dd-59de, U+59e0, U+59e3-59e5, U+59e9-59eb, U+59ee, U+59f1-59f3, U+59f5-59f9, U+59fc-59fd, U+5a00, U+5a04-5a07, U+5a09, U+5a0c, U+5a11, U+5a13, U+5a16-5a17, U+5a1a, U+5a1e, U+5a20, U+5a23-5a24, U+5a29-5a2b, U+5a2d-5a2f, U+5a32-5a34, U+5a38, U+5a3c, U+5a3f-5a44, U+5a47-5a48, U+5a4a, U+5a4c-5a4d, U+5a50)
+);
+
+/* noto-sans-tc-[76]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-76-400-normal.woff2",
+    $range: (U+57a1, U+57a4, U+57a6, U+57a9, U+57ab, U+57b5, U+57b8-57bb, U+57c2, U+57c5-57c8, U+57cc, U+57cf, U+57d2, U+57dc-57de, U+57e1-57e2, U+57e5, U+57e7, U+57ed-57ee, U+57f0, U+57f3-57f6, U+57f8, U+57fb-57fd, U+5800-5801, U+5803-5804, U+5807, U+5809-580b, U+580d-580e, U+5810-5811, U+5814-5815, U+5819, U+581d-581e, U+5820, U+5823, U+5826, U+582c-582d, U+5830, U+583a, U+583f-5841, U+5848, U+584b, U+584d, U+584f, U+5852, U+5859-585a, U+585c, U+5861, U+5864, U+5868-5869, U+586c-586d, U+5871-5872, U+5879, U+587c-5881, U+5887-5889, U+588e, U+5890-5892, U+5896-5899, U+589d, U+58a1, U+58a3, U+58a6, U+58a9, U+58ac, U+58b0-58b1, U+58bb-58bc, U+58c2, U+58c5-58c6, U+58ca, U+58cc, U+58ce, U+58d0-58d1, U+58d5, U+58d9-58da, U+58df-58e0, U+58e9, U+58ec, U+58ee, U+58f1-58f3, U+58f6-58f7, U+58fb-58fc, U+5900, U+5902, U+5906, U+5909-590a)
+);
+
+/* noto-sans-tc-[77]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-77-400-normal.woff2",
+    $range: (U+566f, U+5671-5672, U+5676, U+567a-567c, U+5680, U+5684-5686, U+568c, U+568e-568f, U+5692-5693, U+5697-5699, U+569c, U+569e, U+56a1-56a7, U+56a9, U+56ab-56ad, U+56af, U+56b3, U+56b5-56b6, U+56b8, U+56bf-56c1, U+56c3, U+56c5, U+56c7-56c8, U+56cb-56cc, U+56d2-56d4, U+56d6-56d9, U+56df, U+56e1-56e5, U+56ea-56ec, U+56ee-56ef, U+56f1-56f4, U+56f7, U+56f9, U+56ff-5700, U+5703-5704, U+5706-5707, U+5709-570a, U+570c, U+570f, U+5711, U+5717, U+571c, U+5723-5724, U+5727, U+5729-572a, U+572c, U+572e-572f, U+5734-5735, U+573b, U+5741, U+574b-574d, U+574f, U+5752, U+5754, U+575a-5760, U+5763, U+5768-5769, U+576b, U+576d, U+576f-5770, U+5772-5775, U+5777, U+577b-577d, U+5780, U+5784, U+5788, U+578c, U+578e, U+5792-5793, U+5795, U+579a-579b, U+579f-57a0)
+);
+
+/* noto-sans-tc-[78]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-78-400-normal.woff2",
+    $range: (U+5551, U+5553, U+5555-5557, U+555c, U+5562-5563, U+5567, U+5569, U+556b-556c, U+5570, U+5575-5579, U+557b-557c, U+557f, U+5581, U+5583, U+5586, U+5588, U+558b, U+558f, U+5591, U+5599, U+559f, U+55a1, U+55a3, U+55a5-55a6, U+55a8-55a9, U+55ab, U+55ad, U+55b0-55b1, U+55b3, U+55b6-55b7, U+55b9, U+55bc-55bd, U+55c4-55c5, U+55c7, U+55c9, U+55cc-55cd, U+55d0, U+55d2, U+55d4-55d9, U+55db, U+55dd-55df, U+55e1-55e6, U+55e9-55ea, U+55ec, U+55ee, U+55f1-55f3, U+55f5-55f7, U+55f9-55fa, U+55fe, U+5600-5602, U+5608, U+560c, U+560f, U+5612-5613, U+5615-5616, U+5618, U+561a, U+561c, U+561e, U+5620, U+5623-5625, U+5627, U+562a, U+562c-562e, U+5630-5631, U+5635-5636, U+5638-563a, U+5640, U+5642-5643, U+5649, U+564c-5650, U+5654, U+5658-565d, U+5664-5666, U+5669, U+566b, U+566d)
+);
+
+/* noto-sans-tc-[79]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-79-400-normal.woff2",
+    $range: (U+543d, U+543f, U+5441, U+5444-5445, U+5447, U+5449, U+544b-544d, U+5450-5455, U+5457, U+545b-545c, U+545f-5460, U+5463-5464, U+546a-5472, U+5474, U+5476, U+5478, U+547b, U+547e-547f, U+5482-5488, U+548a, U+548d-5491, U+5494, U+5498-549d, U+54a1-54a5, U+54ab, U+54ad-54af, U+54b5, U+54b7, U+54bb-54bc, U+54be-54bf, U+54ca, U+54cc, U+54cf-54d2, U+54d4, U+54d6-54d7, U+54da, U+54de-54df, U+54e2, U+54e4, U+54e7, U+54eb, U+54f3, U+54fd, U+54ff, U+5501-5502, U+5504-5506, U+550a, U+550c, U+550e-550f, U+5511-5513, U+5516-5517, U+551a-551b, U+551e, U+5520, U+5524, U+5526-5527, U+552a, U+552c-552d, U+5530, U+5532-5533, U+5535-5536, U+553b-553c, U+553e-553f, U+5541-5542, U+5544-5545, U+5547, U+5549, U+554b, U+554d-554e, U+5550)
+);
+
+/* noto-sans-tc-[80]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-80-400-normal.woff2",
+    $range: (U+52db, U+52e0, U+52e3, U+52e6-52e7, U+52eb, U+52ed-52ee, U+52f0-52f2, U+52f7, U+52f9-52fa, U+5300-5302, U+530a-530b, U+530d, U+530f-5310, U+5315, U+531a, U+531c-531d, U+532d-532e, U+5331, U+5338, U+533b-533e, U+5344-5345, U+534b-534d, U+534f-5350, U+5358, U+535e-535f, U+5362-5364, U+5367, U+5369, U+536b-536c, U+536e-536f, U+5372, U+5374, U+5379-537a, U+537c-537d, U+5382, U+5385, U+5389, U+538b-538c, U+538e, U+5392-5396, U+5399, U+53a0-53a2, U+53a4-53a6, U+53a8-53a9, U+53ae, U+53b0, U+53b3-53b4, U+53b6-53b7, U+53b9, U+53bf, U+53c1, U+53c4, U+53ce-53cf, U+53d2, U+53d5, U+53d9-53da, U+53df-53e1, U+53e7-53e9, U+53f1, U+53f5-53f6, U+53f9, U+53fb-53fd, U+5400-5402, U+5405-5407, U+540f, U+5412, U+5414-5417, U+541a, U+5420-5421, U+5424-5425, U+5428-5429, U+542c-542f, U+5431-5432, U+5434, U+5437)
+);
+
+/* noto-sans-tc-[81]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-81-400-normal.woff2",
+    $range: (U+518f, U+5191, U+5193, U+5195-5197, U+519a-519c, U+519e, U+51a2, U+51a6-51a9, U+51ab, U+51ad-51af, U+51b1-51b6, U+51ba-51c0, U+51c3-51c5, U+51c7, U+51c9-51cb, U+51ce-51d1, U+51d4, U+51d6, U+51d9, U+51db-51dc, U+51df, U+51e4, U+51e6, U+51e9-51ea, U+51ed, U+51ef, U+51f4-51f5, U+51fc, U+51ff, U+5201-5202, U+5204-5205, U+5208, U+520b, U+520d-520e, U+5213, U+5215-5216, U+5218, U+521a, U+5220, U+5223, U+5226-5228, U+5232-5234, U+5239, U+523c, U+5241-5242, U+5244, U+5249, U+524c, U+5251-5252, U+5255, U+5257, U+525c, U+525e, U+5261, U+5263-5265, U+526e, U+5270, U+5273-5274, U+5277, U+527d, U+527f, U+5281-5282, U+5284, U+528a, U+528c, U+528f, U+5292-5294, U+529d, U+52a6, U+52ac-52ad, U+52b1-52b5, U+52b9, U+52bb-52bc, U+52be-52c0, U+52c5, U+52cb, U+52cd, U+52d0-52d1, U+52d6-52d7)
+);
+
+/* noto-sans-tc-[82]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-82-400-normal.woff2",
+    $range: (U+5032, U+5036, U+503a-503b, U+503e, U+5040-5041, U+5043, U+5045-5046, U+5048, U+504a-504e, U+5051-5053, U+505d-5060, U+5063, U+506a, U+506f-5072, U+5078, U+507a-507b, U+507f-5080, U+5088-5089, U+508b-508c, U+508e, U+5092, U+5095-5096, U+509a-509d, U+50a3, U+50a5, U+50a8, U+50af, U+50b1, U+50b4, U+50ba, U+50c2, U+50c6-50ca, U+50cd-50ce, U+50d6, U+50d9, U+50dd-50df, U+50e1, U+50e3, U+50e5-50e6, U+50e8-50ea, U+50ec-50f0, U+50f3, U+50fb, U+50fe, U+5101-5102, U+5105-5109, U+510b-510e, U+5110, U+5113-5115, U+5117, U+511a-511c, U+511e, U+5120-5121, U+5125, U+512b, U+5131, U+5134-5135, U+5138-513c, U+5140, U+514e, U+5150-5151, U+5155-5157, U+515a, U+515f, U+5162, U+516a, U+516e, U+5172, U+5174, U+5179, U+517b, U+517d, U+5182, U+5186, U+5188-5189, U+518b)
+);
+
+/* noto-sans-tc-[83]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-83-400-normal.woff2",
+    $range: (U+4f22, U+4f24, U+4f29-4f2b, U+4f2d, U+4f31-4f32, U+4f35, U+4f37, U+4f39, U+4f3b, U+4f3e, U+4f41-4f43, U+4f47, U+4f49, U+4f4c, U+4f52, U+4f57-4f58, U+4f5a, U+4f5d-4f5f, U+4f61, U+4f63-4f64, U+4f67, U+4f6a, U+4f6e-4f6f, U+4f72, U+4f74, U+4f76-4f7b, U+4f7d-4f7e, U+4f80-4f82, U+4f84, U+4f89-4f8a, U+4f8e-4f94, U+4f96-4f98, U+4f9a, U+4f9e, U+4fa0-4fa3, U+4fa5-4fa8, U+4faa-4fac, U+4fb2-4fb3, U+4fb7-4fba, U+4fc0-4fc1, U+4fc5-4fc7, U+4fcb, U+4fcd-4fce, U+4fd1, U+4fd3-4fd4, U+4fd8-4fdc, U+4fdf, U+4fe2-4fe5, U+4fe8-4fea, U+4fec-4fed, U+4ff3-4ff6, U+4ff8-4ffa, U+4ffd, U+5000, U+5002, U+5005, U+5008, U+500c, U+500f, U+5013-5015, U+501b-501c, U+501e, U+5022-5025, U+5027-5028, U+502c-502e, U+5030-5031)
+);
+
+/* noto-sans-tc-[84]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-84-400-normal.woff2",
+    $range: (U+3a17, U+3a52, U+3b22, U+3bd7, U+3bff, U+3ca5, U+3d68, U+3ddb, U+3de7, U+3deb, U+3e03, U+3e74, U+3f08, U+3f0e, U+3f21, U+3f97, U+4102, U+411b, U+4181, U+43c8, U+4552, U+4576, U+46e5, U+4837, U+493d, U+4a3b, U+4d09, U+4e02, U+4e04-4e05, U+4e0c, U+4e0f-4e10, U+4e15, U+4e17, U+4e1b, U+4e21-4e22, U+4e25, U+4e27, U+4e31, U+4e34, U+4e36-4e37, U+4e3d, U+4e3f-4e42, U+4e44, U+4e47, U+4e49, U+4e4c, U+4e52-4e54, U+4e57, U+4e5a-4e5b, U+4e60-4e61, U+4e69, U+4e6d, U+4e78, U+4e80-4e81, U+4e85, U+4e87, U+4e89-4e8a, U+4e8d, U+4e8f, U+4e93, U+4e96, U+4e98-4e99, U+4e9c, U+4e9f-4ea0, U+4ea2, U+4ea5, U+4ea9, U+4eb0, U+4eb2-4eb3, U+4eb5-4eb7, U+4eb9, U+4ebb-4ebc, U+4ebf, U+4ec2-4ec6, U+4ec8-4ec9, U+4ecf, U+4ed1, U+4ed3, U+4edc-4ee1, U+4ee7-4eeb, U+4eee-4eef, U+4ef1, U+4ef3-4ef5, U+4efa, U+4efc, U+4f00, U+4f02-4f03, U+4f05, U+4f07-4f09, U+4f0b, U+4f0e, U+4f15, U+4f17, U+4f1d-4f1f)
+);
+
+/* noto-sans-tc-[85]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-85-400-normal.woff2",
+    $range: (U+305c, U+3062, U+306d, U+307a, U+307c, U+3080, U+308e, U+3090-3091, U+3099-309e, U+30a5, U+30c2, U+30c5, U+30ee, U+30f0-30f2, U+30f4-30f6, U+30fd-30fe, U+3105-3106, U+3108, U+310a-310b, U+310d-3119, U+311b-311e, U+3120-3126, U+3128-3129, U+3131, U+3134, U+3137, U+3139, U+3141-3142, U+3145, U+3147-3148, U+314b, U+314d-314f, U+3153, U+315c, U+3160-3161, U+3163-3164, U+3181, U+318d, U+3192-3193, U+3196-3198, U+319d-319f, U+3220-3226, U+3231, U+3268, U+3281, U+328b, U+3291-3292, U+3295-3297, U+3299, U+329d, U+329f, U+32a3-32a4, U+32d6, U+32e1, U+3314, U+3322, U+337f, U+338e-338f, U+339c-339e, U+33a1, U+33c4, U+33d1-33d2, U+3440, U+3449, U+3479, U+3551, U+3569, U+35ad, U+35ce, U+36ac, U+373a, U+3863, U+38ec, U+39b8, U+3a02)
+);
+
+/* noto-sans-tc-[86]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-86-400-normal.woff2",
+    $range: (U+2749-274f, U+2752-275b, U+275d-275e, U+2761, U+2763, U+2765-2769, U+276e-276f, U+2771, U+2776-277e, U+2780-2782, U+278a-278c, U+2794-2796, U+2798-2799, U+279c-27a6, U+27a8-27ab, U+27ad, U+27af-27b0, U+27b2-27b3, U+27b7-27b9, U+27bc-27bd, U+27bf, U+27e9-27eb, U+27f5-27f6, U+2800, U+28ec, U+2922, U+2934-2935, U+29bf, U+2a2f, U+2b05-2b07, U+2b1b, U+2b50, U+2b55, U+2cf5, U+2e1c-2e1d, U+2f00, U+2f08, U+2f12, U+2f24, U+2f29, U+2f2f, U+2f3c, U+2f3f, U+2f42, U+2f45, U+2f63-2f64, U+2f83, U+2f8f, U+3003-3007, U+3012-3013, U+3016-3019, U+3020-3025, U+3030, U+303d, U+3041, U+3043, U+3045, U+3047, U+3049, U+3052)
+);
+
+/* noto-sans-tc-[87]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-87-400-normal.woff2",
+    $range: (U+264a-2656, U+2658-265c, U+265e-2660, U+2662-2664, U+2666-2669, U+266b-266f, U+267b, U+2692-2696, U+2698, U+269b-269c, U+26a0-26a1, U+26a3-26a5, U+26aa-26ac, U+26bd-26be, U+26c4-26c5, U+26c8, U+26d1, U+26d3-26d4, U+26e4, U+26e9-26ea, U+26f0-26f5, U+26f9-26fa, U+26fd, U+2701-2702, U+2704-2706, U+2708, U+270a-2712, U+2714, U+2716-2727, U+2729-273e, U+2740-2748)
+);
+
+/* noto-sans-tc-[88]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-88-400-normal.woff2",
+    $range: (U+2567-2570, U+2572, U+2574, U+2579, U+2580-258a, U+258c-2595, U+2597, U+25a1, U+25a3-25a4, U+25a6-25ac, U+25b0, U+25b4, U+25b7-25b9, U+25bb, U+25bd, U+25bf-25c2, U+25c7-25ca, U+25cc-25cd, U+25d0-25d9, U+25dc-25e6, U+25ea-25eb, U+25ef, U+25fb-25fe, U+2600-2604, U+2607, U+2609-260b, U+260d-2615, U+2618, U+261a-2623, U+262a, U+262d-2630, U+2638-263e, U+2641-2642, U+2648-2649)
+);
+
+/* noto-sans-tc-[89]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-89-400-normal.woff2",
+    $range: (U+2476-2481, U+2488-2491, U+24b6-24c5, U+24c7-24ca, U+24cc, U+24ce, U+24d0-24df, U+24e1-24ea, U+24f5, U+24ff, U+2501, U+2503-250d, U+250f-2511, U+2513-2515, U+2517-2518, U+251b-251d, U+2520, U+2523-2524, U+2528, U+252b-252c, U+252f, U+2533-2534, U+2537, U+253b-253c, U+2541, U+2543-2545, U+254b, U+2550-2566)
+);
+
+/* noto-sans-tc-[90]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-90-400-normal.woff2",
+    $range: (U+2139, U+2153, U+2194-2197, U+2199, U+219d-219e, U+21a0, U+21a9-21aa, U+21ac, U+21af-21b1, U+21b3-21b5, U+21ba-21bb, U+21c4, U+21ca, U+21cc, U+21d0, U+21d2-21d4, U+21d8, U+21dd, U+21e2-21e9, U+2200, U+2202, U+2205-2208, U+220e-220f, U+2211-2212, U+2215, U+2217-221a, U+221d-2220, U+2225, U+2227-222b, U+222e, U+2234-2237, U+223c-223d, U+2248, U+2256, U+2260-2261, U+2264-2265, U+226a-226b, U+226e-226f, U+2282-2283, U+2295-2296, U+2299, U+22a5, U+22b0-22b1, U+22b9, U+22bf, U+22c5-22c6, U+22c8, U+22d0-22d1, U+22ee, U+2312-2313, U+2318, U+231a-231b, U+2323, U+2328, U+239d, U+23a0, U+23af, U+23e4, U+23e9-23ea, U+23ec, U+23f0-23f3, U+23fa, U+2445, U+2461-2471, U+2474-2475)
+);
+
+/* noto-sans-tc-[91]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-91-400-normal.woff2",
+    $range: (U+1ec0-1ec3, U+1ec5-1ec6, U+1ec9, U+1ecb-1ecd, U+1ecf-1ed1, U+1ed3-1ed5, U+1ed7-1edd, U+1edf, U+1ee1, U+1ee3-1ee7, U+1ee9, U+1eeb, U+1eed, U+1eef-1ef1, U+1ef3, U+1ef7, U+1ef9, U+1f62, U+1fa2, U+2001-2006, U+2009-200a, U+200c-200d, U+200f-2012, U+2015-2016, U+201a, U+201e, U+2020-2021, U+2023-2025, U+2028, U+202a-202d, U+202f-2030, U+2032-2033, U+2035, U+2038, U+203e-203f, U+2042-2044, U+2049, U+204d-204e, U+2060-2061, U+2063, U+2070, U+2074-207b, U+207d-2083, U+208a, U+208d-208e, U+20a1, U+20a4, U+20a6, U+20a8-20ab, U+20ad-20ae, U+20b1-20b3, U+20b5, U+20b8-20ba, U+20bd, U+20dd, U+20e3, U+2105, U+2109, U+2112-2113, U+2115-2117, U+2120-2121, U+2126, U+212b)
+);
+
+/* noto-sans-tc-[92]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-92-400-normal.woff2",
+    $range: (U+11af, U+11b7, U+11bc, U+121b, U+122d, U+129b, U+12a0, U+13a6, U+13a9, U+13ac, U+13af, U+13b3, U+13c2, U+13e3, U+141b, U+1555, U+1557, U+15dc, U+15e8, U+1780-1782, U+1784-1785, U+1787, U+178a, U+178e-1791, U+1793-179c, U+179f, U+17a2, U+17b6-17b9, U+17bb-17bc, U+17bf-17c7, U+17c9, U+17cb, U+17d0, U+17d2, U+17db, U+1871, U+18fa, U+1bff, U+1d00, U+1d04-1d05, U+1d07, U+1d0a-1d0b, U+1d0d, U+1d0f, U+1d17-1d18, U+1d1b-1d1c, U+1d20-1d22, U+1d25, U+1d2c, U+1d2e, U+1d30-1d31, U+1d33-1d3a, U+1d3c, U+1d3e-1d42, U+1d52, U+1d55, U+1d5b, U+1d5e, U+1d9c, U+1da0, U+1dc4-1dc5, U+1e3b, U+1e43, U+1e45, U+1e47, U+1e63, U+1e6d, U+1e73, U+1ea0, U+1ea2, U+1ea4-1ea9, U+1eab-1eaf, U+1eb1, U+1eb3, U+1eb5, U+1eb7, U+1eb9, U+1ebb, U+1ebd-1ebe)
+);
+
+/* noto-sans-tc-[97]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-97-400-normal.woff2",
+    $range: (U+2c8-2c9, U+2cc-2cd, U+2d0, U+2d8, U+2da, U+2dc, U+2e1-2e3, U+2e7, U+2eb, U+2ee, U+2f1-2ff, U+302-304, U+306-309, U+30c-30d, U+311, U+31b, U+321, U+323-325, U+328-329, U+32b-32c, U+32e-32f, U+331-33a, U+33c-33f, U+348, U+353, U+358-359, U+35c, U+35e-35f, U+361, U+363, U+367-368, U+36c, U+36f, U+530-535, U+537-540, U+55e, U+561-565, U+568-56d, U+56f-576, U+578-582, U+584, U+5a1, U+5a3-5a4, U+5aa, U+5ae, U+5b0-5b4)
+);
+
+/* noto-sans-tc-[98]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-98-400-normal.woff2",
+    $range: (U+1af, U+1b1, U+1b4-1be, U+1d0, U+1d2, U+1d4, U+1da, U+1dc-1dd, U+1e1, U+1e3-1e4, U+1e7, U+1e9, U+1eb-1ec, U+1f0-1f1, U+1f3-1f5, U+1f7, U+1f9-1ff, U+219, U+221, U+225-226, U+228-22b, U+22e-22f, U+231-235, U+239, U+23b, U+23e, U+250-252, U+254-255, U+259-25e, U+261-263, U+268-26b, U+26d, U+26f-277, U+279-27a, U+27d-281, U+283, U+28a-28c, U+28f, U+292, U+294-296, U+298-29a, U+29c, U+29f, U+2a1-2a2, U+2a4-2a7, U+2a9-2aa, U+2ae-2b3, U+2b5-2b7, U+2b9-2bf, U+2c2-2c4, U+2c6-2c7)
+);
+
+/* noto-sans-tc-[99]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-99-400-normal.woff2",
+    $range: (U+a1-a2, U+a4, U+a6-a8, U+aa, U+ac, U+af, U+b1, U+b5-b6, U+b8-ba, U+bc-be, U+c0-c8, U+ca-cc, U+ce-d5, U+d8-df, U+f0, U+f5, U+f8, U+fb, U+fe-100, U+102, U+105, U+107, U+109-10b, U+10f, U+112, U+115, U+117, U+119, U+11b, U+11f, U+121, U+123-124, U+127, U+129, U+12c-12d, U+130-13f, U+141-142, U+144, U+148, U+14b-14c, U+14f-153, U+159-15b, U+15e-160, U+163-166, U+169-16a, U+16d-171, U+173-17e, U+192, U+1a0, U+1a4, U+1aa, U+1ac-1ad)
+);
+
+/* noto-sans-tc-[100]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-100-400-normal.woff2",
+    $range: (U+a3, U+2ca, U+2223, U+2460, U+2640, U+273f, U+301c, U+3107, U+310c, U+4e30, U+4e3e, U+4e5e, U+4e71, U+4f26, U+4f7c, U+4f83, U+50da, U+5243, U+5267, U+529e, U+5321, U+5352, U+5477, U+548b, U+54a6, U+54b2, U+54c2, U+54c4, U+54c6, U+54cd, U+54ee, U+5543, U+55d1, U+55d3, U+55f0, U+55fd, U+560d, U+5629, U+5660, U+56d1, U+56dd, U+57ae, U+57e0, U+57e4, U+5904, U+592d, U+5965, U+5a31, U+5a7f, U+5b5a, U+5bb8, U+5c14, U+5c3b, U+5c5c, U+5c5e, U+5d10, U+5e10, U+5e4c, U+603b, U+604d, U+611c, U+6137, U+61c8, U+62c7, U+6371, U+6382, U+645f, U+64ae, U+64c2, U+651e, U+65f1, U+660a, U+663e, U+673d, U+6784, U+6789, U+67b1, U+67ff, U+6813, U+6854, U+68d8, U+68fa, U+697d, U+6a01, U+6a1e, U+6baf, U+6c08, U+6c17, U+6c2b, U+6c81, U+6cbd, U+6dc6, U+6df9, U+6ed9, U+6ee1, U+6f86, U+6fc1, U+6fdb, U+701f, U+7076, U+715c, U+7194, U+71ee, U+71fb, U+720d, U+72b6, U+7396, U+73af, U+745b, U+746f, U+748b, U+7647, U+7699, U+76ce, U+76de, U+77aa, U+786b, U+7881, U+78ca, U+793c, U+797a, U+79b9, U+79bb, U+79bf, U+7a92, U+7ac7, U+7ae3, U+7b19, U+7b20, U+7b51, U+7b94, U+7cbd, U+7cde, U+7cef, U+7d46, U+7dde, U+7f88, U+80da, U+814b, U+81cd, U+8235, U+8282, U+82b9, U+846b, U+84c1, U+84d3, U+8518, U+8611, U+8783, U+8814, U+8a15, U+8aa6, U+8b2c, U+8ba8-8ba9, U+8bc6, U+8be2, U+8be5-8be6, U+8c22, U+8d05, U+8d27, U+8dbe, U+8e34, U+8e66, U+8ec0, U+9005, U+9082, U+914b, U+916f, U+92c5, U+92f0, U+9318, U+938a, U+93e2, U+964b, U+96c1, U+96cc-96cd, U+96db, U+973e, U+97a0, U+9803, U+9876, U+9879, U+9955, U+99f1, U+9a5b, U+9ab7, U+9abc, U+9c57, U+9c9c, U+9d1b, U+9d26, U+9d51, U+9eef, U+9f99, U+c2a4, U+e253, U+e313-e314, U+e5c7, U+e5c9, U+e8db-e8dc, U+ff2d-ff2e, U+ff34, U+ffe5, U+1f60a, U+1f618, U+1f62d)
+);
+
+/* noto-sans-tc-[101]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-101-400-normal.woff2",
+    $range: (U+b4, U+10d, U+2d9, U+641, U+6cc, U+e20, U+e29, U+200e, U+20ac, U+2266, U+25be, U+301d-301e, U+3058, U+4e07, U+4e1d, U+4e66, U+4ece, U+4fde, U+5016, U+5180, U+5199, U+51aa, U+5306, U+5386, U+53d8, U+5413, U+541d, U+54ce, U+54e8, U+54fc, U+5571, U+557e, U+558e, U+55a7, U+56a8, U+57a2-57a3, U+58b3, U+5960, U+5992-5993, U+59a4, U+5a55, U+5ab2, U+5afb, U+5b56, U+5bc5, U+5bc7, U+5bf0, U+5cb1, U+5cc7, U+5dff, U+5e93, U+5ed3, U+5f6a, U+60bc, U+61ff, U+6218, U+6292, U+634d, U+6467, U+64f1-64f2, U+6582, U+65fb, U+6615, U+6687, U+66e6, U+66f0, U+6781, U+67f5, U+68a7, U+6a1f, U+6b27, U+6b4e, U+6b73, U+6b79, U+6bcb, U+6c5d, U+6cf5, U+6dee, U+6ec4, U+6ecc, U+6f88, U+701d, U+703e, U+707c, U+7099, U+710a, U+72d9, U+72e9, U+731d, U+739f, U+7463, U+7480, U+74a8, U+7523, U+7526, U+75e0, U+7613, U+7656, U+76bf, U+76d4, U+773a, U+775c, U+775e, U+780c, U+78e1, U+78f7, U+7960, U+7a20, U+7aaf, U+7b08, U+7b71, U+7be4, U+7cec, U+7cf0, U+7d5e, U+7d62, U+7dbe, U+7e1b, U+7ea2, U+7ec4, U+7ec6, U+7edc, U+7eed, U+7efc, U+7f16, U+7f57, U+7fb9, U+7fca, U+803d, U+816e, U+8258, U+82a5, U+82b7, U+8317, U+8338, U+834a, U+83d3, U+8401, U+8469, U+849e, U+854a, U+8559, U+865e, U+8700, U+8759, U+8760, U+8778, U+8782, U+879e, U+87d1, U+8836, U+8944, U+89c8, U+8aac, U+8b74, U+8ba2, U+8ba4, U+8bae, U+8bfb, U+8c4e, U+8cb3, U+8d16, U+8d28, U+8e44, U+8f3b, U+8f3f, U+8f91, U+8fb9, U+8fc4, U+8fde, U+8ff9, U+9076, U+9091, U+90ae, U+90b8, U+9257, U+9310, U+9382, U+93df, U+94fe, U+95a5, U+962e, U+968f-9690, U+9704, U+9713, U+97f6, U+9824, U+986b, U+9884, U+9886, U+98e2, U+991a, U+9986, U+99a5, U+99dd, U+9ab8, U+9b41, U+9b77, U+9bad, U+c774, U+e5d4, U+fe52, U+ff02, U+ff25, U+1f389, U+1f449, U+1f495)
+);
+
+/* noto-sans-tc-[102]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-102-400-normal.woff2",
+    $range: (U+2cb, U+5d1, U+5d9, U+5e2, U+5e8, U+5ea, U+633, U+e32, U+2252, U+2267, U+2573, U+25b3, U+25c4, U+2713, U+2715, U+30e2, U+4e28, U+4e3c, U+4e4d, U+4e70, U+4f88, U+4fef, U+5018, U+501a, U+5026, U+5137, U+513f, U+51f3, U+524b, U+5254, U+52d8, U+5308, U+5384, U+53cc, U+5436, U+5443, U+5466, U+54a8, U+54bd, U+54c9, U+54cb, U+555e, U+5580, U+560e, U+561f, U+562f, U+566c, U+5679, U+56bc, U+56cd, U+56e7, U+56ed, U+572d, U+57d7, U+582f, U+589f, U+5b09, U+5ba5, U+5c51, U+5c90, U+5cef, U+5d16, U+5d84, U+5dd4, U+5e08, U+5e26, U+5f0a, U+5f20, U+606c, U+61c7, U+620f, U+6254, U+625b, U+62a4, U+62d0, U+62f1, U+63a0, U+63c6, U+63f9, U+6413, U+6417, U+6483, U+64f7, U+650f, U+65a7, U+665f, U+66ae, U+66d6, U+66e0, U+6746, U+6756, U+67d1, U+6837, U+68e0, U+68f5, U+6995, U+69a8, U+69b4, U+69d3, U+6a3d, U+6abb, U+6bb7, U+6bd3, U+6c47, U+6cc4, U+6cd3, U+6dae, U+6e26, U+6e29, U+6eaf, U+6eba, U+6fef, U+7028, U+70b3, U+711a, U+725f, U+7325, U+733f, U+73c0, U+73ee, U+7444, U+745a, U+7487, U+7540, U+75a4, U+7729, U+779e, U+798e, U+79e9, U+7a3d, U+7a4c, U+7a9f, U+7ac4, U+7aff, U+7c27, U+7cd9, U+7d76, U+7e43, U+7ea6, U+7ed9, U+7ff1, U+808b, U+809b, U+80fa, U+827a, U+8309, U+8328, U+832b, U+8396, U+83e0, U+840e, U+8425, U+852d, U+853b, U+8588, U+85e9, U+86b5, U+86e4, U+8718, U+87ec, U+880d, U+8910, U+893b, U+89c1-89c2, U+8b3e, U+8baf, U+8bc1, U+8bdd, U+8c41, U+8c48, U+8cb6, U+8d2d, U+8d5e, U+8fbe, U+9015, U+90a8, U+90b5, U+90e1, U+9169, U+9183, U+91d0, U+91dc, U+9293, U+92f8, U+9472, U+9598, U+95a9, U+95ed, U+95fb, U+9605, U+96c7, U+9739, U+9742, U+9761, U+99ad, U+9ae6, U+9b1a, U+9b44, U+9bc9, U+9d3f, U+9dd7, U+9e7c, U+9e92, U+fe5d-fe5e, U+ff22-ff24, U+ff2f-ff30, U+ff33)
+);
+
+/* noto-sans-tc-[103]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-103-400-normal.woff2",
+    $range: (U+60, U+f7, U+2198, U+2571, U+258b, U+25b6, U+2661, U+3051, U+3109, U+311a, U+4e11, U+4e24, U+4e2b, U+4ef7, U+4f18, U+4f36, U+4fd0, U+5029-502a, U+5055, U+508d, U+50ad, U+50e7, U+50f1, U+50f5, U+51a5, U+51c8, U+51fb, U+5203, U+524e, U+5288, U+5323, U+53c2, U+5458, U+54a7, U+54b1, U+54b3, U+54b8, U+556a, U+5582, U+55b2, U+55ba, U+55da, U+55dc, U+5614, U+5662, U+5678, U+56c2, U+5742, U+57d5, U+5862, U+58e4, U+58f0, U+5907, U+590d, U+5934, U+5978, U+5984, U+5a25, U+5c06, U+5c62, U+5c91, U+5d01, U+5d1b, U+5e87, U+5eff, U+5f27, U+5f3a, U+5f53, U+6001, U+6168, U+61a9, U+6233, U+62a5, U+62ce, U+62ed, U+638f, U+6399, U+646f, U+6590, U+6631, U+664f, U+6689, U+66dc, U+672f, U+67af, U+67ec, U+68d7, U+6977, U+6a44, U+6c14, U+6c40, U+6c70, U+6c76, U+6cb8, U+6ce3, U+6df3, U+6e20, U+6e43, U+6e5b, U+6ebc, U+6eec, U+6f2c, U+6fb1, U+7009, U+7011, U+701a, U+7117, U+7184, U+72f9, U+7426, U+74bd, U+74cf, U+752b, U+7554, U+75b9, U+7621, U+7671-7672, U+7693, U+76ef, U+7737, U+77a7, U+77b3, U+77bb, U+77da, U+77e2, U+77e9, U+77ef, U+7801, U+7940, U+797f, U+79a7, U+79b1, U+79bd, U+79cd, U+7a6b, U+7ac5, U+7b1b, U+7b77, U+7ca7, U+7dab, U+7db4, U+7db8, U+7dcb, U+7ddd, U+7de0, U+7e55, U+7e9c, U+7ed3, U+7ef4, U+803f, U+8046, U+8087, U+8116, U+81a8, U+8214, U+821c, U+82d4, U+831c, U+8339, U+8350, U+8354, U+8526, U+860a, U+86db, U+8713, U+873b, U+8822, U+8993, U+8a1f, U+8ab9, U+8ad7, U+8bcd, U+8e72, U+8f4e, U+8f9c, U+8fd0, U+8fd8, U+8fe6, U+9042, U+907c, U+91ba, U+9452, U+95e2, U+9631, U+9699, U+96b8, U+9709, U+978d, U+9830, U+98ce, U+9945, U+99ed, U+9a8c, U+9ad3, U+9baa, U+9be8, U+9c77, U+9cf6, U+9d72, U+9e1f, U+9ec4, U+fe31, U+fe55, U+ff03, U+ff20, U+ff3b, U+ff3d, U+1f3fb, U+1f44d, U+1f60d)
+);
+
+/* noto-sans-tc-[104]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-104-400-normal.woff2",
+    $range: (U+10c, U+161, U+e44, U+2728, U+3081, U+4e13, U+4e19, U+4e1c, U+4e1e, U+4e5c, U+4ea7, U+4ed7, U+4f20, U+4f8d, U+4ffe, U+5021, U+50d5, U+515c, U+51a4, U+51e0, U+521b, U+522b, U+532a, U+534e, U+5355, U+537f, U+5398, U+541f, U+543c, U+544e, U+5509, U+5598, U+5622, U+563f, U+5641, U+566a, U+5695, U+569f, U+56ae, U+56da, U+573a, U+574e, U+584c, U+5885, U+58ae, U+5a1f, U+5ac2, U+5b24, U+5bb0, U+5bde, U+5be1, U+5bfc, U+5c39, U+5c4c, U+5c60, U+5cfb, U+5d11, U+5e76, U+5e7f, U+5e9a, U+5eb8, U+5f13, U+5f64, U+5f6c, U+6127, U+61f2, U+6208, U+620a, U+620c, U+6252, U+62ef, U+6328, U+633d, U+6362, U+63b0, U+63c0, U+63c9, U+640f, U+64a9, U+6514, U+652c, U+655e, U+6583, U+658c, U+6627, U+66f3, U+6734, U+6743, U+676d, U+67c4, U+67da, U+6807, U+68cd, U+68f2, U+690e, U+6b16, U+6b38, U+6b3d, U+6bc6, U+6ca1, U+6cab, U+6d8c, U+6e32, U+6e3e, U+6e58, U+6eef, U+6ef2, U+708a, U+7130, U+7165, U+7172, U+71ed, U+7232, U+7239, U+7261, U+7280, U+72a7, U+72f8, U+73c8, U+7464, U+753b, U+754f, U+755c, U+75d8, U+76ea, U+776b, U+7779, U+777f, U+7784, U+778e, U+77ee, U+79e4, U+7a46, U+7a57, U+7aba, U+7aed, U+7b4d, U+7c7b, U+7c7d, U+7d13, U+7d33, U+7dbb, U+7df9, U+7e46, U+7ea7, U+8085, U+8165, U+81fb, U+82b8, U+82d3, U+8305, U+8335, U+8343, U+83e9, U+840d, U+851a, U+853d, U+8543, U+859b, U+85fb, U+87fb, U+888d, U+88c5, U+8adc, U+8b0a, U+8bb0, U+8bbe, U+8bc4, U+8bf4, U+8c5a, U+8cc3, U+8ce4, U+8d44, U+8e81, U+8f44, U+8f66, U+8fdb, U+900d, U+9063, U+914c, U+9223, U+9226, U+923a, U+925b, U+9264, U+929c, U+92b9, U+9320, U+934d, U+9444, U+957f, U+9591, U+96a7, U+97ad, U+97cc, U+9811, U+9898, U+98ea, U+9921, U+9952, U+9a55, U+9b0d, U+9bca, U+9ebd, U+e60f, U+ff1c-ff1d, U+ff21, U+ff38, U+ff9f, U+fffd, U+1f602)
+);
+
+/* noto-sans-tc-[105]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-105-400-normal.woff2",
+    $range: (U+e17, U+e22, U+2103, U+25a0, U+266a, U+3014-3015, U+311f, U+4e1a, U+4e50, U+4f10, U+4f6c, U+4f70, U+5006, U+50d1, U+5170, U+518c, U+51f0, U+51f6, U+51f9, U+5219, U+5256, U+525d, U+52c9, U+5349, U+5351, U+5356, U+5375, U+539d, U+53db, U+53ee, U+53f7, U+5492, U+54fa, U+5538, U+55bb, U+55e8, U+5632, U+5757, U+5835, U+58be, U+5937, U+59dc, U+59e8, U+5a49, U+5a9a-5a9b, U+5ab3, U+5b9b, U+5b9e, U+5be8, U+5c37, U+5c4e, U+5d14, U+5d19, U+5d4c, U+5d50, U+5deb, U+5e84, U+5e94, U+5ec2, U+5f17, U+5f26, U+5f55, U+5f77, U+5f7f, U+5fbd, U+6052, U+6064-6065, U+608d, U+609a, U+6101, U+614c, U+621a, U+6237, U+6296, U+62e9, U+632a-632b, U+6488, U+6500, U+652a, U+6556, U+65e0, U+65ec, U+6643, U+6850, U+6893, U+6897, U+68b3, U+68d5, U+6930, U+6960, U+6a11, U+6a3a, U+6ab3, U+6b22, U+6c59, U+6c83, U+6ccc, U+6dea, U+6df5, U+6ef7, U+6f3e, U+6f80, U+6fe4, U+7164, U+71c9, U+722a, U+7260, U+7272, U+73b0, U+74e3, U+7538, U+7586, U+75b5, U+7661-7662, U+77db, U+7838, U+786e, U+788c, U+7950, U+79a6, U+79aa, U+7a40, U+7bf7, U+7c3e, U+7c98, U+7ca5, U+7d21, U+7d2e, U+7dba, U+7dec, U+7e79, U+7ecf, U+7edf, U+7f79, U+8086, U+810a, U+8139, U+813e, U+817a, U+81b3, U+821f, U+8247, U+8259, U+8271, U+839e, U+8431, U+846c, U+849c, U+84b2, U+84c4, U+8513-8514, U+8755, U+8877, U+8881, U+88f9, U+8a1d, U+8a3c, U+8a6d-8a6e, U+8a93, U+8ae7, U+8af7, U+8b17, U+8b5a, U+8ba1, U+8bba, U+8cdc, U+8dea, U+8f6c, U+8f7d, U+8fc7, U+8fd9, U+902e, U+90ca, U+916a, U+916c, U+921e, U+9245, U+935b, U+9594, U+95a8, U+95ee, U+95f4, U+9706, U+971e, U+9756, U+980c, U+9891, U+98b1, U+98fc, U+9903, U+9957, U+99ff, U+9b91, U+9db4, U+9f4b, U+e602-e605, U+e610-e611, U+ff16-ff19)
+);
+
+/* noto-sans-tc-[106]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-106-400-normal.woff2",
+    $range: (U+2190-2191, U+2193, U+22c1, U+2302, U+25cb, U+2699, U+2709, U+3127, U+4e0e, U+4e18, U+4e3a, U+4e48, U+4e91, U+4eec, U+4f3d, U+4fcf, U+5112, U+524a, U+52a3, U+52ab, U+52c3, U+52f3, U+52fb, U+5320, U+5339, U+533f, U+53e2, U+543e, U+5480, U+5495, U+5497, U+5564, U+5572, U+55c6, U+55ef, U+563b, U+5653, U+5657, U+56b7, U+5824, U+58d8, U+5955, U+5983, U+598d, U+59da, U+59e6, U+5a36, U+5bb5, U+5bc2, U+5bf9, U+5cb3, U+5d17, U+5dbc, U+5e2e, U+60df, U+611a, U+6190, U+61a4, U+61be, U+61fc, U+6284, U+62ac, U+62bc, U+634f, U+636e, U+6398, U+63a9, U+6487, U+6495, U+64ab, U+6577, U+65ac, U+6602, U+6652, U+66f9, U+6761, U+679a, U+683d, U+68ad, U+68b5, U+68da, U+68e7, U+6a38, U+6a59, U+6ae5, U+6b47, U+6b67, U+6b6a, U+6bef, U+6c50, U+6c9b, U+6e23, U+6e34, U+6e4a, U+6e67, U+6ea2, U+6eb6, U+6f20, U+6feb, U+70ed, U+714c, U+715e, U+7199, U+71ac, U+7231, U+7262, U+7409, U+745f, U+7469, U+74ca, U+7535, U+753a, U+75f4, U+7624, U+7682, U+76ba, U+76f2, U+77fd, U+780d, U+7832, U+78c5, U+78ef, U+7901, U+79be, U+79c9, U+79e6, U+7a1a, U+7a62, U+7a84, U+7aca, U+7cb5, U+7cb9, U+7cdf, U+7ce7, U+7d6e, U+7db1, U+7def, U+7e61, U+7e7d, U+7e8f, U+7f38, U+7f77, U+7fa8, U+7fc5, U+7fe1, U+7ff9, U+800d, U+8015, U+8054, U+80a2, U+80aa, U+80ba, U+814e, U+8180, U+819d, U+81c0, U+828b, U+82ad, U+82af, U+83f1, U+83f8, U+8403, U+84bc, U+84c9, U+84ec, U+8523, U+8549, U+8569, U+8591, U+85b0, U+881f, U+884d, U+88d4, U+89c4, U+89c6, U+8a60, U+8a79, U+8b19, U+8bd5, U+8bf7, U+8c03, U+8c79, U+8cc8, U+8d9f, U+8e10, U+8e48, U+8faf, U+9009, U+9017, U+9175, U+9187, U+918b, U+9214, U+946b, U+9470, U+947c, U+9640, U+9675, U+96ef, U+97cb, U+97e9, U+985b, U+99ae, U+99b3, U+9b4f, U+9d09, U+9e9f, U+9edb, U+9f90, U+ff14, U+1f464)
+);
+
+/* noto-sans-tc-[107]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-107-400-normal.woff2",
+    $range: (U+a5, U+25ce, U+4e56, U+4e9a, U+4ea8, U+4ead, U+4f3a, U+4f51, U+4f62, U+4faf, U+5098, U+50ac, U+5147, U+5173, U+5187, U+51f8, U+52a1, U+52a8, U+52f8, U+535c, U+53ed, U+541e, U+5435, U+5475, U+54a9, U+54c0, U+54c7, U+5589, U+5605, U+5733, U+5764, U+5782, U+57c3, U+5858, U+5893, U+589c, U+58e2, U+5974, U+599e, U+59a8, U+59ec, U+5b66, U+5b99, U+5b9d, U+5bee, U+5c2c, U+5c65, U+5cfd, U+5d0e, U+5dba, U+5de2, U+5e06, U+5e15, U+5ec1, U+5ed6, U+5f00, U+5f4c, U+5f65, U+6055, U+6070, U+609f, U+60b6, U+6241, U+624e, U+626f, U+6291, U+62cc, U+62d8, U+62da, U+62fe, U+6349, U+6367, U+63ea, U+6435, U+6454, U+64a4, U+64b2, U+64bc, U+64bf, U+64c5, U+64ce, U+6558, U+6572, U+65a5, U+65e8, U+65ed, U+6614, U+6670, U+6688, U+672d, U+673a, U+6770, U+68cb, U+6912, U+6953, U+6a61, U+6aac, U+6aaf, U+6ab8, U+6b20, U+6b96, U+6bbf, U+6bc5, U+6c6a, U+6cbe, U+6d59, U+6d78, U+6dc7, U+6deb, U+6e7e, U+6e9c, U+6f3f, U+6f51, U+6f84, U+704c, U+7051, U+70ab, U+70ad, U+70f9, U+7119, U+7149, U+714e, U+71e6, U+72c4, U+72d0, U+72e0, U+7334, U+744b, U+7455, U+7504, U+75ab, U+75b2, U+766e, U+76c3, U+76fc, U+76fe, U+7891, U+7948, U+7a74, U+7b28, U+7c72, U+7cca, U+7ebf, U+7f55, U+7ff0, U+8154, U+81c2, U+81d8, U+81e3, U+81e5, U+8292, U+8299, U+8302, U+8304, U+8332, U+83c1, U+83c7, U+83ca, U+845b, U+8475, U+8490, U+85af, U+8650, U+8667, U+86d9, U+8774, U+8abc, U+8b0e, U+8b39, U+8bed, U+8c54, U+8c6b, U+8c9e, U+8ca7, U+8caa-8cab, U+8ce6, U+8cec-8ced, U+8eb2, U+8eba, U+8fb0, U+901d, U+908f, U+9127, U+91c0, U+91d8, U+9215, U+92b3, U+932b, U+93fd, U+95ca, U+964c, U+96c0, U+970d, U+9716, U+9774, U+97fb, U+9812, U+9913, U+9935, U+99c1, U+9b31, U+9d5d, U+9d6c, U+9e79, U+fe0f, U+fe30, U+ff05, U+ff0b, U+ff10, U+ff15)
+);
+
+/* noto-sans-tc-[108]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-108-400-normal.woff2",
+    $range: (U+b0, U+926, U+928, U+939, U+93f-940, U+94d, U+200b, U+22ef, U+25ba, U+25c6, U+2665, U+4e08, U+4e2a, U+4e4f, U+4e59, U+4ec7, U+4f0d, U+4f0f, U+4f19, U+4f59, U+4fae, U+5075, U+507d, U+50b2, U+50b5, U+511f, U+5141, U+5146, U+514c, U+5185, U+51dd, U+51fd, U+522e, U+5319, U+533a, U+5378, U+53ad, U+53c9, U+53d1, U+53d4, U+543b, U+5442, U+5446, U+5481, U+54e9, U+5507, U+5565, U+559a, U+55aa, U+5690, U+56ca, U+56fe, U+582a, U+5915, U+5949, U+5962, U+5996, U+59a5, U+59fb, U+5a77, U+5b0c, U+5b5f, U+5bd3, U+5be2, U+5bfa, U+5c41, U+5c48, U+5ca9, U+5d07, U+5ec8, U+5eca, U+5f18, U+5f4e, U+5f59, U+5f6d, U+5f79, U+5fb9, U+6028, U+6068, U+606d, U+6094, U+60f1, U+6108-6109, U+614e, U+6170, U+617e, U+61b2, U+61f8, U+6247, U+626d, U+6276, U+62ab, U+62cb, U+62d3, U+62f3, U+6368, U+6380, U+6492, U+64e0, U+6570, U+6606, U+660f, U+6649, U+6691, U+66a8, U+6749, U+674f, U+6795, U+67f1, U+67f3, U+6842, U+6851, U+687f, U+68df, U+69fd, U+6a58, U+6c27, U+6c88, U+6cca, U+6d29, U+6d66, U+6daf, U+6f01, U+6f58, U+6f6d, U+6f70, U+6fa1, U+6ff1, U+6ffe, U+7058, U+70ae, U+71d9, U+71e5, U+7235, U+7267, U+73ca, U+742a, U+74f7, U+7529, U+758f, U+75bc, U+76c6, U+7955, U+7a00, U+7a3b, U+7b4b, U+7bad, U+7be9, U+7c4c, U+7c60, U+7cfe, U+7dbf, U+7e2b, U+7f9e, U+7fc1, U+7ffc, U+8096, U+809d, U+80de, U+8155, U+816b, U+81df, U+82bd, U+8352, U+8393, U+8404, U+8525, U+856d, U+8606, U+868a, U+87f9, U+886b, U+8870, U+896a, U+896f, U+8a23, U+8a87, U+8ad2, U+8b00, U+8b20, U+8cb8, U+8cca, U+8ce0, U+8d39, U+8d6b, U+8db4, U+8e29, U+8ef8, U+8f1b, U+8f5f, U+8fa8, U+906e, U+9077, U+90aa, U+90b1, U+90c1, U+9165, U+919c, U+92c1, U+95d6, U+95e8, U+975a, U+9817, U+98c6, U+9ecf, U+feff, U+ff06, U+ff0a, U+ff12-ff13)
+);
+
+/* noto-sans-tc-[109]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-109-400-normal.woff2",
+    $range: (U+627-629, U+631, U+639, U+644, U+64a, U+25cf, U+2606, U+2764, U+3008-3009, U+4e38, U+4e43, U+4ed5, U+4ef0, U+4eff, U+4fe0, U+5085, U+50a2, U+50be, U+5118, U+5211-5212, U+5272, U+52fe, U+5366, U+53b2, U+53ec, U+54ac, U+5587, U+55b5, U+5606, U+561b, U+5751, U+576a, U+57cb, U+58ef, U+58fa, U+594f, U+5951, U+596e, U+59d1, U+5ac1, U+5acc, U+5b8b, U+5c4d, U+5ca1, U+5d29, U+5dfe, U+5e7d, U+5edf, U+5ef7, U+5fa1, U+5faa, U+5fcc, U+5ffd, U+6021, U+6046, U+6062, U+62b9, U+6316, U+6350, U+6478, U+647a, U+6490, U+64b0, U+64e6, U+6524, U+6591, U+659c, U+65a4, U+65e6, U+65f6, U+6607, U+6674, U+6765, U+679d, U+67f4, U+68a8, U+6b3a, U+6c57, U+6c61, U+6c90, U+6cbf, U+6cdb, U+6d69, U+6db5, U+6dd1, U+6e21, U+6f06, U+6f62, U+70d8, U+71c3, U+71d5, U+722c, U+727d, U+72ac, U+72fc, U+731c, U+7336, U+7344, U+7384, U+73ab, U+7433, U+745c, U+7470, U+75d5, U+7652, U+76c8, U+76e7, U+7709, U+7720, U+7740, U+7747, U+7763, U+77ac-77ad, U+7802, U+78a7, U+78b3, U+78c1, U+78da, U+7926, U+796d, U+798d, U+7aae, U+7b52, U+7c92, U+7d68, U+7d81, U+7e31, U+7e5e, U+7e69, U+7e73, U+7f50, U+7f70, U+7f75, U+8058, U+8070, U+80c3, U+8105-8106, U+8108, U+8179, U+818f, U+81a9, U+81ed, U+820c-820d, U+8277, U+82d1, U+8461, U+84b8, U+852c, U+857e, U+8587, U+85e4, U+863f, U+8679, U+86c7, U+8702, U+8776, U+87ba, U+8896, U+88c2, U+88d5, U+88f8, U+8af8, U+8b7d, U+8ca2, U+8d64, U+8d74, U+8d81, U+8d99, U+8e5f, U+8e8d, U+8ecc, U+8ed2, U+8fb1, U+8fc5, U+9022, U+9038, U+905c, U+9081, U+9189, U+9234, U+92d2, U+934a, U+95a3, U+962a, U+9646, U+96d5, U+971c, U+9838, U+9875, U+98c4, U+99db, U+9a45, U+9a5f, U+9a6c, U+9ad2, U+9cf4, U+9d28, U+9daf, U+9df9, U+9e7d, U+9f0e, U+9f52, U+9f9c, U+ff11, U+ff1e)
+);
+
+/* noto-sans-tc-[110]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-110-400-normal.woff2",
+    $range: (U+2022, U+2500, U+25bc, U+4e1f, U+4e95, U+4f50, U+4f54, U+4f69, U+4fb6, U+4fc4, U+4fca, U+5009, U+50bb, U+5154, U+51cc, U+528d, U+5291, U+52d2, U+52e4, U+5353, U+5360, U+540a-540b, U+5410, U+54f2, U+5514, U+5537, U+558a, U+55ac, U+5617, U+56fd, U+573e, U+5766, U+5783, U+57d4, U+5806, U+5821, U+5857, U+5875, U+58f9, U+592f, U+5954, U+596a, U+59ae, U+59c6, U+59ca, U+59ff, U+5a03, U+5ae9, U+5b64, U+5bb4, U+5c3f, U+5c6f, U+5de1, U+5e16, U+5e45, U+5e72, U+5ec9, U+5f7c, U+5f81, U+5f90-5f92, U+6016, U+6085, U+6089, U+60a0, U+60a3, U+60b2, U+60d1, U+60f9, U+6155, U+6158, U+6191, U+6212, U+626e, U+62d4, U+632f, U+633a, U+63aa, U+642c, U+64a5, U+64cb, U+6566, U+6597, U+66b1, U+66ec, U+6731, U+6735, U+67ef, U+6846, U+6876, U+6881, U+68af-68b0, U+68c9, U+6905, U+6bc0, U+6beb, U+6c0f, U+6c1b, U+6c41, U+6ce5, U+6cf3, U+6d25, U+6d2a, U+6d3d, U+6dcb, U+6dd8, U+6dfa, U+6e9d, U+6eaa, U+6ec5, U+6ecb, U+6f0f, U+6f32, U+707d, U+708e, U+7092, U+716e, U+723a, U+731b, U+7345, U+7375, U+73b2, U+7434, U+74e6, U+758a, U+75be, U+75de, U+764c, U+76dc, U+788e, U+7897, U+789f, U+78a9, U+78b0, U+790e, U+7965, U+7a4e, U+7c43, U+7d17, U+7dd2, U+7e96, U+7f51, U+7f69, U+7f72, U+7fd4, U+7fe0, U+8017, U+80a9, U+80d6, U+8150, U+8178, U+81bd, U+829d, U+82ac, U+8303, U+838e, U+83cc, U+840c, U+8482, U+8499, U+85a9-85aa, U+883b, U+8861, U+88c1, U+88cf, U+88d9, U+8a3a, U+8a98, U+8aee, U+8c8c, U+8cc0, U+8ce2, U+8d0f, U+8da8, U+8dcc, U+8e0f, U+8f1d, U+8f29, U+8fad, U+9003, U+9006, U+903c, U+903e, U+9059, U+9072, U+9075, U+90ce, U+9130, U+91ac, U+91e3, U+9285, U+9298, U+92ea, U+9326, U+937e, U+95c6, U+9676-9677, U+9727, U+994b, U+99a8, U+99d0, U+9a30, U+9b42, U+9b45, U+9d3b, U+9e7f, U+9ee8, U+9f3b)
+);
+
+/* noto-sans-tc-[111]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-111-400-normal.woff2",
+    $range: (U+5e, U+3042, U+3044, U+3046, U+3048, U+304a-3050, U+3053-3057, U+3059-305b, U+305d-3061, U+3063-306c, U+306e-3079, U+307b, U+307d-307f, U+3082-308d, U+308f, U+3092-3093, U+30a1-30a4, U+30a6-30c1, U+30c3-30c4, U+30c6-30e1, U+30e3-30ed, U+30ef, U+30f3, U+30fb-30fc, U+4e32, U+4ef2, U+4fd7, U+501f, U+5144, U+51c6, U+52c1, U+5440, U+54e6, U+54ed, U+5510, U+5687, U+58c1, U+5b5d, U+5bd2, U+5ee2, U+5f31, U+6012, U+6084, U+6148, U+6182, U+622a, U+6355, U+6372, U+63ee, U+6416, U+6575, U+660c, U+66c9, U+675c, U+6a6b, U+6b32, U+6b49, U+6b98, U+6d6e, U+6dda, U+6ef4, U+6efe, U+7159, U+7378, U+775b, U+78e8, U+7aa9, U+7d1b, U+7de9, U+7f6a, U+7f8a, U+7fbd, U+8000, U+809a, U+8102, U+8170, U+819c, U+8266, U+82b3, U+87f2, U+8972, U+8a17, U+8b02, U+8e22, U+904d, U+90ed, U+91c7, U+93c8, U+9451, U+9a37, U+9b27, U+ad6d, U+c5b4, U+d55c)
+);
+
+/* noto-sans-tc-[112]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-112-400-normal.woff2",
+    $range: (U+2502, U+2605, U+4e39, U+4e58, U+4ea1, U+4ed9, U+4f2f-4f30, U+4f38, U+4f75, U+4fc3, U+4ff1, U+500d, U+5049, U+5074, U+5077, U+5091, U+5175, U+517c, U+51cd, U+51e1, U+5269-526a, U+52aa, U+52c7, U+52df, U+5377, U+541b, U+5439, U+5448, U+54aa, U+5674, U+56f0, U+5761, U+585e, U+588a, U+58a8, U+58fd, U+5925, U+592e, U+5948, U+5999, U+59b3, U+5a18, U+5a1c, U+5a46, U+5b30, U+5b54, U+5b6b, U+5b8f, U+5be9, U+5bf8, U+5c0a, U+5c16, U+5c24, U+5c46, U+5cf0, U+5e1d, U+5e25, U+5e2d, U+5e3d, U+5e79, U+5f04, U+5fcd, U+5fe0, U+60dc, U+6163, U+616e, U+61f6, U+6258, U+6293, U+62c6, U+62d2, U+62d6, U+62fc, U+63da, U+63ed, U+640d, U+6458, U+649e, U+64ec, U+64f4, U+64fe, U+651c, U+6562, U+65cb, U+65e2, U+65fa, U+6628, U+6668, U+66a2, U+66dd, U+66fc, U+66ff, U+6717, U+67cf, U+67d4, U+6817, U+6885, U+695a, U+69cd, U+6afb, U+6bbc, U+6c89, U+6c96, U+6cc9, U+6d1b, U+6d1e, U+6d74, U+6db2, U+6dbc, U+6df7, U+6dfb, U+6e38, U+6f38, U+6f5b, U+6f64, U+6f8e, U+6fa4, U+6fc3, U+6fd5, U+7070, U+70b8, U+70cf, U+70e4, U+7169, U+7210, U+721b, U+7238, U+737b, U+73bb, U+746a, U+7483, U+74dc, U+74f6, U+7518, U+756a, U+75c7, U+7919, U+7956, U+795d, U+7a05, U+7a0d, U+7a3f, U+7bc9, U+7c97, U+7cd5, U+7d0b, U+7d10, U+7dfb, U+7e3e, U+7e6a, U+8036, U+808c, U+80af, U+80ce, U+80e1, U+80f8, U+817f, U+8216, U+8239, U+827e, U+8377, U+8389, U+83ab, U+83f2, U+840a, U+8584, U+85c9, U+865b, U+8766, U+87a2, U+8932, U+8a50, U+8a69, U+8a95, U+8b6f, U+8c37, U+8c6c, U+8ca9, U+8cfa, U+8d95, U+8de1, U+8f14, U+8f9b, U+8fa3, U+8feb, U+8ff4, U+9010, U+901b, U+905e, U+9080, U+912d, U+9177, U+9336, U+947d, U+963b, U+966a, U+9670, U+9769, U+9813, U+9846, U+98fd, U+99d5, U+9a0e, U+9a19, U+9b6f, U+9ce5, U+9cf3, U+9ece, U+9ed8, U+9f13, U+9f20)
+);
+
+/* noto-sans-tc-[113]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-113-400-normal.woff2",
+    $range: (U+201c-201d, U+203b, U+2192, U+25b2, U+300e-300f, U+4e01, U+4e73, U+4e82, U+4e88, U+4e8e, U+4f0a, U+4f5b, U+502b, U+504f, U+5076, U+5100, U+5104, U+5132, U+5192, U+51a0, U+51ac, U+51f1, U+5200, U+5224, U+522a, U+5237-5238, U+523a, U+526f, U+5289, U+52de, U+52f5, U+52ff, U+5371, U+539a, U+53e5, U+540e, U+5433, U+547c, U+552f, U+5531, U+5634, U+56c9, U+574a, U+57f7, U+57f9, U+5805, U+5851, U+5854, U+586b, U+58c7, U+58de, U+5967, U+59bb, U+59d3-59d4, U+5b55, U+5b87, U+5b97, U+5bae, U+5bbf, U+5be7, U+5bec, U+5cb8, U+5df7, U+5e7b-5e7c, U+5f1f, U+5f70, U+5fd9, U+60e1, U+61b6, U+61c2, U+6200, U+6234, U+6263, U+62b5, U+62dc, U+62ec, U+6383, U+638c, U+63cf, U+63d2, U+63e1, U+63f4, U+641e, U+64cd, U+64fa, U+654f, U+6557, U+656c, U+65c1, U+65d7, U+6620, U+6676, U+6696-6697, U+66ab, U+66c6, U+671d, U+672b, U+676f, U+677e, U+67d0, U+67d3, U+684c, U+68c4, U+690d, U+694a, U+699c, U+6a4b, U+6ac3, U+6b04, U+6b23, U+6b78, U+6b8a, U+6bd2, U+6c60, U+6cb3, U+6d89, U+6de1, U+6de8, U+6e6f, U+6f02, U+70c8, U+7126, U+718a, U+7236, U+723d, U+7246, U+72af, U+72d7, U+73cd, U+7532, U+760b, U+7626, U+7687, U+76df, U+7761, U+79cb, U+79d2, U+79df, U+7a69, U+7af6, U+7b80, U+7c3d, U+7c3f, U+7c4d, U+7cd6, U+7d2b, U+7de3, U+7e2e, U+7e54, U+7e6b, U+8010, U+80a5, U+812b, U+819a, U+81a0, U+82d7, U+838a, U+8463, U+84cb, U+8521, U+8607, U+860b, U+864e, U+871c, U+878d, U+885d, U+89f8, U+8a13, U+8aa0, U+8afe, U+8b5c, U+8c46, U+8cbf, U+8cd3, U+8cf4, U+8d08, U+8d0a, U+8ddd, U+8de8, U+8fea, U+9014, U+9055, U+906d, U+907a, U+907f, U+90a6, U+9178, U+92fc, U+934b, U+9396, U+93ae, U+9583, U+9663, U+9694, U+96bb, U+9707, U+9738, U+9905, U+9aa8, U+9b25, U+9b3c, U+9ea5, U+9eb5, U+9f4a, U+9f61, U+ff0d-ff0e)
+);
+
+/* noto-sans-tc-[114]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-114-400-normal.woff2",
+    $range: (U+3c, U+d7, U+2027, U+4e4e, U+4e92, U+4ea6, U+4ec1, U+4ecd, U+4f34, U+4f48, U+4f53, U+4fb5, U+5012, U+50b7, U+51b0, U+5283, U+52dd, U+532f, U+5354, U+53eb, U+53f3, U+5409, U+5496, U+54c8, U+54e5, U+554a, U+5561, U+5594, U+559d, U+56b4, U+56fa, U+5713, U+5750, U+57df, U+584a, U+590f, U+592b, U+593e, U+5976, U+599d, U+59b9, U+59d0, U+5a5a, U+5a66, U+5b85, U+5b88, U+5ba3, U+5bdf, U+5c01, U+5c04, U+5c3a, U+5c3e, U+5c4f, U+5ddd-5dde, U+5de7-5de8, U+5e63, U+5e8a, U+5e9c, U+5eda, U+5ef3, U+5ef6, U+5f48, U+5fb5, U+6015, U+6025, U+602a, U+6050, U+6069, U+6162, U+6176, U+61f7, U+6279, U+627f, U+6297, U+62b1, U+62bd, U+6311, U+6377, U+6388-6389, U+63a1-63a2, U+6436, U+64c1, U+64d4, U+6551, U+6563, U+65bd, U+66b4, U+66f2, U+6751, U+675f, U+6790, U+6838, U+68d2, U+68ee, U+6982, U+69ae, U+69cb, U+6a39, U+6b66, U+6bba, U+6c5f, U+6ce1, U+6d0b, U+6d3e, U+6d6a, U+6e1b, U+6ed1, U+6f22, U+6f54, U+6f6e, U+6fc0, U+6fdf, U+719f, U+71c8, U+71d2, U+7259, U+72c2, U+7389, U+73e0, U+745e, U+751a, U+751c, U+7530, U+7533, U+7562, U+7591, U+75c5, U+75db, U+7642, U+7686, U+76d2, U+76db, U+76e1, U+76e3, U+7701, U+786c, U+7981, U+79c0, U+79fb, U+7a81, U+7a97, U+7adf, U+7aef, U+7b26, U+7c64, U+7d0d, U+7d14, U+7d2f, U+7d9c, U+7dca, U+7df4, U+7e23, U+7f3a, U+8033, U+804a, U+8056, U+805a, U+8173, U+81e8, U+8212, U+821e, U+822a, U+82e6, U+8336, U+83dc, U+8449, U+84ee, U+85e5, U+885b, U+888b, U+8907, U+8a34, U+8a5e, U+8aa4, U+8ab0, U+8ab2, U+8ac7, U+8b66, U+8c6a, U+8c93, U+8c9d, U+8cb4, U+8dd1, U+8f2a, U+8fb2, U+9109, U+9192, U+91cb, U+91dd, U+93e1, U+964d, U+9686, U+968e, U+969c, U+96de, U+96e8, U+96ea, U+96f7, U+975c, U+9760, U+978b, U+9858, U+98ef, U+9918, U+9aee, U+9b54, U+9ebb, U+ff0f, U+ff5c)
+);
+
+/* noto-sans-tc-[115]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-115-400-normal.woff2",
+    $range: (U+23-25, U+3d, U+4e45, U+4e5d, U+4e7e, U+4eac, U+4eae, U+4ed4, U+4ee4, U+4f01, U+4f3c, U+4f8b, U+4fc2, U+505c, U+50c5, U+5145, U+51b7, U+521d, U+523b, U+525b, U+5287, U+52e2, U+5348, U+535a, U+537b, U+5426, U+542b, U+5438, U+5462, U+54ea, U+555f, U+5566, U+5584, U+5609, U+5708, U+570d, U+571f, U+5747, U+5802, U+58d3, U+5920, U+5922, U+5957, U+5979, U+5a01, U+5a92, U+5abd, U+5b63, U+5b69, U+5b83, U+5bb3, U+5bc4, U+5bf5, U+5c3c, U+5c40, U+5c4b, U+5c64, U+5cf6, U+5de6, U+5e0c, U+5e55, U+5e78, U+5eab, U+5ead, U+5ee0, U+5f85, U+5f8b, U+5fd7-5fd8, U+6167, U+6298, U+62db, U+62ff, U+639b, U+63a7, U+642d, U+6469, U+64ad, U+651d, U+653b, U+65b7, U+65cf, U+665a, U+666e, U+66fe, U+6728, U+674e, U+67b6, U+6821, U+6839, U+6843, U+6a94, U+6b4c, U+6b50, U+6b62, U+6b72, U+6b7b, U+6bcd, U+6bdb, U+6c38, U+6c7a, U+6c7d, U+6c99, U+6cb9, U+6ce2, U+6cf0, U+6d17, U+6d32, U+6e2c, U+6e56, U+6fb3, U+722d, U+723e, U+725b, U+734e, U+7387, U+73ed, U+7565, U+7570, U+76ca, U+76e4, U+773e, U+77ed, U+77f3, U+7814, U+7834, U+7968, U+79d8, U+7a7f, U+7af9, U+7b11, U+7b46, U+7b54, U+7bc4, U+7d19, U+7d22, U+7d42, U+7d55, U+7da0, U+7e41, U+7e7c, U+7f85, U+7ffb, U+8077, U+8089, U+80cc, U+81c9, U+81f4, U+81fa, U+820a, U+822c, U+826f, U+8349, U+85cd, U+86cb, U+8840, U+88dc, U+8986, U+8a0e, U+8a73, U+8a8c, U+8b1b, U+8b9a, U+8c50, U+8ca0, U+8cde, U+8cfd, U+8d8a, U+8df3, U+8e64, U+8ecd, U+8edf, U+8f38, U+8fd4, U+8ff0, U+8ff7, U+9000, U+9047, U+9060, U+90f5, U+9152, U+91ce, U+9280, U+9418, U+9435, U+9589, U+9592, U+9678, U+968a, U+96aa, U+96c5, U+96d6, U+96dc, U+96f6, U+9732, U+9748, U+9802, U+9806, U+9808, U+983b, U+984d, U+984f, U+9867, U+98db, U+98f2, U+98fe, U+9a5a, U+9b06, U+9b5a, U+9bae, U+ff5e)
+);
+
+/* noto-sans-tc-[116]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-116-400-normal.woff2",
+    $range: (U+40, U+2026, U+4e03, U+4e14, U+4e9e, U+4ec0, U+4ed8, U+4f11, U+4f4e-4f4f, U+4f73, U+4fee, U+5019, U+503c, U+5047, U+514b, U+516b, U+5178, U+5207, U+520a, U+5236, U+5343, U+5347, U+534a, U+5370, U+53cd, U+53e4, U+53e6, U+53f2, U+5403, U+5411, U+5427, U+5468, U+5473, U+547d, U+552e, U+5740, U+5883, U+589e, U+591c, U+5931, U+59cb, U+5a1b, U+5b58, U+5b98, U+5b9c, U+5ba4, U+5bcc, U+5beb, U+5c45, U+5c6c, U+5dee, U+5df4, U+5e03, U+5e33, U+5e6b, U+5e7e, U+5e8f, U+5e95, U+5ea7, U+5f15, U+5f62, U+5f69, U+5f80, U+5fa9, U+5fae, U+5fb7, U+5ff5, U+600e, U+601d, U+60e0, U+614b, U+6230, U+623f, U+628a, U+6295, U+62c9, U+6309, U+64c7, U+64ca, U+652f, U+6545, U+6548, U+65af, U+65e9, U+6625, U+666f, U+667a, U+670b, U+671b, U+6750, U+677f, U+6975, U+6a13, U+6a21, U+6aa2, U+6b65, U+6b77, U+6bb5, U+6cc1, U+6ce8, U+6df1, U+6e90, U+6e96, U+6eab, U+6f14, U+6f2b, U+700f, U+706b, U+7206, U+724c, U+72c0, U+7368, U+7372, U+74b0, U+756b, U+76ae, U+773c, U+78ba, U+798f, U+79ae, U+7a4d, U+7a76, U+7ae5, U+7b56, U+7b97, U+7bb1, U+7bc7, U+7c73, U+7c89, U+7d00, U+7d20, U+7d39, U+7d72, U+7dad, U+7e8c, U+7fa4, U+7fd2, U+8003, U+807d, U+80a1, U+80b2, U+8166, U+8208-8209, U+82e5, U+843d, U+85cf, U+85dd, U+862d, U+8857, U+8863, U+89ba, U+89d2, U+8a2a, U+8a31, U+8a62, U+8a66, U+8a72, U+8abf, U+8b1d, U+8b58, U+8c61, U+8ca1, U+8ca8, U+8cac, U+8cbc, U+8d70, U+8da3, U+8db3, U+8ddf, U+8f03, U+8f15, U+8f2f, U+8fa6, U+8fce, U+8ffd, U+900f, U+9031, U+9069, U+908a, U+91ab, U+91cc, U+92b7, U+9322, U+932f, U+9375, U+9632, U+963f, U+9644, U+9662, U+9673, U+967d, U+96a8, U+96c4, U+96d9, U+96e2-96e3, U+96f2, U+9752, U+97d3, U+97ff, U+9805, U+9810, U+9818, U+986f, U+990a, U+9910, U+9928, U+9e97, U+9ec3, U+9f8d, U+ff1b)
+);
+
+/* noto-sans-tc-[117]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-117-400-normal.woff2",
+    $range: (U+26, U+3e, U+5f, U+7e, U+3000, U+300a-300b, U+3010-3011, U+4e16, U+4e26, U+4e94, U+4e9b, U+4ea4, U+4eca-4ecb, U+4efb, U+4efd, U+4f46, U+4f55, U+4f9b, U+4f9d, U+4fbf, U+505a, U+5065, U+5099, U+50cf, U+512a, U+5143, U+5148, U+5152, U+5169, U+516d, U+5171, U+5177, U+518a, U+5225, U+5247, U+5275, U+529f, U+52a9, U+5305, U+5341, U+5357, U+5361, U+5373, U+53bb, U+53c3, U+53c8, U+53d6-53d7, U+53e3, U+5404, U+559c, U+55ce, U+5668, U+56db, U+5712, U+5718, U+57ce, U+57fa, U+58eb, U+592a, U+5947, U+5bc6, U+5bf6, U+5c0e, U+5c11, U+5c1a, U+5c55, U+5c71, U+5df1, U+5e2b, U+5e36, U+5e97, U+5eb7, U+5ee3, U+5efa, U+5f35, U+5f37, U+5f88, U+5f9e, U+5fc5, U+606f, U+60a8, U+6232, U+6236, U+624d, U+627e, U+6280, U+62cd, U+6301, U+6307, U+6392, U+63db, U+64da, U+6539, U+653e-653f, U+6559, U+6574, U+65c5, U+6613, U+66f8, U+6797, U+67e5, U+6848, U+6a19, U+6a23, U+6b61, U+6bcf, U+6c11, U+6c42, U+6d41, U+6d77, U+6e2f, U+6eff, U+7167, U+71df, U+738b, U+73a9, U+7403, U+7537, U+754c, U+7559, U+767d-767e, U+78bc, U+793a, U+795e, U+79c1, U+79d1, U+7a2e, U+7a31, U+7a7a, U+7ae0, U+7ba1, U+7bc0, U+7c21, U+7cfb, U+7d04-7d05, U+7d1a, U+7d30, U+7d44, U+7d66, U+7d71, U+7de8, U+7e3d, U+7f6e, U+7fa9, U+8001, U+805e, U+8072, U+81f3, U+82f1, U+83ef, U+842c, U+8457, U+85a6, U+8655, U+8853, U+88ab, U+88dd, U+88e1, U+88fd, U+897f, U+898f, U+89aa, U+89bd, U+89c0, U+89e3, U+8a02, U+8a3b, U+8a55, U+8a8d, U+8a9e, U+8ad6, U+8b49, U+8b70, U+8b77, U+8b80, U+8b8a, U+8b93, U+8cb7, U+8ce3, U+8cea, U+8cfc, U+8f09, U+8fd1, U+9001, U+901f-9020, U+9054, U+90a3, U+914d, U+91cf, U+9304, U+95b1, U+9664, U+969b, U+96b1, U+96c6, U+9700, U+975e, U+97f3, U+98a8, U+98df, U+9999, U+99ac, U+9a57, U+9ebc, U+9ed1)
+);
+
+/* noto-sans-tc-[118]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-118-400-normal.woff2",
+    $range: (U+d, U+2b, U+7c, U+a9, U+300c-300d, U+4e09, U+4e3b, U+4e4b, U+4e5f, U+4e86, U+4e8b-4e8c, U+4eab, U+4ed6, U+4ee3, U+4ef6, U+4f1a, U+4f4d, U+4f60, U+4f7f, U+4fdd, U+4fe1, U+50b3, U+50f9, U+5149, U+514d, U+5167, U+5176, U+518d, U+5217, U+5229, U+524d, U+529b, U+52a0, U+52d9, U+5316-5317, U+5340, U+539f, U+53ca-53cb, U+53ea, U+53f8, U+5408, U+540c-540d, U+544a, U+548c, U+54c1, U+54e1, U+5546, U+554f, U+55ae, U+56de, U+56e0, U+5716, U+578b, U+5831, U+5834, U+5916, U+5973, U+5982, U+5b57, U+5b78, U+5b89, U+5b8c, U+5b9a, U+5ba2, U+5bb9, U+5be6, U+5c07-5c08, U+5c0b, U+5c0d, U+5c31, U+5de5, U+5df2, U+5e02, U+5e38, U+5ea6, U+5f0f, U+5f71, U+5f8c, U+5f97, U+5feb, U+6027, U+60c5, U+60f3, U+610f, U+611b, U+611f, U+61c9, U+6216, U+624b, U+6253, U+63a5, U+63a8, U+63d0, U+641c, U+6536, U+6578, U+6599, U+661f, U+662d, U+670d, U+671f, U+672a, U+6771, U+679c, U+682a, U+683c, U+689d, U+696d, U+6a02, U+6a5f, U+6b0a, U+6b21, U+6b3e, U+6b64, U+6bd4, U+6c23, U+6c34, U+6c92, U+6cd5, U+6d3b, U+6d88, U+6e05, U+7063, U+7121, U+7136, U+71b1, U+7247-7248, U+7269, U+7279, U+73fe, U+7406, U+7522, U+7531, U+7576, U+767b, U+76ee, U+76f4, U+770b, U+771f, U+77e5, U+793e, U+7a0b, U+7acb, U+7ad9, U+7b2c, U+7b49, U+7cbe, U+7d50, U+7d61, U+7d93, U+7dda, U+8005, U+800c, U+806f, U+8207, U+8272, U+82b1, U+865f, U+8868, U+898b, U+8996, U+8a00, U+8a08, U+8a0a, U+8a18, U+8a2d, U+8a71, U+8aaa, U+8acb, U+8cbb, U+8cc7, U+8d77, U+8d85, U+8def, U+8eab, U+8eca, U+8f49, U+9019-901a, U+9023, U+9032, U+904a-904b, U+904e, U+9053, U+9078, U+9084, U+90e8, U+90fd, U+91cd, U+91d1, U+9577, U+9580, U+9593, U+9650, U+9762, U+982d, U+984c, U+985e, U+9ad4, U+9ad8, U+9ede, U+ff01, U+ff08-ff09, U+ff1f)
+);
+
+/* noto-sans-tc-[119]-400-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-119-400-normal.woff2",
+    $range: (U+20-22, U+27-2a, U+2c-3b, U+3f, U+41-5d, U+61-7b, U+7d, U+a0, U+ab, U+ae, U+b2-b3, U+b7, U+bb, U+bf, U+c9, U+cd, U+d6, U+e0-ef, U+f1-f4, U+f6, U+f9-fa, U+fc-fd, U+101, U+103, U+110-111, U+113, U+12b, U+14d, U+16b, U+1a1, U+1b0, U+1ce, U+300-301, U+1ea1, U+1ea3, U+1ebf, U+1ec7, U+2013-2014, U+2039-203a, U+203c, U+2122, U+3001-3002, U+4e00, U+4e0a-4e0b, U+4e0d, U+4e2d, U+4eba, U+4ee5, U+4f5c, U+4f86, U+500b, U+5011, U+5165, U+5168, U+516c, U+51fa, U+5206, U+5230, U+52d5, U+53ef-53f0, U+570b, U+5728, U+5730, U+591a, U+5927, U+5929, U+597d, U+5b50, U+5bb6, U+5c0f, U+5e73-5e74, U+5fc3, U+6210-6211, U+6240, U+6587, U+65b0, U+65b9, U+65bc, U+65e5, U+660e, U+662f, U+6642, U+66f4, U+6700, U+6703, U+6708-6709, U+672c, U+6b63, U+6cbb, U+70b9-70ba, U+751f, U+7528, U+767c, U+7684, U+76f8, U+7db2, U+7f8e, U+80fd, U+81ea, U+884c, U+8981, U+958b, U+95dc, U+96fb, U+9801, U+9996, U+ff0c, U+ff1a)
+);

--- a/src/styles/noto-sans/tc-700-normal.scss
+++ b/src/styles/noto-sans/tc-700-normal.scss
@@ -1,0 +1,809 @@
+$tcFamily: "Noto Sans TC";
+
+/* noto-sans-tc-[0]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-0-700-normal.woff2",
+    $range: (U+1f921-1f930, U+1f932-1f935, U+1f937-1f939, U+1f940-1f944, U+1f947-1f94a, U+1f950-1f95f, U+1f962-1f967, U+1f969-1f96a, U+1f980-1f981, U+1f984-1f98d, U+1f990-1f992, U+1f994-1f996, U+1f9c0, U+1f9d0, U+1f9d2, U+1f9d4, U+1f9d6, U+1f9d8, U+1f9da, U+1f9dc-1f9dd, U+1f9df-1f9e2, U+1f9e5-1f9e6, U+20024, U+20487, U+20779, U+20c41, U+20c78, U+20d71, U+20e98, U+20ef9, U+2107b, U+210c1, U+22c51, U+233b4, U+24a12, U+2512b, U+2546e, U+25683, U+267cc, U+269f2, U+27657, U+282e2, U+2898d, U+29d5a, U+f0001-f0005, U+f0019, U+f009b, U+f0101-f0104, U+f012b, U+f01ba, U+f01d6, U+f0209, U+f0217, U+f0223-f0224, U+fc355, U+fe327, U+fe517, U+feb97, U+fffb4)
+);
+
+/* noto-sans-tc-[6]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-6-700-normal.woff2",
+    $range: (U+ff78-ff7e, U+ff80-ff86, U+ff89-ff94, U+ff97-ff9e, U+ffb9, U+ffe0-ffe3, U+ffe9, U+ffeb, U+ffed, U+fffc, U+1d7c7, U+1f004, U+1f0cf, U+1f141-1f142, U+1f150, U+1f154, U+1f158, U+1f15b, U+1f15d-1f15e, U+1f162-1f163, U+1f170-1f171, U+1f174, U+1f177-1f178, U+1f17d-1f17f, U+1f192-1f195, U+1f197-1f19a, U+1f1e6-1f1f5, U+1f1f7-1f1ff, U+1f21a, U+1f22f, U+1f232-1f237, U+1f239-1f23a, U+1f250-1f251, U+1f300, U+1f302-1f319)
+);
+
+/* noto-sans-tc-[7]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-7-700-normal.woff2",
+    $range: (U+fa0a, U+fa0c, U+fa11, U+fa17, U+fa19, U+fa1b, U+fa1d, U+fa26, U+fa2c, U+fb01, U+fdfc, U+fe0e, U+fe33-fe36, U+fe38-fe44, U+fe49-fe51, U+fe54, U+fe56-fe57, U+fe59-fe5c, U+fe5f-fe6a, U+fe8e, U+fe92-fe93, U+feae, U+fecb-fecc, U+fee0, U+feec, U+fef3, U+ff04, U+ff07, U+ff26-ff2c, U+ff31-ff32, U+ff35-ff37, U+ff39-ff3a, U+ff3c, U+ff3e-ff5b, U+ff5d, U+ff61-ff65, U+ff67-ff68, U+ff6a, U+ff6c-ff77)
+);
+
+/* noto-sans-tc-[8]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-8-700-normal.woff2",
+    $range: (U+f78a-f78c, U+f78e, U+f792-f796, U+f798, U+f79c, U+f7f5, U+f812, U+f815, U+f876, U+f8f5, U+f8f8, U+f8ff, U+f901-f902, U+f904, U+f906, U+f909-f90a, U+f90f, U+f914, U+f918-f919, U+f91b, U+f91d, U+f91f, U+f923, U+f925, U+f92d-f92f, U+f934, U+f937-f938, U+f93d, U+f93f, U+f941, U+f949, U+f94c, U+f94e-f94f, U+f95a, U+f95d-f95e, U+f961-f963, U+f965-f970, U+f974, U+f976-f97a, U+f97c, U+f97e-f97f, U+f981, U+f983, U+f988, U+f98a, U+f98c, U+f98e, U+f996-f997, U+f999-f99a, U+f99c, U+f99f-f9a0, U+f9a3, U+f9a8, U+f9ad, U+f9b2-f9b6, U+f9b9-f9ba, U+f9bd-f9be, U+f9c1, U+f9c4, U+f9c7, U+f9ca, U+f9cd, U+f9d0-f9d1, U+f9d3-f9d4, U+f9d7-f9d8, U+f9dc-f9dd, U+f9df-f9e1, U+f9e4, U+f9e8-f9ea, U+f9f4, U+f9f6-f9f7, U+f9f9-f9fa, U+f9fc-fa01, U+fa03-fa04, U+fa06, U+fa08-fa09)
+);
+
+/* noto-sans-tc-[19]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-19-700-normal.woff2",
+    $range: (U+9eb9-9eba, U+9ebe-9ebf, U+9ecc-9ecd, U+9ed0, U+9ed2, U+9ed4, U+9ed9-9eda, U+9edc-9edd, U+9edf-9ee0, U+9ee2, U+9ee5, U+9ee7, U+9eee, U+9ef3-9ef4, U+9ef6-9ef7, U+9ef9, U+9efb-9efd, U+9eff, U+9f07-9f09, U+9f10, U+9f14-9f15, U+9f19, U+9f22, U+9f29, U+9f2c, U+9f2f, U+9f31, U+9f34, U+9f37, U+9f39, U+9f3d-9f3e, U+9f41, U+9f4c-9f50, U+9f54, U+9f57, U+9f59, U+9f5c, U+9f5f-9f60, U+9f62-9f63, U+9f66-9f67, U+9f6a, U+9f6c, U+9f72, U+9f76-9f77, U+9f7f, U+9f84-9f85, U+9f88, U+9f8e, U+9f91, U+9f94-9f96, U+9f98, U+9f9a-9f9b, U+9f9f-9fa0, U+9fa2, U+9fa4, U+a1f4, U+a4b0-a4b1, U+a4b3, U+a9c1-a9c2, U+aa31, U+ab34, U+ac00-ac01, U+ac04, U+ac08, U+ac10-ac11, U+ac13-ac16, U+ac19, U+ac1c-ac1d, U+ac24, U+ac70-ac71, U+ac74, U+ac77-ac78, U+ac80-ac81, U+ac83, U+ac8c, U+ac90, U+aca0, U+aca8-aca9, U+acac, U+acb0, U+acb8-acb9, U+acbc-acbd, U+acc1, U+acc4, U+ace0-ace1, U+ace4, U+ace8, U+acf0-acf1, U+acf3, U+acf5, U+acfc)
+);
+
+/* noto-sans-tc-[20]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-20-700-normal.woff2",
+    $range: (U+9d34, U+9d37, U+9d3d, U+9d42, U+9d50, U+9d52-9d53, U+9d59, U+9d5c, U+9d5e-9d61, U+9d6a, U+9d6f-9d70, U+9d77, U+9d7a, U+9d7e, U+9d87, U+9d89, U+9d8f, U+9d91-9d93, U+9d96, U+9d98, U+9d9a, U+9da1-9da2, U+9da5, U+9da9, U+9dab-9dac, U+9db1-9db2, U+9db5, U+9db9-9dbc, U+9dbf-9dc2, U+9dc4, U+9dc7-9dc9, U+9dd3, U+9dd6, U+9dd9-9dda, U+9dde-9ddf, U+9de2, U+9de5-9de6, U+9de8, U+9def-9df0, U+9df2-9df4, U+9df8, U+9dfa, U+9dfd, U+9dff, U+9e02, U+9e07, U+9e0a, U+9e11, U+9e15, U+9e18, U+9e1a-9e1b, U+9e1d-9e1e, U+9e20-9e23, U+9e25-9e26, U+9e2d, U+9e2f, U+9e33, U+9e35, U+9e3d-9e3f, U+9e42-9e43, U+9e45, U+9e48-9e4a, U+9e4c, U+9e4f, U+9e51, U+9e55, U+9e64, U+9e66, U+9e6b, U+9e6d-9e6e, U+9e70, U+9e73, U+9e75, U+9e78, U+9e80-9e83, U+9e87-9e88, U+9e8b-9e8c, U+9e90-9e91, U+9e93, U+9e96, U+9e9d, U+9ea1, U+9ea4, U+9ea6, U+9ea9-9eab, U+9ead, U+9eaf, U+9eb4, U+9eb7-9eb8)
+);
+
+/* noto-sans-tc-[21]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-21-700-normal.woff2",
+    $range: (U+9bd3-9bd7, U+9bd9, U+9bdb, U+9bdd, U+9be1-9be2, U+9be4-9be5, U+9be7, U+9bea, U+9bed-9bee, U+9bf0-9bf1, U+9bf5, U+9bf7, U+9bf9, U+9bfd, U+9bff, U+9c02, U+9c06, U+9c08-9c0a, U+9c0d, U+9c10, U+9c12-9c13, U+9c15, U+9c1c, U+9c1f, U+9c21, U+9c23-9c25, U+9c28-9c29, U+9c2d-9c2e, U+9c31-9c33, U+9c35-9c37, U+9c39-9c3b, U+9c3d-9c3e, U+9c40, U+9c42, U+9c45-9c49, U+9c52, U+9c54, U+9c56, U+9c58-9c5a, U+9c5d, U+9c5f-9c60, U+9c63, U+9c67-9c68, U+9c72, U+9c75, U+9c78, U+9c7a-9c7c, U+9c7f-9c81, U+9c87-9c88, U+9c8d, U+9c91, U+9c94, U+9c97, U+9c9b, U+9ca4, U+9ca8, U+9cab, U+9cad, U+9cb1-9cb3, U+9cb6-9cb8, U+9cc4-9cc5, U+9ccc-9ccd, U+9cd5-9cd7, U+9cdd-9cdf, U+9ce7, U+9ce9, U+9cee-9cf0, U+9cf2, U+9cfc-9cfe, U+9d03, U+9d06-9d08, U+9d0e, U+9d10, U+9d12, U+9d15, U+9d17, U+9d1d-9d1f, U+9d23, U+9d2b, U+9d2f-9d30)
+);
+
+/* noto-sans-tc-[22]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-22-700-normal.woff2",
+    $range: (U+9a6f-9a71, U+9a73-9a74, U+9a76, U+9a78-9a79, U+9a7b-9a7c, U+9a7e-9a7f, U+9a81-9a82, U+9a84-9a87, U+9a8a-9a8b, U+9a8f-9a91, U+9a97, U+9a9a, U+9a9e, U+9aa0-9aa1, U+9aa4-9aa5, U+9aaf-9ab1, U+9ab6, U+9ab9-9aba, U+9abe, U+9ac0-9ac5, U+9ac8, U+9acb-9acc, U+9ace-9acf, U+9ad1, U+9ad5-9ad7, U+9ad9, U+9adf, U+9ae1, U+9ae3, U+9aea-9aeb, U+9aed, U+9aef, U+9af2, U+9af4, U+9af9, U+9afb, U+9afd, U+9b03-9b04, U+9b08, U+9b13, U+9b18, U+9b1f, U+9b22-9b23, U+9b28-9b2a, U+9b2c-9b30, U+9b32, U+9b3b, U+9b43, U+9b46-9b49, U+9b4b-9b4e, U+9b51, U+9b55, U+9b58, U+9b5b, U+9b5e-9b60, U+9b63, U+9b68-9b69, U+9b74, U+9b7d, U+9b80-9b81, U+9b83-9b84, U+9b87-9b88, U+9b8a-9b8b, U+9b8d-9b8e, U+9b90, U+9b92-9b95, U+9b97, U+9b9f-9ba0, U+9ba2-9ba3, U+9ba8, U+9bab, U+9bb0, U+9bb8, U+9bc0-9bc1, U+9bc3, U+9bc6-9bc8)
+);
+
+/* noto-sans-tc-[23]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-23-700-normal.woff2",
+    $range: (U+9912, U+9914, U+9916-9917, U+991b-991c, U+991e, U+9920, U+9927, U+992b-992c, U+992e, U+9931-9933, U+9938, U+993a, U+993c-9940, U+9943-9944, U+9948-994a, U+994c-994e, U+9951, U+9954, U+995c, U+995e-995f, U+9961-9962, U+9965, U+9968, U+996a, U+996d-9972, U+9975-9976, U+997a, U+997c, U+997f-9980, U+9984-9985, U+9988, U+998b, U+998d, U+998f, U+9992, U+9994-9995, U+9997-9998, U+999c, U+999e, U+99a0-99a1, U+99ab, U+99af, U+99b1, U+99b4, U+99b9, U+99c4-99c6, U+99cf, U+99d1-99d2, U+99d4, U+99d6, U+99d8-99d9, U+99df, U+99e1-99e2, U+99e9, U+99ee, U+99f0, U+99f8, U+99fb, U+9a01-9a05, U+9a0c, U+9a0f-9a13, U+9a16, U+9a1b-9a1c, U+9a20, U+9a24, U+9a28, U+9a2b, U+9a2d-9a2e, U+9a34-9a36, U+9a38, U+9a3e, U+9a40-9a44, U+9a4a, U+9a4c-9a4e, U+9a52, U+9a56, U+9a62-9a65, U+9a69-9a6b, U+9a6d)
+);
+
+/* noto-sans-tc-[24]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-24-700-normal.woff2",
+    $range: (U+97c6, U+97c9, U+97cd, U+97d6, U+97d8-97d9, U+97dc-97de, U+97e1, U+97e6-97e7, U+97ec-97ee, U+97f0-97f1, U+97f5, U+97f9-97fa, U+97fe, U+9804, U+9807, U+980a, U+980e-980f, U+9814, U+9816, U+981a, U+981c, U+981e, U+9820-9821, U+9823, U+9826, U+9828, U+982a-982c, U+9832, U+9834-9835, U+9837, U+9839, U+983c-983d, U+9845, U+9848-9849, U+984e, U+9852-9857, U+9859-985a, U+9862-9863, U+9865, U+9870-9871, U+9873-9874, U+9877, U+987a-987f, U+9881-9882, U+9885, U+9887-988a, U+988c-988d, U+9890, U+9893, U+9896-9897, U+989a, U+989c-989e, U+98a0, U+98a4, U+98a6-98a7, U+98a9, U+98ae-98af, U+98b2-98b3, U+98b6-98b8, U+98ba-98bd, U+98bf, U+98c7-98c8, U+98ca, U+98d2-98d3, U+98d8-98da, U+98dc, U+98de, U+98e0-98e1, U+98e3, U+98e5, U+98e7-98e9, U+98eb-98ee, U+98f1, U+98f4, U+9901, U+9908-9909, U+990c, U+9911)
+);
+
+/* noto-sans-tc-[25]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-25-700-normal.woff2",
+    $range: (U+964e-964f, U+9651, U+9653-9655, U+9658, U+965b-965f, U+9661, U+9665, U+9668-9669, U+966c, U+9672, U+9674, U+967a, U+9682-9685, U+9688-9689, U+968b, U+968d, U+9695, U+9697-9698, U+969e, U+96a0-96a4, U+96a9, U+96ac, U+96ae, U+96b0, U+96b2-96b4, U+96b6-96b7, U+96b9, U+96bc-96be, U+96c3, U+96c9-96cb, U+96ce-96cf, U+96d1-96d2, U+96d8, U+96dd, U+96e9, U+96eb, U+96f0-96f1, U+96f3-96f4, U+96f9, U+96fe-96ff, U+9701-9702, U+9705, U+9708, U+970a, U+970e-9711, U+9719, U+971d, U+971f-9720, U+9728, U+972a, U+972d, U+9730, U+9733, U+973a, U+973d, U+9744, U+9746-9747, U+9749, U+9750-9751, U+9753, U+9758-9759, U+975b, U+975d, U+9763, U+9765-9766, U+9768, U+976c-976d, U+9771, U+9773, U+9776, U+977a, U+977c, U+9780, U+9784-9786, U+9788, U+978e-978f, U+9798, U+979d-979e, U+97a3, U+97a5-97a6, U+97a8, U+97ab-97ac, U+97ae, U+97b6-97b7, U+97b9, U+97bf, U+97c1, U+97c3)
+);
+
+/* noto-sans-tc-[26]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-26-700-normal.woff2",
+    $range: (U+950c, U+950f-9510, U+9519-951b, U+951d, U+951f, U+9521-9526, U+952d-9530, U+9535, U+953a-953b, U+9540-9542, U+9547, U+9549-954a, U+954d, U+9550-9551, U+9554-9556, U+955c, U+956c-956d, U+956f-9570, U+9573, U+9576, U+9578, U+9582, U+9586, U+9588, U+958e-958f, U+9599, U+959c, U+959e-959f, U+95a1-95a2, U+95a4, U+95a6-95a7, U+95aa-95ae, U+95b0, U+95b2, U+95b6, U+95b9-95bf, U+95c2-95c4, U+95c7-95c9, U+95cb-95cd, U+95d0, U+95d3-95d5, U+95d7-95d8, U+95da, U+95de, U+95e0-95e1, U+95e4-95e5, U+95ea-95eb, U+95ef-95f0, U+95f2-95f3, U+95f5, U+95f7-95fa, U+95fd, U+9600-9602, U+9607-9609, U+960e, U+9610-9611, U+9614, U+9616, U+9619-961a, U+961c-961d, U+961f, U+9621, U+9624, U+9628, U+962f, U+9633-9636, U+963c, U+9641-9643, U+9645, U+9647-9648)
+);
+
+/* noto-sans-tc-[27]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-27-700-normal.woff2",
+    $range: (U+93e4, U+93e8, U+93ee, U+93f0, U+93f5, U+93f7-93f9, U+93fb, U+9403, U+9407, U+940f-9410, U+9413-9414, U+9417, U+9419-941a, U+941c, U+941e, U+9420-9425, U+9427-942b, U+942e, U+9432-9433, U+9436, U+9438, U+943a, U+943d, U+943f-9440, U+9445, U+944a, U+944c, U+9454-9455, U+945a-945b, U+945e, U+9460, U+9462-9463, U+9468, U+946a, U+946d, U+946f, U+9471, U+9474-9477, U+9479, U+947e-9481, U+9488-948a, U+948e, U+9492-9493, U+9497, U+9499, U+949b-94a3, U+94a5-94a9, U+94ac, U+94ae-94b1, U+94b3-94b5, U+94bb-94bc, U+94be-94c3, U+94c5-94c6, U+94c9, U+94ce-94d0, U+94db-94dd, U+94e0, U+94e2-94e3, U+94e8, U+94ec-94ee, U+94f0, U+94f2, U+94f5-94f6, U+94f8, U+94fa, U+94ff-9502, U+9504-9506, U+9508, U+950b)
+);
+
+/* noto-sans-tc-[28]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-28-700-normal.woff2",
+    $range: (U+92e5-92e6, U+92e8-92e9, U+92ed-92ef, U+92f1-92f3, U+92f6, U+92f9, U+92fb, U+9300-9302, U+9306, U+930b, U+930f, U+9312, U+9315, U+9319-931b, U+931d-931f, U+9321, U+9323-9325, U+9327-932a, U+932c-932e, U+9331-9333, U+9335, U+9338, U+933c, U+9340-9341, U+9345-9349, U+934f-9352, U+9354, U+9356-935a, U+935c-9360, U+9363-9367, U+9369-936a, U+936c, U+936e, U+9370-9371, U+9373, U+9376, U+9379-937a, U+937c, U+9385, U+9387, U+938c, U+938f, U+9394, U+9397-9398, U+939a-939b, U+939d-939e, U+93a1-93a3, U+93a6-93a7, U+93a9-93aa, U+93ac-93ad, U+93af-93b0, U+93b3-93bb, U+93bd-93be, U+93c0-93c4, U+93c7, U+93ca-93cd, U+93d0-93d1, U+93d6-93d8, U+93dc-93de, U+93e0)
+);
+
+/* noto-sans-tc-[29]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-29-700-normal.woff2",
+    $range: (U+91f0-91f1, U+91f5-91fa, U+91fd, U+91ff-9201, U+9203-920a, U+920d-920e, U+9210-9211, U+9217, U+9219, U+921c, U+9221, U+9224-9225, U+9227, U+922a, U+922d-922e, U+9230-9231, U+9233, U+9235-9239, U+923b, U+923d-9241, U+9244, U+9246, U+9248-9249, U+924b-9251, U+9253, U+925a, U+925d-925e, U+9262, U+9265-9267, U+926b-926d, U+926f, U+9271-9272, U+9274, U+9276, U+9278, U+927a-927c, U+927e-927f, U+9282-9283, U+9286, U+9288, U+928a, U+928d-928e, U+9291, U+9295-9296, U+9299-929b, U+929d, U+92a0-92ae, U+92b2, U+92b5-92b6, U+92bb-92bc, U+92c2-92c3, U+92c6-92cd, U+92cf-92d1, U+92d5, U+92d7, U+92d9, U+92dd, U+92df, U+92e4)
+);
+
+/* noto-sans-tc-[30]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-30-700-normal.woff2",
+    $range: (U+90bb, U+90bd-90be, U+90c3-90c5, U+90c7, U+90d1, U+90d4-90d5, U+90d7, U+90db-90df, U+90e2-90e4, U+90ea-90eb, U+90ef, U+90f4, U+90f7-90f8, U+90fc, U+90fe-9100, U+9102, U+9104, U+9106, U+9112, U+9114-911a, U+911c, U+911e, U+9120, U+9122-9123, U+9129, U+912b, U+912f, U+9131-9132, U+9134, U+9136, U+9139-913a, U+9143, U+9146, U+9148-914a, U+914e-9150, U+9154, U+9156-9157, U+9159-915a, U+915d-915e, U+9161-9164, U+916b, U+916e, U+9170-9172, U+9174, U+9176, U+9179-917a, U+917f, U+9181-9182, U+9184-9186, U+918c-918e, U+9190-9191, U+9196, U+919a-919b, U+919e, U+91a1-91a4, U+91a7, U+91aa, U+91ae-91b2, U+91b4-91b5, U+91b8, U+91bd-91be, U+91c1, U+91c3, U+91c5-91c6, U+91c8-91ca, U+91d2-91d5, U+91d7, U+91d9, U+91e1, U+91e4, U+91e6-91e9, U+91ec-91ed)
+);
+
+/* noto-sans-tc-[31]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-31-700-normal.woff2",
+    $range: (U+8f68-8f69, U+8f6d-8f72, U+8f74, U+8f76, U+8f7b-8f7c, U+8f7f, U+8f83-8f86, U+8f88-8f8a, U+8f8d, U+8f90, U+8f93, U+8f95-8f97, U+8f99, U+8f9e-8f9f, U+8fa2, U+8fa7, U+8fa9, U+8fab, U+8fae, U+8fb3, U+8fb5-8fb6, U+8fba-8fbd, U+8fbf, U+8fc1-8fc2, U+8fc6, U+8fc8, U+8fcc-8fcd, U+8fd2-8fd3, U+8fd5, U+8fdc-8fdd, U+8fdf, U+8fe2-8fe5, U+8fe8-8fe9, U+8fed-8fee, U+8ff3, U+8ff5, U+8ff8, U+8ffa-8ffc, U+8ffe, U+9002, U+9004, U+9008, U+900a-900b, U+9011-9013, U+9016, U+901e, U+9021, U+9024, U+902d, U+902f-9030, U+9034-9036, U+9039-903b, U+9041, U+9044-9045, U+904f-9052, U+9057-9058, U+905b, U+905d, U+9061-9062, U+9065, U+9068, U+906f, U+9074, U+9079, U+907d, U+9083, U+9085, U+9087-9089, U+908b, U+9090, U+9093, U+9095, U+9097, U+9099, U+909b, U+909d-909e, U+90a0-90a2, U+90ac, U+90af-90b0, U+90b2-90b4, U+90b6, U+90b9)
+);
+
+/* noto-sans-tc-[32]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-32-700-normal.woff2",
+    $range: (U+8e18, U+8e1d-8e21, U+8e23, U+8e26-8e28, U+8e2a-8e2b, U+8e2d-8e2e, U+8e30-8e31, U+8e35, U+8e39, U+8e3c-8e3d, U+8e40-8e42, U+8e47, U+8e49-8e4e, U+8e50, U+8e53-8e55, U+8e59-8e5b, U+8e60, U+8e62-8e63, U+8e67, U+8e69, U+8e6c-8e6d, U+8e6f, U+8e74, U+8e76, U+8e7a-8e7c, U+8e82, U+8e84-8e85, U+8e87, U+8e89-8e8b, U+8e8f-8e95, U+8e99-8e9a, U+8e9d-8e9e, U+8ea1, U+8ea3, U+8ea5-8ea6, U+8eaa, U+8eac-8ead, U+8eaf-8eb1, U+8eb9, U+8ebc, U+8ebe, U+8ec6, U+8ecb, U+8ecf, U+8ed1, U+8ed4, U+8ed7, U+8eda-8edb, U+8ee2, U+8ee8, U+8eeb, U+8ef2, U+8ef9-8efe, U+8f05, U+8f07-8f08, U+8f0a-8f0c, U+8f12-8f13, U+8f17, U+8f19-8f1a, U+8f1c, U+8f1e-8f1f, U+8f25-8f26, U+8f2d, U+8f30, U+8f33, U+8f36, U+8f3e, U+8f40-8f42, U+8f45-8f47, U+8f4d, U+8f54-8f55, U+8f5d, U+8f61-8f62, U+8f64, U+8f67)
+);
+
+/* noto-sans-tc-[33]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-33-700-normal.woff2",
+    $range: (U+8cc1-8cc2, U+8cc4-8cc5, U+8ccf-8cd2, U+8cd4-8cd5, U+8cd9-8cdb, U+8ce1, U+8ce8, U+8ceb, U+8cf0, U+8cf8, U+8cfb, U+8cfe, U+8d04, U+8d07, U+8d0b, U+8d0d, U+8d10, U+8d12-8d14, U+8d17, U+8d1b-8d1f, U+8d21-8d26, U+8d29-8d2c, U+8d2e-8d32, U+8d34-8d35, U+8d37-8d38, U+8d3a-8d3c, U+8d3e-8d3f, U+8d41-8d43, U+8d48, U+8d4b-8d4c, U+8d4e-8d50, U+8d54, U+8d56, U+8d58, U+8d5a-8d5b, U+8d5f-8d60, U+8d62-8d63, U+8d66-8d69, U+8d6c-8d6e, U+8d73, U+8d75-8d76, U+8d7b, U+8d7d, U+8d84, U+8d8b, U+8d90-8d91, U+8d94, U+8d96, U+8d9c, U+8dab, U+8daf, U+8db2, U+8db5, U+8db7, U+8dba, U+8dbc, U+8dbf, U+8dc2-8dc3, U+8dc6, U+8dcb, U+8dce-8dd0, U+8dd6-8dd7, U+8dda-8ddb, U+8de3-8de4, U+8de9, U+8deb-8dec, U+8df1, U+8df5-8df7, U+8dfa-8dfd, U+8e05, U+8e08-8e0a, U+8e0e, U+8e14, U+8e16)
+);
+
+/* noto-sans-tc-[34]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-34-700-normal.woff2",
+    $range: (U+8b6c-8b6d, U+8b72, U+8b7e, U+8b83, U+8b89, U+8b8c, U+8b8e, U+8b90, U+8b92, U+8b95-8b96, U+8b99, U+8b9c, U+8b9e-8b9f, U+8ba3, U+8ba5, U+8ba7, U+8baa, U+8bad, U+8bb2-8bb4, U+8bb6-8bb9, U+8bbc-8bbd, U+8bbf-8bc0, U+8bc3, U+8bc5, U+8bc8-8bcb, U+8bcf, U+8bd1, U+8bd7-8bdc, U+8bde-8be1, U+8be3, U+8be7, U+8be9, U+8beb-8bec, U+8bef, U+8bf1-8bf2, U+8bf5-8bf6, U+8bf8, U+8bfa, U+8bfd-8bfe, U+8c01-8c02, U+8c05, U+8c08, U+8c0a-8c11, U+8c13-8c15, U+8c18-8c1c, U+8c1f, U+8c23-8c29, U+8c2c-8c2d, U+8c31, U+8c34, U+8c36, U+8c39, U+8c3f, U+8c47, U+8c49-8c4c, U+8c4f, U+8c51, U+8c55, U+8c62, U+8c68, U+8c73, U+8c78, U+8c7a-8c7c, U+8c82, U+8c85, U+8c89-8c8a, U+8c8d-8c8e, U+8c90, U+8c94, U+8c98-8c99, U+8ca3-8ca4, U+8cad-8cb0, U+8cb2, U+8cb9-8cba, U+8cbd)
+);
+
+/* noto-sans-tc-[35]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-35-700-normal.woff2",
+    $range: (U+89f6, U+89ff, U+8a01, U+8a03, U+8a07, U+8a09, U+8a0c, U+8a0f-8a12, U+8a16, U+8a1b, U+8a22, U+8a25, U+8a27, U+8a2b, U+8a33, U+8a36, U+8a38, U+8a3d-8a3e, U+8a41, U+8a45-8a46, U+8a48, U+8a4e, U+8a51-8a52, U+8a54, U+8a56-8a58, U+8a5b, U+8a5d, U+8a61, U+8a63, U+8a67, U+8a6a-8a6c, U+8a70, U+8a74-8a76, U+8a7a-8a7c, U+8a82, U+8a84-8a86, U+8a89, U+8a8f-8a92, U+8a94, U+8a9a, U+8aa1, U+8aa3, U+8aa5, U+8aa7-8aa8, U+8aad, U+8ab1, U+8ab6, U+8abe, U+8ac2, U+8ac4, U+8ac6, U+8ac9, U+8acc-8acf, U+8ad1, U+8adb, U+8add-8ae2, U+8ae4, U+8ae6, U+8aea-8aeb, U+8aed, U+8af1-8af6, U+8afa, U+8afc, U+8b01, U+8b04-8b05, U+8b07, U+8b0b-8b0d, U+8b0f-8b10, U+8b13-8b14, U+8b16, U+8b1a, U+8b1c, U+8b21-8b22, U+8b26, U+8b28, U+8b2b, U+8b2e, U+8b33, U+8b41, U+8b46, U+8b4c-8b4f, U+8b53-8b54, U+8b56, U+8b59, U+8b5e-8b60, U+8b64, U+8b6a-8b6b)
+);
+
+/* noto-sans-tc-[36]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-36-700-normal.woff2",
+    $range: (U+889b-889c, U+889e, U+88a2, U+88a4, U+88a8, U+88aa, U+88ad-88ae, U+88b1, U+88b4, U+88b7-88b8, U+88bc-88be, U+88c0, U+88c4, U+88c6-88c7, U+88c9-88cc, U+88ce, U+88d2, U+88d6, U+88d8, U+88db, U+88df, U+88e4, U+88e8-88e9, U+88ec, U+88ef-88f1, U+88f3-88f5, U+88fc, U+88fe, U+8900, U+8902, U+8906, U+890a-890c, U+8912-8915, U+8918-891a, U+891f, U+8921, U+8923, U+8925, U+892a-892b, U+892d, U+8930, U+8933, U+8935-8936, U+8938, U+893d, U+8941-8943, U+8946-8947, U+8949, U+894c-894d, U+8956-8957, U+8959, U+895c, U+895e-8960, U+8964, U+8966, U+896c, U+8971, U+8974, U+897b, U+897e, U+8980, U+8982-8983, U+8987-8988, U+898a, U+898c, U+8991, U+8994-8995, U+8997-8998, U+899a, U+899c, U+89a1, U+89a4-89a7, U+89a9, U+89ac, U+89af, U+89b2-89b3, U+89b7, U+89bb, U+89bf, U+89c5, U+89c9-89ca, U+89d1, U+89d4-89d5, U+89da, U+89dc-89de, U+89e5-89e7, U+89ed, U+89f1, U+89f3-89f4)
+);
+
+/* noto-sans-tc-[37]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-37-700-normal.woff2",
+    $range: (U+874c, U+874e-874f, U+8753, U+8757-8758, U+875d, U+875f, U+8761-8765, U+8768, U+876a, U+876c-8770, U+8772, U+8777, U+877a-877b, U+877d, U+8781, U+8784-8785, U+8788, U+878b, U+8793, U+8797-8798, U+879f, U+87a3, U+87a8, U+87ab-87ad, U+87af, U+87b3, U+87b5, U+87b9, U+87bb, U+87bd-87c0, U+87c4-87c8, U+87ca-87cc, U+87ce, U+87d2, U+87db-87dc, U+87e0-87e1, U+87e3, U+87e5, U+87e7, U+87ea-87eb, U+87ee-87ef, U+87f3-87f4, U+87f6-87f7, U+87fe, U+8802-8806, U+880a-880b, U+880e, U+8810-8811, U+8813, U+8815-8816, U+881b, U+8821, U+8823, U+8827, U+8831-8832, U+8835, U+8839-883a, U+883c, U+8844-8846, U+884a, U+884e, U+8852, U+8854-8856, U+8859-885a, U+885e, U+8862, U+8864-8865, U+8869-886a, U+886c-886e, U+8871-8872, U+8875, U+8879, U+887d-887f, U+8882, U+8884-8885, U+8888, U+8890, U+8892-8893, U+8897-8898, U+889a)
+);
+
+/* noto-sans-tc-[38]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-38-700-normal.woff2",
+    $range: (U+8602, U+8604-8605, U+8610, U+8616-8618, U+861a, U+861e, U+8621-8622, U+8627, U+8629-862a, U+8634-8636, U+8638, U+863a, U+863c, U+8640, U+8642, U+8646, U+864c-864d, U+864f, U+8651-8654, U+8657, U+8659-865a, U+865c, U+8662, U+866b-866c, U+866f-8671, U+8673, U+8677, U+867a-867b, U+867d-867e, U+8680-8682, U+868b-868d, U+8693-8696, U+869a, U+869c-869d, U+86a1, U+86a3-86a4, U+86a7-86aa, U+86af-86b1, U+86b3-86b4, U+86b6, U+86b9-86ba, U+86c0-86c2, U+86c4, U+86c6, U+86c9-86ca, U+86cc-86ce, U+86d0, U+86d3-86d4, U+86de-86df, U+86e9, U+86ed-86f0, U+86f3, U+86f8-86fc, U+86fe, U+8703, U+8706-870a, U+870d-870e, U+8711-8712, U+8715, U+8717, U+8719-871a, U+871e, U+8721-8723, U+8725, U+8728-8729, U+872e, U+8731, U+8734, U+8737, U+873a, U+873e-8740, U+8742, U+8747, U+8749, U+874b)
+);
+
+/* noto-sans-tc-[39]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-39-700-normal.woff2",
+    $range: (U+84b1, U+84b4, U+84b9-84bb, U+84bd-84c0, U+84c2, U+84c6-84c7, U+84ca, U+84cd-84d2, U+84d6, U+84dd, U+84df, U+84e2, U+84e6-84e8, U+84ea, U+84ef-84f0, U+84f3-84f4, U+84f7, U+84fa, U+84fc-84fd, U+84ff-8500, U+8506, U+850c, U+8511, U+8515, U+8517, U+851d-851f, U+8524, U+852b, U+852f, U+8532, U+8534-8535, U+8537-8538, U+853a, U+853c, U+853e, U+8541-8542, U+8545, U+8548, U+854b, U+854d-854e, U+8552-8553, U+8555-8558, U+855a, U+855e, U+8561-8565, U+8568, U+856a-856c, U+856f, U+8574, U+8577-857b, U+8580-8581, U+8585-8586, U+858a, U+858c, U+858f-8590, U+8594, U+8597-8599, U+859c, U+859f, U+85a1-85a2, U+85a4, U+85a8, U+85ab-85ac, U+85ae, U+85b3-85b4, U+85b7, U+85b9-85ba, U+85bd-85be, U+85c1-85c2, U+85cb, U+85ce, U+85d0, U+85d3, U+85d5, U+85dc, U+85e0, U+85e6, U+85e8, U+85ea, U+85ed, U+85f4, U+85f6-85f7, U+85f9-85fa, U+85ff)
+);
+
+/* noto-sans-tc-[40]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-40-700-normal.woff2",
+    $range: (U+8378, U+837a-8380, U+8383, U+8385-8386, U+8392, U+8394-8395, U+8398-8399, U+839b-839c, U+83a0, U+83a2, U+83a4, U+83a7-83aa, U+83af-83b5, U+83b7, U+83b9-83ba, U+83bc-83c0, U+83c2, U+83c4-83c5, U+83c8-83c9, U+83cb, U+83ce-83cf, U+83d1, U+83d4-83d6, U+83d8, U+83dd, U+83df, U+83e1-83e2, U+83e5, U+83ea-83eb, U+83f0, U+83f3-83f4, U+83f9, U+83fb-83fe, U+8406-8407, U+840b, U+840f, U+8411, U+8413, U+8418, U+841b-841d, U+8420-8421, U+8423-8424, U+8426-8429, U+842b, U+842d-842e, U+8432-8433, U+8435, U+8437-8439, U+843b-843c, U+843e, U+8445-8447, U+844e, U+8451-8452, U+8456, U+8459-845a, U+845c, U+845f, U+8462, U+8466-8467, U+846d, U+846f-8471, U+8473-8474, U+8476-8478, U+847a, U+8484, U+848b, U+848d-848e, U+8493-8494, U+8497, U+849d, U+849f, U+84a1, U+84a8, U+84af)
+);
+
+/* noto-sans-tc-[41]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-41-700-normal.woff2",
+    $range: (U+826e, U+8270, U+8273, U+8276, U+8278-8279, U+827d, U+827f, U+8283-8284, U+8288-828a, U+828d-8291, U+8293-8294, U+8298, U+829a-829c, U+829e-82a4, U+82a6-82ab, U+82ae, U+82b0, U+82b4, U+82b6, U+82ba-82bc, U+82be, U+82c1, U+82c4-82c5, U+82c7, U+82cb, U+82cd, U+82cf-82d0, U+82d2, U+82d5-82d6, U+82d9, U+82db-82dc, U+82de-82e1, U+82e3-82e4, U+82e7, U+82ea-82eb, U+82ef-82f0, U+82f3-82f4, U+82f6-82f7, U+82f9-82fc, U+82fe-8301, U+8306-8308, U+830b-830e, U+8316, U+8318, U+831a-831b, U+831d-831e, U+8327, U+832a, U+832c-832d, U+832f, U+8331, U+8333-8334, U+8337, U+833a-833c, U+833f-8340, U+8342, U+8344-8347, U+834b-834c, U+834f, U+8351, U+8356-8358, U+835a, U+835e-8361, U+8363-8364, U+8367-8368, U+836b, U+836f, U+8373, U+8375)
+);
+
+/* noto-sans-tc-[42]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-42-700-normal.woff2",
+    $range: (U+8113, U+8115, U+8117-8118, U+811a-811b, U+811e, U+8121-8127, U+8129, U+812c, U+812f-8134, U+8137-8138, U+813a, U+813d, U+8144, U+8146, U+8148, U+814a, U+814c-814d, U+8151, U+8153, U+8156, U+8158, U+815a, U+8160, U+8167, U+8169, U+816d, U+816f, U+8171, U+8174, U+817b-817c, U+817e, U+8182, U+8188, U+818a, U+8194-8195, U+8198, U+819b, U+819e, U+81a3, U+81a6-81a7, U+81ab, U+81af-81b0, U+81b5-81b6, U+81b8, U+81ba-81bb, U+81be-81bf, U+81c3, U+81c6, U+81ca, U+81cc, U+81cf, U+81d1-81d3, U+81d6-81d7, U+81d9-81da, U+81dd-81de, U+81e0-81e2, U+81e7, U+81ec, U+81ef, U+81fc, U+81fe, U+8200-8202, U+8204-8206, U+820b, U+820e, U+8210, U+8215, U+8217-8218, U+821b, U+821d, U+8221-8222, U+8224, U+8228-8229, U+822b, U+822f-8234, U+8236-8238, U+823a, U+823e, U+8240, U+8244-8245, U+8249, U+824b, U+824e-824f, U+8257, U+825a, U+825f, U+8264, U+8268, U+826b)
+);
+
+/* noto-sans-tc-[43]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-43-700-normal.woff2",
+    $range: (U+7fb1-7fb2, U+7fb4, U+7fb6, U+7fb8, U+7fbc, U+7fbf-7fc0, U+7fc3, U+7fcb-7fcc, U+7fce-7fcf, U+7fd1, U+7fd5, U+7fd8, U+7fdb, U+7fde-7fdf, U+7fe5-7fe6, U+7fe9, U+7feb-7fec, U+7fee, U+7ff2-7ff3, U+7ffa, U+7ffd-7ffe, U+8002, U+8004, U+8006, U+800b, U+800e, U+8011-8012, U+8014, U+8016, U+8018-8019, U+801c, U+8024, U+8026, U+8028, U+802c, U+8030, U+8035, U+8037-8039, U+803b, U+8042-8043, U+804b-804c, U+8052, U+8061, U+8068, U+806a, U+806e, U+8071, U+8073-8076, U+8079, U+807c, U+807e-807f, U+8083-8084, U+808f, U+8093, U+8095, U+8098, U+809c, U+809f-80a0, U+80a4, U+80a7, U+80ab, U+80ad-80ae, U+80b0-80b1, U+80b4-80b6, U+80b8, U+80bc-80c2, U+80c4, U+80c6-80c7, U+80cb, U+80cd, U+80cf, U+80d4, U+80d7, U+80d9, U+80db-80dd, U+80e0, U+80e3-80e5, U+80e7, U+80eb-80ed, U+80ef-80f1, U+80f3-80f4, U+80f6-80f7, U+80fc, U+80fe-80ff, U+8101, U+8107, U+8109, U+810f-8112)
+);
+
+/* noto-sans-tc-[44]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-44-700-normal.woff2",
+    $range: (U+7eaf, U+7eb1-7eb3, U+7eb5-7eba, U+7ebd-7ebe, U+7ec0-7ec1, U+7ec3, U+7ec5, U+7ec7-7eca, U+7ecd-7ece, U+7ed1-7ed2, U+7ed4-7ed5, U+7ed7-7ed8, U+7eda-7edb, U+7edd-7ede, U+7ee2-7ee3, U+7ee5, U+7ee7, U+7ee9-7eeb, U+7eee-7ef0, U+7ef3, U+7ef5, U+7ef7-7ef8, U+7efd-7f01, U+7f03, U+7f05-7f09, U+7f0e, U+7f10, U+7f13-7f15, U+7f18-7f1a, U+7f1c-7f1d, U+7f20, U+7f24-7f25, U+7f28-7f2a, U+7f2d-7f2e, U+7f30, U+7f34, U+7f36-7f37, U+7f3d, U+7f42-7f45, U+7f47-7f4e, U+7f52, U+7f54, U+7f58, U+7f5a, U+7f5d, U+7f5f-7f63, U+7f65, U+7f68, U+7f6b, U+7f78, U+7f7d-7f7e, U+7f81-7f83, U+7f86-7f87, U+7f8b-7f8d, U+7f91, U+7f93-7f95, U+7f97, U+7f99-7f9a, U+7f9d, U+7f9f, U+7fa1-7fa3, U+7fa5, U+7fa7, U+7fad-7fb0)
+);
+
+/* noto-sans-tc-[45]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-45-700-normal.woff2",
+    $range: (U+7d89, U+7d8b-7d8f, U+7d91, U+7d95-7d96, U+7d98-7d9a, U+7d9d-7d9e, U+7da2-7da3, U+7da6, U+7daa, U+7dac, U+7dae-7db0, U+7db3, U+7db5, U+7db7, U+7db9, U+7dbd, U+7dc1, U+7dc3-7dc7, U+7dcc-7dcf, U+7dd1, U+7dd6-7dd9, U+7ddb-7ddc, U+7de1-7de2, U+7de6, U+7df0-7df3, U+7df6, U+7dfe, U+7e01-7e02, U+7e04, U+7e08-7e0b, U+7e10-7e11, U+7e13, U+7e15, U+7e1d-7e20, U+7e22, U+7e25-7e27, U+7e29, U+7e2d, U+7e2f-7e30, U+7e32-7e37, U+7e39, U+7e3b, U+7e44-7e45, U+7e47-7e48, U+7e4a-7e4b, U+7e4d, U+7e50-7e52, U+7e56, U+7e58-7e5b, U+7e62, U+7e68, U+7e6d-7e70, U+7e76, U+7e78, U+7e7b, U+7e7e, U+7e81-7e82, U+7e86-7e88, U+7e8a, U+7e8d-7e8e, U+7e92-7e94, U+7e98-7e9b, U+7e9e, U+7ea0, U+7ea3-7ea4, U+7ea8, U+7eaa-7eae)
+);
+
+/* noto-sans-tc-[46]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-46-700-normal.woff2",
+    $range: (U+7c20, U+7c23, U+7c25-7c26, U+7c2a-7c2b, U+7c37-7c39, U+7c40-7c41, U+7c48-7c49, U+7c50, U+7c53-7c54, U+7c56-7c57, U+7c59-7c5c, U+7c5f, U+7c63, U+7c65, U+7c69, U+7c6c-7c6e, U+7c74-7c75, U+7c79, U+7c7c, U+7c7e, U+7c84, U+7c8b, U+7c8d, U+7c91, U+7c94-7c95, U+7c9b, U+7c9f, U+7ca2, U+7ca4, U+7ca6, U+7ca8-7caa, U+7cae, U+7cb1-7cb3, U+7cba, U+7cbc, U+7cbf-7cc0, U+7cc5, U+7cc8-7cc9, U+7ccc-7cce, U+7cd7, U+7cdc-7cdd, U+7ce0, U+7ce2, U+7ce8, U+7cea, U+7ced, U+7cf2, U+7cf4, U+7cf6, U+7cf8-7cfa, U+7cfc, U+7d02, U+7d06-7d0a, U+7d0f, U+7d11-7d12, U+7d15, U+7d18, U+7d1c-7d1e, U+7d25, U+7d27, U+7d29, U+7d2c, U+7d31-7d32, U+7d35, U+7d38, U+7d3a, U+7d3c, U+7d3e-7d41, U+7d43, U+7d45, U+7d4c, U+7d4e-7d4f, U+7d53-7d54, U+7d56, U+7d5b-7d5d, U+7d5f, U+7d63, U+7d67, U+7d6a, U+7d6d, U+7d70, U+7d73, U+7d75, U+7d79-7d7b, U+7d7d, U+7d80, U+7d83-7d84, U+7d86-7d88)
+);
+
+/* noto-sans-tc-[47]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-47-700-normal.woff2",
+    $range: (U+7afb, U+7afd-7afe, U+7b01-7b06, U+7b09-7b0b, U+7b0e-7b10, U+7b14, U+7b18, U+7b1a, U+7b1e-7b1f, U+7b22-7b25, U+7b29-7b2b, U+7b2d-7b2e, U+7b31-7b35, U+7b38-7b3c, U+7b45, U+7b47-7b48, U+7b4a, U+7b4c, U+7b4e-7b50, U+7b58, U+7b5b, U+7b5d, U+7b60, U+7b62, U+7b65-7b67, U+7b69, U+7b6d-7b6f, U+7b72-7b76, U+7b79, U+7b7e, U+7b82, U+7b84-7b85, U+7b87, U+7b8b, U+7b8d-7b93, U+7b95-7b96, U+7b98, U+7b9c-7b9d, U+7ba0, U+7ba7, U+7ba9-7bac, U+7bb0, U+7bb4, U+7bb6, U+7bb8-7bb9, U+7bc1, U+7bc3, U+7bc6, U+7bcb-7bcc, U+7bcf, U+7bd4, U+7bd9-7bdb, U+7bdd, U+7be0-7be1, U+7be5-7be6, U+7bea, U+7bed-7bee, U+7bf1-7bf3, U+7bf8-7bf9, U+7bfc-7c01, U+7c03, U+7c07, U+7c0a-7c0d, U+7c0f, U+7c11-7c12, U+7c15, U+7c1e-7c1f)
+);
+
+/* noto-sans-tc-[48]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-48-700-normal.woff2",
+    $range: (U+7988, U+798a-798b, U+7991, U+7993-7996, U+7998, U+799a-799b, U+799f-79a2, U+79a4, U+79a8-79a9, U+79af-79b0, U+79b3, U+79b5, U+79b8, U+79ba, U+79c3, U+79c6, U+79c8, U+79cf, U+79d5-79d6, U+79dc-79de, U+79e3, U+79e7, U+79ea-79ed, U+79ef-79f0, U+79f4, U+79f6-79f8, U+79fd, U+7a02-7a03, U+7a08-7a0a, U+7a0c, U+7a0e, U+7a10-7a11, U+7a14, U+7a17-7a19, U+7a1c, U+7a1e-7a1f, U+7a23, U+7a26, U+7a2d, U+7a32-7a33, U+7a37, U+7a39, U+7a3c, U+7a42, U+7a45, U+7a49, U+7a4f, U+7a56, U+7a5a, U+7a5c, U+7a60-7a61, U+7a63, U+7a68, U+7a6d-7a6e, U+7a70-7a71, U+7a77-7a79, U+7a80, U+7a83, U+7a85-7a86, U+7a88, U+7a8d, U+7a90-7a91, U+7a93-7a96, U+7a98, U+7a9c-7a9d, U+7aa0, U+7aa3, U+7aa5-7aa6, U+7aa8, U+7aaa, U+7aac, U+7ab0, U+7ab3, U+7ab6, U+7ab8, U+7abb, U+7abe-7abf, U+7ac2, U+7ac8-7ac9, U+7ad1-7ad2, U+7ad6, U+7ada, U+7adc-7ade, U+7ae4, U+7ae6, U+7ae9-7aeb, U+7af4, U+7af8, U+7afa)
+);
+
+/* noto-sans-tc-[49]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-49-700-normal.woff2",
+    $range: (U+7840, U+7842-7843, U+7845, U+7847, U+784a, U+784c-7850, U+7852-7853, U+7855, U+7858, U+785a, U+785c-785d, U+7864, U+7866, U+7868, U+786a, U+786f, U+7874, U+7876, U+787c, U+787f, U+7886-7887, U+7889, U+788d, U+788f, U+7893, U+7895-7896, U+7898, U+789a, U+789e, U+78a1, U+78a3, U+78a5, U+78aa, U+78ad, U+78b1-78b2, U+78b4, U+78b6, U+78b8, U+78be, U+78c8-78c9, U+78cb, U+78ce, U+78d0-78d1, U+78d4-78d5, U+78d7-78d8, U+78de, U+78e3, U+78e6-78e7, U+78ea, U+78ec, U+78f2-78f4, U+78fa-78fb, U+78fd-7900, U+7904-7906, U+790a, U+790c, U+7910-7912, U+791c, U+791e, U+7920-7921, U+792a-792c, U+792e, U+7931, U+7934, U+7938, U+793b, U+793d, U+793f, U+7941-7942, U+7945-7947, U+7949, U+794c, U+794e, U+7953-7954, U+7957-795c, U+795f, U+7961-7962, U+7964, U+7967, U+7969, U+796b-796c, U+796f, U+7972-7973, U+7977-7979, U+797b-797c, U+797e, U+7980, U+7982, U+7984-7987)
+);
+
+/* noto-sans-tc-[50]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-50-700-normal.woff2",
+    $range: (U+7705, U+7707-7708, U+770a, U+770c, U+770f, U+7715, U+7719-771b, U+771d-771e, U+7722, U+7725-7726, U+7728, U+772d, U+772f, U+7733-7736, U+7738, U+773b, U+773d, U+7741, U+7744, U+7746, U+774c, U+774e-7752, U+7755, U+7759-775a, U+775f-7760, U+7762, U+7765-7766, U+7768-776a, U+776c-776e, U+7771, U+7778, U+777a, U+777d-777e, U+7780, U+7785, U+7787, U+7789, U+778b-778d, U+7791-7793, U+779c, U+779f-77a0, U+77a2, U+77a5, U+77a9, U+77b0-77b1, U+77b4, U+77b6-77b7, U+77b9, U+77bc-77bf, U+77c5, U+77c7, U+77cc-77cd, U+77d3, U+77d6-77d7, U+77dc, U+77de, U+77e3, U+77e7, U+77eb-77ec, U+77f0, U+77f2, U+77f6, U+77f8, U+77fa-77fc, U+77fe-7800, U+7803, U+7805-7806, U+7809, U+7810-7812, U+7815-7816, U+781a, U+781c-781d, U+781f-7823, U+7825-7827, U+7829, U+782c-7830, U+7833, U+7835, U+7837, U+7839-783a, U+783c, U+783e)
+);
+
+/* noto-sans-tc-[51]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-51-700-normal.woff2",
+    $range: (U+75cc-75cd, U+75d2, U+75d4, U+75d9, U+75df, U+75e2-75e4, U+75e6-75e7, U+75e9-75ec, U+75f0-75f3, U+75f7, U+75f9-75fa, U+75fc, U+75fe-7602, U+7608-760a, U+760c-760d, U+7610, U+7615-7616, U+7618-7620, U+7622-7623, U+7625, U+7627, U+7629, U+762b, U+762e, U+7630, U+7632-7635, U+7638, U+763a-763c, U+763e, U+7640, U+7643, U+7646, U+7648-7649, U+764d-764e, U+7654, U+7658, U+765c, U+765f, U+7663-7667, U+7669, U+766b-766d, U+766f-7670, U+7676, U+7678-767a, U+767f-7681, U+7683, U+7688, U+768a-768b, U+768e, U+7690, U+7695-7696, U+769a-769e, U+76a3-76a4, U+76aa, U+76b0-76b1, U+76b4, U+76b7-76b8, U+76c2, U+76c5, U+76c9, U+76cc-76cd, U+76cf-76d1, U+76d6-76d8, U+76e5-76e6, U+76e9, U+76ec, U+76f1, U+76f7, U+76f9-76fb, U+76ff-7700, U+7704)
+);
+
+/* noto-sans-tc-[52]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-52-700-normal.woff2",
+    $range: (U+749a, U+749c-74a1, U+74a3, U+74a5-74a7, U+74a9-74ab, U+74ae, U+74b1-74b2, U+74b5, U+74b8, U+74ba, U+74bf, U+74c5, U+74c8, U+74cc-74cd, U+74d2, U+74d4, U+74d6, U+74d8, U+74da, U+74de-74e0, U+74e2, U+74e4, U+74e8-74e9, U+74ee-74ef, U+74f4, U+74f9, U+74fb, U+74ff-7501, U+7503, U+7507, U+750c-750d, U+7511, U+7513, U+7515-7517, U+7519, U+751e, U+7521, U+7525, U+752a, U+752c-752f, U+7534, U+753e, U+7542, U+7545, U+7547-7548, U+754a-754b, U+754e, U+7551, U+755a-755b, U+755d, U+7560, U+7563-7564, U+7566-7568, U+756c-756f, U+7572-7575, U+7577-757a, U+757c, U+757e-757f, U+7583-7584, U+7587, U+7589, U+758b-758e, U+7590, U+7592, U+7594-7595, U+7597, U+7599-759a, U+759d, U+759f, U+75a1-75a3, U+75a5, U+75a7, U+75aa, U+75ac, U+75ae-75b1, U+75b3-75b4, U+75b8, U+75bd, U+75c0, U+75c2-75c4, U+75c9-75ca)
+);
+
+/* noto-sans-tc-[53]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-53-700-normal.woff2",
+    $range: (U+73b3-73ba, U+73bc, U+73bf, U+73c2, U+73c4-73c6, U+73c9, U+73cb-73cc, U+73ce-73d2, U+73d6-73d7, U+73d9, U+73db-73de, U+73e3, U+73e5-73eb, U+73ef, U+73f5-73f7, U+73f9-73fa, U+73fc-73fd, U+7400-7401, U+7404-7405, U+7407-7408, U+740a-740d, U+740f-7410, U+7416, U+741a-741b, U+741d-741e, U+7420-7425, U+7428-7429, U+742c-7432, U+7435-7436, U+7438-743a, U+743c-7442, U+7445-7446, U+7448-744a, U+7451-7452, U+7454, U+7457, U+7459, U+745d, U+7460-7462, U+7465, U+7467-7468, U+746c-746e, U+7471-7477, U+7479-747a, U+747c-747f, U+7481-7482, U+7484-7486, U+7488-748a, U+748e-7490, U+7492, U+7498)
+);
+
+/* noto-sans-tc-[54]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-54-700-normal.woff2",
+    $range: (U+727f, U+7281-7282, U+7284, U+7287, U+728a, U+728d, U+7292, U+7296, U+7298, U+729b, U+729f-72a2, U+72ad-72ae, U+72b0-72b5, U+72b8-72b9, U+72bc-72bd, U+72c1, U+72c3, U+72c5-72c6, U+72c8, U+72cc-72ce, U+72d2, U+72d4, U+72db, U+72dd, U+72df, U+72e1, U+72e8, U+72ec-72ee, U+72f1, U+72f3-72f4, U+72f7, U+72fa-72fb, U+72fd, U+7300-7301, U+7304, U+7307, U+730a-730b, U+730e, U+7313, U+7315-7317, U+7319, U+731e-731f, U+7322, U+7328-732e, U+7330-7331, U+7337, U+733a-733c, U+733e, U+7340-7341, U+7343, U+734c-734d, U+734f-7350, U+7352, U+7355, U+7357, U+7359-735a, U+7360-7363, U+7365, U+7369-7370, U+7373-7374, U+7377, U+737a, U+737c, U+737e, U+7380, U+7385-7386, U+738a, U+738e-738f, U+7391-7395, U+7397-7398, U+739b, U+73a0-73a2, U+73a5-73a8, U+73ad-73ae)
+);
+
+/* noto-sans-tc-[55]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-55-700-normal.woff2",
+    $range: (U+7113-7116, U+7118, U+711c, U+711e, U+7120, U+7122, U+712e-712f, U+7131, U+7134, U+713c, U+713f, U+7143, U+7145-7147, U+714a-714b, U+7150-7153, U+7155-7156, U+715a, U+7160, U+7162, U+7166, U+7168, U+716c, U+7171, U+7173, U+7178, U+717a-717b, U+717d, U+7180-7181, U+7185, U+7187-7188, U+718b, U+718f-7190, U+7192, U+7196-7198, U+719a-719c, U+71a0, U+71a4, U+71a8, U+71af, U+71b2-71b3, U+71b5, U+71b7-71ba, U+71be, U+71c1, U+71c4, U+71ca-71cb, U+71ce-71d0, U+71d4, U+71d7-71d8, U+71da, U+71dc, U+71e0-71e1, U+71e7, U+71ec, U+71f4-71f6, U+71f9, U+71fc, U+71fe-7201, U+7203, U+7207, U+7209, U+720c, U+7213-7215, U+7217, U+721a, U+721d, U+7222-7223, U+7228, U+722b, U+7230, U+7237, U+723b, U+723f-7242, U+724b, U+724d, U+7252-7253, U+7256, U+7258, U+725d, U+7263-7266, U+726a-726b, U+726e-7270, U+7273-7275, U+7277, U+727a-727b, U+727e)
+);
+
+/* noto-sans-tc-[56]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-56-700-normal.woff2",
+    $range: (U+6fe8-6fe9, U+6fec, U+6fee, U+6ff0, U+6ff3, U+6ff5-6ff6, U+6ffa, U+6ffc, U+6fff-7001, U+7003, U+7005-7007, U+700b, U+700d, U+7015, U+7018, U+701b, U+701e, U+7020-7021, U+7023, U+7026-7027, U+702c, U+702f-7032, U+7034-7035, U+7037-703c, U+7040, U+7042-7044, U+7046, U+7049, U+704b, U+704f, U+7052, U+7054-7055, U+705c-7061, U+7064-7069, U+706c-706d, U+706f, U+7073-7075, U+7078, U+707a, U+707e-7081, U+7085-7086, U+7089, U+7090-7091, U+7094-7096, U+7098, U+709c, U+709f, U+70a1, U+70a4, U+70a9, U+70ac, U+70af-70b2, U+70b4-70b5, U+70b7, U+70bb-70be, U+70c0-70c3, U+70ca-70cb, U+70d2, U+70d4-70d5, U+70d9-70dd, U+70df, U+70e6-70e9, U+70eb-70ec, U+70ef, U+70f1, U+70f4, U+70f7, U+70fa, U+70fd, U+70ff, U+7104, U+7106, U+7109, U+710c, U+7110)
+);
+
+/* noto-sans-tc-[57]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-57-700-normal.woff2",
+    $range: (U+6ed6, U+6ed8, U+6eda-6edb, U+6edd-6ede, U+6ee2, U+6ee4-6ee5, U+6ee8-6ee9, U+6eeb, U+6eee, U+6ef3, U+6ef8-6efb, U+6f00, U+6f08-6f0a, U+6f0d-6f0e, U+6f11-6f13, U+6f15, U+6f19-6f1a, U+6f23, U+6f25-6f2a, U+6f2d-6f31, U+6f33-6f36, U+6f3a-6f3c, U+6f40-6f41, U+6f43-6f44, U+6f47, U+6f4d-6f4f, U+6f53, U+6f57, U+6f59-6f5a, U+6f5c, U+6f5e-6f61, U+6f63, U+6f66-6f67, U+6f69-6f6c, U+6f6f, U+6f72-6f78, U+6f7a-6f7f, U+6f81-6f82, U+6f87, U+6f89, U+6f8b-6f8d, U+6f90, U+6f92, U+6f94-6f97, U+6f9c, U+6f9f-6fa0, U+6fa2-6fa3, U+6fa5-6fa8, U+6faa-6fab, U+6fae-6faf, U+6fb4, U+6fb6, U+6fb9-6fba, U+6fbc, U+6fc2, U+6fc6-6fcb, U+6fce, U+6fd1-6fd2, U+6fd4, U+6fd8, U+6fda, U+6fde, U+6fe0-6fe2)
+);
+
+/* noto-sans-tc-[58]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-58-700-normal.woff2",
+    $range: (U+6dd3, U+6dd5-6dd6, U+6dd9, U+6ddb-6de0, U+6de2-6de6, U+6de9, U+6dec, U+6def-6df0, U+6df2, U+6df4, U+6df6, U+6df8, U+6dfc-6dfd, U+6e00, U+6e02-6e03, U+6e07-6e0b, U+6e0d-6e0e, U+6e10, U+6e13-6e15, U+6e17, U+6e19-6e1a, U+6e1d, U+6e1f, U+6e22, U+6e24-6e25, U+6e27, U+6e2b, U+6e2d-6e2e, U+6e30-6e31, U+6e36, U+6e39-6e3a, U+6e3c-6e3d, U+6e40-6e41, U+6e44-6e45, U+6e47, U+6e49, U+6e4b, U+6e4d-6e4f, U+6e51, U+6e53-6e54, U+6e59, U+6e5c, U+6e5e-6e61, U+6e63-6e66, U+6e69-6e6b, U+6e6e, U+6e70-6e76, U+6e78, U+6e7c, U+6e7f-6e80, U+6e83, U+6e85-6e86, U+6e88-6e89, U+6e8b, U+6e8d-6e8f, U+6e93, U+6e98-6e9a, U+6e9f, U+6ea1, U+6ea4-6ea7, U+6eae, U+6eb1-6eb2, U+6eb4-6eb5, U+6eb7, U+6ebd, U+6ec1-6ec3, U+6ec7-6ec9, U+6ecd-6ed0, U+6ed3-6ed5)
+);
+
+/* noto-sans-tc-[59]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-59-700-normal.woff2",
+    $range: (U+6cda, U+6cdc-6cde, U+6ce0, U+6ce7, U+6ce9-6cec, U+6cee-6cef, U+6cf1, U+6cf7-6cf8, U+6cfb-6cfe, U+6d00-6d02, U+6d04, U+6d06-6d07, U+6d09-6d0a, U+6d0c, U+6d0e-6d12, U+6d18-6d1a, U+6d1f, U+6d22-6d24, U+6d27-6d28, U+6d2b, U+6d2d-6d31, U+6d33-6d3a, U+6d3c, U+6d3f, U+6d43-6d47, U+6d4a-6d4b, U+6d4e-6d4f, U+6d51-6d53, U+6d57-6d58, U+6d5a, U+6d5c, U+6d5e-6d65, U+6d67, U+6d6c-6d6d, U+6d6f-6d70, U+6d72, U+6d75, U+6d79, U+6d7c, U+6d7f, U+6d82, U+6d85, U+6d87, U+6d8e-6d8f, U+6d91-6d95, U+6d97-6d99, U+6d9b, U+6d9d, U+6d9f, U+6da1, U+6da4, U+6da6-6dac, U+6db3-6db4, U+6db7-6db8, U+6dbe-6dc0, U+6dc2, U+6dc4-6dc5, U+6dc8-6dca, U+6dcc-6dcd, U+6dcf-6dd0, U+6dd2)
+);
+
+/* noto-sans-tc-[60]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-60-700-normal.woff2",
+    $range: (U+6bbb, U+6bbd, U+6bc1-6bc2, U+6bcc, U+6bce, U+6bd0-6bd1, U+6bd5-6bd9, U+6bde, U+6be1, U+6bec, U+6bf3, U+6bf9, U+6bfd, U+6bff-6c00, U+6c02, U+6c05-6c06, U+6c0a, U+6c0c-6c0d, U+6c10, U+6c13, U+6c16, U+6c18-6c1a, U+6c1f, U+6c21-6c22, U+6c24, U+6c26, U+6c28-6c2a, U+6c2c, U+6c2e-6c33, U+6c35-6c37, U+6c39-6c3a, U+6c3d-6c3f, U+6c43, U+6c46, U+6c49-6c4f, U+6c54-6c55, U+6c58, U+6c5a-6c5c, U+6c5e, U+6c64-6c69, U+6c6b-6c6f, U+6c71-6c75, U+6c78-6c79, U+6c7c, U+6c7e, U+6c82, U+6c84-6c87, U+6c8c-6c8d, U+6c8f, U+6c93-6c94, U+6c98, U+6c9a, U+6c9d, U+6c9f, U+6ca2, U+6ca5-6ca8, U+6caa, U+6cac-6cb2, U+6cb4-6cb5, U+6cba, U+6cbc, U+6cc2-6cc3, U+6cc5-6cc7, U+6cd0-6cd2, U+6cd4, U+6cd6-6cd7, U+6cd9)
+);
+
+/* noto-sans-tc-[61]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-61-700-normal.woff2",
+    $range: (U+6a31-6a32, U+6a35, U+6a3b, U+6a3e-6a40, U+6a47-6a48, U+6a50, U+6a52, U+6a55-6a57, U+6a5a-6a5b, U+6a5e, U+6a62, U+6a66, U+6a6a, U+6a71, U+6a79, U+6a7c, U+6a7e-6a81, U+6a84, U+6a87, U+6a89, U+6a8d-6a8e, U+6a90-6a92, U+6a97, U+6a9c, U+6a9e-6aa1, U+6aa3-6aa5, U+6aa8, U+6aab, U+6aae, U+6ab5, U+6aba, U+6abe, U+6ac2, U+6ac5-6ac6, U+6ac8-6ac9, U+6acc, U+6ad3, U+6ada-6adb, U+6add-6adf, U+6ae3, U+6ae7-6ae8, U+6aea-6aec, U+6af1, U+6af3, U+6af8, U+6afa, U+6afc, U+6b05, U+6b09, U+6b0e-6b13, U+6b17, U+6b1d-6b1e, U+6b25, U+6b2c, U+6b31, U+6b35-6b37, U+6b39, U+6b3b, U+6b40, U+6b43, U+6b46, U+6b48, U+6b53-6b55, U+6b59, U+6b5b, U+6b5f-6b60, U+6b68-6b69, U+6b6f, U+6b74, U+6b7a, U+6b7c, U+6b7f-6b84, U+6b86-6b87, U+6b89, U+6b8b, U+6b8d, U+6b91-6b93, U+6b9b, U+6b9e, U+6ba1-6ba2, U+6ba4, U+6baa-6bab, U+6bad-6bae, U+6bb2-6bb4)
+);
+
+/* noto-sans-tc-[62]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-62-700-normal.woff2",
+    $range: (U+6900, U+6902, U+6904, U+6906-6907, U+6909, U+690b, U+690f-6910, U+6917, U+691a-691c, U+6925, U+692a, U+692c-692d, U+6932, U+6934, U+6939, U+693c-6940, U+6942, U+6949, U+6952, U+6954-6957, U+6959, U+695b-695f, U+6961-696c, U+696e-6970, U+6973-6974, U+6976, U+6978-697a, U+697c, U+6980, U+6984-6986, U+6988-698a, U+698d-698e, U+6990-6991, U+6994, U+6996-699b, U+699e, U+69a3-69a7, U+69ab, U+69ad, U+69af, U+69b1, U+69b3, U+69b6-69b7, U+69bb-69bc, U+69bf, U+69c1, U+69c3-69c5, U+69c7, U+69ca, U+69cc, U+69ce, U+69d0-69d1, U+69d4, U+69d8-69d9, U+69db, U+69df, U+69e4, U+69e8-69ea, U+69ed-69ee, U+69f1-69f4, U+69f6, U+69f8, U+69fa-69fb, U+69ff-6a00, U+6a05, U+6a0a-6a0b, U+6a17-6a18, U+6a1b, U+6a28-6a2b)
+);
+
+/* noto-sans-tc-[63]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-63-700-normal.woff2",
+    $range: (U+67d9, U+67db-67e0, U+67e2, U+67e4, U+67e9-67ea, U+67f0, U+67f2, U+67f6-67f8, U+67fa-67fb, U+67fe, U+6800-6805, U+6808-6809, U+680b, U+680e-680f, U+6811-6812, U+6814, U+6816, U+6818, U+681c-681e, U+6820, U+6822, U+6825, U+6827-6829, U+682b, U+682e-682f, U+6831-6834, U+683a-683b, U+683e, U+6840-6841, U+6844-6845, U+6849, U+684e, U+6853, U+6855-6856, U+685c-685d, U+685f, U+6861-6863, U+6865-6869, U+686b, U+686d, U+686f, U+6871-6872, U+6874-6875, U+6877, U+6879, U+687b-687c, U+687e, U+6880, U+6882-6883, U+6886, U+688f, U+6891-6892, U+6894, U+6896, U+6898, U+689b-689c, U+689f-68a0, U+68a2-68a3, U+68a6, U+68a9, U+68b1-68b2, U+68b4, U+68b6, U+68c0, U+68c3, U+68c6, U+68c8, U+68ca, U+68d0-68d1, U+68d3, U+68d6, U+68e1, U+68e3, U+68e6, U+68e8-68ec, U+68ef-68f1, U+68f3, U+68f6-68f7, U+68f9, U+68fb-68fd)
+);
+
+/* noto-sans-tc-[64]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-64-700-normal.woff2",
+    $range: (U+66a7, U+66aa, U+66b2-66b3, U+66b5, U+66b8-66bc, U+66be, U+66c1, U+66c4, U+66c7-66c8, U+66cc, U+66cf, U+66d5, U+66d8-66db, U+66df, U+66e1-66e2, U+66e8-66e9, U+66ef, U+66f1, U+66f5, U+66f7, U+66fa, U+66fd, U+6705, U+670a, U+670f-6710, U+6713-6715, U+6718-6719, U+6720, U+6722-6727, U+6729, U+672e, U+6733, U+6736, U+6738-6739, U+673f-6740, U+6742, U+6745, U+6747-6748, U+674b-674d, U+6753, U+6755, U+6759, U+675d-675e, U+6760, U+6762-6763, U+6767-676a, U+676c, U+676e, U+6772-6777, U+677a-677c, U+6782, U+6786-6787, U+678a-678c, U+678e-678f, U+6791-6793, U+6796, U+6798-6799, U+679f-67a3, U+67a5, U+67aa-67ae, U+67b0, U+67b2-67b5, U+67b7-67bc, U+67c0-67c3, U+67c5-67c6, U+67c8-67ca, U+67ce, U+67d2, U+67d8)
+);
+
+/* noto-sans-tc-[65]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-65-700-normal.woff2",
+    $range: (U+655d, U+6561, U+6564-6565, U+6567, U+656b, U+656d-656e, U+6573, U+6576, U+6579-657b, U+6581, U+6586, U+6588-6589, U+658b, U+658e, U+6593, U+6595, U+659b, U+659d, U+659f-65a1, U+65a9, U+65ab, U+65ad, U+65b2-65b3, U+65b5, U+65bb, U+65be-65bf, U+65c2-65c4, U+65c6, U+65cc, U+65ce, U+65d2, U+65d6, U+65db, U+65e1, U+65e3, U+65e7, U+65ee-65f0, U+65f2-65f4, U+65f7-65f8, U+65fc-65fd, U+6600, U+6603-6605, U+6609, U+660d, U+6610-6611, U+6619, U+661c-661e, U+6621-6622, U+6624, U+6626, U+6629, U+662b, U+6630, U+6633-6636, U+6639-663d, U+6640-6641, U+6644-6645, U+664a-664c, U+6653-6657, U+6659, U+665b, U+665d-665e, U+6661-6667, U+6669, U+666c, U+6672-6673, U+6677-6679, U+667b-667e, U+6681-6684, U+668b-6690, U+6692, U+6698, U+669d, U+669f-66a0, U+66a6)
+);
+
+/* noto-sans-tc-[66]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-66-700-normal.woff2",
+    $range: (U+6427-6428, U+642a-642b, U+642f-6430, U+6432, U+6434, U+6437, U+643a, U+643d-6444, U+6446-6447, U+644a-644b, U+644e, U+6450-6453, U+6456, U+6459, U+645b-645c, U+645e, U+6460-6461, U+6463-6465, U+6468, U+646c-646e, U+6470, U+6472-6477, U+6479, U+647b, U+647d, U+6480, U+6482, U+6485, U+648b-648c, U+6491, U+6493, U+6496-649a, U+649d, U+649f-64a0, U+64a2-64a3, U+64ac, U+64b1, U+64b3-64b4, U+64b7-64b9, U+64bb, U+64be, U+64c0, U+64c3-64c4, U+64d0, U+64d2, U+64d5, U+64d7-64d8, U+64e1-64e4, U+64e7, U+64e9, U+64ed, U+64ef-64f0, U+64f3, U+64f8, U+64fb-64fc, U+64ff, U+6504-6506, U+6509, U+6511-6512, U+6516, U+6518-6519, U+651b, U+6520-6523, U+6525-6526, U+6529, U+652b, U+652e, U+6530, U+6532, U+6534-6535, U+6537-6538, U+653a, U+653d, U+6542-6543, U+6549, U+654c-654e, U+6554-6555, U+655b)
+);
+
+/* noto-sans-tc-[67]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-67-700-normal.woff2",
+    $range: (U+630d-630e, U+6310, U+6312-6313, U+6319-631b, U+631d-6321, U+6323-6325, U+632d-632e, U+6332, U+6334-6339, U+633b-633c, U+633e-6340, U+6342-6346, U+634b-634c, U+634e, U+6352, U+6357, U+635a, U+635c, U+635e-635f, U+6361, U+6363, U+6365, U+6369, U+636b-636d, U+636f-6370, U+6373, U+6375-6376, U+637a-637b, U+637d, U+6381, U+6384, U+6387, U+638a, U+638d-638e, U+6390, U+6394-6397, U+639e-639f, U+63a3-63a4, U+63a6, U+63ac-63af, U+63b1-63b4, U+63b7, U+63b9-63bb, U+63bd-63be, U+63c3-63c4, U+63c8, U+63cd-63ce, U+63d1, U+63d6, U+63dc, U+63de, U+63e0, U+63e3-63e4, U+63e6, U+63e9, U+63f0, U+63f2-63f3, U+63f5-63f8, U+63fa, U+63fc-63fe, U+6400-6402, U+6405-6406, U+6409-640c, U+6410, U+6414-6415, U+6418, U+641b, U+641f-6423, U+6425-6426)
+);
+
+/* noto-sans-tc-[68]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-68-700-normal.woff2",
+    $range: (U+61c6, U+61ca-61cd, U+61d0, U+61d2, U+61de-61e0, U+61e3, U+61e6, U+61e8, U+61ed-61ee, U+61f5, U+61f9-61fa, U+61fd-61fe, U+6207, U+6209, U+620d-620e, U+6213-6215, U+6219, U+621b, U+621d-6223, U+6225-6227, U+6229, U+622b-622c, U+622e-622f, U+6231, U+6238, U+623b, U+623d-623e, U+6242-6243, U+6246, U+6248-6249, U+624c, U+6251, U+6255, U+6259-625a, U+625e, U+6260-6262, U+6265-6267, U+6269, U+626b-626c, U+6270-6273, U+6275, U+627a-627d, U+6283, U+6285-6286, U+6289, U+628c, U+628e, U+6294, U+629a-629e, U+62a0, U+62a2, U+62a6, U+62a8, U+62af, U+62b3, U+62b6, U+62ba-62bb, U+62be-62bf, U+62c2, U+62c4-62c5, U+62c8, U+62ca, U+62cf, U+62d1, U+62d5, U+62d7, U+62d9, U+62dd, U+62df-62e3, U+62e5-62e8, U+62ee, U+62f4-62fb, U+62fd, U+6300, U+6302, U+6308, U+630c)
+);
+
+/* noto-sans-tc-[69]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-69-700-normal.woff2",
+    $range: (U+60ac-60ad, U+60af-60b1, U+60b3-60b5, U+60b8, U+60bb, U+60bd-60be, U+60c0, U+60c6-60c7, U+60ca-60cb, U+60d3-60d5, U+60d7-60db, U+60dd, U+60e2-60e3, U+60e6-60f0, U+60f2, U+60f4, U+60f6, U+60fa-60fb, U+60ff-6100, U+6103, U+6106, U+610a-610b, U+610d-610e, U+6110, U+6112-6116, U+6120, U+6123-6124, U+6128-6130, U+6134, U+6136, U+613c-613f, U+6144, U+6146-6147, U+6149-614a, U+614d, U+6151-6153, U+6159-615a, U+615c-615f, U+6164-6165, U+6169-616d, U+616f, U+6171-6175, U+6177, U+617a, U+617c, U+617f-6180, U+6187, U+618a-618e, U+6192-6194, U+6199-619b, U+619f, U+61a1, U+61a7-61a8, U+61aa-61af, U+61b8, U+61ba, U+61bf, U+61c3)
+);
+
+/* noto-sans-tc-[70]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-70-700-normal.woff2",
+    $range: (U+5f78, U+5f7b, U+5f7d, U+5f82-5f84, U+5f87, U+5f89-5f8a, U+5f8d, U+5f93, U+5f95, U+5f98-5f99, U+5f9b-5f9c, U+5fa0, U+5fa4, U+5fa6-5fa8, U+5fab-5fad, U+5fb3-5fb4, U+5fbc, U+5fc4, U+5fc6, U+5fc9, U+5fcb, U+5fce-5fd6, U+5fdc-5fdf, U+5fe1, U+5fe4, U+5fe7, U+5fea, U+5fec-5fee, U+5ff1, U+5ff3, U+5ff8, U+5ffa-5ffc, U+5fff-6000, U+6002, U+6005, U+600a, U+600d, U+600f-6010, U+6014, U+6017, U+6019-601c, U+601e, U+6020, U+6022, U+6026, U+6029, U+602b-602c, U+602e-602f, U+6031, U+6033-6035, U+6039, U+603c, U+6040-6043, U+6045, U+6047, U+604a-604c, U+604f, U+6053, U+6059-605b, U+605d, U+6060, U+6063, U+6067, U+606a-606b, U+606e, U+6072-6076, U+6078, U+607a, U+607c, U+607f-6081, U+6083, U+6086, U+608a, U+608c, U+608e, U+6092-6093, U+6095-6097, U+609b, U+609d, U+60a2, U+60a6-60a7, U+60a9-60aa)
+);
+
+/* noto-sans-tc-[71]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-71-700-normal.woff2",
+    $range: (U+5e34, U+5e37, U+5e3a, U+5e3c, U+5e40, U+5e42-5e44, U+5e47, U+5e54, U+5e57-5e5b, U+5e5e-5e5f, U+5e61-5e62, U+5e64, U+5e6a, U+5e6c, U+5e6e, U+5e75, U+5e77, U+5e7a, U+5e80-5e81, U+5e83, U+5e86, U+5e88, U+5e8b, U+5e90, U+5e92, U+5e96, U+5e99, U+5e9b, U+5e9d-5ea2, U+5ea4-5ea5, U+5eb3-5eb6, U+5eb9, U+5ebe, U+5ec3-5ec4, U+5ec6, U+5ecb-5ecd, U+5ed0-5ed2, U+5ed4-5ed5, U+5ed8-5ed9, U+5edb, U+5edd, U+5ee1, U+5ee8-5ee9, U+5eec, U+5eef-5ef0, U+5ef4-5ef5, U+5ef8, U+5efb-5efc, U+5efe, U+5f01-5f03, U+5f05, U+5f07-5f09, U+5f0b-5f0e, U+5f10-5f12, U+5f14, U+5f16, U+5f1b, U+5f1d, U+5f22, U+5f25, U+5f28-5f29, U+5f2d, U+5f2f-5f30, U+5f36, U+5f38-5f39, U+5f3c, U+5f3e, U+5f40-5f42, U+5f45-5f46, U+5f4a, U+5f50-5f52, U+5f54, U+5f56-5f58, U+5f5a-5f5e, U+5f61, U+5f63, U+5f66-5f67, U+5f6b, U+5f72-5f74, U+5f76)
+);
+
+/* noto-sans-tc-[72]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-72-700-normal.woff2",
+    $range: (U+5ce0-5ce1, U+5ce5-5ce6, U+5ce8-5cea, U+5ced-5cee, U+5cf1, U+5cf4-5cf5, U+5cf8, U+5cfe-5d00, U+5d06, U+5d08, U+5d0a-5d0d, U+5d15, U+5d18, U+5d1a, U+5d1d, U+5d1f-5d22, U+5d24, U+5d26-5d28, U+5d2c-5d2e, U+5d33-5d35, U+5d3d, U+5d3f, U+5d42-5d43, U+5d46-5d47, U+5d49-5d4b, U+5d4e, U+5d52-5d53, U+5d57-5d59, U+5d5b-5d5c, U+5d65, U+5d68-5d69, U+5d6b-5d6c, U+5d6f, U+5d74-5d75, U+5d7e-5d7f, U+5d81-5d82, U+5d85-5d88, U+5d8b-5d8c, U+5d92, U+5d94, U+5d97, U+5d99, U+5d9d, U+5da0-5da2, U+5da7, U+5da9-5daa, U+5dae, U+5db2, U+5db4, U+5db7-5db8, U+5dbd, U+5dc2-5dc5, U+5dc9, U+5dcb-5dcd, U+5dd2, U+5dd6, U+5dd8, U+5ddb-5ddc, U+5de0, U+5de3, U+5de9, U+5df0, U+5df3, U+5df5, U+5df9, U+5dfb-5dfd, U+5e00-5e01, U+5e04-5e05, U+5e0a, U+5e11, U+5e14, U+5e18-5e1c, U+5e1f-5e22, U+5e27-5e28, U+5e2f-5e30)
+);
+
+/* noto-sans-tc-[73]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-73-700-normal.woff2",
+    $range: (U+5b80-5b82, U+5b84, U+5b8d, U+5b92-5b93, U+5b95-5b96, U+5b9f-5ba1, U+5ba6-5ba8, U+5baa-5bad, U+5bbd-5bbe, U+5bc0-5bc1, U+5bc3, U+5bd0-5bd1, U+5bd4-5bd8, U+5bdb-5bdd, U+5be4-5be5, U+5bef, U+5bf3, U+5bfb, U+5bfe-5bff, U+5c02-5c03, U+5c05, U+5c09, U+5c0c, U+5c10, U+5c12-5c13, U+5c15, U+5c18-5c19, U+5c1b, U+5c1d-5c1f, U+5c22, U+5c25, U+5c27-5c28, U+5c2a-5c2b, U+5c34, U+5c38, U+5c3d, U+5c42, U+5c44, U+5c47, U+5c49-5c4a, U+5c50, U+5c53, U+5c58-5c59, U+5c5b, U+5c5d, U+5c61, U+5c63, U+5c68, U+5c6d-5c6e, U+5c74, U+5c79-5c84, U+5c86, U+5c88, U+5c8a-5c8d, U+5c92-5c9c, U+5ca0, U+5ca2-5ca3, U+5ca5-5ca7, U+5cab-5cad, U+5cb5, U+5cb7, U+5cba-5cbb, U+5cc1, U+5cc8, U+5cca-5ccb, U+5cce, U+5cd2, U+5cd6, U+5cd8-5cda, U+5cdf)
+);
+
+/* noto-sans-tc-[74]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-74-700-normal.woff2",
+    $range: (U+5a51, U+5a53, U+5a56-5a57, U+5a5d-5a5e, U+5a60-5a62, U+5a65, U+5a67, U+5a6a, U+5a6c-5a6d, U+5a73-5a76, U+5a7a-5a7c, U+5a81-5a84, U+5a8c, U+5a90, U+5a93, U+5a96-5a97, U+5a9c, U+5a9e-5aa0, U+5aa4, U+5aa7, U+5aab-5aac, U+5aae-5aaf, U+5ab1, U+5ab4-5ab5, U+5ab8, U+5aba-5abc, U+5abe-5abf, U+5ac3-5ac4, U+5ac6-5acb, U+5acf-5ad2, U+5ad4-5adc, U+5ae0-5ae1, U+5ae3, U+5ae5-5ae6, U+5ae8, U+5aea-5aeb, U+5aee, U+5af0, U+5af2, U+5af5, U+5afa, U+5aff, U+5b01, U+5b05, U+5b08, U+5b0b, U+5b11, U+5b16-5b17, U+5b19, U+5b1b, U+5b1d, U+5b21-5b23, U+5b28, U+5b2a-5b2d, U+5b32, U+5b34, U+5b36-5b38, U+5b3e-5b40, U+5b43-5b46, U+5b4b-5b4c, U+5b51, U+5b53, U+5b59, U+5b5b-5b5c, U+5b62, U+5b65, U+5b6c-5b6e, U+5b70-5b73, U+5b75, U+5b7a-5b7b, U+5b7d, U+5b7f)
+);
+
+/* noto-sans-tc-[75]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-75-700-normal.woff2",
+    $range: (U+590b-590c, U+590e, U+5910-5911, U+5914, U+5919, U+591b, U+591f, U+5923-5924, U+592c, U+5932, U+5938-593a, U+5940, U+5942, U+5944, U+594b-594c, U+594e, U+5950, U+5953, U+5956, U+5958, U+595a, U+5961, U+5966, U+5968-5969, U+596c-596d, U+5975, U+5977, U+597b-597c, U+597e, U+5980-5981, U+5986-5988, U+598a, U+598f, U+5997-5998, U+599f-59a3, U+59a6-59a7, U+59a9, U+59ab-59ac, U+59af, U+59b1-59b2, U+59b6, U+59b8, U+59ba, U+59be, U+59c1, U+59c3, U+59c7-59c9, U+59cd-59ce, U+59d2, U+59d6-59d9, U+59dd-59de, U+59e0, U+59e3-59e5, U+59e9-59eb, U+59ee, U+59f1-59f3, U+59f5-59f9, U+59fc-59fd, U+5a00, U+5a04-5a07, U+5a09, U+5a0c, U+5a11, U+5a13, U+5a16-5a17, U+5a1a, U+5a1e, U+5a20, U+5a23-5a24, U+5a29-5a2b, U+5a2d-5a2f, U+5a32-5a34, U+5a38, U+5a3c, U+5a3f-5a44, U+5a47-5a48, U+5a4a, U+5a4c-5a4d, U+5a50)
+);
+
+/* noto-sans-tc-[76]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-76-700-normal.woff2",
+    $range: (U+57a1, U+57a4, U+57a6, U+57a9, U+57ab, U+57b5, U+57b8-57bb, U+57c2, U+57c5-57c8, U+57cc, U+57cf, U+57d2, U+57dc-57de, U+57e1-57e2, U+57e5, U+57e7, U+57ed-57ee, U+57f0, U+57f3-57f6, U+57f8, U+57fb-57fd, U+5800-5801, U+5803-5804, U+5807, U+5809-580b, U+580d-580e, U+5810-5811, U+5814-5815, U+5819, U+581d-581e, U+5820, U+5823, U+5826, U+582c-582d, U+5830, U+583a, U+583f-5841, U+5848, U+584b, U+584d, U+584f, U+5852, U+5859-585a, U+585c, U+5861, U+5864, U+5868-5869, U+586c-586d, U+5871-5872, U+5879, U+587c-5881, U+5887-5889, U+588e, U+5890-5892, U+5896-5899, U+589d, U+58a1, U+58a3, U+58a6, U+58a9, U+58ac, U+58b0-58b1, U+58bb-58bc, U+58c2, U+58c5-58c6, U+58ca, U+58cc, U+58ce, U+58d0-58d1, U+58d5, U+58d9-58da, U+58df-58e0, U+58e9, U+58ec, U+58ee, U+58f1-58f3, U+58f6-58f7, U+58fb-58fc, U+5900, U+5902, U+5906, U+5909-590a)
+);
+
+/* noto-sans-tc-[77]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-77-700-normal.woff2",
+    $range: (U+566f, U+5671-5672, U+5676, U+567a-567c, U+5680, U+5684-5686, U+568c, U+568e-568f, U+5692-5693, U+5697-5699, U+569c, U+569e, U+56a1-56a7, U+56a9, U+56ab-56ad, U+56af, U+56b3, U+56b5-56b6, U+56b8, U+56bf-56c1, U+56c3, U+56c5, U+56c7-56c8, U+56cb-56cc, U+56d2-56d4, U+56d6-56d9, U+56df, U+56e1-56e5, U+56ea-56ec, U+56ee-56ef, U+56f1-56f4, U+56f7, U+56f9, U+56ff-5700, U+5703-5704, U+5706-5707, U+5709-570a, U+570c, U+570f, U+5711, U+5717, U+571c, U+5723-5724, U+5727, U+5729-572a, U+572c, U+572e-572f, U+5734-5735, U+573b, U+5741, U+574b-574d, U+574f, U+5752, U+5754, U+575a-5760, U+5763, U+5768-5769, U+576b, U+576d, U+576f-5770, U+5772-5775, U+5777, U+577b-577d, U+5780, U+5784, U+5788, U+578c, U+578e, U+5792-5793, U+5795, U+579a-579b, U+579f-57a0)
+);
+
+/* noto-sans-tc-[78]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-78-700-normal.woff2",
+    $range: (U+5551, U+5553, U+5555-5557, U+555c, U+5562-5563, U+5567, U+5569, U+556b-556c, U+5570, U+5575-5579, U+557b-557c, U+557f, U+5581, U+5583, U+5586, U+5588, U+558b, U+558f, U+5591, U+5599, U+559f, U+55a1, U+55a3, U+55a5-55a6, U+55a8-55a9, U+55ab, U+55ad, U+55b0-55b1, U+55b3, U+55b6-55b7, U+55b9, U+55bc-55bd, U+55c4-55c5, U+55c7, U+55c9, U+55cc-55cd, U+55d0, U+55d2, U+55d4-55d9, U+55db, U+55dd-55df, U+55e1-55e6, U+55e9-55ea, U+55ec, U+55ee, U+55f1-55f3, U+55f5-55f7, U+55f9-55fa, U+55fe, U+5600-5602, U+5608, U+560c, U+560f, U+5612-5613, U+5615-5616, U+5618, U+561a, U+561c, U+561e, U+5620, U+5623-5625, U+5627, U+562a, U+562c-562e, U+5630-5631, U+5635-5636, U+5638-563a, U+5640, U+5642-5643, U+5649, U+564c-5650, U+5654, U+5658-565d, U+5664-5666, U+5669, U+566b, U+566d)
+);
+
+/* noto-sans-tc-[79]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-79-700-normal.woff2",
+    $range: (U+543d, U+543f, U+5441, U+5444-5445, U+5447, U+5449, U+544b-544d, U+5450-5455, U+5457, U+545b-545c, U+545f-5460, U+5463-5464, U+546a-5472, U+5474, U+5476, U+5478, U+547b, U+547e-547f, U+5482-5488, U+548a, U+548d-5491, U+5494, U+5498-549d, U+54a1-54a5, U+54ab, U+54ad-54af, U+54b5, U+54b7, U+54bb-54bc, U+54be-54bf, U+54ca, U+54cc, U+54cf-54d2, U+54d4, U+54d6-54d7, U+54da, U+54de-54df, U+54e2, U+54e4, U+54e7, U+54eb, U+54f3, U+54fd, U+54ff, U+5501-5502, U+5504-5506, U+550a, U+550c, U+550e-550f, U+5511-5513, U+5516-5517, U+551a-551b, U+551e, U+5520, U+5524, U+5526-5527, U+552a, U+552c-552d, U+5530, U+5532-5533, U+5535-5536, U+553b-553c, U+553e-553f, U+5541-5542, U+5544-5545, U+5547, U+5549, U+554b, U+554d-554e, U+5550)
+);
+
+/* noto-sans-tc-[80]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-80-700-normal.woff2",
+    $range: (U+52db, U+52e0, U+52e3, U+52e6-52e7, U+52eb, U+52ed-52ee, U+52f0-52f2, U+52f7, U+52f9-52fa, U+5300-5302, U+530a-530b, U+530d, U+530f-5310, U+5315, U+531a, U+531c-531d, U+532d-532e, U+5331, U+5338, U+533b-533e, U+5344-5345, U+534b-534d, U+534f-5350, U+5358, U+535e-535f, U+5362-5364, U+5367, U+5369, U+536b-536c, U+536e-536f, U+5372, U+5374, U+5379-537a, U+537c-537d, U+5382, U+5385, U+5389, U+538b-538c, U+538e, U+5392-5396, U+5399, U+53a0-53a2, U+53a4-53a6, U+53a8-53a9, U+53ae, U+53b0, U+53b3-53b4, U+53b6-53b7, U+53b9, U+53bf, U+53c1, U+53c4, U+53ce-53cf, U+53d2, U+53d5, U+53d9-53da, U+53df-53e1, U+53e7-53e9, U+53f1, U+53f5-53f6, U+53f9, U+53fb-53fd, U+5400-5402, U+5405-5407, U+540f, U+5412, U+5414-5417, U+541a, U+5420-5421, U+5424-5425, U+5428-5429, U+542c-542f, U+5431-5432, U+5434, U+5437)
+);
+
+/* noto-sans-tc-[81]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-81-700-normal.woff2",
+    $range: (U+518f, U+5191, U+5193, U+5195-5197, U+519a-519c, U+519e, U+51a2, U+51a6-51a9, U+51ab, U+51ad-51af, U+51b1-51b6, U+51ba-51c0, U+51c3-51c5, U+51c7, U+51c9-51cb, U+51ce-51d1, U+51d4, U+51d6, U+51d9, U+51db-51dc, U+51df, U+51e4, U+51e6, U+51e9-51ea, U+51ed, U+51ef, U+51f4-51f5, U+51fc, U+51ff, U+5201-5202, U+5204-5205, U+5208, U+520b, U+520d-520e, U+5213, U+5215-5216, U+5218, U+521a, U+5220, U+5223, U+5226-5228, U+5232-5234, U+5239, U+523c, U+5241-5242, U+5244, U+5249, U+524c, U+5251-5252, U+5255, U+5257, U+525c, U+525e, U+5261, U+5263-5265, U+526e, U+5270, U+5273-5274, U+5277, U+527d, U+527f, U+5281-5282, U+5284, U+528a, U+528c, U+528f, U+5292-5294, U+529d, U+52a6, U+52ac-52ad, U+52b1-52b5, U+52b9, U+52bb-52bc, U+52be-52c0, U+52c5, U+52cb, U+52cd, U+52d0-52d1, U+52d6-52d7)
+);
+
+/* noto-sans-tc-[82]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-82-700-normal.woff2",
+    $range: (U+5032, U+5036, U+503a-503b, U+503e, U+5040-5041, U+5043, U+5045-5046, U+5048, U+504a-504e, U+5051-5053, U+505d-5060, U+5063, U+506a, U+506f-5072, U+5078, U+507a-507b, U+507f-5080, U+5088-5089, U+508b-508c, U+508e, U+5092, U+5095-5096, U+509a-509d, U+50a3, U+50a5, U+50a8, U+50af, U+50b1, U+50b4, U+50ba, U+50c2, U+50c6-50ca, U+50cd-50ce, U+50d6, U+50d9, U+50dd-50df, U+50e1, U+50e3, U+50e5-50e6, U+50e8-50ea, U+50ec-50f0, U+50f3, U+50fb, U+50fe, U+5101-5102, U+5105-5109, U+510b-510e, U+5110, U+5113-5115, U+5117, U+511a-511c, U+511e, U+5120-5121, U+5125, U+512b, U+5131, U+5134-5135, U+5138-513c, U+5140, U+514e, U+5150-5151, U+5155-5157, U+515a, U+515f, U+5162, U+516a, U+516e, U+5172, U+5174, U+5179, U+517b, U+517d, U+5182, U+5186, U+5188-5189, U+518b)
+);
+
+/* noto-sans-tc-[83]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-83-700-normal.woff2",
+    $range: (U+4f22, U+4f24, U+4f29-4f2b, U+4f2d, U+4f31-4f32, U+4f35, U+4f37, U+4f39, U+4f3b, U+4f3e, U+4f41-4f43, U+4f47, U+4f49, U+4f4c, U+4f52, U+4f57-4f58, U+4f5a, U+4f5d-4f5f, U+4f61, U+4f63-4f64, U+4f67, U+4f6a, U+4f6e-4f6f, U+4f72, U+4f74, U+4f76-4f7b, U+4f7d-4f7e, U+4f80-4f82, U+4f84, U+4f89-4f8a, U+4f8e-4f94, U+4f96-4f98, U+4f9a, U+4f9e, U+4fa0-4fa3, U+4fa5-4fa8, U+4faa-4fac, U+4fb2-4fb3, U+4fb7-4fba, U+4fc0-4fc1, U+4fc5-4fc7, U+4fcb, U+4fcd-4fce, U+4fd1, U+4fd3-4fd4, U+4fd8-4fdc, U+4fdf, U+4fe2-4fe5, U+4fe8-4fea, U+4fec-4fed, U+4ff3-4ff6, U+4ff8-4ffa, U+4ffd, U+5000, U+5002, U+5005, U+5008, U+500c, U+500f, U+5013-5015, U+501b-501c, U+501e, U+5022-5025, U+5027-5028, U+502c-502e, U+5030-5031)
+);
+
+/* noto-sans-tc-[84]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-84-700-normal.woff2",
+    $range: (U+3a17, U+3a52, U+3b22, U+3bd7, U+3bff, U+3ca5, U+3d68, U+3ddb, U+3de7, U+3deb, U+3e03, U+3e74, U+3f08, U+3f0e, U+3f21, U+3f97, U+4102, U+411b, U+4181, U+43c8, U+4552, U+4576, U+46e5, U+4837, U+493d, U+4a3b, U+4d09, U+4e02, U+4e04-4e05, U+4e0c, U+4e0f-4e10, U+4e15, U+4e17, U+4e1b, U+4e21-4e22, U+4e25, U+4e27, U+4e31, U+4e34, U+4e36-4e37, U+4e3d, U+4e3f-4e42, U+4e44, U+4e47, U+4e49, U+4e4c, U+4e52-4e54, U+4e57, U+4e5a-4e5b, U+4e60-4e61, U+4e69, U+4e6d, U+4e78, U+4e80-4e81, U+4e85, U+4e87, U+4e89-4e8a, U+4e8d, U+4e8f, U+4e93, U+4e96, U+4e98-4e99, U+4e9c, U+4e9f-4ea0, U+4ea2, U+4ea5, U+4ea9, U+4eb0, U+4eb2-4eb3, U+4eb5-4eb7, U+4eb9, U+4ebb-4ebc, U+4ebf, U+4ec2-4ec6, U+4ec8-4ec9, U+4ecf, U+4ed1, U+4ed3, U+4edc-4ee1, U+4ee7-4eeb, U+4eee-4eef, U+4ef1, U+4ef3-4ef5, U+4efa, U+4efc, U+4f00, U+4f02-4f03, U+4f05, U+4f07-4f09, U+4f0b, U+4f0e, U+4f15, U+4f17, U+4f1d-4f1f)
+);
+
+/* noto-sans-tc-[85]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-85-700-normal.woff2",
+    $range: (U+305c, U+3062, U+306d, U+307a, U+307c, U+3080, U+308e, U+3090-3091, U+3099-309e, U+30a5, U+30c2, U+30c5, U+30ee, U+30f0-30f2, U+30f4-30f6, U+30fd-30fe, U+3105-3106, U+3108, U+310a-310b, U+310d-3119, U+311b-311e, U+3120-3126, U+3128-3129, U+3131, U+3134, U+3137, U+3139, U+3141-3142, U+3145, U+3147-3148, U+314b, U+314d-314f, U+3153, U+315c, U+3160-3161, U+3163-3164, U+3181, U+318d, U+3192-3193, U+3196-3198, U+319d-319f, U+3220-3226, U+3231, U+3268, U+3281, U+328b, U+3291-3292, U+3295-3297, U+3299, U+329d, U+329f, U+32a3-32a4, U+32d6, U+32e1, U+3314, U+3322, U+337f, U+338e-338f, U+339c-339e, U+33a1, U+33c4, U+33d1-33d2, U+3440, U+3449, U+3479, U+3551, U+3569, U+35ad, U+35ce, U+36ac, U+373a, U+3863, U+38ec, U+39b8, U+3a02)
+);
+
+/* noto-sans-tc-[86]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-86-700-normal.woff2",
+    $range: (U+2749-274f, U+2752-275b, U+275d-275e, U+2761, U+2763, U+2765-2769, U+276e-276f, U+2771, U+2776-277e, U+2780-2782, U+278a-278c, U+2794-2796, U+2798-2799, U+279c-27a6, U+27a8-27ab, U+27ad, U+27af-27b0, U+27b2-27b3, U+27b7-27b9, U+27bc-27bd, U+27bf, U+27e9-27eb, U+27f5-27f6, U+2800, U+28ec, U+2922, U+2934-2935, U+29bf, U+2a2f, U+2b05-2b07, U+2b1b, U+2b50, U+2b55, U+2cf5, U+2e1c-2e1d, U+2f00, U+2f08, U+2f12, U+2f24, U+2f29, U+2f2f, U+2f3c, U+2f3f, U+2f42, U+2f45, U+2f63-2f64, U+2f83, U+2f8f, U+3003-3007, U+3012-3013, U+3016-3019, U+3020-3025, U+3030, U+303d, U+3041, U+3043, U+3045, U+3047, U+3049, U+3052)
+);
+
+/* noto-sans-tc-[87]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-87-700-normal.woff2",
+    $range: (U+264a-2656, U+2658-265c, U+265e-2660, U+2662-2664, U+2666-2669, U+266b-266f, U+267b, U+2692-2696, U+2698, U+269b-269c, U+26a0-26a1, U+26a3-26a5, U+26aa-26ac, U+26bd-26be, U+26c4-26c5, U+26c8, U+26d1, U+26d3-26d4, U+26e4, U+26e9-26ea, U+26f0-26f5, U+26f9-26fa, U+26fd, U+2701-2702, U+2704-2706, U+2708, U+270a-2712, U+2714, U+2716-2727, U+2729-273e, U+2740-2748)
+);
+
+/* noto-sans-tc-[88]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-88-700-normal.woff2",
+    $range: (U+2567-2570, U+2572, U+2574, U+2579, U+2580-258a, U+258c-2595, U+2597, U+25a1, U+25a3-25a4, U+25a6-25ac, U+25b0, U+25b4, U+25b7-25b9, U+25bb, U+25bd, U+25bf-25c2, U+25c7-25ca, U+25cc-25cd, U+25d0-25d9, U+25dc-25e6, U+25ea-25eb, U+25ef, U+25fb-25fe, U+2600-2604, U+2607, U+2609-260b, U+260d-2615, U+2618, U+261a-2623, U+262a, U+262d-2630, U+2638-263e, U+2641-2642, U+2648-2649)
+);
+
+/* noto-sans-tc-[89]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-89-700-normal.woff2",
+    $range: (U+2476-2481, U+2488-2491, U+24b6-24c5, U+24c7-24ca, U+24cc, U+24ce, U+24d0-24df, U+24e1-24ea, U+24f5, U+24ff, U+2501, U+2503-250d, U+250f-2511, U+2513-2515, U+2517-2518, U+251b-251d, U+2520, U+2523-2524, U+2528, U+252b-252c, U+252f, U+2533-2534, U+2537, U+253b-253c, U+2541, U+2543-2545, U+254b, U+2550-2566)
+);
+
+/* noto-sans-tc-[90]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-90-700-normal.woff2",
+    $range: (U+2139, U+2153, U+2194-2197, U+2199, U+219d-219e, U+21a0, U+21a9-21aa, U+21ac, U+21af-21b1, U+21b3-21b5, U+21ba-21bb, U+21c4, U+21ca, U+21cc, U+21d0, U+21d2-21d4, U+21d8, U+21dd, U+21e2-21e9, U+2200, U+2202, U+2205-2208, U+220e-220f, U+2211-2212, U+2215, U+2217-221a, U+221d-2220, U+2225, U+2227-222b, U+222e, U+2234-2237, U+223c-223d, U+2248, U+2256, U+2260-2261, U+2264-2265, U+226a-226b, U+226e-226f, U+2282-2283, U+2295-2296, U+2299, U+22a5, U+22b0-22b1, U+22b9, U+22bf, U+22c5-22c6, U+22c8, U+22d0-22d1, U+22ee, U+2312-2313, U+2318, U+231a-231b, U+2323, U+2328, U+239d, U+23a0, U+23af, U+23e4, U+23e9-23ea, U+23ec, U+23f0-23f3, U+23fa, U+2445, U+2461-2471, U+2474-2475)
+);
+
+/* noto-sans-tc-[91]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-91-700-normal.woff2",
+    $range: (U+1ec0-1ec3, U+1ec5-1ec6, U+1ec9, U+1ecb-1ecd, U+1ecf-1ed1, U+1ed3-1ed5, U+1ed7-1edd, U+1edf, U+1ee1, U+1ee3-1ee7, U+1ee9, U+1eeb, U+1eed, U+1eef-1ef1, U+1ef3, U+1ef7, U+1ef9, U+1f62, U+1fa2, U+2001-2006, U+2009-200a, U+200c-200d, U+200f-2012, U+2015-2016, U+201a, U+201e, U+2020-2021, U+2023-2025, U+2028, U+202a-202d, U+202f-2030, U+2032-2033, U+2035, U+2038, U+203e-203f, U+2042-2044, U+2049, U+204d-204e, U+2060-2061, U+2063, U+2070, U+2074-207b, U+207d-2083, U+208a, U+208d-208e, U+20a1, U+20a4, U+20a6, U+20a8-20ab, U+20ad-20ae, U+20b1-20b3, U+20b5, U+20b8-20ba, U+20bd, U+20dd, U+20e3, U+2105, U+2109, U+2112-2113, U+2115-2117, U+2120-2121, U+2126, U+212b)
+);
+
+/* noto-sans-tc-[92]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-92-700-normal.woff2",
+    $range: (U+11af, U+11b7, U+11bc, U+121b, U+122d, U+129b, U+12a0, U+13a6, U+13a9, U+13ac, U+13af, U+13b3, U+13c2, U+13e3, U+141b, U+1555, U+1557, U+15dc, U+15e8, U+1780-1782, U+1784-1785, U+1787, U+178a, U+178e-1791, U+1793-179c, U+179f, U+17a2, U+17b6-17b9, U+17bb-17bc, U+17bf-17c7, U+17c9, U+17cb, U+17d0, U+17d2, U+17db, U+1871, U+18fa, U+1bff, U+1d00, U+1d04-1d05, U+1d07, U+1d0a-1d0b, U+1d0d, U+1d0f, U+1d17-1d18, U+1d1b-1d1c, U+1d20-1d22, U+1d25, U+1d2c, U+1d2e, U+1d30-1d31, U+1d33-1d3a, U+1d3c, U+1d3e-1d42, U+1d52, U+1d55, U+1d5b, U+1d5e, U+1d9c, U+1da0, U+1dc4-1dc5, U+1e3b, U+1e43, U+1e45, U+1e47, U+1e63, U+1e6d, U+1e73, U+1ea0, U+1ea2, U+1ea4-1ea9, U+1eab-1eaf, U+1eb1, U+1eb3, U+1eb5, U+1eb7, U+1eb9, U+1ebb, U+1ebd-1ebe)
+);
+
+/* noto-sans-tc-[97]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-97-700-normal.woff2",
+    $range: (U+2c8-2c9, U+2cc-2cd, U+2d0, U+2d8, U+2da, U+2dc, U+2e1-2e3, U+2e7, U+2eb, U+2ee, U+2f1-2ff, U+302-304, U+306-309, U+30c-30d, U+311, U+31b, U+321, U+323-325, U+328-329, U+32b-32c, U+32e-32f, U+331-33a, U+33c-33f, U+348, U+353, U+358-359, U+35c, U+35e-35f, U+361, U+363, U+367-368, U+36c, U+36f, U+530-535, U+537-540, U+55e, U+561-565, U+568-56d, U+56f-576, U+578-582, U+584, U+5a1, U+5a3-5a4, U+5aa, U+5ae, U+5b0-5b4)
+);
+
+/* noto-sans-tc-[98]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-98-700-normal.woff2",
+    $range: (U+1af, U+1b1, U+1b4-1be, U+1d0, U+1d2, U+1d4, U+1da, U+1dc-1dd, U+1e1, U+1e3-1e4, U+1e7, U+1e9, U+1eb-1ec, U+1f0-1f1, U+1f3-1f5, U+1f7, U+1f9-1ff, U+219, U+221, U+225-226, U+228-22b, U+22e-22f, U+231-235, U+239, U+23b, U+23e, U+250-252, U+254-255, U+259-25e, U+261-263, U+268-26b, U+26d, U+26f-277, U+279-27a, U+27d-281, U+283, U+28a-28c, U+28f, U+292, U+294-296, U+298-29a, U+29c, U+29f, U+2a1-2a2, U+2a4-2a7, U+2a9-2aa, U+2ae-2b3, U+2b5-2b7, U+2b9-2bf, U+2c2-2c4, U+2c6-2c7)
+);
+
+/* noto-sans-tc-[99]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-99-700-normal.woff2",
+    $range: (U+a1-a2, U+a4, U+a6-a8, U+aa, U+ac, U+af, U+b1, U+b5-b6, U+b8-ba, U+bc-be, U+c0-c8, U+ca-cc, U+ce-d5, U+d8-df, U+f0, U+f5, U+f8, U+fb, U+fe-100, U+102, U+105, U+107, U+109-10b, U+10f, U+112, U+115, U+117, U+119, U+11b, U+11f, U+121, U+123-124, U+127, U+129, U+12c-12d, U+130-13f, U+141-142, U+144, U+148, U+14b-14c, U+14f-153, U+159-15b, U+15e-160, U+163-166, U+169-16a, U+16d-171, U+173-17e, U+192, U+1a0, U+1a4, U+1aa, U+1ac-1ad)
+);
+
+/* noto-sans-tc-[100]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-100-700-normal.woff2",
+    $range: (U+a3, U+2ca, U+2223, U+2460, U+2640, U+273f, U+301c, U+3107, U+310c, U+4e30, U+4e3e, U+4e5e, U+4e71, U+4f26, U+4f7c, U+4f83, U+50da, U+5243, U+5267, U+529e, U+5321, U+5352, U+5477, U+548b, U+54a6, U+54b2, U+54c2, U+54c4, U+54c6, U+54cd, U+54ee, U+5543, U+55d1, U+55d3, U+55f0, U+55fd, U+560d, U+5629, U+5660, U+56d1, U+56dd, U+57ae, U+57e0, U+57e4, U+5904, U+592d, U+5965, U+5a31, U+5a7f, U+5b5a, U+5bb8, U+5c14, U+5c3b, U+5c5c, U+5c5e, U+5d10, U+5e10, U+5e4c, U+603b, U+604d, U+611c, U+6137, U+61c8, U+62c7, U+6371, U+6382, U+645f, U+64ae, U+64c2, U+651e, U+65f1, U+660a, U+663e, U+673d, U+6784, U+6789, U+67b1, U+67ff, U+6813, U+6854, U+68d8, U+68fa, U+697d, U+6a01, U+6a1e, U+6baf, U+6c08, U+6c17, U+6c2b, U+6c81, U+6cbd, U+6dc6, U+6df9, U+6ed9, U+6ee1, U+6f86, U+6fc1, U+6fdb, U+701f, U+7076, U+715c, U+7194, U+71ee, U+71fb, U+720d, U+72b6, U+7396, U+73af, U+745b, U+746f, U+748b, U+7647, U+7699, U+76ce, U+76de, U+77aa, U+786b, U+7881, U+78ca, U+793c, U+797a, U+79b9, U+79bb, U+79bf, U+7a92, U+7ac7, U+7ae3, U+7b19, U+7b20, U+7b51, U+7b94, U+7cbd, U+7cde, U+7cef, U+7d46, U+7dde, U+7f88, U+80da, U+814b, U+81cd, U+8235, U+8282, U+82b9, U+846b, U+84c1, U+84d3, U+8518, U+8611, U+8783, U+8814, U+8a15, U+8aa6, U+8b2c, U+8ba8-8ba9, U+8bc6, U+8be2, U+8be5-8be6, U+8c22, U+8d05, U+8d27, U+8dbe, U+8e34, U+8e66, U+8ec0, U+9005, U+9082, U+914b, U+916f, U+92c5, U+92f0, U+9318, U+938a, U+93e2, U+964b, U+96c1, U+96cc-96cd, U+96db, U+973e, U+97a0, U+9803, U+9876, U+9879, U+9955, U+99f1, U+9a5b, U+9ab7, U+9abc, U+9c57, U+9c9c, U+9d1b, U+9d26, U+9d51, U+9eef, U+9f99, U+c2a4, U+e253, U+e313-e314, U+e5c7, U+e5c9, U+e8db-e8dc, U+ff2d-ff2e, U+ff34, U+ffe5, U+1f60a, U+1f618, U+1f62d)
+);
+
+/* noto-sans-tc-[101]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-101-700-normal.woff2",
+    $range: (U+b4, U+10d, U+2d9, U+641, U+6cc, U+e20, U+e29, U+200e, U+20ac, U+2266, U+25be, U+301d-301e, U+3058, U+4e07, U+4e1d, U+4e66, U+4ece, U+4fde, U+5016, U+5180, U+5199, U+51aa, U+5306, U+5386, U+53d8, U+5413, U+541d, U+54ce, U+54e8, U+54fc, U+5571, U+557e, U+558e, U+55a7, U+56a8, U+57a2-57a3, U+58b3, U+5960, U+5992-5993, U+59a4, U+5a55, U+5ab2, U+5afb, U+5b56, U+5bc5, U+5bc7, U+5bf0, U+5cb1, U+5cc7, U+5dff, U+5e93, U+5ed3, U+5f6a, U+60bc, U+61ff, U+6218, U+6292, U+634d, U+6467, U+64f1-64f2, U+6582, U+65fb, U+6615, U+6687, U+66e6, U+66f0, U+6781, U+67f5, U+68a7, U+6a1f, U+6b27, U+6b4e, U+6b73, U+6b79, U+6bcb, U+6c5d, U+6cf5, U+6dee, U+6ec4, U+6ecc, U+6f88, U+701d, U+703e, U+707c, U+7099, U+710a, U+72d9, U+72e9, U+731d, U+739f, U+7463, U+7480, U+74a8, U+7523, U+7526, U+75e0, U+7613, U+7656, U+76bf, U+76d4, U+773a, U+775c, U+775e, U+780c, U+78e1, U+78f7, U+7960, U+7a20, U+7aaf, U+7b08, U+7b71, U+7be4, U+7cec, U+7cf0, U+7d5e, U+7d62, U+7dbe, U+7e1b, U+7ea2, U+7ec4, U+7ec6, U+7edc, U+7eed, U+7efc, U+7f16, U+7f57, U+7fb9, U+7fca, U+803d, U+816e, U+8258, U+82a5, U+82b7, U+8317, U+8338, U+834a, U+83d3, U+8401, U+8469, U+849e, U+854a, U+8559, U+865e, U+8700, U+8759, U+8760, U+8778, U+8782, U+879e, U+87d1, U+8836, U+8944, U+89c8, U+8aac, U+8b74, U+8ba2, U+8ba4, U+8bae, U+8bfb, U+8c4e, U+8cb3, U+8d16, U+8d28, U+8e44, U+8f3b, U+8f3f, U+8f91, U+8fb9, U+8fc4, U+8fde, U+8ff9, U+9076, U+9091, U+90ae, U+90b8, U+9257, U+9310, U+9382, U+93df, U+94fe, U+95a5, U+962e, U+968f-9690, U+9704, U+9713, U+97f6, U+9824, U+986b, U+9884, U+9886, U+98e2, U+991a, U+9986, U+99a5, U+99dd, U+9ab8, U+9b41, U+9b77, U+9bad, U+c774, U+e5d4, U+fe52, U+ff02, U+ff25, U+1f389, U+1f449, U+1f495)
+);
+
+/* noto-sans-tc-[102]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-102-700-normal.woff2",
+    $range: (U+2cb, U+5d1, U+5d9, U+5e2, U+5e8, U+5ea, U+633, U+e32, U+2252, U+2267, U+2573, U+25b3, U+25c4, U+2713, U+2715, U+30e2, U+4e28, U+4e3c, U+4e4d, U+4e70, U+4f88, U+4fef, U+5018, U+501a, U+5026, U+5137, U+513f, U+51f3, U+524b, U+5254, U+52d8, U+5308, U+5384, U+53cc, U+5436, U+5443, U+5466, U+54a8, U+54bd, U+54c9, U+54cb, U+555e, U+5580, U+560e, U+561f, U+562f, U+566c, U+5679, U+56bc, U+56cd, U+56e7, U+56ed, U+572d, U+57d7, U+582f, U+589f, U+5b09, U+5ba5, U+5c51, U+5c90, U+5cef, U+5d16, U+5d84, U+5dd4, U+5e08, U+5e26, U+5f0a, U+5f20, U+606c, U+61c7, U+620f, U+6254, U+625b, U+62a4, U+62d0, U+62f1, U+63a0, U+63c6, U+63f9, U+6413, U+6417, U+6483, U+64f7, U+650f, U+65a7, U+665f, U+66ae, U+66d6, U+66e0, U+6746, U+6756, U+67d1, U+6837, U+68e0, U+68f5, U+6995, U+69a8, U+69b4, U+69d3, U+6a3d, U+6abb, U+6bb7, U+6bd3, U+6c47, U+6cc4, U+6cd3, U+6dae, U+6e26, U+6e29, U+6eaf, U+6eba, U+6fef, U+7028, U+70b3, U+711a, U+725f, U+7325, U+733f, U+73c0, U+73ee, U+7444, U+745a, U+7487, U+7540, U+75a4, U+7729, U+779e, U+798e, U+79e9, U+7a3d, U+7a4c, U+7a9f, U+7ac4, U+7aff, U+7c27, U+7cd9, U+7d76, U+7e43, U+7ea6, U+7ed9, U+7ff1, U+808b, U+809b, U+80fa, U+827a, U+8309, U+8328, U+832b, U+8396, U+83e0, U+840e, U+8425, U+852d, U+853b, U+8588, U+85e9, U+86b5, U+86e4, U+8718, U+87ec, U+880d, U+8910, U+893b, U+89c1-89c2, U+8b3e, U+8baf, U+8bc1, U+8bdd, U+8c41, U+8c48, U+8cb6, U+8d2d, U+8d5e, U+8fbe, U+9015, U+90a8, U+90b5, U+90e1, U+9169, U+9183, U+91d0, U+91dc, U+9293, U+92f8, U+9472, U+9598, U+95a9, U+95ed, U+95fb, U+9605, U+96c7, U+9739, U+9742, U+9761, U+99ad, U+9ae6, U+9b1a, U+9b44, U+9bc9, U+9d3f, U+9dd7, U+9e7c, U+9e92, U+fe5d-fe5e, U+ff22-ff24, U+ff2f-ff30, U+ff33)
+);
+
+/* noto-sans-tc-[103]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-103-700-normal.woff2",
+    $range: (U+60, U+f7, U+2198, U+2571, U+258b, U+25b6, U+2661, U+3051, U+3109, U+311a, U+4e11, U+4e24, U+4e2b, U+4ef7, U+4f18, U+4f36, U+4fd0, U+5029-502a, U+5055, U+508d, U+50ad, U+50e7, U+50f1, U+50f5, U+51a5, U+51c8, U+51fb, U+5203, U+524e, U+5288, U+5323, U+53c2, U+5458, U+54a7, U+54b1, U+54b3, U+54b8, U+556a, U+5582, U+55b2, U+55ba, U+55da, U+55dc, U+5614, U+5662, U+5678, U+56c2, U+5742, U+57d5, U+5862, U+58e4, U+58f0, U+5907, U+590d, U+5934, U+5978, U+5984, U+5a25, U+5c06, U+5c62, U+5c91, U+5d01, U+5d1b, U+5e87, U+5eff, U+5f27, U+5f3a, U+5f53, U+6001, U+6168, U+61a9, U+6233, U+62a5, U+62ce, U+62ed, U+638f, U+6399, U+646f, U+6590, U+6631, U+664f, U+6689, U+66dc, U+672f, U+67af, U+67ec, U+68d7, U+6977, U+6a44, U+6c14, U+6c40, U+6c70, U+6c76, U+6cb8, U+6ce3, U+6df3, U+6e20, U+6e43, U+6e5b, U+6ebc, U+6eec, U+6f2c, U+6fb1, U+7009, U+7011, U+701a, U+7117, U+7184, U+72f9, U+7426, U+74bd, U+74cf, U+752b, U+7554, U+75b9, U+7621, U+7671-7672, U+7693, U+76ef, U+7737, U+77a7, U+77b3, U+77bb, U+77da, U+77e2, U+77e9, U+77ef, U+7801, U+7940, U+797f, U+79a7, U+79b1, U+79bd, U+79cd, U+7a6b, U+7ac5, U+7b1b, U+7b77, U+7ca7, U+7dab, U+7db4, U+7db8, U+7dcb, U+7ddd, U+7de0, U+7e55, U+7e9c, U+7ed3, U+7ef4, U+803f, U+8046, U+8087, U+8116, U+81a8, U+8214, U+821c, U+82d4, U+831c, U+8339, U+8350, U+8354, U+8526, U+860a, U+86db, U+8713, U+873b, U+8822, U+8993, U+8a1f, U+8ab9, U+8ad7, U+8bcd, U+8e72, U+8f4e, U+8f9c, U+8fd0, U+8fd8, U+8fe6, U+9042, U+907c, U+91ba, U+9452, U+95e2, U+9631, U+9699, U+96b8, U+9709, U+978d, U+9830, U+98ce, U+9945, U+99ed, U+9a8c, U+9ad3, U+9baa, U+9be8, U+9c77, U+9cf6, U+9d72, U+9e1f, U+9ec4, U+fe31, U+fe55, U+ff03, U+ff20, U+ff3b, U+ff3d, U+1f3fb, U+1f44d, U+1f60d)
+);
+
+/* noto-sans-tc-[104]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-104-700-normal.woff2",
+    $range: (U+10c, U+161, U+e44, U+2728, U+3081, U+4e13, U+4e19, U+4e1c, U+4e1e, U+4e5c, U+4ea7, U+4ed7, U+4f20, U+4f8d, U+4ffe, U+5021, U+50d5, U+515c, U+51a4, U+51e0, U+521b, U+522b, U+532a, U+534e, U+5355, U+537f, U+5398, U+541f, U+543c, U+544e, U+5509, U+5598, U+5622, U+563f, U+5641, U+566a, U+5695, U+569f, U+56ae, U+56da, U+573a, U+574e, U+584c, U+5885, U+58ae, U+5a1f, U+5ac2, U+5b24, U+5bb0, U+5bde, U+5be1, U+5bfc, U+5c39, U+5c4c, U+5c60, U+5cfb, U+5d11, U+5e76, U+5e7f, U+5e9a, U+5eb8, U+5f13, U+5f64, U+5f6c, U+6127, U+61f2, U+6208, U+620a, U+620c, U+6252, U+62ef, U+6328, U+633d, U+6362, U+63b0, U+63c0, U+63c9, U+640f, U+64a9, U+6514, U+652c, U+655e, U+6583, U+658c, U+6627, U+66f3, U+6734, U+6743, U+676d, U+67c4, U+67da, U+6807, U+68cd, U+68f2, U+690e, U+6b16, U+6b38, U+6b3d, U+6bc6, U+6ca1, U+6cab, U+6d8c, U+6e32, U+6e3e, U+6e58, U+6eef, U+6ef2, U+708a, U+7130, U+7165, U+7172, U+71ed, U+7232, U+7239, U+7261, U+7280, U+72a7, U+72f8, U+73c8, U+7464, U+753b, U+754f, U+755c, U+75d8, U+76ea, U+776b, U+7779, U+777f, U+7784, U+778e, U+77ee, U+79e4, U+7a46, U+7a57, U+7aba, U+7aed, U+7b4d, U+7c7b, U+7c7d, U+7d13, U+7d33, U+7dbb, U+7df9, U+7e46, U+7ea7, U+8085, U+8165, U+81fb, U+82b8, U+82d3, U+8305, U+8335, U+8343, U+83e9, U+840d, U+851a, U+853d, U+8543, U+859b, U+85fb, U+87fb, U+888d, U+88c5, U+8adc, U+8b0a, U+8bb0, U+8bbe, U+8bc4, U+8bf4, U+8c5a, U+8cc3, U+8ce4, U+8d44, U+8e81, U+8f44, U+8f66, U+8fdb, U+900d, U+9063, U+914c, U+9223, U+9226, U+923a, U+925b, U+9264, U+929c, U+92b9, U+9320, U+934d, U+9444, U+957f, U+9591, U+96a7, U+97ad, U+97cc, U+9811, U+9898, U+98ea, U+9921, U+9952, U+9a55, U+9b0d, U+9bca, U+9ebd, U+e60f, U+ff1c-ff1d, U+ff21, U+ff38, U+ff9f, U+fffd, U+1f602)
+);
+
+/* noto-sans-tc-[105]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-105-700-normal.woff2",
+    $range: (U+e17, U+e22, U+2103, U+25a0, U+266a, U+3014-3015, U+311f, U+4e1a, U+4e50, U+4f10, U+4f6c, U+4f70, U+5006, U+50d1, U+5170, U+518c, U+51f0, U+51f6, U+51f9, U+5219, U+5256, U+525d, U+52c9, U+5349, U+5351, U+5356, U+5375, U+539d, U+53db, U+53ee, U+53f7, U+5492, U+54fa, U+5538, U+55bb, U+55e8, U+5632, U+5757, U+5835, U+58be, U+5937, U+59dc, U+59e8, U+5a49, U+5a9a-5a9b, U+5ab3, U+5b9b, U+5b9e, U+5be8, U+5c37, U+5c4e, U+5d14, U+5d19, U+5d4c, U+5d50, U+5deb, U+5e84, U+5e94, U+5ec2, U+5f17, U+5f26, U+5f55, U+5f77, U+5f7f, U+5fbd, U+6052, U+6064-6065, U+608d, U+609a, U+6101, U+614c, U+621a, U+6237, U+6296, U+62e9, U+632a-632b, U+6488, U+6500, U+652a, U+6556, U+65e0, U+65ec, U+6643, U+6850, U+6893, U+6897, U+68b3, U+68d5, U+6930, U+6960, U+6a11, U+6a3a, U+6ab3, U+6b22, U+6c59, U+6c83, U+6ccc, U+6dea, U+6df5, U+6ef7, U+6f3e, U+6f80, U+6fe4, U+7164, U+71c9, U+722a, U+7260, U+7272, U+73b0, U+74e3, U+7538, U+7586, U+75b5, U+7661-7662, U+77db, U+7838, U+786e, U+788c, U+7950, U+79a6, U+79aa, U+7a40, U+7bf7, U+7c3e, U+7c98, U+7ca5, U+7d21, U+7d2e, U+7dba, U+7dec, U+7e79, U+7ecf, U+7edf, U+7f79, U+8086, U+810a, U+8139, U+813e, U+817a, U+81b3, U+821f, U+8247, U+8259, U+8271, U+839e, U+8431, U+846c, U+849c, U+84b2, U+84c4, U+8513-8514, U+8755, U+8877, U+8881, U+88f9, U+8a1d, U+8a3c, U+8a6d-8a6e, U+8a93, U+8ae7, U+8af7, U+8b17, U+8b5a, U+8ba1, U+8bba, U+8cdc, U+8dea, U+8f6c, U+8f7d, U+8fc7, U+8fd9, U+902e, U+90ca, U+916a, U+916c, U+921e, U+9245, U+935b, U+9594, U+95a8, U+95ee, U+95f4, U+9706, U+971e, U+9756, U+980c, U+9891, U+98b1, U+98fc, U+9903, U+9957, U+99ff, U+9b91, U+9db4, U+9f4b, U+e602-e605, U+e610-e611, U+ff16-ff19)
+);
+
+/* noto-sans-tc-[106]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-106-700-normal.woff2",
+    $range: (U+2190-2191, U+2193, U+22c1, U+2302, U+25cb, U+2699, U+2709, U+3127, U+4e0e, U+4e18, U+4e3a, U+4e48, U+4e91, U+4eec, U+4f3d, U+4fcf, U+5112, U+524a, U+52a3, U+52ab, U+52c3, U+52f3, U+52fb, U+5320, U+5339, U+533f, U+53e2, U+543e, U+5480, U+5495, U+5497, U+5564, U+5572, U+55c6, U+55ef, U+563b, U+5653, U+5657, U+56b7, U+5824, U+58d8, U+5955, U+5983, U+598d, U+59da, U+59e6, U+5a36, U+5bb5, U+5bc2, U+5bf9, U+5cb3, U+5d17, U+5dbc, U+5e2e, U+60df, U+611a, U+6190, U+61a4, U+61be, U+61fc, U+6284, U+62ac, U+62bc, U+634f, U+636e, U+6398, U+63a9, U+6487, U+6495, U+64ab, U+6577, U+65ac, U+6602, U+6652, U+66f9, U+6761, U+679a, U+683d, U+68ad, U+68b5, U+68da, U+68e7, U+6a38, U+6a59, U+6ae5, U+6b47, U+6b67, U+6b6a, U+6bef, U+6c50, U+6c9b, U+6e23, U+6e34, U+6e4a, U+6e67, U+6ea2, U+6eb6, U+6f20, U+6feb, U+70ed, U+714c, U+715e, U+7199, U+71ac, U+7231, U+7262, U+7409, U+745f, U+7469, U+74ca, U+7535, U+753a, U+75f4, U+7624, U+7682, U+76ba, U+76f2, U+77fd, U+780d, U+7832, U+78c5, U+78ef, U+7901, U+79be, U+79c9, U+79e6, U+7a1a, U+7a62, U+7a84, U+7aca, U+7cb5, U+7cb9, U+7cdf, U+7ce7, U+7d6e, U+7db1, U+7def, U+7e61, U+7e7d, U+7e8f, U+7f38, U+7f77, U+7fa8, U+7fc5, U+7fe1, U+7ff9, U+800d, U+8015, U+8054, U+80a2, U+80aa, U+80ba, U+814e, U+8180, U+819d, U+81c0, U+828b, U+82ad, U+82af, U+83f1, U+83f8, U+8403, U+84bc, U+84c9, U+84ec, U+8523, U+8549, U+8569, U+8591, U+85b0, U+881f, U+884d, U+88d4, U+89c4, U+89c6, U+8a60, U+8a79, U+8b19, U+8bd5, U+8bf7, U+8c03, U+8c79, U+8cc8, U+8d9f, U+8e10, U+8e48, U+8faf, U+9009, U+9017, U+9175, U+9187, U+918b, U+9214, U+946b, U+9470, U+947c, U+9640, U+9675, U+96ef, U+97cb, U+97e9, U+985b, U+99ae, U+99b3, U+9b4f, U+9d09, U+9e9f, U+9edb, U+9f90, U+ff14, U+1f464)
+);
+
+/* noto-sans-tc-[107]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-107-700-normal.woff2",
+    $range: (U+a5, U+25ce, U+4e56, U+4e9a, U+4ea8, U+4ead, U+4f3a, U+4f51, U+4f62, U+4faf, U+5098, U+50ac, U+5147, U+5173, U+5187, U+51f8, U+52a1, U+52a8, U+52f8, U+535c, U+53ed, U+541e, U+5435, U+5475, U+54a9, U+54c0, U+54c7, U+5589, U+5605, U+5733, U+5764, U+5782, U+57c3, U+5858, U+5893, U+589c, U+58e2, U+5974, U+599e, U+59a8, U+59ec, U+5b66, U+5b99, U+5b9d, U+5bee, U+5c2c, U+5c65, U+5cfd, U+5d0e, U+5dba, U+5de2, U+5e06, U+5e15, U+5ec1, U+5ed6, U+5f00, U+5f4c, U+5f65, U+6055, U+6070, U+609f, U+60b6, U+6241, U+624e, U+626f, U+6291, U+62cc, U+62d8, U+62da, U+62fe, U+6349, U+6367, U+63ea, U+6435, U+6454, U+64a4, U+64b2, U+64bc, U+64bf, U+64c5, U+64ce, U+6558, U+6572, U+65a5, U+65e8, U+65ed, U+6614, U+6670, U+6688, U+672d, U+673a, U+6770, U+68cb, U+6912, U+6953, U+6a61, U+6aac, U+6aaf, U+6ab8, U+6b20, U+6b96, U+6bbf, U+6bc5, U+6c6a, U+6cbe, U+6d59, U+6d78, U+6dc7, U+6deb, U+6e7e, U+6e9c, U+6f3f, U+6f51, U+6f84, U+704c, U+7051, U+70ab, U+70ad, U+70f9, U+7119, U+7149, U+714e, U+71e6, U+72c4, U+72d0, U+72e0, U+7334, U+744b, U+7455, U+7504, U+75ab, U+75b2, U+766e, U+76c3, U+76fc, U+76fe, U+7891, U+7948, U+7a74, U+7b28, U+7c72, U+7cca, U+7ebf, U+7f55, U+7ff0, U+8154, U+81c2, U+81d8, U+81e3, U+81e5, U+8292, U+8299, U+8302, U+8304, U+8332, U+83c1, U+83c7, U+83ca, U+845b, U+8475, U+8490, U+85af, U+8650, U+8667, U+86d9, U+8774, U+8abc, U+8b0e, U+8b39, U+8bed, U+8c54, U+8c6b, U+8c9e, U+8ca7, U+8caa-8cab, U+8ce6, U+8cec-8ced, U+8eb2, U+8eba, U+8fb0, U+901d, U+908f, U+9127, U+91c0, U+91d8, U+9215, U+92b3, U+932b, U+93fd, U+95ca, U+964c, U+96c0, U+970d, U+9716, U+9774, U+97fb, U+9812, U+9913, U+9935, U+99c1, U+9b31, U+9d5d, U+9d6c, U+9e79, U+fe0f, U+fe30, U+ff05, U+ff0b, U+ff10, U+ff15)
+);
+
+/* noto-sans-tc-[108]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-108-700-normal.woff2",
+    $range: (U+b0, U+926, U+928, U+939, U+93f-940, U+94d, U+200b, U+22ef, U+25ba, U+25c6, U+2665, U+4e08, U+4e2a, U+4e4f, U+4e59, U+4ec7, U+4f0d, U+4f0f, U+4f19, U+4f59, U+4fae, U+5075, U+507d, U+50b2, U+50b5, U+511f, U+5141, U+5146, U+514c, U+5185, U+51dd, U+51fd, U+522e, U+5319, U+533a, U+5378, U+53ad, U+53c9, U+53d1, U+53d4, U+543b, U+5442, U+5446, U+5481, U+54e9, U+5507, U+5565, U+559a, U+55aa, U+5690, U+56ca, U+56fe, U+582a, U+5915, U+5949, U+5962, U+5996, U+59a5, U+59fb, U+5a77, U+5b0c, U+5b5f, U+5bd3, U+5be2, U+5bfa, U+5c41, U+5c48, U+5ca9, U+5d07, U+5ec8, U+5eca, U+5f18, U+5f4e, U+5f59, U+5f6d, U+5f79, U+5fb9, U+6028, U+6068, U+606d, U+6094, U+60f1, U+6108-6109, U+614e, U+6170, U+617e, U+61b2, U+61f8, U+6247, U+626d, U+6276, U+62ab, U+62cb, U+62d3, U+62f3, U+6368, U+6380, U+6492, U+64e0, U+6570, U+6606, U+660f, U+6649, U+6691, U+66a8, U+6749, U+674f, U+6795, U+67f1, U+67f3, U+6842, U+6851, U+687f, U+68df, U+69fd, U+6a58, U+6c27, U+6c88, U+6cca, U+6d29, U+6d66, U+6daf, U+6f01, U+6f58, U+6f6d, U+6f70, U+6fa1, U+6ff1, U+6ffe, U+7058, U+70ae, U+71d9, U+71e5, U+7235, U+7267, U+73ca, U+742a, U+74f7, U+7529, U+758f, U+75bc, U+76c6, U+7955, U+7a00, U+7a3b, U+7b4b, U+7bad, U+7be9, U+7c4c, U+7c60, U+7cfe, U+7dbf, U+7e2b, U+7f9e, U+7fc1, U+7ffc, U+8096, U+809d, U+80de, U+8155, U+816b, U+81df, U+82bd, U+8352, U+8393, U+8404, U+8525, U+856d, U+8606, U+868a, U+87f9, U+886b, U+8870, U+896a, U+896f, U+8a23, U+8a87, U+8ad2, U+8b00, U+8b20, U+8cb8, U+8cca, U+8ce0, U+8d39, U+8d6b, U+8db4, U+8e29, U+8ef8, U+8f1b, U+8f5f, U+8fa8, U+906e, U+9077, U+90aa, U+90b1, U+90c1, U+9165, U+919c, U+92c1, U+95d6, U+95e8, U+975a, U+9817, U+98c6, U+9ecf, U+feff, U+ff06, U+ff0a, U+ff12-ff13)
+);
+
+/* noto-sans-tc-[109]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-109-700-normal.woff2",
+    $range: (U+627-629, U+631, U+639, U+644, U+64a, U+25cf, U+2606, U+2764, U+3008-3009, U+4e38, U+4e43, U+4ed5, U+4ef0, U+4eff, U+4fe0, U+5085, U+50a2, U+50be, U+5118, U+5211-5212, U+5272, U+52fe, U+5366, U+53b2, U+53ec, U+54ac, U+5587, U+55b5, U+5606, U+561b, U+5751, U+576a, U+57cb, U+58ef, U+58fa, U+594f, U+5951, U+596e, U+59d1, U+5ac1, U+5acc, U+5b8b, U+5c4d, U+5ca1, U+5d29, U+5dfe, U+5e7d, U+5edf, U+5ef7, U+5fa1, U+5faa, U+5fcc, U+5ffd, U+6021, U+6046, U+6062, U+62b9, U+6316, U+6350, U+6478, U+647a, U+6490, U+64b0, U+64e6, U+6524, U+6591, U+659c, U+65a4, U+65e6, U+65f6, U+6607, U+6674, U+6765, U+679d, U+67f4, U+68a8, U+6b3a, U+6c57, U+6c61, U+6c90, U+6cbf, U+6cdb, U+6d69, U+6db5, U+6dd1, U+6e21, U+6f06, U+6f62, U+70d8, U+71c3, U+71d5, U+722c, U+727d, U+72ac, U+72fc, U+731c, U+7336, U+7344, U+7384, U+73ab, U+7433, U+745c, U+7470, U+75d5, U+7652, U+76c8, U+76e7, U+7709, U+7720, U+7740, U+7747, U+7763, U+77ac-77ad, U+7802, U+78a7, U+78b3, U+78c1, U+78da, U+7926, U+796d, U+798d, U+7aae, U+7b52, U+7c92, U+7d68, U+7d81, U+7e31, U+7e5e, U+7e69, U+7e73, U+7f50, U+7f70, U+7f75, U+8058, U+8070, U+80c3, U+8105-8106, U+8108, U+8179, U+818f, U+81a9, U+81ed, U+820c-820d, U+8277, U+82d1, U+8461, U+84b8, U+852c, U+857e, U+8587, U+85e4, U+863f, U+8679, U+86c7, U+8702, U+8776, U+87ba, U+8896, U+88c2, U+88d5, U+88f8, U+8af8, U+8b7d, U+8ca2, U+8d64, U+8d74, U+8d81, U+8d99, U+8e5f, U+8e8d, U+8ecc, U+8ed2, U+8fb1, U+8fc5, U+9022, U+9038, U+905c, U+9081, U+9189, U+9234, U+92d2, U+934a, U+95a3, U+962a, U+9646, U+96d5, U+971c, U+9838, U+9875, U+98c4, U+99db, U+9a45, U+9a5f, U+9a6c, U+9ad2, U+9cf4, U+9d28, U+9daf, U+9df9, U+9e7d, U+9f0e, U+9f52, U+9f9c, U+ff11, U+ff1e)
+);
+
+/* noto-sans-tc-[110]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-110-700-normal.woff2",
+    $range: (U+2022, U+2500, U+25bc, U+4e1f, U+4e95, U+4f50, U+4f54, U+4f69, U+4fb6, U+4fc4, U+4fca, U+5009, U+50bb, U+5154, U+51cc, U+528d, U+5291, U+52d2, U+52e4, U+5353, U+5360, U+540a-540b, U+5410, U+54f2, U+5514, U+5537, U+558a, U+55ac, U+5617, U+56fd, U+573e, U+5766, U+5783, U+57d4, U+5806, U+5821, U+5857, U+5875, U+58f9, U+592f, U+5954, U+596a, U+59ae, U+59c6, U+59ca, U+59ff, U+5a03, U+5ae9, U+5b64, U+5bb4, U+5c3f, U+5c6f, U+5de1, U+5e16, U+5e45, U+5e72, U+5ec9, U+5f7c, U+5f81, U+5f90-5f92, U+6016, U+6085, U+6089, U+60a0, U+60a3, U+60b2, U+60d1, U+60f9, U+6155, U+6158, U+6191, U+6212, U+626e, U+62d4, U+632f, U+633a, U+63aa, U+642c, U+64a5, U+64cb, U+6566, U+6597, U+66b1, U+66ec, U+6731, U+6735, U+67ef, U+6846, U+6876, U+6881, U+68af-68b0, U+68c9, U+6905, U+6bc0, U+6beb, U+6c0f, U+6c1b, U+6c41, U+6ce5, U+6cf3, U+6d25, U+6d2a, U+6d3d, U+6dcb, U+6dd8, U+6dfa, U+6e9d, U+6eaa, U+6ec5, U+6ecb, U+6f0f, U+6f32, U+707d, U+708e, U+7092, U+716e, U+723a, U+731b, U+7345, U+7375, U+73b2, U+7434, U+74e6, U+758a, U+75be, U+75de, U+764c, U+76dc, U+788e, U+7897, U+789f, U+78a9, U+78b0, U+790e, U+7965, U+7a4e, U+7c43, U+7d17, U+7dd2, U+7e96, U+7f51, U+7f69, U+7f72, U+7fd4, U+7fe0, U+8017, U+80a9, U+80d6, U+8150, U+8178, U+81bd, U+829d, U+82ac, U+8303, U+838e, U+83cc, U+840c, U+8482, U+8499, U+85a9-85aa, U+883b, U+8861, U+88c1, U+88cf, U+88d9, U+8a3a, U+8a98, U+8aee, U+8c8c, U+8cc0, U+8ce2, U+8d0f, U+8da8, U+8dcc, U+8e0f, U+8f1d, U+8f29, U+8fad, U+9003, U+9006, U+903c, U+903e, U+9059, U+9072, U+9075, U+90ce, U+9130, U+91ac, U+91e3, U+9285, U+9298, U+92ea, U+9326, U+937e, U+95c6, U+9676-9677, U+9727, U+994b, U+99a8, U+99d0, U+9a30, U+9b42, U+9b45, U+9d3b, U+9e7f, U+9ee8, U+9f3b)
+);
+
+/* noto-sans-tc-[111]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-111-700-normal.woff2",
+    $range: (U+5e, U+3042, U+3044, U+3046, U+3048, U+304a-3050, U+3053-3057, U+3059-305b, U+305d-3061, U+3063-306c, U+306e-3079, U+307b, U+307d-307f, U+3082-308d, U+308f, U+3092-3093, U+30a1-30a4, U+30a6-30c1, U+30c3-30c4, U+30c6-30e1, U+30e3-30ed, U+30ef, U+30f3, U+30fb-30fc, U+4e32, U+4ef2, U+4fd7, U+501f, U+5144, U+51c6, U+52c1, U+5440, U+54e6, U+54ed, U+5510, U+5687, U+58c1, U+5b5d, U+5bd2, U+5ee2, U+5f31, U+6012, U+6084, U+6148, U+6182, U+622a, U+6355, U+6372, U+63ee, U+6416, U+6575, U+660c, U+66c9, U+675c, U+6a6b, U+6b32, U+6b49, U+6b98, U+6d6e, U+6dda, U+6ef4, U+6efe, U+7159, U+7378, U+775b, U+78e8, U+7aa9, U+7d1b, U+7de9, U+7f6a, U+7f8a, U+7fbd, U+8000, U+809a, U+8102, U+8170, U+819c, U+8266, U+82b3, U+87f2, U+8972, U+8a17, U+8b02, U+8e22, U+904d, U+90ed, U+91c7, U+93c8, U+9451, U+9a37, U+9b27, U+ad6d, U+c5b4, U+d55c)
+);
+
+/* noto-sans-tc-[112]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-112-700-normal.woff2",
+    $range: (U+2502, U+2605, U+4e39, U+4e58, U+4ea1, U+4ed9, U+4f2f-4f30, U+4f38, U+4f75, U+4fc3, U+4ff1, U+500d, U+5049, U+5074, U+5077, U+5091, U+5175, U+517c, U+51cd, U+51e1, U+5269-526a, U+52aa, U+52c7, U+52df, U+5377, U+541b, U+5439, U+5448, U+54aa, U+5674, U+56f0, U+5761, U+585e, U+588a, U+58a8, U+58fd, U+5925, U+592e, U+5948, U+5999, U+59b3, U+5a18, U+5a1c, U+5a46, U+5b30, U+5b54, U+5b6b, U+5b8f, U+5be9, U+5bf8, U+5c0a, U+5c16, U+5c24, U+5c46, U+5cf0, U+5e1d, U+5e25, U+5e2d, U+5e3d, U+5e79, U+5f04, U+5fcd, U+5fe0, U+60dc, U+6163, U+616e, U+61f6, U+6258, U+6293, U+62c6, U+62d2, U+62d6, U+62fc, U+63da, U+63ed, U+640d, U+6458, U+649e, U+64ec, U+64f4, U+64fe, U+651c, U+6562, U+65cb, U+65e2, U+65fa, U+6628, U+6668, U+66a2, U+66dd, U+66fc, U+66ff, U+6717, U+67cf, U+67d4, U+6817, U+6885, U+695a, U+69cd, U+6afb, U+6bbc, U+6c89, U+6c96, U+6cc9, U+6d1b, U+6d1e, U+6d74, U+6db2, U+6dbc, U+6df7, U+6dfb, U+6e38, U+6f38, U+6f5b, U+6f64, U+6f8e, U+6fa4, U+6fc3, U+6fd5, U+7070, U+70b8, U+70cf, U+70e4, U+7169, U+7210, U+721b, U+7238, U+737b, U+73bb, U+746a, U+7483, U+74dc, U+74f6, U+7518, U+756a, U+75c7, U+7919, U+7956, U+795d, U+7a05, U+7a0d, U+7a3f, U+7bc9, U+7c97, U+7cd5, U+7d0b, U+7d10, U+7dfb, U+7e3e, U+7e6a, U+8036, U+808c, U+80af, U+80ce, U+80e1, U+80f8, U+817f, U+8216, U+8239, U+827e, U+8377, U+8389, U+83ab, U+83f2, U+840a, U+8584, U+85c9, U+865b, U+8766, U+87a2, U+8932, U+8a50, U+8a69, U+8a95, U+8b6f, U+8c37, U+8c6c, U+8ca9, U+8cfa, U+8d95, U+8de1, U+8f14, U+8f9b, U+8fa3, U+8feb, U+8ff4, U+9010, U+901b, U+905e, U+9080, U+912d, U+9177, U+9336, U+947d, U+963b, U+966a, U+9670, U+9769, U+9813, U+9846, U+98fd, U+99d5, U+9a0e, U+9a19, U+9b6f, U+9ce5, U+9cf3, U+9ece, U+9ed8, U+9f13, U+9f20)
+);
+
+/* noto-sans-tc-[113]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-113-700-normal.woff2",
+    $range: (U+201c-201d, U+203b, U+2192, U+25b2, U+300e-300f, U+4e01, U+4e73, U+4e82, U+4e88, U+4e8e, U+4f0a, U+4f5b, U+502b, U+504f, U+5076, U+5100, U+5104, U+5132, U+5192, U+51a0, U+51ac, U+51f1, U+5200, U+5224, U+522a, U+5237-5238, U+523a, U+526f, U+5289, U+52de, U+52f5, U+52ff, U+5371, U+539a, U+53e5, U+540e, U+5433, U+547c, U+552f, U+5531, U+5634, U+56c9, U+574a, U+57f7, U+57f9, U+5805, U+5851, U+5854, U+586b, U+58c7, U+58de, U+5967, U+59bb, U+59d3-59d4, U+5b55, U+5b87, U+5b97, U+5bae, U+5bbf, U+5be7, U+5bec, U+5cb8, U+5df7, U+5e7b-5e7c, U+5f1f, U+5f70, U+5fd9, U+60e1, U+61b6, U+61c2, U+6200, U+6234, U+6263, U+62b5, U+62dc, U+62ec, U+6383, U+638c, U+63cf, U+63d2, U+63e1, U+63f4, U+641e, U+64cd, U+64fa, U+654f, U+6557, U+656c, U+65c1, U+65d7, U+6620, U+6676, U+6696-6697, U+66ab, U+66c6, U+671d, U+672b, U+676f, U+677e, U+67d0, U+67d3, U+684c, U+68c4, U+690d, U+694a, U+699c, U+6a4b, U+6ac3, U+6b04, U+6b23, U+6b78, U+6b8a, U+6bd2, U+6c60, U+6cb3, U+6d89, U+6de1, U+6de8, U+6e6f, U+6f02, U+70c8, U+7126, U+718a, U+7236, U+723d, U+7246, U+72af, U+72d7, U+73cd, U+7532, U+760b, U+7626, U+7687, U+76df, U+7761, U+79cb, U+79d2, U+79df, U+7a69, U+7af6, U+7b80, U+7c3d, U+7c3f, U+7c4d, U+7cd6, U+7d2b, U+7de3, U+7e2e, U+7e54, U+7e6b, U+8010, U+80a5, U+812b, U+819a, U+81a0, U+82d7, U+838a, U+8463, U+84cb, U+8521, U+8607, U+860b, U+864e, U+871c, U+878d, U+885d, U+89f8, U+8a13, U+8aa0, U+8afe, U+8b5c, U+8c46, U+8cbf, U+8cd3, U+8cf4, U+8d08, U+8d0a, U+8ddd, U+8de8, U+8fea, U+9014, U+9055, U+906d, U+907a, U+907f, U+90a6, U+9178, U+92fc, U+934b, U+9396, U+93ae, U+9583, U+9663, U+9694, U+96bb, U+9707, U+9738, U+9905, U+9aa8, U+9b25, U+9b3c, U+9ea5, U+9eb5, U+9f4a, U+9f61, U+ff0d-ff0e)
+);
+
+/* noto-sans-tc-[114]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-114-700-normal.woff2",
+    $range: (U+3c, U+d7, U+2027, U+4e4e, U+4e92, U+4ea6, U+4ec1, U+4ecd, U+4f34, U+4f48, U+4f53, U+4fb5, U+5012, U+50b7, U+51b0, U+5283, U+52dd, U+532f, U+5354, U+53eb, U+53f3, U+5409, U+5496, U+54c8, U+54e5, U+554a, U+5561, U+5594, U+559d, U+56b4, U+56fa, U+5713, U+5750, U+57df, U+584a, U+590f, U+592b, U+593e, U+5976, U+599d, U+59b9, U+59d0, U+5a5a, U+5a66, U+5b85, U+5b88, U+5ba3, U+5bdf, U+5c01, U+5c04, U+5c3a, U+5c3e, U+5c4f, U+5ddd-5dde, U+5de7-5de8, U+5e63, U+5e8a, U+5e9c, U+5eda, U+5ef3, U+5ef6, U+5f48, U+5fb5, U+6015, U+6025, U+602a, U+6050, U+6069, U+6162, U+6176, U+61f7, U+6279, U+627f, U+6297, U+62b1, U+62bd, U+6311, U+6377, U+6388-6389, U+63a1-63a2, U+6436, U+64c1, U+64d4, U+6551, U+6563, U+65bd, U+66b4, U+66f2, U+6751, U+675f, U+6790, U+6838, U+68d2, U+68ee, U+6982, U+69ae, U+69cb, U+6a39, U+6b66, U+6bba, U+6c5f, U+6ce1, U+6d0b, U+6d3e, U+6d6a, U+6e1b, U+6ed1, U+6f22, U+6f54, U+6f6e, U+6fc0, U+6fdf, U+719f, U+71c8, U+71d2, U+7259, U+72c2, U+7389, U+73e0, U+745e, U+751a, U+751c, U+7530, U+7533, U+7562, U+7591, U+75c5, U+75db, U+7642, U+7686, U+76d2, U+76db, U+76e1, U+76e3, U+7701, U+786c, U+7981, U+79c0, U+79fb, U+7a81, U+7a97, U+7adf, U+7aef, U+7b26, U+7c64, U+7d0d, U+7d14, U+7d2f, U+7d9c, U+7dca, U+7df4, U+7e23, U+7f3a, U+8033, U+804a, U+8056, U+805a, U+8173, U+81e8, U+8212, U+821e, U+822a, U+82e6, U+8336, U+83dc, U+8449, U+84ee, U+85e5, U+885b, U+888b, U+8907, U+8a34, U+8a5e, U+8aa4, U+8ab0, U+8ab2, U+8ac7, U+8b66, U+8c6a, U+8c93, U+8c9d, U+8cb4, U+8dd1, U+8f2a, U+8fb2, U+9109, U+9192, U+91cb, U+91dd, U+93e1, U+964d, U+9686, U+968e, U+969c, U+96de, U+96e8, U+96ea, U+96f7, U+975c, U+9760, U+978b, U+9858, U+98ef, U+9918, U+9aee, U+9b54, U+9ebb, U+ff0f, U+ff5c)
+);
+
+/* noto-sans-tc-[115]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-115-700-normal.woff2",
+    $range: (U+23-25, U+3d, U+4e45, U+4e5d, U+4e7e, U+4eac, U+4eae, U+4ed4, U+4ee4, U+4f01, U+4f3c, U+4f8b, U+4fc2, U+505c, U+50c5, U+5145, U+51b7, U+521d, U+523b, U+525b, U+5287, U+52e2, U+5348, U+535a, U+537b, U+5426, U+542b, U+5438, U+5462, U+54ea, U+555f, U+5566, U+5584, U+5609, U+5708, U+570d, U+571f, U+5747, U+5802, U+58d3, U+5920, U+5922, U+5957, U+5979, U+5a01, U+5a92, U+5abd, U+5b63, U+5b69, U+5b83, U+5bb3, U+5bc4, U+5bf5, U+5c3c, U+5c40, U+5c4b, U+5c64, U+5cf6, U+5de6, U+5e0c, U+5e55, U+5e78, U+5eab, U+5ead, U+5ee0, U+5f85, U+5f8b, U+5fd7-5fd8, U+6167, U+6298, U+62db, U+62ff, U+639b, U+63a7, U+642d, U+6469, U+64ad, U+651d, U+653b, U+65b7, U+65cf, U+665a, U+666e, U+66fe, U+6728, U+674e, U+67b6, U+6821, U+6839, U+6843, U+6a94, U+6b4c, U+6b50, U+6b62, U+6b72, U+6b7b, U+6bcd, U+6bdb, U+6c38, U+6c7a, U+6c7d, U+6c99, U+6cb9, U+6ce2, U+6cf0, U+6d17, U+6d32, U+6e2c, U+6e56, U+6fb3, U+722d, U+723e, U+725b, U+734e, U+7387, U+73ed, U+7565, U+7570, U+76ca, U+76e4, U+773e, U+77ed, U+77f3, U+7814, U+7834, U+7968, U+79d8, U+7a7f, U+7af9, U+7b11, U+7b46, U+7b54, U+7bc4, U+7d19, U+7d22, U+7d42, U+7d55, U+7da0, U+7e41, U+7e7c, U+7f85, U+7ffb, U+8077, U+8089, U+80cc, U+81c9, U+81f4, U+81fa, U+820a, U+822c, U+826f, U+8349, U+85cd, U+86cb, U+8840, U+88dc, U+8986, U+8a0e, U+8a73, U+8a8c, U+8b1b, U+8b9a, U+8c50, U+8ca0, U+8cde, U+8cfd, U+8d8a, U+8df3, U+8e64, U+8ecd, U+8edf, U+8f38, U+8fd4, U+8ff0, U+8ff7, U+9000, U+9047, U+9060, U+90f5, U+9152, U+91ce, U+9280, U+9418, U+9435, U+9589, U+9592, U+9678, U+968a, U+96aa, U+96c5, U+96d6, U+96dc, U+96f6, U+9732, U+9748, U+9802, U+9806, U+9808, U+983b, U+984d, U+984f, U+9867, U+98db, U+98f2, U+98fe, U+9a5a, U+9b06, U+9b5a, U+9bae, U+ff5e)
+);
+
+/* noto-sans-tc-[116]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-116-700-normal.woff2",
+    $range: (U+40, U+2026, U+4e03, U+4e14, U+4e9e, U+4ec0, U+4ed8, U+4f11, U+4f4e-4f4f, U+4f73, U+4fee, U+5019, U+503c, U+5047, U+514b, U+516b, U+5178, U+5207, U+520a, U+5236, U+5343, U+5347, U+534a, U+5370, U+53cd, U+53e4, U+53e6, U+53f2, U+5403, U+5411, U+5427, U+5468, U+5473, U+547d, U+552e, U+5740, U+5883, U+589e, U+591c, U+5931, U+59cb, U+5a1b, U+5b58, U+5b98, U+5b9c, U+5ba4, U+5bcc, U+5beb, U+5c45, U+5c6c, U+5dee, U+5df4, U+5e03, U+5e33, U+5e6b, U+5e7e, U+5e8f, U+5e95, U+5ea7, U+5f15, U+5f62, U+5f69, U+5f80, U+5fa9, U+5fae, U+5fb7, U+5ff5, U+600e, U+601d, U+60e0, U+614b, U+6230, U+623f, U+628a, U+6295, U+62c9, U+6309, U+64c7, U+64ca, U+652f, U+6545, U+6548, U+65af, U+65e9, U+6625, U+666f, U+667a, U+670b, U+671b, U+6750, U+677f, U+6975, U+6a13, U+6a21, U+6aa2, U+6b65, U+6b77, U+6bb5, U+6cc1, U+6ce8, U+6df1, U+6e90, U+6e96, U+6eab, U+6f14, U+6f2b, U+700f, U+706b, U+7206, U+724c, U+72c0, U+7368, U+7372, U+74b0, U+756b, U+76ae, U+773c, U+78ba, U+798f, U+79ae, U+7a4d, U+7a76, U+7ae5, U+7b56, U+7b97, U+7bb1, U+7bc7, U+7c73, U+7c89, U+7d00, U+7d20, U+7d39, U+7d72, U+7dad, U+7e8c, U+7fa4, U+7fd2, U+8003, U+807d, U+80a1, U+80b2, U+8166, U+8208-8209, U+82e5, U+843d, U+85cf, U+85dd, U+862d, U+8857, U+8863, U+89ba, U+89d2, U+8a2a, U+8a31, U+8a62, U+8a66, U+8a72, U+8abf, U+8b1d, U+8b58, U+8c61, U+8ca1, U+8ca8, U+8cac, U+8cbc, U+8d70, U+8da3, U+8db3, U+8ddf, U+8f03, U+8f15, U+8f2f, U+8fa6, U+8fce, U+8ffd, U+900f, U+9031, U+9069, U+908a, U+91ab, U+91cc, U+92b7, U+9322, U+932f, U+9375, U+9632, U+963f, U+9644, U+9662, U+9673, U+967d, U+96a8, U+96c4, U+96d9, U+96e2-96e3, U+96f2, U+9752, U+97d3, U+97ff, U+9805, U+9810, U+9818, U+986f, U+990a, U+9910, U+9928, U+9e97, U+9ec3, U+9f8d, U+ff1b)
+);
+
+/* noto-sans-tc-[117]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-117-700-normal.woff2",
+    $range: (U+26, U+3e, U+5f, U+7e, U+3000, U+300a-300b, U+3010-3011, U+4e16, U+4e26, U+4e94, U+4e9b, U+4ea4, U+4eca-4ecb, U+4efb, U+4efd, U+4f46, U+4f55, U+4f9b, U+4f9d, U+4fbf, U+505a, U+5065, U+5099, U+50cf, U+512a, U+5143, U+5148, U+5152, U+5169, U+516d, U+5171, U+5177, U+518a, U+5225, U+5247, U+5275, U+529f, U+52a9, U+5305, U+5341, U+5357, U+5361, U+5373, U+53bb, U+53c3, U+53c8, U+53d6-53d7, U+53e3, U+5404, U+559c, U+55ce, U+5668, U+56db, U+5712, U+5718, U+57ce, U+57fa, U+58eb, U+592a, U+5947, U+5bc6, U+5bf6, U+5c0e, U+5c11, U+5c1a, U+5c55, U+5c71, U+5df1, U+5e2b, U+5e36, U+5e97, U+5eb7, U+5ee3, U+5efa, U+5f35, U+5f37, U+5f88, U+5f9e, U+5fc5, U+606f, U+60a8, U+6232, U+6236, U+624d, U+627e, U+6280, U+62cd, U+6301, U+6307, U+6392, U+63db, U+64da, U+6539, U+653e-653f, U+6559, U+6574, U+65c5, U+6613, U+66f8, U+6797, U+67e5, U+6848, U+6a19, U+6a23, U+6b61, U+6bcf, U+6c11, U+6c42, U+6d41, U+6d77, U+6e2f, U+6eff, U+7167, U+71df, U+738b, U+73a9, U+7403, U+7537, U+754c, U+7559, U+767d-767e, U+78bc, U+793a, U+795e, U+79c1, U+79d1, U+7a2e, U+7a31, U+7a7a, U+7ae0, U+7ba1, U+7bc0, U+7c21, U+7cfb, U+7d04-7d05, U+7d1a, U+7d30, U+7d44, U+7d66, U+7d71, U+7de8, U+7e3d, U+7f6e, U+7fa9, U+8001, U+805e, U+8072, U+81f3, U+82f1, U+83ef, U+842c, U+8457, U+85a6, U+8655, U+8853, U+88ab, U+88dd, U+88e1, U+88fd, U+897f, U+898f, U+89aa, U+89bd, U+89c0, U+89e3, U+8a02, U+8a3b, U+8a55, U+8a8d, U+8a9e, U+8ad6, U+8b49, U+8b70, U+8b77, U+8b80, U+8b8a, U+8b93, U+8cb7, U+8ce3, U+8cea, U+8cfc, U+8f09, U+8fd1, U+9001, U+901f-9020, U+9054, U+90a3, U+914d, U+91cf, U+9304, U+95b1, U+9664, U+969b, U+96b1, U+96c6, U+9700, U+975e, U+97f3, U+98a8, U+98df, U+9999, U+99ac, U+9a57, U+9ebc, U+9ed1)
+);
+
+/* noto-sans-tc-[118]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-118-700-normal.woff2",
+    $range: (U+d, U+2b, U+7c, U+a9, U+300c-300d, U+4e09, U+4e3b, U+4e4b, U+4e5f, U+4e86, U+4e8b-4e8c, U+4eab, U+4ed6, U+4ee3, U+4ef6, U+4f1a, U+4f4d, U+4f60, U+4f7f, U+4fdd, U+4fe1, U+50b3, U+50f9, U+5149, U+514d, U+5167, U+5176, U+518d, U+5217, U+5229, U+524d, U+529b, U+52a0, U+52d9, U+5316-5317, U+5340, U+539f, U+53ca-53cb, U+53ea, U+53f8, U+5408, U+540c-540d, U+544a, U+548c, U+54c1, U+54e1, U+5546, U+554f, U+55ae, U+56de, U+56e0, U+5716, U+578b, U+5831, U+5834, U+5916, U+5973, U+5982, U+5b57, U+5b78, U+5b89, U+5b8c, U+5b9a, U+5ba2, U+5bb9, U+5be6, U+5c07-5c08, U+5c0b, U+5c0d, U+5c31, U+5de5, U+5df2, U+5e02, U+5e38, U+5ea6, U+5f0f, U+5f71, U+5f8c, U+5f97, U+5feb, U+6027, U+60c5, U+60f3, U+610f, U+611b, U+611f, U+61c9, U+6216, U+624b, U+6253, U+63a5, U+63a8, U+63d0, U+641c, U+6536, U+6578, U+6599, U+661f, U+662d, U+670d, U+671f, U+672a, U+6771, U+679c, U+682a, U+683c, U+689d, U+696d, U+6a02, U+6a5f, U+6b0a, U+6b21, U+6b3e, U+6b64, U+6bd4, U+6c23, U+6c34, U+6c92, U+6cd5, U+6d3b, U+6d88, U+6e05, U+7063, U+7121, U+7136, U+71b1, U+7247-7248, U+7269, U+7279, U+73fe, U+7406, U+7522, U+7531, U+7576, U+767b, U+76ee, U+76f4, U+770b, U+771f, U+77e5, U+793e, U+7a0b, U+7acb, U+7ad9, U+7b2c, U+7b49, U+7cbe, U+7d50, U+7d61, U+7d93, U+7dda, U+8005, U+800c, U+806f, U+8207, U+8272, U+82b1, U+865f, U+8868, U+898b, U+8996, U+8a00, U+8a08, U+8a0a, U+8a18, U+8a2d, U+8a71, U+8aaa, U+8acb, U+8cbb, U+8cc7, U+8d77, U+8d85, U+8def, U+8eab, U+8eca, U+8f49, U+9019-901a, U+9023, U+9032, U+904a-904b, U+904e, U+9053, U+9078, U+9084, U+90e8, U+90fd, U+91cd, U+91d1, U+9577, U+9580, U+9593, U+9650, U+9762, U+982d, U+984c, U+985e, U+9ad4, U+9ad8, U+9ede, U+ff01, U+ff08-ff09, U+ff1f)
+);
+
+/* noto-sans-tc-[119]-700-normal */
+@include fontFace(
+    $family: $tcFamily,
+    $weight: 700,
+    $url: "~@fontsource/noto-sans-tc/files/noto-sans-tc-119-700-normal.woff2",
+    $range: (U+20-22, U+27-2a, U+2c-3b, U+3f, U+41-5d, U+61-7b, U+7d, U+a0, U+ab, U+ae, U+b2-b3, U+b7, U+bb, U+bf, U+c9, U+cd, U+d6, U+e0-ef, U+f1-f4, U+f6, U+f9-fa, U+fc-fd, U+101, U+103, U+110-111, U+113, U+12b, U+14d, U+16b, U+1a1, U+1b0, U+1ce, U+300-301, U+1ea1, U+1ea3, U+1ebf, U+1ec7, U+2013-2014, U+2039-203a, U+203c, U+2122, U+3001-3002, U+4e00, U+4e0a-4e0b, U+4e0d, U+4e2d, U+4eba, U+4ee5, U+4f5c, U+4f86, U+500b, U+5011, U+5165, U+5168, U+516c, U+51fa, U+5206, U+5230, U+52d5, U+53ef-53f0, U+570b, U+5728, U+5730, U+591a, U+5927, U+5929, U+597d, U+5b50, U+5bb6, U+5c0f, U+5e73-5e74, U+5fc3, U+6210-6211, U+6240, U+6587, U+65b0, U+65b9, U+65bc, U+65e5, U+660e, U+662f, U+6642, U+66f4, U+6700, U+6703, U+6708-6709, U+672c, U+6b63, U+6cbb, U+70b9-70ba, U+751f, U+7528, U+767c, U+7684, U+76f8, U+7db2, U+7f8e, U+80fd, U+81ea, U+884c, U+8981, U+958b, U+95dc, U+96fb, U+9801, U+9996, U+ff0c, U+ff1a)
+);


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

- Update `lang` attribute of `html` element on user preference change.
- Choose appropriate `font-family` depending on `lang` attribute using attribute selectors in CSS.
- Add `Noto Sans TC`, the Traditional Chinese (Taiwan) variant.
- Fix event listener registration in `globalize.js`.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes https://github.com/jellyfin/jellyfin-web/issues/913.

**How to Test**

1. Add a media with name `返`.
2. Change the language setting in http://localhost:8080/#/mypreferencesdisplay.html to `日本語` (Japanese).
3. Navigate to the media added at the step 1.
4. Compare the displayed name with an image here: https://en.wikipedia.org/wiki/Source_Han_Sans#/media/File:Source_Han_Sans_Version_Difference.svg.
5. Repeat from the step 2 for each languages `한국어` (Korean), `汉语 (简化字)` (Simplified Chinese), `漢語 (繁体字)` (Traditional Chinese - Taiwan), and `廣東話 (香港)` (Traditional Chinese - Hong Kong).