### PR TITLE
Fix broken link for subtitles help

### DIFF
--- a/src/components/subtitleeditor/subtitleeditor.template.html
+++ b/src/components/subtitleeditor/subtitleeditor.template.html
@@ -2,7 +2,7 @@
     <button is="paper-icon-button-light" class="btnCancel autoSize" tabindex="-1" title="${ButtonBack}"><span class="material-icons arrow_back" aria-hidden="true"></span></button>
     <h3 class="formDialogHeaderTitle">${Subtitles}</h3>
 
-    <a is="emby-linkbutton" rel="noopener noreferrer" data-autohide="true" class="button-link btnHelp flex align-items-center" href="https://docs.jellyfin.org/general/server/media/subtitles.html" target="_blank" style="margin-left:auto;margin-right:.5em;padding:.25em;" title="${Help}"><span class="material-icons info" aria-hidden="true"></span><span style="margin-left:.25em;">${Help}</span></a>
+    <a is="emby-linkbutton" rel="noopener noreferrer" data-autohide="true" class="button-link btnHelp flex align-items-center" href="https://jellyfin.org/docs/general/server/media/external-files.html" target="_blank" style="margin-left:auto;margin-right:.5em;padding:.25em;" title="${Help}"><span class="material-icons info" aria-hidden="true"></span><span style="margin-left:.25em;">${Help}</span></a>
 </div>
 <div class="formDialogContent smoothScrollY">
     <div class="dialogContentInner dialog-content-centered">


### PR DESCRIPTION
Hi!

With commit https://github.com/jellyfin/jellyfin-docs/commit/b488c99929b6156e3a3479b02ec242e558d5e214 pages 'external-audio-files' and 'subtitles' were merged together to a new page 'external-files'. 

Web UI does not reflect these changes, this should fix that.

**Changes**
Changes the link that points to subtitles documentation.