### PR TITLE
Fix locale with suffix

### DIFF
--- a/src/components/dashboard/users/UserCardBox.tsx
+++ b/src/components/dashboard/users/UserCardBox.tsx
@@ -1,7 +1,7 @@
 import type { UserDto } from '@thornbill/jellyfin-sdk/dist/generated-client';
 import React, { FunctionComponent } from 'react';
 import { formatDistanceToNow } from 'date-fns';
-import { localeWithSuffix } from '../../../scripts/dfnshelper';
+import { getLocaleWithSuffix } from '../../../scripts/dfnshelper';
 import globalize from '../../../scripts/globalize';
 import cardBuilder from '../../cardbuilder/cardBuilder';
 
@@ -31,7 +31,7 @@ type IProps = {
 
 const getLastSeenText = (lastActivityDate?: string | null) => {
     if (lastActivityDate) {
-        return globalize.translate('LastSeen', formatDistanceToNow(Date.parse(lastActivityDate), localeWithSuffix));
+        return globalize.translate('LastSeen', formatDistanceToNow(Date.parse(lastActivityDate), getLocaleWithSuffix()));
     }
 
     return '';

--- a/src/controllers/dashboard/dashboard.js
+++ b/src/controllers/dashboard/dashboard.js
@@ -6,7 +6,7 @@ import serverNotifications from '../../scripts/serverNotifications';
 import dom from '../../scripts/dom';
 import globalize from '../../scripts/globalize';
 import { formatDistanceToNow } from 'date-fns';
-import { localeWithSuffix } from '../../scripts/dfnshelper';
+import { getLocaleWithSuffix } from '../../scripts/dfnshelper';
 import loading from '../../components/loading/loading';
 import playMethodHelper from '../../components/playback/playmethodhelper';
 import cardBuilder from '../../components/cardbuilder/cardBuilder';
@@ -476,7 +476,7 @@ import confirm from '../../components/confirm/confirm';
             // how dates are returned by the server when the session is active and show something like 'Active now', instead of past/future sentences
             if (!nowPlayingItem) {
                 return {
-                    html: globalize.translate('LastSeen', formatDistanceToNow(Date.parse(session.LastActivityDate), localeWithSuffix)),
+                    html: globalize.translate('LastSeen', formatDistanceToNow(Date.parse(session.LastActivityDate), getLocaleWithSuffix())),
                     image: imgUrl
                 };
             }

--- a/src/controllers/dashboard/devices/devices.js
+++ b/src/controllers/dashboard/devices/devices.js
@@ -5,7 +5,7 @@ import dom from '../../../scripts/dom';
 import globalize from '../../../scripts/globalize';
 import imageHelper from '../../../scripts/imagehelper';
 import { formatDistanceToNow } from 'date-fns';
-import { localeWithSuffix } from '../../../scripts/dfnshelper';
+import { getLocaleWithSuffix } from '../../../scripts/dfnshelper';
 import '../../../elements/emby-button/emby-button';
 import '../../../elements/emby-itemscontainer/emby-itemscontainer';
 import '../../../components/cardbuilder/card.scss';
@@ -91,6 +91,8 @@ import confirm from '../../../components/confirm/confirm';
     }
 
     function load(page, devices) {
+        const localeWithSuffix = getLocaleWithSuffix();
+
         let html = '';
         html += devices.map(function (device) {
             let deviceHtml = '';

--- a/src/controllers/dashboard/scheduledtasks/scheduledtasks.js
+++ b/src/controllers/dashboard/scheduledtasks/scheduledtasks.js
@@ -4,7 +4,7 @@ import { Events } from 'jellyfin-apiclient';
 import globalize from '../../../scripts/globalize';
 import serverNotifications from '../../../scripts/serverNotifications';
 import { formatDistance, formatDistanceToNow } from 'date-fns';
-import { getLocale, localeWithSuffix } from '../../../scripts/dfnshelper';
+import { getLocale, getLocaleWithSuffix } from '../../../scripts/dfnshelper';
 import '../../../components/listview/listview.scss';
 import '../../../elements/emby-button/emby-button';
 
@@ -77,7 +77,7 @@ import '../../../elements/emby-button/emby-button';
             if (task.LastExecutionResult) {
                 const endtime = Date.parse(task.LastExecutionResult.EndTimeUtc);
                 const starttime = Date.parse(task.LastExecutionResult.StartTimeUtc);
-                html += globalize.translate('LabelScheduledTaskLastRan', formatDistanceToNow(endtime, localeWithSuffix),
+                html += globalize.translate('LabelScheduledTaskLastRan', formatDistanceToNow(endtime, getLocaleWithSuffix()),
                     formatDistance(starttime, endtime, { locale: getLocale() }));
                 if (task.LastExecutionResult.Status === 'Failed') {
                     html += " <span style='color:#FF0000;'>(" + globalize.translate('LabelFailed') + ')</span>';

--- a/src/scripts/dfnshelper.js
+++ b/src/scripts/dfnshelper.js
@@ -67,9 +67,14 @@ export function getLocale() {
     return dateLocales(globalize.getCurrentLocale()) || dateLocales(globalize.getCurrentLocale().replace(/-.*/, '')) || enUS;
 }
 
-export const localeWithSuffix = { addSuffix: true, locale: getLocale() };
+export function getLocaleWithSuffix() {
+    return {
+        addSuffix: true,
+        locale: getLocale()
+    };
+}
 
 export default {
     getLocale: getLocale,
-    localeWithSuffix: localeWithSuffix
+    getLocaleWithSuffix
 };


### PR DESCRIPTION
**Changes**
Construct "locale with suffix" when needed.

**Issues**
Wrong (initial/browser) locale is used in `Active Devices`, `Devices` and `Users`.

:question:  Alternatively, we can update locale object when language changes.