### PR TITLE
Add epubjs theme support to the book player

### DIFF
--- a/src/plugins/bookPlayer/plugin.js
+++ b/src/plugins/bookPlayer/plugin.js
@@ -9,6 +9,7 @@ import Screenfull from 'screenfull';
 import TableOfContents from './tableOfContents';
 import dom from '../../scripts/dom';
 import { translateHtml } from '../../scripts/globalize';
+import * as userSettings from '../../scripts/settings/userSettings';
 
 import '../../elements/emby-button/paper-icon-button-light';
 
@@ -293,6 +294,12 @@ export class BookPlayer {
 
                 this.currentSrc = downloadHref;
                 this.rendition = rendition;
+
+                rendition.themes.register('dark', { 'body': { 'color': '#fff' } });
+
+                if (userSettings.theme(undefined) === 'dark' || userSettings.theme(undefined) === null) {
+                    rendition.themes.select('dark');
+                }
 
                 return rendition.display().then(() => {
                     const epubElem = document.querySelector('.epub-container');


### PR DESCRIPTION
**Changes**
Add a dark theme to the book player via epubjs. For everything but the text, the dark theme from Jellyfin is retained. 

Should any other theme than the dark theme be chosen by the user, epubjs falls back to it's default theme (the one Jellyfin used before the book player got a dark theme).

**Note:** This change assumes that the dark theme is the default theme of Jellyfin as `userSettings.theme()` returns `null` should the user use the default theme.

**Issues**
Fixes #3930