### PR TITLE
Add option to allow extras to use embedded titles

### DIFF
--- a/src/components/libraryoptionseditor/libraryoptionseditor.js
+++ b/src/components/libraryoptionseditor/libraryoptionseditor.js
@@ -589,7 +589,7 @@ import template from './libraryoptionseditor.template.html';
         parent.querySelector('#chkSaveLocal').checked = options.SaveLocalMetadata;
         parent.querySelector('.chkAutomaticallyGroupSeries').checked = options.EnableAutomaticSeriesGrouping;
         parent.querySelector('#chkEnableEmbeddedTitles').checked = options.EnableEmbeddedTitles;
-    parent.querySelector('.chkEnableEmbeddedExtrasTitlesContainer').classList.toggle('hide', !options.EnableEmbeddedTitles);
+        parent.querySelector('.chkEnableEmbeddedExtrasTitlesContainer').classList.toggle('hide', !options.EnableEmbeddedTitles);
         parent.querySelector('#chkEnableEmbeddedExtrasTitles').checked = options.EnableEmbeddedExtrasTitles;
         parent.querySelector('#chkEnableEmbeddedEpisodeInfos').value = options.EnableEmbeddedEpisodeInfos;
         parent.querySelector('#selectAllowEmbeddedSubtitles').value = options.AllowEmbeddedSubtitles;

--- a/src/components/libraryoptionseditor/libraryoptionseditor.js
+++ b/src/components/libraryoptionseditor/libraryoptionseditor.js
@@ -366,6 +366,14 @@ import template from './libraryoptionseditor.template.html';
         parent.querySelector('.subtitleFetchers').addEventListener('click', onSortableContainerClick);
         parent.querySelector('.metadataFetchers').addEventListener('click', onSortableContainerClick);
         parent.querySelector('.imageFetchers').addEventListener('click', onImageFetchersContainerClick);
