### PR TITLE
Fix loading indicator showing when loaded

### DIFF
--- a/src/components/ConnectionRequired.tsx
+++ b/src/components/ConnectionRequired.tsx
@@ -146,12 +146,14 @@ const ConnectionRequired: FunctionComponent<ConnectionRequiredProps> = ({
             setIsLoading(false);
         };
 
-        loading.show();
         validateConnection();
     }, [ isAdminRequired, isUserRequired, navigate ]);
 
+    // Show/hide the loading indicator
     useEffect(() => {
-        if (!isLoading) {
+        if (isLoading) {
+            loading.show();
+        } else {
             loading.hide();
         }
     }, [ isLoading ]);


### PR DESCRIPTION
**Changes**
Fixes an issue I found when testing https://github.com/jellyfin/jellyfin-web/pull/3567 where the loading indicator will sometimes show when changing pages and `isLoading` is false.

**Issues**
N/A
