### PR TITLE
Add autoplay timer to slideshow.js. 

### DIFF
--- a/src/components/slideshow/slideshow.js
+++ b/src/components/slideshow/slideshow.js
@@ -296,7 +296,7 @@ export default function (options) {
         },
         {
             id: '5000',
-            name: '5 second'
+            name: '5 seconds'
         },
         {
             id: '10000',
@@ -307,7 +307,7 @@ export default function (options) {
             items,
             positionTo: button
         };
-        
+
         actionSheet.show(actionSheetOptions).then(function (result) {
             if (result) {
                 swiperInstance.params.autoplay.delay = result;

--- a/src/components/slideshow/slideshow.js
+++ b/src/components/slideshow/slideshow.js
@@ -17,6 +17,7 @@ import ServerConnections from '../ServerConnections';
 import { Swiper } from 'swiper/swiper-bundle.esm';
 import 'swiper/swiper-bundle.css';
 import screenfull from 'screenfull';
+import actionSheet from '../actionSheet/actionSheet';
 
 /**
  * Name of transition event.
@@ -192,6 +193,7 @@ export default function (options) {
                 html += '<div class="slideshowBottomBar hide">';
 
                 html += getIcon('play_arrow', 'btnSlideshowPause slideshowButton', true, true);
+                html += getIcon('timer', 'btnAutoplayTimer', true, true);
                 if (appHost.supports('filedownload') && options.user && options.user.Policy.EnableContentDownloading) {
                     html += getIcon('file_download', 'btnDownload slideshowButton', true);
                 }
@@ -222,6 +224,13 @@ export default function (options) {
             const btnPause = dialog.querySelector('.btnSlideshowPause');
             if (btnPause) {
                 btnPause.addEventListener('click', getClickHandler(playPause));
+            }
+
+            const btnAutoplayTimer = dialog.querySelector('.btnAutoplayTimer');
+            if (btnAutoplayTimer) {
+                btnAutoplayTimer.addEventListener('click', function (e) {
+                    showDelayMenu(e.target);
+                });
             }
 
             const btnDownload = dialog.querySelector('.btnDownload');
@@ -274,6 +283,36 @@ export default function (options) {
         if (btnSlideshowPrevious) btnSlideshowPrevious.classList.add('hide');
         const btnSlideshowNext = dialog.querySelector('.btnSlideshowNext');
         if (btnSlideshowNext) btnSlideshowNext.classList.add('hide');
+    }
+
+    function showDelayMenu(button) {
+        const items = [{
+            id: '1000',
+            name: '1 second'
+        },
+        {
+            id: '3000',
+            name: '3 seconds'
+        },
+        {
+            id: '5000',
+            name: '5 second'
+        },
+        {
+            id: '10000',
+            name: '10 seconds'
+        }];
+
+        const actionSheetOptions = {
+            items,
+            positionTo: button
+        };
+        
+        actionSheet.show(actionSheetOptions).then(function (result) {
+            if (result) {
+                swiperInstance.params.autoplay.delay = result;
+            }
+        }).catch(() => { return undefined; });//don't throw exception whenever not selecting item
     }
 
     /**

--- a/src/components/slideshow/slideshow.js
+++ b/src/components/slideshow/slideshow.js
@@ -195,7 +195,7 @@ export default function (options) {
                 html += '<div class="slideshowBottomBar hide">';
 
                 html += getIcon('play_arrow', 'btnSlideshowPause slideshowButton', true, true);
-                html += getIcon('timer', 'btnAutoplayTimer', true, true);
+                html += getIcon('timer', 'btnAutoplayDelay', true, true);
                 if (appHost.supports('filedownload') && options.user && options.user.Policy.EnableContentDownloading) {
                     html += getIcon('file_download', 'btnDownload slideshowButton', true);
                 }
@@ -228,10 +228,10 @@ export default function (options) {
                 btnPause.addEventListener('click', getClickHandler(playPause));
             }
 
-            const btnAutoplayTimer = dialog.querySelector('.btnAutoplayTimer');
-            if (btnAutoplayTimer) {
-                btnAutoplayTimer.addEventListener('click', function (e) {
-                    showDelayMenu(e.target);
+            const btnAutoplayDelay = dialog.querySelector('.btnAutoplayDelay');
+            if (btnAutoplayDelay) {
+                btnAutoplayDelay.addEventListener('click', function (e) {
+                    showAutoplayDelayMenu(e.target);
                 });
             }
 
@@ -287,7 +287,7 @@ export default function (options) {
         if (btnSlideshowNext) btnSlideshowNext.classList.add('hide');
     }
 
-    function showDelayMenu(button) {
+    function showAutoplayDelayMenu(button) {
         const delayLengths = [1, 3, 5, 10, 15];
         const items = delayLengths.map(length => {
             return {
@@ -382,7 +382,6 @@ export default function (options) {
         }
 
         const autoplayDelay = userSettings.get('autoplayDelay', true) || 3000;
-        console.log('autoplaydelay: ', autoplayDelay);
         const autoplay = options.autoplay ? {delay:autoplayDelay} : false;
 
         swiperInstance = new Swiper(dialog.querySelector('.slideshowSwiperContainer'), {

--- a/src/components/slideshow/slideshow.js
+++ b/src/components/slideshow/slideshow.js
@@ -287,6 +287,11 @@ export default function (options) {
         if (btnSlideshowNext) btnSlideshowNext.classList.add('hide');
     }
 
+    /**
+     * Opens actionSheetOptions to show possible delay timings
+     * On selection, saves that delay selection, starting autoplay if necessary.
+     * @param {Object} button Location of button to open menu at
+     */
     function showAutoplayDelayMenu(button) {
         const delayLengths = [1, 3, 5, 10, 15];
         const items = delayLengths.map(length => {
@@ -301,17 +306,27 @@ export default function (options) {
             positionTo: button
         };
 
-        actionSheet.show(actionSheetOptions).then(function (result) {
-            if (result) {
-                swiperInstance.params.autoplay.delay = result;
-                swiperInstance.autoplay.start();
-                userSettings.set('autoplayDelay', result, true);
-            }
-        }).catch(() => { /* swallow errors */ });
+        actionSheet.show(actionSheetOptions).then(
+            (result) => updateAutoplayDelay(result)
+        ).catch(() => { /* swallow errors */ });
     }
 
     /**
-     * Handles OSD changes when the autoplay is started.
+     * Updates autoplay delay length.
+     * Starts autoplay.
+     * Saves delay to userSettings.
+     * @param {string} delay Length of delay for autoplay in ms
+     */
+    function updateAutoplayDelay(delay) {
+        if (delay) {
+            swiperInstance.params.autoplay.delay = delay;
+            swiperInstance.autoplay.start();
+            userSettings.set('autoplayDelay', delay, true);
+        }
+    }
+
+    /**
+     * Handles OSD changes when the autoplay is started and applies custom delay if necessary.
      */
     function onAutoplayStart(autoplayDelay) {
         const btnSlideshowPause = dialog.querySelector('.btnSlideshowPause .material-icons');

--- a/src/components/slideshow/slideshow.js
+++ b/src/components/slideshow/slideshow.js
@@ -19,7 +19,7 @@ import 'swiper/swiper-bundle.css';
 import screenfull from 'screenfull';
 import actionSheet from '../actionSheet/actionSheet';
 import globalize from '../../scripts/globalize';
-import * as userSettings from '../../scripts/settings/userSettings';
+import { currentSettings as userSettings } from '../../scripts/settings/userSettings';
 
 /**
  * Name of transition event.

--- a/src/components/slideshow/slideshow.js
+++ b/src/components/slideshow/slideshow.js
@@ -18,6 +18,7 @@ import { Swiper } from 'swiper/swiper-bundle.esm';
 import 'swiper/swiper-bundle.css';
 import screenfull from 'screenfull';
 import actionSheet from '../actionSheet/actionSheet';
+import globalize from '../../scripts/globalize';
 
 /**
  * Name of transition event.
@@ -286,22 +287,13 @@ export default function (options) {
     }
 
     function showDelayMenu(button) {
-        const items = [{
-            id: '1000',
-            name: '1 second'
-        },
-        {
-            id: '3000',
-            name: '3 seconds'
-        },
-        {
-            id: '5000',
-            name: '5 seconds'
-        },
-        {
-            id: '10000',
-            name: '10 seconds'
-        }];
+        const delayLengths = [1, 3, 5, 10];
+        const items = delayLengths.map(length => {
+            return {
+                id: length * 1000,
+                name: globalize.translate('ValueSeconds', length)
+            };
+        });
 
         const actionSheetOptions = {
             items,
@@ -311,8 +303,9 @@ export default function (options) {
         actionSheet.show(actionSheetOptions).then(function (result) {
             if (result) {
                 swiperInstance.params.autoplay.delay = result;
+                swiperInstance.autoplay.start();
             }
-        }).catch(() => { return undefined; });//don't throw exception whenever not selecting item
+        }).catch(() => { /* swallow errors */ });
     }
 
     /**

--- a/src/components/slideshow/slideshow.js
+++ b/src/components/slideshow/slideshow.js
@@ -382,7 +382,7 @@ export default function (options) {
         }
 
         const autoplayDelay = userSettings.get('autoplayDelay', true) || 3000;
-        const autoplay = options.autoplay ? {delay:autoplayDelay} : false;
+        const autoplay = !options.interactive || options.autoplay ? { delay: autoplayDelay } : false;
 
         swiperInstance = new Swiper(dialog.querySelector('.slideshowSwiperContainer'), {
             direction: 'horizontal',
@@ -392,7 +392,7 @@ export default function (options) {
                 minRatio: 1,
                 toggle: true
             },
-            autoplay: !options.interactive || autoplay,
+            autoplay: autoplay,
             keyboard: {
                 enabled: true
             },


### PR DESCRIPTION
**Motivation**
I felt the slide show went through the items too quickly and it didn't have any customization.

**Changes**
Added a new button to slideshowBottomBar, btnAutoplayTimer.
Added function triggered by btnAutoplayTimer, showDelayMenu.
This function opens a actionSheet with 4 items. Each item is a different delay option in seconds: 1, 3, 5, 10.
Selecting one of those options will also start the autoplay if it currently is not.

**Before View**
![image](https://user-images.githubusercontent.com/96920381/177025671-7c34eb6a-b90d-484d-9687-3689291bf15e.png)

**After View**
![image](https://user-images.githubusercontent.com/96920381/177025665-5228ba01-147e-463f-9481-e65418cba81d.png)
![image](https://user-images.githubusercontent.com/96920381/177025876-47e9e717-33a8-4875-b481-021dc0aa7cef.png)

**Possible Next Steps**
Could use a cleaner way to add new options to playback, right now it's just hard coded.
