### PR TITLE
Add DownloadAll for season and series

### DIFF
--- a/src/components/itemContextMenu.js
+++ b/src/components/itemContextMenu.js
@@ -324,6 +324,7 @@ import toast from './toast/toast';
         const apiClient = ServerConnections.getApiClient(serverId);
 
         return new Promise(function (resolve, reject) {
+            // eslint-disable-next-line sonarjs/max-switch-cases
             switch (id) {
                 case 'addtocollection':
                     import('./collectionEditor/collectionEditor').then(({default: CollectionEditor}) => {
@@ -380,8 +381,8 @@ import toast from './toast/toast';
                                     Fields: 'CanDownload,Path'
                                 });
                             }
-                        )).then(seasons => {
-                            downloadEpisodes([].concat.apply([], seasons.map(season => season.Items)));
+                        )).then(seasonData => {
+                            downloadEpisodes([].concat.apply([], seasonData.map(season => season.Items)));
                         });
                     };
 

--- a/src/components/itemContextMenu.js
+++ b/src/components/itemContextMenu.js
@@ -143,7 +143,7 @@ import toast from './toast/toast';
 
         if (item.Type === 'Season' || item.Type == 'Series') {
             commands.push({
-                name: 'Download All',
+                name: globalize.translate('DownloadAll'),
                 id: 'downloadall',
                 icon: 'file_download'
             });

--- a/src/components/itemContextMenu.js
+++ b/src/components/itemContextMenu.js
@@ -382,7 +382,7 @@ import toast from './toast/toast';
                                 });
                             }
                         )).then(seasonData => {
-                            downloadEpisodes([].concat.apply([], seasonData.map(season => season.Items)));
+                            downloadEpisodes(seasonData.map(season => season.Items).flat());
                         });
                     };
 

--- a/src/scripts/shell.js
+++ b/src/scripts/shell.js
@@ -42,6 +42,10 @@ export default {
      * @returns true on success
      */
     downloadFiles(items) {
+        if (window.NativeShell?.downloadFiles) {
+            window.NativeShell.downloadFiles(items);
+            return true;
+        }
         if (window.NativeShell?.downloadFile) {
             items.forEach(item => {
                 window.NativeShell.downloadFile(item);

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -208,6 +208,7 @@
     "DoNotRecord": "Do not record",
     "Down": "Down",
     "Download": "Download",
+    "DownloadAll": "Download All",
     "DownloadsValue": "{0} downloads",
     "DrmChannelsNotImported": "Channels with DRM will not be imported.",
     "DropShadow": "Drop Shadow",


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Add a Download All button to Series and Season item types.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
This is mostly for the Android app, which uses jellyfin-web.

**To Discuss**
This code still has minor issues:
* The `Download All` string isn't translated
* The functions in the handler should probably be moved somehwere else? Where to?

* On both Firefox and Chromium the DownloadAll button only downloads *some*. It's been 7 or so on both for me. This is due to a parallel download limit in the browsers. Should this code pull in a check whether it's running native before it shows the button?