### PR TITLE
Add comic and book viewer to dark theme

### DIFF
--- a/src/themes/dark/theme.css
+++ b/src/themes/dark/theme.css
@@ -481,3 +481,37 @@ html {
     background-color: #f2f2f2;
     color: #00a4dc;
 }
+
+#comicsPlayer,
+#bookPlayer {
+    background: #101010;
+}
+
+#bookPlayer .topButtons {
+    color: #fff;
+}
+
+.actionButtonIcon {
+    color: #fff;
+}
+
+#dialogToc {
+    background-color: #101010;
+}
+
+#dialogToc .bookplayerButtonIcon {
+    color: #ccc;
+}
+
+#dialogToc .bookplayerButtonIcon:hover {
+    color: #00a4dc;
+}
+
+.toc li a:link {
+    color: #ccc;
+}
+
+.toc li a:active,
+.toc li a:hover {
+    color: #00a4dc;
+}


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
Adds the comic viewer, book viewer and the book table of contents pop up to the dark theme. It includes dark background for all, light buttons, and light links to each chapter in the table of contents. The only thing I couldn't figure out is how to get the "X" close buttons to turn blue for the comic book viewer and the book table of contents pop up.


