### PR TITLE
automatically switch to LocalAddress when accessible

### DIFF
--- a/src/components/ServerConnections.js
+++ b/src/components/ServerConnections.js
@@ -58,7 +58,7 @@ class ServerConnections extends ConnectionManager {
         );
 
         apiClient.enableAutomaticNetworking = false;
-        apiClient.manualAddressOnly = true;
+        apiClient.manualAddressOnly = false;
 
         this.addApiClient(apiClient);
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
a server has two addresses: ManualAddress (via internet) + LocalAddress (local only).
when a server LocalAddress is accessible, it should not use ManualAddress.
it seems like this feature was disabled somehow, this PR just enable it

I'd test it on my server and it works well.

![image](https://user-images.githubusercontent.com/2725379/169060269-7a745c7a-4cde-44aa-82d6-427f6130d9cd.png)
![image](https://user-images.githubusercontent.com/2725379/169060445-46544934-27f8-40f8-8ff7-0eb2849bf876.png)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
