### PR TITLE
Fix itemcontextmenu fails to update for items with no image metadata

### DIFF
--- a/src/components/nowPlayingBar/nowPlayingBar.js
+++ b/src/components/nowPlayingBar/nowPlayingBar.js
@@ -530,6 +530,7 @@ import { appRouter } from '../appRouter';
             nowPlayingImageElement.style.display = null;
             nowPlayingTextElement.style.marginLeft = null;
         } else {
+            nowPlayingImageUrl = null;
             nowPlayingImageElement.style.backgroundImage = '';
             nowPlayingImageElement.style.display = 'none';
             nowPlayingTextElement.style.marginLeft = '1em';

--- a/src/components/nowPlayingBar/nowPlayingBar.js
+++ b/src/components/nowPlayingBar/nowPlayingBar.js
@@ -524,16 +524,18 @@ import { appRouter } from '../appRouter';
             height: imgHeight
         })) : null;
 
-        if (url && url !== nowPlayingImageUrl) {
-            nowPlayingImageUrl = url;
-            imageLoader.lazyImage(nowPlayingImageElement, nowPlayingImageUrl);
-            nowPlayingImageElement.style.display = null;
-            nowPlayingTextElement.style.marginLeft = null;
-        } else {
-            nowPlayingImageUrl = null;
-            nowPlayingImageElement.style.backgroundImage = '';
-            nowPlayingImageElement.style.display = 'none';
-            nowPlayingTextElement.style.marginLeft = '1em';
+        if (url !== nowPlayingImageUrl) {
+            if (url) {
+                nowPlayingImageUrl = url;
+                imageLoader.lazyImage(nowPlayingImageElement, nowPlayingImageUrl);
+                nowPlayingImageElement.style.display = null;
+                nowPlayingTextElement.style.marginLeft = null;
+            } else {
+                nowPlayingImageUrl = null;
+                nowPlayingImageElement.style.backgroundImage = '';
+                nowPlayingImageElement.style.display = 'none';
+                nowPlayingTextElement.style.marginLeft = '1em';
+            }
         }
 
         if (nowPlayingItem.Id) {

--- a/src/components/nowPlayingBar/nowPlayingBar.js
+++ b/src/components/nowPlayingBar/nowPlayingBar.js
@@ -24,6 +24,7 @@ import { appRouter } from '../appRouter';
 
     let currentTimeElement;
     let nowPlayingImageElement;
+    let nowPlayingImageUrl;
     let nowPlayingTextElement;
     let nowPlayingUserData;
     let muteButton;
@@ -488,7 +489,6 @@ import { appRouter } from '../appRouter';
         return null;
     }
 
-    let currentImgUrl;
     function updateNowPlayingInfo(state) {
         const nowPlayingItem = state.NowPlayingItem;
 
@@ -524,54 +524,46 @@ import { appRouter } from '../appRouter';
             height: imgHeight
         })) : null;
 
