### PR TITLE
Fix legacy browsers

### DIFF
--- a/cssnano.config.js
+++ b/cssnano.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+    preset: [
+        'default',
+        // Turn off `mergeLonghand` because it combines `padding-*` and `margin-*`,
+        // breaking fallback styles.
+        // https://github.com/cssnano/cssnano/issues/1163
+        // https://github.com/cssnano/cssnano/issues/1192
+        { mergeLonghand: false }
+    ]
+};

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -121,7 +121,7 @@ const config = {
             },
             {
                 test: /\.(js|jsx)$/,
-                exclude: /node_modules[\\/](?!@uupaa[\\/]dynamic-import-polyfill|blurhash|date-fns|epubjs|flv.js|libarchive.js|marked|react-router|screenfull)/,
+                exclude: /node_modules[\\/](?!@uupaa[\\/]dynamic-import-polyfill|@remix-run[\\/]router|blurhash|date-fns|epubjs|flv.js|libarchive.js|marked|react-router|screenfull)/,
                 use: [{
                     loader: 'babel-loader',
                     options: {


### PR DESCRIPTION
**Changes**
- Add `@remix-run/router` to `babel-loader`.
- Turn off `mergeLonghand` (cssnano) because it combines `padding-*`, breaking fallback styles (https://github.com/cssnano/cssnano/issues/1192, https://github.com/cssnano/cssnano/issues/1163).

**Issues**
- webOS 1.2 cannot load Jeff with `const`/`let`.
- webOS 1.2 lost some padding (video OSD) after #3676.