### PR TITLE
Recognize MIME for transcoded audio in streams

### DIFF
--- a/src/plugins/htmlAudioPlayer/plugin.js
+++ b/src/plugins/htmlAudioPlayer/plugin.js
@@ -74,7 +74,7 @@ function enableHlsPlayer(url, item, mediaSource, mediaType) {
                 type: 'HEAD'
             }).then(function (response) {
                 const contentType = (response.headers.get('Content-Type') || '').toLowerCase();
-                if (contentType === 'application/x-mpegurl') {
+                if (contentType === 'application/vnd.apple.mpegurl') {
                     resolve();
                 } else {
                     reject();

--- a/src/plugins/htmlAudioPlayer/plugin.js
+++ b/src/plugins/htmlAudioPlayer/plugin.js
@@ -74,7 +74,7 @@ function enableHlsPlayer(url, item, mediaSource, mediaType) {
                 type: 'HEAD'
             }).then(function (response) {
                 const contentType = (response.headers.get('Content-Type') || '').toLowerCase();
-                if (contentType === 'application/vnd.apple.mpegurl') {
+                if (contentType === 'application/vnd.apple.mpegurl' || contentType === 'application/x-mpegurl') {
                     resolve();
                 } else {
                     reject();


### PR DESCRIPTION
After jellyfin/jellyfin#6941 MIME library returns IETF-approved type (`application/vnd.apple.mpegurl`) instead of old one (`application/x-mpegURL`), but latter was hardcoded in player plugin.

**Changes**
Use correct MIME-type for transcoded streams.

**Issues**
Fixes: #3663
