### PR TITLE
Support searching for tv programs

### DIFF
--- a/src/components/search/LiveTVSearchResults.tsx
+++ b/src/components/search/LiveTVSearchResults.tsx
@@ -83,7 +83,11 @@ const LiveTVSearchResults: FunctionComponent<LiveTVSearchResultsProps> = ({ serv
             // Episodes row
             fetchItems(apiClient, {
                 IncludeItemTypes: 'LiveTvProgram',
-                IsSeries: true
+                IsMovie: false,
+                IsSeries: true,
+                IsSports: false,
+                IsKids: false,
+                IsNews: false
             }).then(result => setEpisodes(result.Items || []));
             // Sports row
             fetchItems(apiClient, {
@@ -101,8 +105,14 @@ const LiveTVSearchResults: FunctionComponent<LiveTVSearchResultsProps> = ({ serv
                 IsNews: true
             }).then(result => setNews(result.Items || []));
             // Programs row
-            fetchItems(apiClient, { IncludeItemTypes: 'LiveTvProgram' })
-                .then(result => setPrograms(result.Items || []));
+            fetchItems(apiClient, {
+                IncludeItemTypes: 'LiveTvProgram',
+                IsMovie: false,
+                IsSeries: false,
+                IsSports: false,
+                IsKids: false,
+                IsNews: false
+            }).then(result => setPrograms(result.Items || []));
             // Channels row
             fetchItems(apiClient, { IncludeItemTypes: 'TvChannel' })
                 .then(result => setChannels(result.Items || []));

--- a/src/components/search/LiveTVSearchResults.tsx
+++ b/src/components/search/LiveTVSearchResults.tsx
@@ -54,7 +54,6 @@ const LiveTVSearchResults: FunctionComponent<LiveTVSearchResultsProps> = ({ serv
             IncludeArtists: false
         });
 
-        // FIXME: This query does not support Live TV filters
         const fetchItems = (apiClient: ApiClient, params = {}) => apiClient?.getItems(
             apiClient?.getCurrentUserId(),
             {
@@ -79,57 +78,31 @@ const LiveTVSearchResults: FunctionComponent<LiveTVSearchResultsProps> = ({ serv
             // Movies row
             fetchItems(apiClient, {
                 IncludeItemTypes: 'LiveTvProgram',
-                IsMovie: true,
-                IsSeries: false,
-                IsSports: false,
-                IsKids: false,
-                IsNews: false
+                IsMovie: true
             }).then(result => setMovies(result.Items || []));
             // Episodes row
             fetchItems(apiClient, {
                 IncludeItemTypes: 'LiveTvProgram',
-                IsMovie: false,
-                IsSeries: true,
-                IsSports: false,
-                IsKids: false,
-                IsNews: false
+                IsSeries: true
             }).then(result => setEpisodes(result.Items || []));
             // Sports row
             fetchItems(apiClient, {
                 IncludeItemTypes: 'LiveTvProgram',
-                IsMovie: false,
-                IsSeries: false,
-                IsSports: true,
-                IsKids: false,
-                IsNews: false
+                IsSports: true
             }).then(result => setSports(result.Items || []));
             // Kids row
             fetchItems(apiClient, {
                 IncludeItemTypes: 'LiveTvProgram',
-                IsMovie: false,
-                IsSeries: false,
-                IsSports: false,
-                IsKids: true,
-                IsNews: false
+                IsKids: true
             }).then(result => setKids(result.Items || []));
             // News row
             fetchItems(apiClient, {
                 IncludeItemTypes: 'LiveTvProgram',
-                IsMovie: false,
-                IsSeries: false,
-                IsSports: false,
-                IsKids: false,
                 IsNews: true
             }).then(result => setNews(result.Items || []));
             // Programs row
-            fetchItems(apiClient, {
-                IncludeItemTypes: 'LiveTvProgram',
-                IsMovie: false,
-                IsSeries: false,
-                IsSports: false,
-                IsKids: false,
-                IsNews: false
-            }).then(result => setPrograms(result.Items || []));
+            fetchItems(apiClient, { IncludeItemTypes: 'LiveTvProgram' })
+                .then(result => setPrograms(result.Items || []));
             // Channels row
             fetchItems(apiClient, { IncludeItemTypes: 'TvChannel' })
                 .then(result => setChannels(result.Items || []));


### PR DESCRIPTION
Previously, if a show was tagged as "IsKids" and "IsSeries" it would show up in neither of those categories on search because the search excluded results tagged as anything but the target category. This change removes the requirement that a show be only one type to show up in search.

**Changes**
- Remove false flags from category filters to not exclude things that fall into multiple sections

**Issues**
Related to jellyfin/jellyfin#7204
Requires jellyfin/jellyfin#7780