-        let isRefreshing = false;
-
-        if (url !== currentImgUrl) {
-            currentImgUrl = url;
-            isRefreshing = true;
-
-            if (url) {
-                imageLoader.lazyImage(nowPlayingImageElement, url);
-                nowPlayingImageElement.style.display = null;
-                nowPlayingTextElement.style.marginLeft = null;
-            } else {
-                nowPlayingImageElement.style.backgroundImage = '';
-                nowPlayingImageElement.style.display = 'none';
-                nowPlayingTextElement.style.marginLeft = '1em';
-            }
+        if (url && url !== nowPlayingImageUrl) {
+            nowPlayingImageUrl = url;
+            imageLoader.lazyImage(nowPlayingImageElement, url);
+            nowPlayingImageElement.style.display = null;
+            nowPlayingTextElement.style.marginLeft = null;
+        } else {
+            nowPlayingImageElement.style.backgroundImage = '';
+            nowPlayingImageElement.style.display = 'none';
+            nowPlayingTextElement.style.marginLeft = '1em';
         }
 
         if (nowPlayingItem.Id) {
-            if (isRefreshing) {
-                const apiClient = ServerConnections.getApiClient(nowPlayingItem.ServerId);
-                apiClient.getItem(apiClient.getCurrentUserId(), nowPlayingItem.Id).then(function (item) {
-                    const userData = item.UserData || {};
-                    const likes = userData.Likes == null ? '' : userData.Likes;
-                    if (!layoutManager.mobile) {
-                        let contextButton = nowPlayingBarElement.querySelector('.btnToggleContextMenu');
-                        // We remove the previous event listener by replacing the item in each update event
-                        const contextButtonClone = contextButton.cloneNode(true);
-                        contextButton.parentNode.replaceChild(contextButtonClone, contextButton);
-                        contextButton = nowPlayingBarElement.querySelector('.btnToggleContextMenu');
-                        const options = {
-                            play: false,
-                            queue: false,
-                            stopPlayback: true,
-                            clearQueue: true,
-                            positionTo: contextButton
-                        };
-                        apiClient.getCurrentUser().then(function (user) {
-                            contextButton.addEventListener('click', function () {
-                                itemContextMenu.show(Object.assign({
-                                    item: item,
-                                    user: user
-                                }, options));
-                            });
+            const apiClient = ServerConnections.getApiClient(nowPlayingItem.ServerId);
+            apiClient.getItem(apiClient.getCurrentUserId(), nowPlayingItem.Id).then(function (item) {
+                const userData = item.UserData || {};
+                const likes = userData.Likes == null ? '' : userData.Likes;
+                if (!layoutManager.mobile) {
+                    let contextButton = nowPlayingBarElement.querySelector('.btnToggleContextMenu');
+                    // We remove the previous event listener by replacing the item in each update event
+                    const contextButtonClone = contextButton.cloneNode(true);
+                    contextButton.parentNode.replaceChild(contextButtonClone, contextButton);
+                    contextButton = nowPlayingBarElement.querySelector('.btnToggleContextMenu');
+                    const options = {
+                        play: false,
+                        queue: false,
+                        stopPlayback: true,
+                        clearQueue: true,
+                        positionTo: contextButton
+                    };
+                    apiClient.getCurrentUser().then(function (user) {
+                        contextButton.addEventListener('click', function () {
+                            itemContextMenu.show(Object.assign({
+                                item: item,
+                                user: user
+                            }, options));
                         });
-                    }
-                    nowPlayingUserData.innerHTML = '<button is="emby-ratingbutton" type="button" class="listItemButton mediaButton paper-icon-button-light" data-id="' + item.Id + '" data-serverid="' + item.ServerId + '" data-itemtype="' + item.Type + '" data-likes="' + likes + '" data-isfavorite="' + (userData.IsFavorite) + '"><span class="material-icons favorite" aria-hidden="true"></span></button>';
-                });
-            }
+                    });
+                }
+                nowPlayingUserData.innerHTML = '<button is="emby-ratingbutton" type="button" class="listItemButton mediaButton paper-icon-button-light" data-id="' + item.Id + '" data-serverid="' + item.ServerId + '" data-itemtype="' + item.Type + '" data-likes="' + likes + '" data-isfavorite="' + (userData.IsFavorite) + '"><span class="material-icons favorite" aria-hidden="true"></span></button>';
+            });
         } else {
             nowPlayingUserData.innerHTML = '';
         }

--- a/src/components/nowPlayingBar/nowPlayingBar.js
+++ b/src/components/nowPlayingBar/nowPlayingBar.js
@@ -526,7 +526,7 @@ import { appRouter } from '../appRouter';
 
         if (url && url !== nowPlayingImageUrl) {
             nowPlayingImageUrl = url;
-            imageLoader.lazyImage(nowPlayingImageElement, url);
+            imageLoader.lazyImage(nowPlayingImageElement, nowPlayingImageUrl);
             nowPlayingImageElement.style.display = null;
             nowPlayingTextElement.style.marginLeft = null;
         } else {


### PR DESCRIPTION
Changes #3860 to a 10.8.x release fix. Close deprecated PR as appropriate.

Desktop web client (Firefox, Chrome)
Jellyfin Version: 10.8.5

itemContextMenu for the nowPlayingBar media bar manipulates incorrect item (e.g. song) if there is no image metadata due to the relevant EventListener not being replaced on transition to the next item played.
Can manifest as the wrong song being added to a playlist, deleted, or receiving user supplied metadata, etc.

Changes

Removed isRefreshing - no longer longer seems relevant. Rename and small tidy of variable used to track currently played item's metadata image that interacted with isRefreshing.