### PR TITLE
Webpack build improvements

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -81,10 +81,28 @@ module.exports = {
         })
     ],
     output: {
-        filename: '[name].jellyfin.bundle.js',
+        filename: '[name].bundle.js',
         chunkFilename: '[name].[contenthash].chunk.js',
         path: path.resolve(__dirname, 'dist'),
         publicPath: ''
+    },
+    optimization: {
+        runtimeChunk: 'single',
+        splitChunks: {
+            chunks: 'all',
+            maxInitialRequests: Infinity,
+            cacheGroups: {
+                vendor: {
+                    test: /[\\/]node_modules[\\/]/,
+                    name(module) {
+                        // get the name. E.g. node_modules/packageName/not/this/part.js
+                        // or node_modules/packageName
+                        const packageName = module.context.match(/[\\/]node_modules[\\/](.*?)([\\/]|$)/)[1];
+                        return `node_modules.${packageName}`;
+                    }
+                }
+            }
+        }
     },
     module: {
         rules: [

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -116,7 +116,11 @@ module.exports = {
                 test: /\.(js|jsx)$/,
                 exclude: /node_modules[\\/](?!@uupaa[\\/]dynamic-import-polyfill|blurhash|date-fns|epubjs|flv.js|libarchive.js|marked|react-router|screenfull)/,
                 use: [{
-                    loader: 'babel-loader'
+                    loader: 'babel-loader',
+                    options: {
+                        cacheCompression: false,
+                        cacheDirectory: true
+                    }
                 }]
             },
             {
@@ -140,6 +144,8 @@ module.exports = {
                 use: [{
                     loader: 'babel-loader',
                     options: {
+                        cacheCompression: false,
+                        cacheDirectory: true,
                         plugins: [
                             '@babel/transform-modules-umd'
                         ]

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -6,7 +6,7 @@ module.exports = merge(common, {
     target: process.env.WEBPACK_SERVE ? 'web' : 'browserslist',
     mode: 'development',
     entry: { 'main.jellyfin': './scripts/site.js' },
-    devtool: 'source-map',
+    devtool: 'eval',
     module: {
         rules: [
             {

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -5,7 +5,7 @@ module.exports = merge(common, {
     // In order for live reload to work we must use "web" as the target not "browserslist"
     target: process.env.WEBPACK_SERVE ? 'web' : 'browserslist',
     mode: 'development',
-    entry: './scripts/site.js',
+    entry: { 'main.jellyfin': './scripts/site.js' },
     devtool: 'source-map',
     module: {
         rules: [

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -6,7 +6,7 @@ module.exports = merge(common, {
     target: process.env.WEBPACK_SERVE ? 'web' : 'browserslist',
     mode: 'development',
     entry: { 'main.jellyfin': './scripts/site.js' },
-    devtool: 'eval',
+    devtool: 'eval-cheap-module-source-map',
     module: {
         rules: [
             {

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -5,7 +5,7 @@ const WorkboxPlugin = require('workbox-webpack-plugin');
 
 module.exports = merge(common, {
     mode: 'production',
-    entry: './scripts/site.js',
+    entry: { 'main.jellyfin': './scripts/site.js' },
     plugins: [
         new WorkboxPlugin.InjectManifest({
             swSrc: path.resolve(__dirname, 'src/serviceworker.js'),


### PR DESCRIPTION
**Changes**
* Split `node_modules` to separate bundle files
  This makes it easier to identify large dependencies where additional optimizations should be investigated
  ![2022-09-06_10-32](https://user-images.githubusercontent.com/3450688/188662724-4bc464b1-aa42-477f-acd7-2f4505bc6d8a.png)
(Inspired by [this guide](https://medium.com/hackernoon/the-100-correct-way-to-split-your-chunks-with-webpack-f8a9df5b7758).)
* Enable babel build caching
  This **significantly** improves build times once the cache has been primed. I was seeing initial build times of around 55-60s and subsequent builds at around 35s.
* Use recommended `devtool` value for development builds
  This doesn't seem to make a substantial difference, but should save a few seconds (maybe 5-10s). https://webpack.js.org/guides/build-performance/#devtool

**Issues**
N/A
