### PR TITLE
Enable no-return-await eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -49,6 +49,7 @@ module.exports = {
         'no-multi-spaces': ['error'],
         'no-multiple-empty-lines': ['error', { 'max': 1 }],
         'no-restricted-globals': ['error'].concat(restrictedGlobals),
+        'no-return-await': ['error'],
         'no-trailing-spaces': ['error'],
         '@babel/no-unused-expressions': ['error', { 'allowShortCircuit': true, 'allowTernary': true, 'allowTaggedTemplates': true }],
         'no-void': ['error', { 'allowAsStatement': true }],

--- a/src/components/pluginManager.js
+++ b/src/components/pluginManager.js
@@ -34,7 +34,7 @@ class PluginManager {
             // translations won't be loaded for skins until needed
             return plugin;
         } else {
-            return await this.#loadStrings(plugin);
+            return this.#loadStrings(plugin);
         }
     }
 


### PR DESCRIPTION
**Changes**
Add 'no-return-await' rule to `.eslintrc.js` and remove redundant await from `pluginManager.js`

**Issues**
Related to issue #3494 
