### PR TITLE
Remove naive scaling of video playback controls

### DIFF
--- a/src/assets/css/videoosd.scss
+++ b/src/assets/css/videoosd.scss
@@ -115,10 +115,6 @@
     padding: 0 0.8em;
 }
 
-.layout-desktop .osdControls {
-    max-width: calc(100vh * 1.77 - 2vh);
-}
-
 .videoOsdBottom .buttons {
     padding: 0.25em 0 0;
     display: -webkit-box;


### PR DESCRIPTION
**Changes**
Removes the scaling of the video playback controls. While it seems like it would be a good idea, in practice it feels awkward and naively assumes all video is 16:9.

**Issues**
N/A
