### PR TITLE
Set mp2 unsupported for android devices

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -390,6 +390,9 @@ import browser from './browser';
             if (supportsMp3VideoAudio && (browser.chrome || browser.edgeChromium || (browser.firefox && browser.versionMajor >= 83))) {
                 supportsMp2VideoAudio = true;
             }
+            if (browser.android) {
+                supportsMp2VideoAudio = false;
+            }
         }
 
         /* eslint-disable compat/compat */


### PR DESCRIPTION
Some users encounter mp2 audio not decoded on android devices (see https://github.com/jellyfin/jellyfin-android/issues/764).

**Changes**
This fix sets mp2 support on android devices to unsupported and therefor forces transcoding of audio in such cases (usually DVB recordings).

**Issues**
- https://github.com/jellyfin/jellyfin-android/issues/764
