### PR TITLE
Enable native subtitles for firefox

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -52,6 +52,7 @@
  - [MinecraftPlaye](https://github.com/MinecraftPlaye)
  - [Matthew Jones](https://github.com/matthew-jones-uk)
  - [taku0](https://github.com/taku0)
+ - [is343](https://github.com/is343)
 
 # Emby Contributors
 

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1150,8 +1150,7 @@ function tryRemoveElement(elem) {
                 return true;
             }
 
-            // This is unfortunate, but we're unable to remove the textTrack that gets added via addTextTrack
-            if (browser.firefox || browser.web0s) {
+            if (browser.web0s) {
                 return true;
             }
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
- removed firefox from the check that determines whether to use native or custom implementations for rendering subtitle tracks
  - Firefox already natively supports [TextTrack](https://developer.mozilla.org/en-US/docs/Web/API/TextTrack)
- removed an outdated comment
  - it is correct that there is no way to remove a track once it is added with `addTextTrack` (there is no `removeTextTrack`), but we already have a working method that was added a few years after that comment. See comment [here](https://github.com/jellyfin/jellyfin-web/blob/e95b457567fd7e6d8d2ef62287f31b3b8e971b4a/src/plugins/htmlVideoPlayer/plugin.js#L1263). We are clearing out the text track cue and disabling the track in order to remove/hide it (as seen [here](https://github.com/jellyfin/jellyfin-web/blob/e95b457567fd7e6d8d2ef62287f31b3b8e971b4a/src/plugins/htmlVideoPlayer/plugin.js#L1254)).
  - I have no way of testing `web0s` to confirm if native subtitles also work there.

**Issues**
There are no issues directly related to this.

I discovered that subtitles natively work with firefox because I am working on this feature request for [multiple subtitles at once](https://features.jellyfin.org/posts/936/multi-language-subtitles).

After getting a native implementation working with primary and secondary subtitles at once, I started working on the custom track rendering. I then questioned why firefox was using a custom renderer in the first place. Once I realized it works, I figured that it's a good idea to make this change in it's own small PR.

![Screen Recording 2022-09-12 at 2 00 10 PM](https://user-images.githubusercontent.com/30599893/189724759-b759b3d4-8287-47d9-ad55-f6517cf2a1fe.gif)

