### PR TITLE
Enable no-throw-literal eslint rule and fix errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,6 +42,7 @@ module.exports = {
         'indent': ['error', 4, { 'SwitchCase': 1 }],
         'jsx-quotes': ['error', 'prefer-single'],
         'keyword-spacing': ['error'],
+        'no-throw-literal': ['error'],
         'max-statements-per-line': ['error'],
         'no-duplicate-imports': ['error'],
         'no-empty-function': ['error'],

--- a/src/scripts/datetime.js
+++ b/src/scripts/datetime.js
@@ -19,7 +19,7 @@ import globalize from './globalize';
         //     "00", "00", ".000", "Z", undefined, undefined, undefined]
 
         if (!d) {
-            throw "Couldn't parse ISO 8601 date string '" + s + "'";
+            throw new Error("Couldn't parse ISO 8601 date string '" + s + "'");
         }
 
         // parse strings, leading zeros into proper ints


### PR DESCRIPTION
**Changes**
Add 'no-throw-literal' rule to .eslintrc.js and fix throwing a string in datetime.js

**Issues**
Related to issue #3494 
