### PR TITLE
Add title and filename to download request in item details

### DIFF
--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -1966,7 +1966,7 @@ export default function (view, params) {
         download([{
             url: downloadHref,
             itemId: currentItem.Id,
-            serverId: currentItem.serverId,
+            serverId: currentItem.ServerId,
             title: currentItem.Name,
             filename: currentItem.Path.replace(/^.*[\\/]/, '')
         }]);

--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -1966,7 +1966,9 @@ export default function (view, params) {
         download([{
             url: downloadHref,
             itemId: currentItem.Id,
-            serverId: currentItem.serverId
+            serverId: currentItem.serverId,
+            title: currentItem.Name,
+            filename: currentItem.Path.replace(/^.*[\\/]/, '')
         }]);
     }
 


### PR DESCRIPTION
Changes in this PR are untested (I don't have book libraries to test with) but I'm confident they should work. The `currentItem` is a result of a `apiClient.getItem` call which should contain a rich BaseItem. The two added options are copied from the itemContextMenu.js source.

**Changes**

- Add title and filename to download request in item details
  - This does not fix the same issue in slideshow.js

**Issues**

Fixes https://github.com/jellyfin/jellyfin-android/issues/312
