### PR TITLE
Enable Lint job on release branches

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,9 @@ name: Lint
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, release* ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, release* ]
 
 jobs:
   run-eslint:

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -38,7 +38,7 @@ import { getIncludeCorsCredentials } from '../../scripts/settings/webSettings';
  */
 function resolveUrl(url) {
     return new Promise((resolve) => {
-        var xhr = new XMLHttpRequest();
+        const xhr = new XMLHttpRequest();
         xhr.open('HEAD', url, true);
         xhr.onload = function () {
             resolve(xhr.responseURL || url);


### PR DESCRIPTION
**Changes**
Enable Lint job on release branches.

**Issues**
Lazy devs like me don't run lint manually :sweat_smile: https://github.com/jellyfin/jellyfin-web/pull/3666#discussion_r878836666

