### PR TITLE
Remove MPEG4 hwaccel from AMF

### DIFF
--- a/src/controllers/dashboard/encodingsettings.html
+++ b/src/controllers/dashboard/encodingsettings.html
@@ -46,7 +46,7 @@
                                 <span>MPEG2</span>
                             </label>
                             <label>
-                                <input type="checkbox" is="emby-checkbox" class="chkDecodeCodec" data-codec="mpeg4" data-types="amf,nvenc,videotoolbox" />
+                                <input type="checkbox" is="emby-checkbox" class="chkDecodeCodec" data-codec="mpeg4" data-types="nvenc,videotoolbox" />
                                 <span>MPEG4</span>
                             </label>
                             <label>


### PR DESCRIPTION
**Changes**
- Remove MPEG4 hwaccel from AMF, which is not supported by ffmpeg

**Set this to "stable backport" please, thanks!**
