### PR TITLE
Show PlaySettings button even if transcoding isn't supported

### DIFF
--- a/src/components/playback/playersettingsmenu.js
+++ b/src/components/playback/playersettingsmenu.js
@@ -199,7 +199,8 @@ function showWithUser(options, player, user) {
         });
     }
 
-    if (user && user.Policy.EnableVideoPlaybackTranscoding) {
+    if (options.quality && supportedCommands.includes('SetMaxStreamingBitrate')
+            && user?.Policy?.EnableVideoPlaybackTranscoding) {
         const secondaryQualityText = getQualitySecondaryText(player);
 
         menuItems.push({

--- a/src/controllers/playback/video/index.html
+++ b/src/controllers/playback/video/index.html
@@ -77,7 +77,7 @@
                         <input is="emby-slider" type="range" step="1" min="0" max="100" value="0" class="osdVolumeSlider" />
                     </div>
                 </div>
-                <button is="paper-icon-button-light" class="btnVideoOsdSettings hide autoSize" title="${Settings}">
+                <button is="paper-icon-button-light" class="btnVideoOsdSettings autoSize" title="${Settings}">
                     <span class="largePaperIconButton material-icons settings" aria-hidden="true"></span>
                 </button>
                 <button is="paper-icon-button-light" class="btnAirPlay hide autoSize" title="${AirPlay}">

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -677,12 +677,6 @@ import { appRouter } from '../../../components/appRouter';
             updateTimeDisplay(playState.PositionTicks, nowPlayingItem.RunTimeTicks, playState.PlaybackStartTimeTicks, playState.PlaybackRate, playState.BufferedRanges || []);
             updateNowPlayingInfo(player, state);
 
-            if (state.MediaSource && state.MediaSource.SupportsTranscoding && supportedCommands.indexOf('SetMaxStreamingBitrate') !== -1) {
-                view.querySelector('.btnVideoOsdSettings').classList.remove('hide');
-            } else {
-                view.querySelector('.btnVideoOsdSettings').classList.add('hide');
-            }
-
             const isProgressClear = state.MediaSource && state.MediaSource.RunTimeTicks == null;
             nowPlayingPositionSlider.setIsClear(isProgressClear);
 
@@ -860,6 +854,8 @@ import { appRouter } from '../../../components/appRouter';
                 const player = currentPlayer;
 
                 if (player) {
+                    const state = playbackManager.getPlayerState(player);
+
                     // show subtitle offset feature only if player and media support it
                     const showSubOffset = playbackManager.supportSubtitleOffset(player) &&
                         playbackManager.canHandleOffsetOnCurrentSubtitle(player);
@@ -868,6 +864,7 @@ import { appRouter } from '../../../components/appRouter';
                         mediaType: 'Video',
                         player: player,
                         positionTo: btn,
+                        quality: state.MediaSource?.SupportsTranscoding,
                         stats: true,
                         suboffset: showSubOffset,
                         onOption: onSettingsOption


### PR DESCRIPTION
**Changes**
Show PlaySettings button even if transcoding isn't supported

**Issues**
There is no way to show play stats, set subtitles offset and aspect ratio if the video is DirectPlay (`!SupportsTranscoding`).
