### PR TITLE
Make book table of contents prettier

### DIFF
--- a/src/plugins/bookPlayer/style.scss
+++ b/src/plugins/bookPlayer/style.scss
@@ -42,6 +42,12 @@
 
 #dialogToc {
     background-color: white;
+    height: fit-content;
+    width: fit-content;
+    max-height: 80%;
+    max-width: 60%;
+    padding-right: 50px;
+    padding-bottom: 15px;
 
     .bookplayerButtonIcon {
         color: black;
@@ -49,5 +55,18 @@
 
     .toc li {
         margin-bottom: 5px;
+
+        list-style-type: none;
+        font-size: 120%;
+
+        a:link {
+            color: #black;
+            text-decoration: none;
+
+        a:active,
+        a:hover {
+            color: #00a4dc;
+            text-decoration: none;
+        }
     }
 }

--- a/src/plugins/bookPlayer/style.scss
+++ b/src/plugins/bookPlayer/style.scss
@@ -60,7 +60,7 @@
         font-size: 120%;
 
         a:link {
-            color: #black;
+            color: #000000;
             text-decoration: none;
         }
 

--- a/src/plugins/bookPlayer/style.scss
+++ b/src/plugins/bookPlayer/style.scss
@@ -60,7 +60,7 @@
         font-size: 120%;
 
         a:link {
-            color: #000000;
+            color: #000;
             text-decoration: none;
         }
 

--- a/src/plugins/bookPlayer/style.scss
+++ b/src/plugins/bookPlayer/style.scss
@@ -62,6 +62,7 @@
         a:link {
             color: #black;
             text-decoration: none;
+        }
 
         a:active,
         a:hover {


### PR DESCRIPTION
**Changes**
Changes the way the table of contents looks. The two biggest parts are hiding the bullets in the list, making each link black and hiding the link underline. This makes them look more like buttons than web links. The `#dialogToc` changes resize the table of contents based on the length of the list and the length of the longest chapter name rather than have the table of contents take up most of the screen for a short and small list. The link text size was also increased from 92% to 120%.
