### PR TITLE
Remove resizeObserver

### DIFF
--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -273,10 +273,6 @@ function tryRemoveElement(elem) {
          * @type {any | undefined}
          */
         #lastProfile;
-        /**
-         * @type {MutationObserver | IntersectionObserver | undefined} (Unclear observer typing)
-         */
-        #resizeObserver;
 
         constructor() {
             if (browser.edgeUwp) {
@@ -963,11 +959,6 @@ function tryRemoveElement(elem) {
          * @private
          */
         destroyCustomTrack(videoElement) {
-            if (this.#resizeObserver) {
-                this.#resizeObserver.disconnect();
-                this.#resizeObserver = null;
-            }
-
             if (this.#videoSubtitlesElem) {
                 const subtitlesContainer = this.#videoSubtitlesElem.parentNode;
                 if (subtitlesContainer) {


### PR DESCRIPTION
**Changes**
Remove `resizeObserver` - leftover from https://github.com/jellyfin/jellyfin-web/commit/0cb54feb539ef4e7e7192b1fc92fdb5de24b4815