### PR TITLE
Fix dialog closing flow

### DIFF
--- a/src/components/playback/playersettingsmenu.js
+++ b/src/components/playback/playersettingsmenu.js
@@ -238,7 +238,6 @@ function showWithUser(options, player, user) {
 
     return actionsheet.show({
         items: menuItems,
-        resolveOnClick: true,
         positionTo: options.positionTo
     }).then(function (id) {
         return handleSelectedOption(id, options, player);


### PR DESCRIPTION
**Changes**
When closing the dialog, wait for the browser history to finish updating the state.

**Issues**
Fixes #3978 
