### PR TITLE
Turn backdrops on by default

### DIFF
--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -239,7 +239,7 @@ export class UserSettings {
             return this.set('enableBackdrops', val.toString(), false);
         }
 
-        return toBoolean(this.get('enableBackdrops', false), false);
+        return toBoolean(this.get('enableBackdrops', false), true);
     }
 
     /**

--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -1,6 +1,7 @@
 import appSettings from './appSettings';
 import { Events } from 'jellyfin-apiclient';
 import { toBoolean } from '../../utils/string.ts';
+import browser from '../browser';
 
 function onSaveTimeout() {
     const self = this;

--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -239,7 +239,7 @@ export class UserSettings {
             return this.set('enableBackdrops', val.toString(), false);
         }
 
-        return toBoolean(this.get('enableBackdrops', false), true);
+        return toBoolean(this.get('enableBackdrops', false), !browser.slow);
     }
 
     /**


### PR DESCRIPTION
All new users have backdrops disabled by default. Previously, this could be changed by editing the main.*.bundle.js file, but since 10.8.0 that no longer applies.

**Changes**
Change the default setting for backdrops to true.