### PR TITLE
Fix fullscreen scrobble not working for Audiobooks

### DIFF
--- a/src/components/remotecontrol/remotecontrol.js
+++ b/src/components/remotecontrol/remotecontrol.js
@@ -139,7 +139,7 @@ function updateNowPlayingInfo(context, state, serverId) {
     const displayName = item ? getNowPlayingNameHtml(item).replace('<br/>', ' - ') : '';
     if (item) {
         const nowPlayingServerId = (item.ServerId || serverId);
-        if (item.Type == 'Audio' || item.MediaStreams[0].Type == 'Audio') {
+        if (item.Type == 'AudioBook' || item.Type == 'Audio' || item.MediaStreams[0].Type == 'Audio') {
             let artistsSeries = '';
             let albumName = '';
             if (item.Artists != null) {


### PR DESCRIPTION
**Changes**
Fixes the bug that prevents album art from showing and the scrobble from working when in fullscreen for Audiobooks.

**Issues**
Fixes #[2556](https://github.com/jellyfin/jellyfin-web/issues/2556)