+
+        parent.querySelector('#chkEnableEmbeddedTitles').addEventListener('change', (e) => {
+            if (e.currentTarget.checked) {
+                parent.querySelector('.chkEnableEmbeddedExtrasTitlesContainer').classList.remove('hide');
+            } else {
+                parent.querySelector('.chkEnableEmbeddedExtrasTitlesContainer').classList.add('hide');
+            }
+        });
     }
 
     export async function embed(parent, contentType, libraryOptions) {
@@ -412,8 +420,12 @@ import template from './libraryoptionseditor.template.html';
 
         if (contentType === 'books' || contentType === 'boxsets' || contentType === 'playlists' || contentType === 'music') {
             parent.querySelector('.chkEnableEmbeddedTitlesContainer').classList.add('hide');
+            parent.querySelector('.chkEnableEmbeddedExtrasTitlesContainer').classList.add('hide');
         } else {
             parent.querySelector('.chkEnableEmbeddedTitlesContainer').classList.remove('hide');
+            if (parent.querySelector('#chkEnableEmbeddedTitles').checked) {
+                parent.querySelector('.chkEnableEmbeddedExtrasTitlesContainer').classList.remove('hide');
+            }
         }
 
         if (contentType === 'tvshows') {
@@ -525,6 +537,7 @@ import template from './libraryoptionseditor.template.html';
             SeasonZeroDisplayName: parent.querySelector('#txtSeasonZeroName').value,
             AutomaticRefreshIntervalDays: parseInt(parent.querySelector('#selectAutoRefreshInterval').value),
             EnableEmbeddedTitles: parent.querySelector('#chkEnableEmbeddedTitles').checked,
+            EnableEmbeddedExtrasTitles: parent.querySelector('#chkEnableEmbeddedExtrasTitles').checked,
             EnableEmbeddedEpisodeInfos: parent.querySelector('#chkEnableEmbeddedEpisodeInfos').checked,
             AllowEmbeddedSubtitles: parent.querySelector('#selectAllowEmbeddedSubtitles').value,
             SkipSubtitlesIfEmbeddedSubtitlesPresent: parent.querySelector('#chkSkipIfGraphicalSubsPresent').checked,
@@ -580,6 +593,12 @@ import template from './libraryoptionseditor.template.html';
         parent.querySelector('#chkSaveLocal').checked = options.SaveLocalMetadata;
         parent.querySelector('.chkAutomaticallyGroupSeries').checked = options.EnableAutomaticSeriesGrouping;
         parent.querySelector('#chkEnableEmbeddedTitles').checked = options.EnableEmbeddedTitles;
+        if (options.EnableEmbeddedTitles) {
+            parent.querySelector('.chkEnableEmbeddedExtrasTitlesContainer').classList.remove('hide');
+        } else {
+            parent.querySelector('.chkEnableEmbeddedExtrasTitlesContainer').classList.add('hide');
+        }
+        parent.querySelector('#chkEnableEmbeddedExtrasTitles').checked = options.EnableEmbeddedExtrasTitles;
         parent.querySelector('#chkEnableEmbeddedEpisodeInfos').value = options.EnableEmbeddedEpisodeInfos;
         parent.querySelector('#selectAllowEmbeddedSubtitles').value = options.AllowEmbeddedSubtitles;
         parent.querySelector('#chkSkipIfGraphicalSubsPresent').checked = options.SkipSubtitlesIfEmbeddedSubtitlesPresent;

--- a/src/components/libraryoptionseditor/libraryoptionseditor.js
+++ b/src/components/libraryoptionseditor/libraryoptionseditor.js
@@ -368,11 +368,7 @@ import template from './libraryoptionseditor.template.html';
         parent.querySelector('.imageFetchers').addEventListener('click', onImageFetchersContainerClick);
 
         parent.querySelector('#chkEnableEmbeddedTitles').addEventListener('change', (e) => {
-            if (e.currentTarget.checked) {
-                parent.querySelector('.chkEnableEmbeddedExtrasTitlesContainer').classList.remove('hide');
-            } else {
-                parent.querySelector('.chkEnableEmbeddedExtrasTitlesContainer').classList.add('hide');
-            }
+            parent.querySelector('.chkEnableEmbeddedExtrasTitlesContainer').classList.toggle('hide', !e.currentTarget.checked);
         });
     }
 
@@ -593,11 +589,7 @@ import template from './libraryoptionseditor.template.html';
         parent.querySelector('#chkSaveLocal').checked = options.SaveLocalMetadata;
         parent.querySelector('.chkAutomaticallyGroupSeries').checked = options.EnableAutomaticSeriesGrouping;
         parent.querySelector('#chkEnableEmbeddedTitles').checked = options.EnableEmbeddedTitles;
-        if (options.EnableEmbeddedTitles) {
-            parent.querySelector('.chkEnableEmbeddedExtrasTitlesContainer').classList.remove('hide');
-        } else {
-            parent.querySelector('.chkEnableEmbeddedExtrasTitlesContainer').classList.add('hide');
-        }
+    parent.querySelector('.chkEnableEmbeddedExtrasTitlesContainer').classList.toggle('hide', !options.EnableEmbeddedTitles);
         parent.querySelector('#chkEnableEmbeddedExtrasTitles').checked = options.EnableEmbeddedExtrasTitles;
         parent.querySelector('#chkEnableEmbeddedEpisodeInfos').value = options.EnableEmbeddedEpisodeInfos;
         parent.querySelector('#selectAllowEmbeddedSubtitles').value = options.AllowEmbeddedSubtitles;

--- a/src/components/libraryoptionseditor/libraryoptionseditor.template.html
+++ b/src/components/libraryoptionseditor/libraryoptionseditor.template.html
@@ -23,6 +23,13 @@
     </label>
     <div class="fieldDescription checkboxFieldDescription">${PreferEmbeddedTitlesOverFileNamesHelp}</div>
 </div>
+<div class="checkboxContainer checkboxContainer-withDescription chkEnableEmbeddedExtrasTitlesContainer hide advanced">
+    <label>
+        <input is="emby-checkbox" type="checkbox" id="chkEnableEmbeddedExtrasTitles" />
+        <span>${PreferEmbeddedExtrasTitlesOverFileNames}</span>
+    </label>
+    <div class="fieldDescription checkboxFieldDescription">${PreferEmbeddedExtrasTitlesOverFileNamesHelp}</div>
+</div>
 <div class="checkboxContainer checkboxContainer-withDescription chkEnableEmbeddedEpisodeInfosContainer hide advanced">
     <label>
         <input is="emby-checkbox" type="checkbox" id="chkEnableEmbeddedEpisodeInfos" />

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1313,6 +1313,8 @@
     "PosterCard": "Poster Card",
     "PreferEmbeddedEpisodeInfosOverFileNames": "Prefer embedded episode information over filenames",
     "PreferEmbeddedEpisodeInfosOverFileNamesHelp": "Use the episode information from the embedded metadata if available.",
+    "PreferEmbeddedExtrasTitlesOverFileNames": "Prefer embedded titles over filenames for extras",
+    "PreferEmbeddedExtrasTitlesOverFileNamesHelp": "Extras often have the same embedded name as the parent, check this to use embedded titles for them anyway.",
     "PreferEmbeddedTitlesOverFileNames": "Prefer embedded titles over filenames",
     "PreferEmbeddedTitlesOverFileNamesHelp": "Determine the display title to use when no internet metadata or local metadata is available.",
     "AllowEmbeddedSubtitles": "Disable different types of embedded subtitles",


### PR DESCRIPTION
I took the time to embed titles in my extras (including characters not valid for use in filenames) and was annoyed when Jellyfin ignored the embedded value. Finally got around to adding an option to enable it.

**Changes**
- Add a sub-option for `EnableEmbeddedTitles` to also `EnableEmbeddedExtrasTitles`

**Issues**
- Implements UI side of jellyfin/jellyfin#7767