### PR TITLE
Remove play button highlighting

### DIFF
--- a/src/controllers/itemDetails/index.html
+++ b/src/controllers/itemDetails/index.html
@@ -13,7 +13,7 @@
             </div>
 
             <div class="mainDetailButtons focuscontainer-x">
-                <button is="emby-button" type="button" class="button-flat btnPlay hide detailButton raised" title="${ButtonResume}" data-action="resume">
+                <button is="emby-button" type="button" class="button-flat btnPlay hide detailButton" title="${ButtonResume}" data-action="resume">
                     <div class="detailButton-content">
                         <span class="material-icons detailButton-icon play_arrow" aria-hidden="true"></span>
                     </div>


### PR DESCRIPTION
Looks like I dragged this highlighting to Desktop and Mobile in #3443

Originally it was in TV only.
> from #1845
> I used a FAB for the play button (Set dynamically between play and resume, depending on what should be the primary action) in order to make it more obvious as to what the default action is.

**Changes**
Remove play button highlighting

**Issues**
Fixes https://github.com/jellyfin/jellyfin-web/issues/3320

**Screenshots**
| Was | Now |
| :---: | :---: |
| <img src="https://user-images.githubusercontent.com/56478732/169478062-d11493f7-8953-452a-ab09-721774609601.png" width="50%"> | <img src="https://user-images.githubusercontent.com/56478732/169478053-fbd2f4bf-d7c5-4b9f-a43e-a20e1f483910.png" width="50%"> |
| <img src="https://user-images.githubusercontent.com/56478732/169478080-a369580c-f62b-4b47-a677-977c547e7dff.png"> | <img src="https://user-images.githubusercontent.com/56478732/169478067-57cc2831-363f-447d-810b-e8330ec024b0.png"> |

For reference, this is what the active button (`More`) in TV looks like:
<img src="https://user-images.githubusercontent.com/56478732/150380999-0e364149-f9c8-4454-9f77-d34c67f5727b.png" width="50%">