### PR TITLE
Fix resume not working on LG WebOS

### DIFF
--- a/src/components/htmlMediaHelper.js
+++ b/src/components/htmlMediaHelper.js
@@ -131,7 +131,8 @@ import { Events } from 'jellyfin-apiclient';
     }
 
     function setCurrentTimeIfNeeded(element, seconds) {
-        if (Math.abs(element.currentTime || 0, seconds) <= 1) {
+        // If it's worth skipping (1 sec or less of a difference)
+        if (Math.abs((element.currentTime || 0) - seconds) >= 1) {
             element.currentTime = seconds;
         }
     }

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1375,6 +1375,9 @@ function tryRemoveElement(elem) {
                         // Can't autoplay in these browsers so we need to use the full controls, at least until playback starts
                         if (!appHost.supports('htmlvideoautoplay')) {
                             html += '<video class="' + cssClass + '" preload="metadata" autoplay="autoplay" controls="controls" webkit-playsinline playsinline>';
+                        } else if (browser.web0s) {
+                            // in webOS, setting peload auto allows resuming videos
+                            html += '<video class="' + cssClass + '" preload="auto" autoplay="autoplay" webkit-playsinline playsinline>';
                         } else {
                             // Chrome 35 won't play with preload none
                             html += '<video class="' + cssClass + '" preload="metadata" autoplay="autoplay" webkit-playsinline playsinline>';

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1376,7 +1376,7 @@ function tryRemoveElement(elem) {
                         if (!appHost.supports('htmlvideoautoplay')) {
                             html += '<video class="' + cssClass + '" preload="metadata" autoplay="autoplay" controls="controls" webkit-playsinline playsinline>';
                         } else if (browser.web0s) {
-                            // in webOS, setting peload auto allows resuming videos
+                            // in webOS, setting preload auto allows resuming videos
                             html += '<video class="' + cssClass + '" preload="auto" autoplay="autoplay" webkit-playsinline playsinline>';
                         } else {
                             // Chrome 35 won't play with preload none


### PR DESCRIPTION
Resume wasn't working for me on LG WebOS (via jellyfin-webos) on Jellyfin 10.8.0, jellyfin-webos 1.0.1 and latest jellyfin-web (master)

**Description**
I believe the issue is that:
- ?t=XXX is ignored on the video element in the WebOS browser
- Flawed logic in setCurrentTimeIfNeeded
- For some reason, changing currentTime in the 'playing' event (of the HTML video element) doesn't seem to do anything. I also tried 'loadeddata', 'loadedmetadata', 'canplay' but none of them worked. Only thing that worked is to delay the execution with setTimeout.
- Also possible that this only effects DirectStream MKV files

**Changes**
- I'm not sure what the original intention was, but `Math.abs(element.currentTime || 0, seconds)` is actually `Math.abs(element.currentTime || 0)`. I interpreted the logic was meant to not skip if the diff is smaller than 1 sec.
- Maybe someone has a less hack-y way to change (i.e. without using setTimeout) currentTime 

**Issues**
Probably solves jellyfin/jellyfin-webos#46