### PR TITLE
Make comic page not overflow horizontally

### DIFF
--- a/src/plugins/comicsPlayer/style.scss
+++ b/src/plugins/comicsPlayer/style.scss
@@ -12,6 +12,6 @@
 
     .swiper-slide-img {
         max-height: 100%;
-        max-width:100%;
+        max-width: 100%;
     }
 }

--- a/src/plugins/comicsPlayer/style.scss
+++ b/src/plugins/comicsPlayer/style.scss
@@ -12,5 +12,6 @@
 
     .swiper-slide-img {
         max-height: 100%;
+        max-width:100%;
     }
 }


### PR DESCRIPTION
**Changes**
Comic pages would get cut off horizontally if the image's width was larger than the viewer. Added a max width to keep it in view.

Note: image does not get centered vertically, but stays at the top. 

**Issues**
Should fix #3378 and possibly jellyfin/jellyfin-expo#382
