### PR TITLE
Fix splash screen checkbox always unchecked

### DIFF
--- a/src/controllers/dashboard/general.js
+++ b/src/controllers/dashboard/general.js
@@ -15,7 +15,6 @@ import alert from '../../components/alert';
         page.querySelector('#txtServerName').value = systemInfo.ServerName;
         page.querySelector('#txtCachePath').value = systemInfo.CachePath || '';
         page.querySelector('#chkQuickConnectAvailable').checked = config.QuickConnectAvailable === true;
-        page.querySelector('#chkSplashScreenAvailable').checked = config.SplashscreenEnabled === true;
         $('#txtMetadataPath', page).val(systemInfo.InternalMetadataPath || '');
         $('#txtMetadataNetworkPath', page).val(systemInfo.MetadataNetworkPath || '');
         $('#selectLocalizationLanguage', page).html(languageOptions.map(function (language) {
@@ -108,6 +107,7 @@ import alert from '../../components/alert';
             ApiClient.getNamedConfiguration(brandingConfigKey).then(function (config) {
                 view.querySelector('#txtLoginDisclaimer').value = config.LoginDisclaimer || '';
                 view.querySelector('#txtCustomCss').value = config.CustomCss || '';
+                view.querySelector('#chkSplashScreenAvailable').checked = config.SplashscreenEnabled === true;
             });
         });
     }


### PR DESCRIPTION
In 10.8.1 the options was read from the server configuration but it should be read from the branding options.

**Changes**

- Fix splash screen checkbox always unchecked

**Issues**

- Fixes issue reported in Matrix
- Fixes #3750 
