### PR TITLE
Add workaround for channel card images

### DIFF
--- a/src/assets/css/livetv.scss
+++ b/src/assets/css/livetv.scss
@@ -7,3 +7,8 @@
         padding-left: 0.5em;
     }
 }
+
+// FIXME: background sizing for cards really needs revisited, but these are particularly terrible
+#channelsTab .cardImageContainer {
+    background-size: contain;
+}


### PR DESCRIPTION
**Changes**
Adds a workaround for the card sizing issues with channel logos

**Before**
![Screenshot 2022-05-20 at 13-25-40 Jellyfin](https://user-images.githubusercontent.com/3450688/169581220-71f84ae2-8def-430b-a381-1d1e78d8a877.png)

**After**
![Screenshot 2022-05-20 at 13-25-22 Jellyfin](https://user-images.githubusercontent.com/3450688/169581246-e92e44d6-2345-4435-85fd-61ee65ee3471.png)

**Issues**
N/A
