### PR TITLE
Punctuation bug fix in right to left languages.

### DIFF
--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1037,7 +1037,20 @@ function tryRemoveElement(elem) {
                     throw new Error(response);
                 }
 
-                return response.json();
+                const json = await response.json();
+
+                const rtlLanguages = ['heb', 'aze', 'div', 'kur', 'per', 'urd'];
+                if (rtlLanguages.includes(track.Language)) {
+                // if the subtitles are in a RTL langauge forece right to left.
+                    console.debug('Forcing right to left subtitles.');
+
+                    for (const trackEvent of json.TrackEvents) {
+                        trackEvent.Text = '\u200E' + trackEvent.Text;
+                        trackEvent.Text = trackEvent.Text.replace('\n', '\n\u200E');
+                    }
+                }
+
+                return json;
             } finally {
                 this.decrementFetchQueue();
             }


### PR DESCRIPTION
Punctuation is reversed when using subtitles with RTL (right to left) languages.

**Changes**
Forcing RTL (right to left) text direction for RTL languages.

