### PR TITLE
Add secondary subtitle support to html video player

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -1580,7 +1580,7 @@ class PlaybackManager {
                 try {
                     return player.setSecondarySubtitleStreamIndex(index);
                 } catch (e) {
-                    console.error(`AutoSet - Failed to set secondary track: ${e}`);
+                    console.error('[playbackmanager] AutoSet - Failed to set secondary track:', e);
                 }
             }
 

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -1495,7 +1495,7 @@ class PlaybackManager {
                     return player.getSecondarySubtitleStreamIndex();
                 }
             } catch (e) {
-                console.error(`Failed to get secondary stream index: ${e}`);
+                console.error('[playbackmanager] Failed to get secondary stream index:', e);
             }
 
             if (!player) {

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -1724,7 +1724,7 @@ class PlaybackManager {
             }).then(function (deviceProfile) {
                 const audioStreamIndex = params.AudioStreamIndex == null ? getPlayerData(player).audioStreamIndex : params.AudioStreamIndex;
                 const subtitleStreamIndex = params.SubtitleStreamIndex == null ? getPlayerData(player).subtitleStreamIndex : params.SubtitleStreamIndex;
-                const secondarySubtitleStreamIndex = params.SubtitleStreamIndex == null ? getPlayerData(player).secondarySubtitleStreamIndex : params.secondarySubtitleStreamIndex;
+                const secondarySubtitleStreamIndex = params.SecondarySubtitleStreamIndex == null ? getPlayerData(player).secondarySubtitleStreamIndex : params.SecondarySubtitleStreamIndex;
 
                 let currentMediaSource = self.currentMediaSource(player);
                 const apiClient = ServerConnections.getApiClient(currentItem.ServerId);
@@ -2399,7 +2399,7 @@ class PlaybackManager {
             }
         }
 
-        function autoSetNextTracks(prevSource, mediaSource, audio, subtitle, secondarySubtitle) {
+        function autoSetNextTracks(prevSource, mediaSource, audio, subtitle) {
             try {
                 if (!prevSource) return;
 
@@ -2416,7 +2416,7 @@ class PlaybackManager {
                     rankStreamType(prevSource.DefaultSubtitleStreamIndex, prevSource, mediaSource, 'Subtitle');
                 }
 
-                if (secondarySubtitle && typeof prevSource.DefaultSecondarySubtitleStreamIndex == 'number') {
+                if (subtitle && typeof prevSource.DefaultSecondarySubtitleStreamIndex == 'number') {
                     rankStreamType(prevSource.DefaultSecondarySubtitleStreamIndex, prevSource, mediaSource, 'Subtitle', true);
                 }
             } catch (e) {
@@ -2484,13 +2484,13 @@ class PlaybackManager {
 
                 return getPlaybackMediaSource(player, apiClient, deviceProfile, maxBitrate, item, startPosition, mediaSourceId, audioStreamIndex, subtitleStreamIndex).then(async (mediaSource) => {
                     const user = await apiClient.getCurrentUser();
-                    const playerData = getPlayerData(player);
-
-                    autoSetNextTracks(prevSource, mediaSource, user.Configuration.RememberAudioSelections, user.Configuration.RememberSubtitleSelections, playerData.secondarySubtitleStreamIndex);
+                    autoSetNextTracks(prevSource, mediaSource, user.Configuration.RememberAudioSelections, user.Configuration.RememberSubtitleSelections);
 
                     const streamInfo = createStreamInfo(apiClient, item.MediaType, item, mediaSource, startPosition, player);
 
                     streamInfo.fullscreen = playOptions.fullscreen;
+
+                    const playerData = getPlayerData(player);
 
                     playerData.isChangingStream = false;
                     playerData.maxStreamingBitrate = maxBitrate;

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -3017,7 +3017,11 @@ class PlaybackManager {
             if (mediaSource) {
                 playerData.audioStreamIndex = mediaSource.DefaultAudioStreamIndex;
                 playerData.subtitleStreamIndex = mediaSource.DefaultSubtitleStreamIndex;
-                playerData.secondarySubtitleStreamIndex = mediaSource.DefaultSecondarySubtitleStreamIndex;
+                if (self.trackHasSecondarySubtitleSupport(mediaSource.MediaStreams[mediaSource.DefaultSubtitleStreamIndex])) {
+                    playerData.secondarySubtitleStreamIndex = mediaSource.DefaultSecondarySubtitleStreamIndex;
+                } else {
+                    playerData.secondarySubtitleStreamIndex = -1;
+                }
             } else {
                 playerData.audioStreamIndex = null;
                 playerData.subtitleStreamIndex = null;

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -1603,7 +1603,7 @@ class PlaybackManager {
             try {
                 player.setSecondarySubtitleStreamIndex(index);
             } catch (e) {
-                console.error(`AutoSet - Failed to set secondary track: ${e}`);
+                console.error('[playbackmanager] AutoSet - Failed to set secondary track:', e);
             }
         };
 

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -3017,11 +3017,7 @@ class PlaybackManager {
             if (mediaSource) {
                 playerData.audioStreamIndex = mediaSource.DefaultAudioStreamIndex;
                 playerData.subtitleStreamIndex = mediaSource.DefaultSubtitleStreamIndex;
-                if (self.trackHasSecondarySubtitleSupport(mediaSource.MediaStreams[mediaSource.DefaultSubtitleStreamIndex])) {
-                    playerData.secondarySubtitleStreamIndex = mediaSource.DefaultSecondarySubtitleStreamIndex;
-                } else {
-                    playerData.secondarySubtitleStreamIndex = -1;
-                }
+                playerData.secondarySubtitleStreamIndex = mediaSource.DefaultSecondarySubtitleStreamIndex;
             } else {
                 playerData.audioStreamIndex = null;
                 playerData.subtitleStreamIndex = null;

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -1490,16 +1490,16 @@ class PlaybackManager {
         self.getSecondarySubtitleStreamIndex = function (player) {
             player = player || self._currentPlayer;
 
+            if (!player) {
+                throw new Error('player cannot be null');
+            }
+
             try {
-                if (player && !enableLocalPlaylistManagement(player)) {
+                if (!enableLocalPlaylistManagement(player)) {
                     return player.getSecondarySubtitleStreamIndex();
                 }
             } catch (e) {
                 console.error('[playbackmanager] Failed to get secondary stream index:', e);
-            }
-
-            if (!player) {
-                throw new Error('player cannot be null');
             }
 
             return getPlayerData(player).secondarySubtitleStreamIndex;

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -891,7 +891,7 @@ class PlaybackManager {
          * - or if it can be paired with a secondary subtitle when used as a primary subtitle
          */
         self.trackHasSecondarySubtitleSupport = function (track, player = self._currentPlayer) {
-            if (!player) return false;
+            if (!player || !track) return false;
             const format = (track.Codec || '').toLowerCase();
             // Currently, only non-SSA/non-ASS external subtitles are supported.
             // Showing secondary subtitles does not work with any SSA/ASS subtitle combinations because

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -900,26 +900,12 @@ class PlaybackManager {
             return streams.filter((stream) => self.trackHasSecondarySubtitleSupport(stream, player));
         };
 
-        function getCurrentSubtitleStream(player) {
+        function getCurrentSubtitleStream(player, isSecondaryStream = false) {
             if (!player) {
                 throw new Error('player cannot be null');
             }
 
-            const index = getPlayerData(player).subtitleStreamIndex;
-
-            if (index == null || index === -1) {
-                return null;
-            }
-
-            return self.getSubtitleStream(player, index);
-        }
-
-        function getCurrentSecondarySubtitleStream(player) {
-            if (!player) {
-                throw new Error('player cannot be null');
-            }
-
-            const index = getPlayerData(player).secondarySubtitleStreamIndex;
+            const index = isSecondaryStream ? getPlayerData(player).secondarySubtitleStreamIndex : getPlayerData(player).subtitleStreamIndex;
 
             if (index == null || index === -1) {
                 return null;
@@ -1598,7 +1584,7 @@ class PlaybackManager {
                 }
             }
 
-            const currentStream = getCurrentSecondarySubtitleStream(player);
+            const currentStream = getCurrentSubtitleStream(player, true);
 
             const newStream = self.getSubtitleStream(player, index);
 

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -2387,7 +2387,11 @@ class PlaybackManager {
                 console.debug(`AutoSet ${streamType} - Using ${bestStreamIndex} score ${bestStreamScore}.`);
                 if (streamType == 'Subtitle') {
                     if (isSecondarySubtitle) {
-                        mediaSource.DefaultSecondarySubtitleStreamIndex = bestStreamIndex;
+                        if (self.trackHasSecondarySubtitleSupport(mediaSource.MediaStreams[bestStreamIndex])) {
+                            mediaSource.DefaultSecondarySubtitleStreamIndex = bestStreamIndex;
+                        } else {
+                            mediaSource.DefaultSecondarySubtitleStreamIndex = -1;
+                        }
                     } else {
                         mediaSource.DefaultSubtitleStreamIndex = bestStreamIndex;
                     }

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -1598,10 +1598,9 @@ class PlaybackManager {
                 return;
             }
 
-            getPlayerData(player).secondarySubtitleStreamIndex = index;
-
             try {
                 player.setSecondarySubtitleStreamIndex(index);
+                getPlayerData(player).secondarySubtitleStreamIndex = index;
             } catch (e) {
                 console.error('[playbackmanager] AutoSet - Failed to set secondary track:', e);
             }

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -2387,11 +2387,7 @@ class PlaybackManager {
                 console.debug(`AutoSet ${streamType} - Using ${bestStreamIndex} score ${bestStreamScore}.`);
                 if (streamType == 'Subtitle') {
                     if (isSecondarySubtitle) {
-                        if (self.trackHasSecondarySubtitleSupport(mediaSource.MediaStreams[bestStreamIndex])) {
-                            mediaSource.DefaultSecondarySubtitleStreamIndex = bestStreamIndex;
-                        } else {
-                            mediaSource.DefaultSecondarySubtitleStreamIndex = -1;
-                        }
+                        mediaSource.DefaultSecondarySubtitleStreamIndex = bestStreamIndex;
                     } else {
                         mediaSource.DefaultSubtitleStreamIndex = bestStreamIndex;
                     }

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -911,7 +911,7 @@ class PlaybackManager {
                 return null;
             }
 
-            return getSubtitleStream(player, index);
+            return self.getSubtitleStream(player, index);
         }
 
         function getCurrentSecondarySubtitleStream(player) {
@@ -925,14 +925,14 @@ class PlaybackManager {
                 return null;
             }
 
-            return getSubtitleStream(player, index);
+            return self.getSubtitleStream(player, index);
         }
 
-        function getSubtitleStream(player, index) {
+        self.getSubtitleStream = function (player, index) {
             return self.subtitleTracks(player).filter(function (s) {
                 return s.Type === 'Subtitle' && s.Index === index;
             })[0];
-        }
+        };
 
         self.getPlaylist = function (player) {
             player = player || self._currentPlayer;
@@ -1536,7 +1536,7 @@ class PlaybackManager {
 
             const currentStream = getCurrentSubtitleStream(player);
 
-            const newStream = getSubtitleStream(player, index);
+            const newStream = self.getSubtitleStream(player, index);
 
             if (!currentStream && !newStream) {
                 return;
@@ -1581,7 +1581,7 @@ class PlaybackManager {
             // Also disable secondary subtitles when disabling the primary
             // subtitles, or if it doesn't support a secondary pair
             if (selectedTrackElementIndex === -1 || !self.trackHasSecondarySubtitleSupport(newStream)) {
-                self.setSecondarySubtitleStreamIndex(selectedTrackElementIndex);
+                self.setSecondarySubtitleStreamIndex(-1);
             }
 
             getPlayerData(player).subtitleStreamIndex = index;
@@ -1600,7 +1600,7 @@ class PlaybackManager {
 
             const currentStream = getCurrentSecondarySubtitleStream(player);
 
-            const newStream = getSubtitleStream(player, index);
+            const newStream = self.getSubtitleStream(player, index);
 
             if (!currentStream && !newStream) {
                 return;
@@ -1644,7 +1644,7 @@ class PlaybackManager {
         };
 
         self.isSubtitleStreamExternal = function (index, player) {
-            const stream = getSubtitleStream(player, index);
+            const stream = self.getSubtitleStream(player, index);
             return stream ? getDeliveryMethod(stream) === 'External' : false;
         };
 

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -1598,7 +1598,7 @@ class PlaybackManager {
 
             // Secondary subtitles are currently only handled client side
             // Changes to the server code are required before we can handle other delivery methods
-            if (newStream && getDeliveryMethod(newStream) !== 'External') {
+            if (newStream && !self.trackHasSecondarySubtitleSupport(newStream, player)) {
                 return;
             }
 

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -2486,6 +2486,19 @@ class PlaybackManager {
                     const user = await apiClient.getCurrentUser();
                     autoSetNextTracks(prevSource, mediaSource, user.Configuration.RememberAudioSelections, user.Configuration.RememberSubtitleSelections);
 
+                    if (mediaSource.DefaultSubtitleStreamIndex == null || mediaSource.DefaultSubtitleStreamIndex < 0) {
+                        mediaSource.DefaultSubtitleStreamIndex = mediaSource.DefaultSecondarySubtitleStreamIndex;
+                        mediaSource.DefaultSecondarySubtitleStreamIndex = -1;
+                    }
+
+                    const subtitleTrack1 = mediaSource.MediaStreams[mediaSource.DefaultSubtitleStreamIndex];
+                    const subtitleTrack2 = mediaSource.MediaStreams[mediaSource.DefaultSecondarySubtitleStreamIndex];
+
+                    if (!self.trackHasSecondarySubtitleSupport(subtitleTrack1, player)
+                        || !self.trackHasSecondarySubtitleSupport(subtitleTrack2, player)) {
+                        mediaSource.DefaultSecondarySubtitleStreamIndex = -1;
+                    }
+
                     const streamInfo = createStreamInfo(apiClient, item.MediaType, item, mediaSource, startPosition, player);
 
                     streamInfo.fullscreen = playOptions.fullscreen;

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -1488,6 +1488,24 @@ class PlaybackManager {
             return getPlayerData(player).subtitleStreamIndex;
         };
 
+        self.getSecondarySubtitleStreamIndex = function (player) {
+            player = player || self._currentPlayer;
+
+            try {
+                if (player && !enableLocalPlaylistManagement(player)) {
+                    return player.getSecondarySubtitleStreamIndex();
+                }
+            } catch (e) {
+                console.error(`Failed to get secondary stream index: ${e}`);
+            }
+
+            if (!player) {
+                throw new Error('player cannot be null');
+            }
+
+            return getPlayerData(player).secondarySubtitleStreamIndex;
+        };
+
         function getDeliveryMethod(subtitleStream) {
             // This will be null for internal subs for local items
             if (subtitleStream.DeliveryMethod) {

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -887,7 +887,7 @@ class PlaybackManager {
          * - or if it can be paired with a secondary subtitle when used as a primary subtitle
          */
         self.trackHasSecondarySubtitleSupport = function (track, player = self._currentPlayer) {
-            if (!player || !self.playerHasSecondarySubtitleSupport(player)) return false;
+            if (!player) return false;
             const format = (track.Codec || '').toLowerCase();
             // Currently, only non-SSA/non-ASS external subtitles are supported.
             // Showing secondary subtitles does not work with any SSA/ASS subtitle combinations because
@@ -1578,8 +1578,9 @@ class PlaybackManager {
 
             player.setSubtitleStreamIndex(selectedTrackElementIndex);
 
-            // Also disable secondary subtitles when disabling the primary subtitles
-            if (selectedTrackElementIndex === -1) {
+            // Also disable secondary subtitles when disabling the primary
+            // subtitles, or if it doesn't support a secondary pair
+            if (selectedTrackElementIndex === -1 || !self.trackHasSecondarySubtitleSupport(newStream)) {
                 self.setSecondarySubtitleStreamIndex(selectedTrackElementIndex);
             }
 
@@ -1605,12 +1606,9 @@ class PlaybackManager {
                 return;
             }
 
-            const clearingStream = currentStream && !newStream;
-            const changingStream = currentStream && newStream;
-            const addingStream = !currentStream && newStream;
             // Secondary subtitles are currently only handled client side
             // Changes to the server code are required before we can handle other delivery methods
-            if (!clearingStream && (changingStream || addingStream) && getDeliveryMethod(newStream) !== 'External') {
+            if (newStream && getDeliveryMethod(newStream) !== 'External') {
                 return;
             }
 

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -988,9 +988,57 @@ import { setBackdropTransparency, TRANSPARENCY_LEVEL } from '../../../components
             });
         }
 
+        function showSecondarySubtitlesMenu(actionsheet, positionTo) {
+            const player = currentPlayer;
+            if (!playbackManager.hasSecondarySubtitleSupport(player)) return;
+            let currentIndex = playbackManager.getSecondarySubtitleStreamIndex(player);
+            const streams = playbackManager.secondarySubtitleTracks(player);
+
+            if (currentIndex == null) {
+                currentIndex = -1;
+            }
+
+            streams.unshift({
+                Index: -1,
+                DisplayTitle: globalize.translate('Off')
+            });
+
+            const menuItems = streams.map(function (stream) {
+                const opt = {
+                    name: stream.DisplayTitle,
+                    id: stream.Index
+                };
+
+                if (stream.Index === currentIndex) {
+                    opt.selected = true;
+                }
+
+                return opt;
+            });
+
+            actionsheet.show({
+                title: globalize.translate('SecondarySubtitles'),
+                items: menuItems,
+                positionTo
+            }).then(function (id) {
+                if (id) {
+                    const index = parseInt(id);
+                    if (index !== currentIndex) {
+                        playbackManager.setSecondarySubtitleStreamIndex(index, player);
+                    }
+                }
+            })
+            .finally(() => {
+                resetIdle();
+            });
+
+            setTimeout(resetIdle, 0);
+        }
+
         function showSubtitleTrackSelection() {
             const player = currentPlayer;
             const streams = playbackManager.subtitleTracks(player);
+            const secondaryStreams = playbackManager.secondarySubtitleTracks(player);
             let currentIndex = playbackManager.getSubtitleStreamIndex(player);
 
             if (currentIndex == null) {
@@ -1013,18 +1061,37 @@ import { setBackdropTransparency, TRANSPARENCY_LEVEL } from '../../../components
 
                 return opt;
             });
+
+            // Only show option if: player has support, has more than 1 subtitle track, has valid secondary tracks, primary subtitle is not off
+            if (playbackManager.hasSecondarySubtitleSupport(player) && streams.length > 1 && secondaryStreams.length > 0 && currentIndex !== -1) {
+                const secondarySubtitleMenuItem = {
+                    name: globalize.translate('SecondarySubtitles'),
+                    id: 'secondarysubtitle'
+                };
+                menuItems.unshift(secondarySubtitleMenuItem);
+            }
+
             const positionTo = this;
 
             import('../../../components/actionSheet/actionSheet').then(({default: actionsheet}) => {
                 actionsheet.show({
                     title: globalize.translate('Subtitles'),
                     items: menuItems,
+                    resolveOnClick: true,
                     positionTo: positionTo
                 }).then(function (id) {
-                    const index = parseInt(id);
+                    if (id === 'secondarysubtitle') {
+                        try {
+                            showSecondarySubtitlesMenu(actionsheet, positionTo);
+                        } catch (e) {
+                            console.error(e);
+                        }
+                    } else {
+                        const index = parseInt(id);
 
-                    if (index !== currentIndex) {
-                        playbackManager.setSubtitleStreamIndex(index, player);
+                        if (index !== currentIndex) {
+                            playbackManager.setSubtitleStreamIndex(index, player);
+                        }
                     }
 
                     toggleSubtitleSync();

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1070,11 +1070,11 @@ import { setBackdropTransparency, TRANSPARENCY_LEVEL } from '../../../components
             * - primary subtitle is not off
             * - primary subtitle has support
             */
-            const currentTrackCanAddSecondarySubtitle = playbackManager.playerHasSecondarySubtitleSupport(player) &&
-            streams.length > 1 &&
-            secondaryStreams.length > 0 &&
-            currentIndex !== -1 &&
-            playbackManager.trackHasSecondarySubtitleSupport(playbackManager.getSubtitleStream(player, currentIndex), player);
+            const currentTrackCanAddSecondarySubtitle = playbackManager.playerHasSecondarySubtitleSupport(player)
+                && streams.length > 1
+                && secondaryStreams.length > 0
+                && currentIndex !== -1
+                && playbackManager.trackHasSecondarySubtitleSupport(playbackManager.getSubtitleStream(player, currentIndex), player);
 
             if (currentTrackCanAddSecondarySubtitle) {
                 const secondarySubtitleMenuItem = {

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -990,7 +990,7 @@ import { setBackdropTransparency, TRANSPARENCY_LEVEL } from '../../../components
 
         function showSecondarySubtitlesMenu(actionsheet, positionTo) {
             const player = currentPlayer;
-            if (!playbackManager.hasSecondarySubtitleSupport(player)) return;
+            if (!playbackManager.playerHasSecondarySubtitleSupport(player)) return;
             let currentIndex = playbackManager.getSecondarySubtitleStreamIndex(player);
             const streams = playbackManager.secondarySubtitleTracks(player);
 
@@ -1071,7 +1071,7 @@ import { setBackdropTransparency, TRANSPARENCY_LEVEL } from '../../../components
              * - primary subtitle is `External`
              */
             if (
-                playbackManager.hasSecondarySubtitleSupport(player) &&
+                playbackManager.playerHasSecondarySubtitleSupport(player) &&
                 streams.length > 1 &&
                 secondaryStreams.length > 0 &&
                 currentIndex !== -1 &&

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1062,8 +1062,21 @@ import { setBackdropTransparency, TRANSPARENCY_LEVEL } from '../../../components
                 return opt;
             });
 
-            // Only show option if: player has support, has more than 1 subtitle track, has valid secondary tracks, primary subtitle is not off
-            if (playbackManager.hasSecondarySubtitleSupport(player) && streams.length > 1 && secondaryStreams.length > 0 && currentIndex !== -1) {
+            /**
+             * Only show option if:
+             * - player has support
+             * - has more than 1 subtitle track
+             * - has valid secondary tracks
+             * - primary subtitle is not off
+             * - primary subtitle is `External`
+             */
+            if (
+                playbackManager.hasSecondarySubtitleSupport(player) &&
+                streams.length > 1 &&
+                secondaryStreams.length > 0 &&
+                currentIndex !== -1 &&
+                playbackManager.isSubtitleStreamExternal(currentIndex, player)
+                ) {
                 const secondarySubtitleMenuItem = {
                     name: globalize.translate('SecondarySubtitles'),
                     id: 'secondarysubtitle'
@@ -1077,7 +1090,6 @@ import { setBackdropTransparency, TRANSPARENCY_LEVEL } from '../../../components
                 actionsheet.show({
                     title: globalize.translate('Subtitles'),
                     items: menuItems,
-                    resolveOnClick: true,
                     positionTo: positionTo
                 }).then(function (id) {
                     if (id === 'secondarysubtitle') {

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1068,13 +1068,13 @@ import { setBackdropTransparency, TRANSPARENCY_LEVEL } from '../../../components
             * - has more than 1 subtitle track
             * - has valid secondary tracks
             * - primary subtitle is not off
-            * - primary subtitle has support (index + 1 because `'Off'` is index 0 in `streams` array)
+            * - primary subtitle has support
             */
             const currentTrackCanAddSecondarySubtitle = playbackManager.playerHasSecondarySubtitleSupport(player) &&
             streams.length > 1 &&
             secondaryStreams.length > 0 &&
             currentIndex !== -1 &&
-            playbackManager.trackHasSecondarySubtitleSupport(streams[currentIndex + 1], player);
+            playbackManager.trackHasSecondarySubtitleSupport(playbackManager.getSubtitleStream(player, currentIndex), player);
 
             if (currentTrackCanAddSecondarySubtitle) {
                 const secondarySubtitleMenuItem = {

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1035,26 +1035,10 @@ import { setBackdropTransparency, TRANSPARENCY_LEVEL } from '../../../components
             setTimeout(resetIdle, 0);
         }
 
-        /**
-        * Only show option if:
-        * - player has support
-        * - has more than 1 subtitle track
-        * - has valid secondary tracks
-        * - primary subtitle is not off
-        * - primary subtitle has support (index + 1 because `'Off'` is index 0 in `streams` array)
-        */
-        function currentTrackCanHaveSecondarySubtitle(player, streams, currentIndex) {
-            const secondaryStreams = playbackManager.secondarySubtitleTracks(player);
-            return playbackManager.playerHasSecondarySubtitleSupport(player) &&
-            streams.length > 1 &&
-            secondaryStreams.length > 0 &&
-            currentIndex !== -1 &&
-            playbackManager.trackHasSecondarySubtitleSupport(streams[currentIndex + 1], player);
-        }
-
         function showSubtitleTrackSelection() {
             const player = currentPlayer;
             const streams = playbackManager.subtitleTracks(player);
+            const secondaryStreams = playbackManager.secondarySubtitleTracks(player);
             let currentIndex = playbackManager.getSubtitleStreamIndex(player);
 
             if (currentIndex == null) {
@@ -1078,7 +1062,21 @@ import { setBackdropTransparency, TRANSPARENCY_LEVEL } from '../../../components
                 return opt;
             });
 
-            if (currentTrackCanHaveSecondarySubtitle(player, streams, currentIndex)) {
+            /**
+            * Only show option if:
+            * - player has support
+            * - has more than 1 subtitle track
+            * - has valid secondary tracks
+            * - primary subtitle is not off
+            * - primary subtitle has support (index + 1 because `'Off'` is index 0 in `streams` array)
+            */
+            const currentTrackCanAddSecondarySubtitle = playbackManager.playerHasSecondarySubtitleSupport(player) &&
+            streams.length > 1 &&
+            secondaryStreams.length > 0 &&
+            currentIndex !== -1 &&
+            playbackManager.trackHasSecondarySubtitleSupport(streams[currentIndex + 1], player);
+
+            if (currentTrackCanAddSecondarySubtitle) {
                 const secondarySubtitleMenuItem = {
                     name: globalize.translate('SecondarySubtitles'),
                     id: 'secondarysubtitle'

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1035,10 +1035,26 @@ import { setBackdropTransparency, TRANSPARENCY_LEVEL } from '../../../components
             setTimeout(resetIdle, 0);
         }
 
+        /**
+        * Only show option if:
+        * - player has support
+        * - has more than 1 subtitle track
+        * - has valid secondary tracks
+        * - primary subtitle is not off
+        * - primary subtitle has support (index + 1 because `'Off'` is index 0 in `streams` array)
+        */
+        function currentTrackCanHaveSecondarySubtitle(player, streams, currentIndex) {
+            const secondaryStreams = playbackManager.secondarySubtitleTracks(player);
+            return playbackManager.playerHasSecondarySubtitleSupport(player) &&
+            streams.length > 1 &&
+            secondaryStreams.length > 0 &&
+            currentIndex !== -1 &&
+            playbackManager.trackHasSecondarySubtitleSupport(streams[currentIndex + 1], player);
+        }
+
         function showSubtitleTrackSelection() {
             const player = currentPlayer;
             const streams = playbackManager.subtitleTracks(player);
-            const secondaryStreams = playbackManager.secondarySubtitleTracks(player);
             let currentIndex = playbackManager.getSubtitleStreamIndex(player);
 
             if (currentIndex == null) {
@@ -1062,21 +1078,7 @@ import { setBackdropTransparency, TRANSPARENCY_LEVEL } from '../../../components
                 return opt;
             });
 
-            /**
-             * Only show option if:
-             * - player has support
-             * - has more than 1 subtitle track
-             * - has valid secondary tracks
-             * - primary subtitle is not off
-             * - primary subtitle is `External`
-             */
-            if (
-                playbackManager.playerHasSecondarySubtitleSupport(player) &&
-                streams.length > 1 &&
-                secondaryStreams.length > 0 &&
-                currentIndex !== -1 &&
-                playbackManager.isSubtitleStreamExternal(currentIndex, player)
-                ) {
+            if (currentTrackCanHaveSecondarySubtitle(player, streams, currentIndex)) {
                 const secondarySubtitleMenuItem = {
                     name: globalize.translate('SecondarySubtitles'),
                     id: 'secondarysubtitle'

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -495,7 +495,7 @@ function tryRemoveElement(elem) {
                 this.#secondarySubtitleTrackIndexToSetOnPlaying = options.mediaSource.DefaultSecondarySubtitleStreamIndex == null ? -1 : options.mediaSource.DefaultSecondarySubtitleStreamIndex;
                 if (this.#secondarySubtitleTrackIndexToSetOnPlaying != null && this.#secondarySubtitleTrackIndexToSetOnPlaying >= 0) {
                     const initialSecondarySubtitleStream = options.mediaSource.MediaStreams[this.#secondarySubtitleTrackIndexToSetOnPlaying];
-                    if (!initialSecondarySubtitleStream || initialSecondarySubtitleStream.DeliveryMethod !== 'External') {
+                    if (!initialSecondarySubtitleStream || !playbackManager.trackHasSecondarySubtitleSupport(initialSecondarySubtitleStream, this)) {
                         this.#secondarySubtitleTrackIndexToSetOnPlaying = -1;
                     }
                 }

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -581,7 +581,9 @@ function tryRemoveElement(elem) {
                 const trackElements = this.getTextTracks();
                 // if .vtt currently rendering
                 if (trackElements.length > 0) {
-                    trackElements.forEach((trackElement, index) => this.setTextTrackSubtitleOffset(trackElement, offsetValue, index));
+                    trackElements.forEach(function (trackElement, index) {
+                        this.setTextTrackSubtitleOffset(trackElement, offsetValue, index);
+                    });
                 } else if (this.#currentTrackEvents || this.#currentSecondaryTrackEvents) {
                     this.#currentTrackEvents && this.setTrackEventsSubtitleOffset(this.#currentTrackEvents, offsetValue, PRIMARY_TEXT_TRACK_INDEX);
                     this.#currentSecondaryTrackEvents && this.setTrackEventsSubtitleOffset(this.#currentSecondaryTrackEvents, offsetValue, SECONDARY_TEXT_TRACK_INDEX);

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -155,6 +155,9 @@ function tryRemoveElement(elem) {
         return profileBuilder({});
     }
 
+    const PRIMARY_TEXT_TRACK_INDEX = 0;
+    const SECONDARY_TEXT_TRACK_INDEX = 1;
+
     export class HtmlVideoPlayer {
         /**
          * @type {string}
@@ -285,14 +288,6 @@ function tryRemoveElement(elem) {
          * @type {any | undefined}
          */
         _currentPlayOptions;
-        /**
-         * @type {number}
-         */
-        _PRIMARY_TEXT_TRACK_INDEX = 0;
-        /**
-         * @type {number}
-         */
-        _SECONDARY_TEXT_TRACK_INDEX = 1;
         /**
          * @type {any | undefined}
          */
@@ -539,7 +534,7 @@ function tryRemoveElement(elem) {
         }
 
         setSecondarySubtitleStreamIndex(index) {
-            this.setCurrentTrackElement(index, this._SECONDARY_TEXT_TRACK_INDEX);
+            this.setCurrentTrackElement(index, SECONDARY_TEXT_TRACK_INDEX);
         }
 
         resetSubtitleOffset() {
@@ -588,8 +583,8 @@ function tryRemoveElement(elem) {
                 if (trackElements.length > 0) {
                     trackElements.forEach((trackElement, index) => this.setTextTrackSubtitleOffset(trackElement, offsetValue, index));
                 } else if (this.#currentTrackEvents || this.#currentSecondaryTrackEvents) {
-                    this.#currentTrackEvents && this.setTrackEventsSubtitleOffset(this.#currentTrackEvents, offsetValue, this._PRIMARY_TEXT_TRACK_INDEX);
-                    this.#currentSecondaryTrackEvents && this.setTrackEventsSubtitleOffset(this.#currentSecondaryTrackEvents, offsetValue, this._SECONDARY_TEXT_TRACK_INDEX);
+                    this.#currentTrackEvents && this.setTrackEventsSubtitleOffset(this.#currentTrackEvents, offsetValue, PRIMARY_TEXT_TRACK_INDEX);
+                    this.#currentSecondaryTrackEvents && this.setTrackEventsSubtitleOffset(this.#currentSecondaryTrackEvents, offsetValue, SECONDARY_TEXT_TRACK_INDEX);
                 } else {
                     console.debug('No available track, cannot apply offset: ', offsetValue);
                 }
@@ -600,7 +595,7 @@ function tryRemoveElement(elem) {
          * @private
          */
         updateCurrentTrackOffset(offsetValue, currentTrackIndex = 0) {
-            const skipRelativeOffset = currentTrackIndex !== this._PRIMARY_TEXT_TRACK_INDEX;
+            const skipRelativeOffset = currentTrackIndex !== PRIMARY_TEXT_TRACK_INDEX;
             let relativeOffset = offsetValue;
             const newTrackOffset = offsetValue;
             if (this.#currentTrackOffset && !skipRelativeOffset) {
@@ -629,10 +624,7 @@ function tryRemoveElement(elem) {
          * remain next to the new tracks until they reach the new offset's instance of the track.
          */
         requiresHidingActiveCuesOnOffsetChange() {
-            if (browser.firefox) {
-                return true;
-            }
-            return false;
+            return !!browser.firefox;
         }
 
         /**
@@ -687,11 +679,11 @@ function tryRemoveElement(elem) {
         }
 
         isPrimaryTrack(textTrackIndex) {
-            return textTrackIndex === this._PRIMARY_TEXT_TRACK_INDEX;
+            return textTrackIndex === PRIMARY_TEXT_TRACK_INDEX;
         }
 
         isSecondaryTrack(textTrackIndex) {
-            return textTrackIndex === this._SECONDARY_TEXT_TRACK_INDEX;
+            return textTrackIndex === SECONDARY_TEXT_TRACK_INDEX;
         }
 
         /**
@@ -1190,7 +1182,7 @@ function tryRemoveElement(elem) {
         /**
          * @private
          */
-        setTrackForDisplay(videoElement, track, targetTextTrackIndex = this._PRIMARY_TEXT_TRACK_INDEX) {
+        setTrackForDisplay(videoElement, track, targetTextTrackIndex = PRIMARY_TEXT_TRACK_INDEX) {
             if (!track) {
                 // Destroy all tracks by passing undefined if there is no valid primary track
                 this.destroyCustomTrack(videoElement, this.isSecondaryTrack(targetTextTrackIndex) ? targetTextTrackIndex : undefined);
@@ -1397,7 +1389,7 @@ function tryRemoveElement(elem) {
         /**
          * @private
          */
-        renderTracksEvents(videoElement, track, item, targetTextTrackIndex = this._PRIMARY_TEXT_TRACK_INDEX) {
+        renderTracksEvents(videoElement, track, item, targetTextTrackIndex = PRIMARY_TEXT_TRACK_INDEX) {
             if (!itemHelper.isLocalItem(item) || track.IsExternal) {
                 const format = (track.Codec || '').toLowerCase();
                 if (format === 'ssa' || format === 'ass') {

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -491,20 +491,16 @@ function tryRemoveElement(elem) {
 
             this._currentPlayOptions = options;
 
-            // Get the secondary track that has been set during this watch session
-            let currentSecondaryTrackIndex = playbackManager.getSecondarySubtitleStreamIndex(this);
-
-            if (!secondaryTrackValid) {
-                currentSecondaryTrackIndex = -1;
-                playbackManager.setSecondarySubtitleStreamIndex(currentSecondaryTrackIndex, this);
-            }
-
-            this.#secondarySubtitleTrackIndexToSetOnPlaying = currentSecondaryTrackIndex == null ? -1 : currentSecondaryTrackIndex;
-            if (this.#secondarySubtitleTrackIndexToSetOnPlaying != null && this.#secondarySubtitleTrackIndexToSetOnPlaying >= 0) {
-                const initialSecondarySubtitleStream = options.mediaSource.MediaStreams[this.#secondarySubtitleTrackIndexToSetOnPlaying];
-                if (!initialSecondarySubtitleStream || initialSecondarySubtitleStream.DeliveryMethod !== 'External') {
-                    this.#secondarySubtitleTrackIndexToSetOnPlaying = -1;
+            if (secondaryTrackValid) {
+                this.#secondarySubtitleTrackIndexToSetOnPlaying = options.mediaSource.DefaultSecondarySubtitleStreamIndex == null ? -1 : options.mediaSource.DefaultSecondarySubtitleStreamIndex;
+                if (this.#secondarySubtitleTrackIndexToSetOnPlaying != null && this.#secondarySubtitleTrackIndexToSetOnPlaying >= 0) {
+                    const initialSecondarySubtitleStream = options.mediaSource.MediaStreams[this.#secondarySubtitleTrackIndexToSetOnPlaying];
+                    if (!initialSecondarySubtitleStream || initialSecondarySubtitleStream.DeliveryMethod !== 'External') {
+                        this.#secondarySubtitleTrackIndexToSetOnPlaying = -1;
+                    }
                 }
+            } else {
+                this.#secondarySubtitleTrackIndexToSetOnPlaying = -1;
             }
 
             const crossOrigin = getCrossOriginValue(options.mediaSource);

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -478,9 +478,10 @@ function tryRemoveElement(elem) {
                 const initialSubtitleStream = options.mediaSource.MediaStreams[this.#subtitleTrackIndexToSetOnPlaying];
                 if (!initialSubtitleStream || initialSubtitleStream.DeliveryMethod === 'Encode') {
                     this.#subtitleTrackIndexToSetOnPlaying = -1;
+                    secondaryTrackValid = false;
                 }
-                // secondary track should not be shown if primary track is no longer `External` or is not on
-                if (initialSubtitleStream && initialSubtitleStream.DeliveryMethod !== 'External') {
+                // secondary track should not be shown if primary track is no longer a valid pair
+                if (initialSubtitleStream && !playbackManager.trackHasSecondarySubtitleSupport(initialSubtitleStream)) {
                     secondaryTrackValid = false;
                 }
             } else {

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1292,17 +1292,20 @@ function tryRemoveElement(elem) {
          */
         renderSubtitlesWithCustomElement(videoElement, track, item, targetTextTrackIndex) {
             this.fetchSubtitles(track, item).then((data) => {
-                if (!this.#videoSubtitlesElem) {
-                    if (!this.isSecondaryTrack(targetTextTrackIndex)) {
-                        const subtitlesContainer = document.createElement('div');
+                if (!this.#videoSubtitlesElem && !this.isSecondaryTrack(targetTextTrackIndex)) {
+                    let subtitlesContainer = document.querySelector('.videoSubtitles');
+                    if (!subtitlesContainer) {
+                        subtitlesContainer = document.createElement('div');
                         subtitlesContainer.classList.add('videoSubtitles');
-                        subtitlesContainer.innerHTML = '<div class="videoSubtitlesInner"></div>';
-                        this.#videoSubtitlesElem = subtitlesContainer.querySelector('.videoSubtitlesInner');
-                        this.setSubtitleAppearance(subtitlesContainer, this.#videoSubtitlesElem);
-                        videoElement.parentNode.appendChild(subtitlesContainer);
-                        this.#currentTrackEvents = data.TrackEvents;
                     }
-                } else if (this.isSecondaryTrack(targetTextTrackIndex)) {
+                    const subtitlesElement = document.createElement('div');
+                    subtitlesElement.classList.add('videoSubtitlesInner');
+                    subtitlesContainer.appendChild(subtitlesElement);
+                    this.#videoSubtitlesElem = subtitlesContainer.querySelector('.videoSubtitlesInner');
+                    this.setSubtitleAppearance(subtitlesContainer, this.#videoSubtitlesElem);
+                    videoElement.parentNode.appendChild(subtitlesContainer);
+                    this.#currentTrackEvents = data.TrackEvents;
+                } else if (!this.#videoSecondarySubtitlesElem && this.isSecondaryTrack(targetTextTrackIndex)) {
                     const subtitlesContainer = document.querySelector('.videoSubtitles');
                     if (!subtitlesContainer) return;
                     const secondarySubtitlesElement = document.createElement('div');

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1342,7 +1342,7 @@ function tryRemoveElement(elem) {
                     const subtitlesElement = document.createElement('div');
                     subtitlesElement.classList.add('videoSubtitlesInner');
                     subtitlesContainer.appendChild(subtitlesElement);
-                    this.#videoSubtitlesElem = subtitlesContainer.querySelector('.videoSubtitlesInner');
+                    this.#videoSubtitlesElem = subtitlesElement;
                     this.setSubtitleAppearance(subtitlesContainer, this.#videoSubtitlesElem);
                     videoElement.parentNode.appendChild(subtitlesContainer);
                     this.#currentTrackEvents = subtitleData.TrackEvents;

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -487,6 +487,10 @@ function tryRemoveElement(elem) {
                 secondaryTrackValid = false;
             }
 
+            this.#audioTrackIndexToSetOnPlaying = options.playMethod === 'Transcode' ? null : options.mediaSource.DefaultAudioStreamIndex;
+
+            this._currentPlayOptions = options;
+
             // Get the secondary track that has been set during this watch session
             let currentSecondaryTrackIndex = playbackManager.getSecondarySubtitleStreamIndex(this);
 
@@ -502,10 +506,6 @@ function tryRemoveElement(elem) {
                     this.#secondarySubtitleTrackIndexToSetOnPlaying = -1;
                 }
             }
-
-            this.#audioTrackIndexToSetOnPlaying = options.playMethod === 'Transcode' ? null : options.mediaSource.DefaultAudioStreamIndex;
-
-            this._currentPlayOptions = options;
 
             const crossOrigin = getCrossOriginValue(options.mediaSource);
             if (crossOrigin) {

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -626,37 +626,12 @@ function tryRemoveElement(elem) {
 
         /**
          * @private
-         * These browsers will not clear the existing active cue when setting an offset
-         * for native TextTracks.
-         * Any previous text tracks that are on the screen when the offset changes will
-         * remain next to the new tracks until they reach the new offset's instance of the track.
-         */
-        requiresHidingActiveCuesOnOffsetChange() {
-            return !!browser.firefox;
-        }
-
-        /**
-         * @private
-         */
-        hideTextTrackActiveCues(currentTrack) {
-            if (currentTrack.activeCues) {
-                Array.from(currentTrack.activeCues).forEach((cue) => {
-                    cue.text = '';
-                });
-            }
-        }
-
-        /**
-         * @private
          */
         setTextTrackSubtitleOffset(currentTrack, offsetValue, currentTrackIndex) {
             if (currentTrack.cues) {
                 offsetValue = this.updateCurrentTrackOffset(offsetValue, currentTrackIndex);
                 if (offsetValue === 0) {
                     return;
-                }
-                if (this.requiresHidingActiveCuesOnOffsetChange()) {
-                    this.hideTextTrackActiveCues(currentTrack);
                 }
                 Array.from(currentTrack.cues)
                     .forEach(function (cue) {

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -670,6 +670,10 @@ function tryRemoveElement(elem) {
             return this.#currentTrackOffset;
         }
 
+        isPrimaryTrack(textTrackIndex) {
+            return textTrackIndex === this._PRIMARY_TEXT_TRACK_INDEX;
+        }
+
         isSecondaryTrack(textTrackIndex) {
             return textTrackIndex === this._SECONDARY_TEXT_TRACK_INDEX;
         }
@@ -1050,15 +1054,12 @@ function tryRemoveElement(elem) {
          * @private
          */
         destroyCustomRenderedTrackElements(targetTrackIndex) {
-            const destroyPrimaryTrack = targetTrackIndex === this._PRIMARY_TEXT_TRACK_INDEX;
-            const destroySecondaryTrack = targetTrackIndex === this._SECONDARY_TEXT_TRACK_INDEX;
-
-            if (destroyPrimaryTrack) {
+            if (this.isPrimaryTrack(targetTrackIndex)) {
                 if (this.#videoSubtitlesElem) {
                     tryRemoveElement(this.#videoSubtitlesElem);
                     this.#videoSubtitlesElem = null;
                 }
-            } else if (destroySecondaryTrack) {
+            } else if (this.isSecondaryTrack(targetTrackIndex)) {
                 if (this.#videoSecondarySubtitlesElem) {
                     tryRemoveElement(this.#videoSecondarySubtitlesElem);
                     this.#videoSecondarySubtitlesElem = null;
@@ -1099,13 +1100,10 @@ function tryRemoveElement(elem) {
          * @private
          */
         destroyStoredTrackInfo(targetTrackIndex) {
-            const destroyPrimaryTrack = targetTrackIndex === this._PRIMARY_TEXT_TRACK_INDEX;
-            const destroySecondaryTrack = targetTrackIndex === this._SECONDARY_TEXT_TRACK_INDEX;
-
-            if (destroyPrimaryTrack) {
+            if (this.isPrimaryTrack(targetTrackIndex)) {
                 this.#customTrackIndex = -1;
                 this.#currentTrackEvents = null;
-            } else if (destroySecondaryTrack) {
+            } else if (this.isSecondaryTrack(targetTrackIndex)) {
                 this.#customSecondaryTrackIndex = -1;
                 this.#currentSecondaryTrackEvents = null;
             } else { // destroy all

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -480,7 +480,7 @@ function tryRemoveElement(elem) {
                     secondaryTrackValid = false;
                 }
                 // secondary track should not be shown if primary track is no longer a valid pair
-                if (initialSubtitleStream && !playbackManager.trackHasSecondarySubtitleSupport(initialSubtitleStream)) {
+                if (initialSubtitleStream && !playbackManager.trackHasSecondarySubtitleSupport(initialSubtitleStream, this)) {
                     secondaryTrackValid = false;
                 }
             } else {
@@ -488,11 +488,11 @@ function tryRemoveElement(elem) {
             }
 
             // Get the secondary track that has been set during this watch session
-            let currentSecondaryTrackIndex = playbackManager.getSecondarySubtitleStreamIndex();
+            let currentSecondaryTrackIndex = playbackManager.getSecondarySubtitleStreamIndex(this);
 
             if (!secondaryTrackValid) {
                 currentSecondaryTrackIndex = -1;
-                playbackManager.setSecondarySubtitleStreamIndex(currentSecondaryTrackIndex);
+                playbackManager.setSecondarySubtitleStreamIndex(currentSecondaryTrackIndex, this);
             }
 
             this.#secondarySubtitleTrackIndexToSetOnPlaying = currentSecondaryTrackIndex == null ? -1 : currentSecondaryTrackIndex;

--- a/src/plugins/htmlVideoPlayer/style.scss
+++ b/src/plugins/htmlVideoPlayer/style.scss
@@ -80,6 +80,7 @@ video[controls]::-webkit-media-controls {
     margin: auto;
     display: block;
     min-height: 0 !important;
+    margin-top: 0.5em !important;
     margin-bottom: 0.5em !important;
 }
 

--- a/src/plugins/htmlVideoPlayer/style.scss
+++ b/src/plugins/htmlVideoPlayer/style.scss
@@ -79,7 +79,8 @@ video[controls]::-webkit-media-controls {
     background-color: rgba(0, 0, 0, 0.8);
     margin: auto;
     display: block;
-    margin-bottom: 0 !important;
+    min-height: 0 !important;
+    margin-bottom: 0.5em !important;
 }
 
 @keyframes htmlvideoplayer-zoomin {

--- a/src/plugins/htmlVideoPlayer/style.scss
+++ b/src/plugins/htmlVideoPlayer/style.scss
@@ -74,6 +74,14 @@ video[controls]::-webkit-media-controls {
     display: inline-block;
 }
 
+.videoSecondarySubtitlesInner {
+    max-width: 70%;
+    background-color: rgba(0, 0, 0, 0.8);
+    margin: auto;
+    display: block;
+    margin-bottom: 0 !important;
+}
+
 @keyframes htmlvideoplayer-zoomin {
     from {
         transform: scale3d(0.2, 0.2, 0.2);

--- a/src/plugins/htmlVideoPlayer/style.scss
+++ b/src/plugins/htmlVideoPlayer/style.scss
@@ -65,20 +65,19 @@ video[controls]::-webkit-media-controls {
     padding-left: env(safe-area-inset-left);
     padding-right: env(safe-area-inset-right);
     padding-bottom: env(safe-area-inset-bottom);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 }
 
 .videoSubtitlesInner {
     max-width: 70%;
     background-color: rgba(0, 0, 0, 0.8);
-    margin: auto;
-    display: inline-block;
 }
 
 .videoSecondarySubtitlesInner {
     max-width: 70%;
     background-color: rgba(0, 0, 0, 0.8);
-    margin: auto;
-    display: block;
     min-height: 0 !important;
     margin-top: 0.5em !important;
     margin-bottom: 0.5em !important;

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1412,6 +1412,7 @@
     "SearchForSubtitles": "Search for Subtitles",
     "SearchResults": "Search Results",
     "Season": "Season",
+    "SecondarySubtitles": "Secondary Subtitles",
     "SelectAdminUsername": "Please select a username for the admin account.",
     "SelectServer": "Select Server",
     "SendMessage": "Send message",


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->


This PR adds the ability to view multiple subtitle tracks via the html video player as requested in this [feature request](https://features.jellyfin.org/posts/936/multi-language-subtitles).
I have done this by allowing the user to select a secondary track when a primary subtitle track is already playing. Depending on browser support, it will play natively or use the custom subtitle renderer.
The selected secondary track index is saved in the player instance's state, so the selected secondary subtitle will be remembered for the current play session. This is convenient for watching several episodes of a show, for example. The secondary track index is not saved anywhere else, so it will need to be set again when coming back for a new session. Subtitle offsets will also apply to both tracks. I also applied a fix for a firefox bug where the current visible track would not clear when setting an offset.

Since we are only handling the secondary subtitles on the client-side, only `External` text-based subtitles are currently supported. Anything burned in or done on the server-side will require changes there before we can make them work.

I was originally planning on allowing the user to select any number of extra subtitles by handling arrays of indexes, but that seemed like a lot more work to build in such a way that would not break current compatibility with existing methods or plugins. Also, I don't see the number of users wanting more than 2 subtitles to be that many.

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
- ~~fix issue with opening multiple actionsheets~~ #3900
  - ~~required since I added a new nested actionsheet~~
- add actionsheet for selecting secondary subtitles
  - All of the other actionsheets that are opened within another actionsheet do not have titles
  - I added a title to the secondary subtitle actionsheet because the contents of this actionsheet are likely to be the same as the one we just came from (main subtitle actionsheet). It might be easy for the user to not notice that they are on a new menu. So, I added the title to this one to let the user know what they are looking at.
- added new `playbackmanager` methods for handling secondary subtitles, getters, setters
  - resetting secondary subtitle state in `setSubtitleStreamIndex` when primary subtitle is cleared
- added new methods and updated logic to the main html player plugin
  - added logic to make sure we know which subtitle to manage (create, update, destroy) by adding a new argument for the target track index
  - updated logic for subtitle offsets. There was an issue when passing the offset to the second track. It was not getting the correct relative offset. Also no longer looping through all cues if the calculated offset === 0
  - added a workaround to fixed a bug in firefox where the currently visible text track would not clear when offset was changed
  - add logic to fetch the currently selected secondary track and start playing it
- added a new css class for the custom rendered secondary subtitles.
  - using `!important` because the `min-height` is set to over `4em` directly to the element's styles. This makes the spacing between the subtitles too big. Also for used in `margin-bottom` just to give a little bit of space between the two, while still being able to use `margin: auto`.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
[multi-language-subtitles feature request](https://features.jellyfin.org/posts/936/multi-language-subtitles)


Sorry for the bad quality gifs. I had to keep them under 10mb to add them to this PR.

Chrome - native subtitles
![Screen Recording 2022-09-14 at 5 47 24 PM](https://user-images.githubusercontent.com/30599893/190533966-ef69e951-6b54-4504-b1a5-bb0a82782be0.gif)

Chrome - custom renderer - tested by setting `requiresCustomSubtitlesElement` return `true`. (this was before I updated the spacing in the custom renderer css)
![Screen Recording 2022-09-14 at 5 40 28 PM](https://user-images.githubusercontent.com/30599893/190534100-55950ea4-8fe8-4f6f-8fd4-0044aa3713dc.gif)

(with current updated spacing for custom rendered subtitles)
<img width="905" alt="Screen Shot 2022-09-15 at 9 33 23 PM" src="https://user-images.githubusercontent.com/30599893/190537397-0c186b3b-1c92-4b08-871c-53ee8d69078c.png">


Firefox - native
![Screen Recording 2022-09-14 at 6 08 24 PM](https://user-images.githubusercontent.com/30599893/190534251-1fcb3927-4a73-40c5-9133-0739c1b07b2a.gif)


Firefox - (before fix) showing the bug where the current visible track does not clear when changing the offset. You can see the currently visible text (music notes) remains rendered until it reaches the point where it would be rendered again with the new offset timing
![Screen Recording 2022-09-14 at 6 10 24 PM](https://user-images.githubusercontent.com/30599893/190534347-20ef9269-afa3-43c6-ad08-a5b2bfd74b26.gif)

Firefox - (after fix) no longer showing the the bug from above
![Screen Recording 2022-09-14 at 8 01 33 PM](https://user-images.githubusercontent.com/30599893/190534674-3506ce7c-82dd-41da-9e6b-65b37fbfc7dc.gif)





