### PR TITLE
Fix bundle names for packages under namespaces

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -105,6 +105,14 @@ const config = {
                         // get the name. E.g. node_modules/packageName/not/this/part.js
                         // or node_modules/packageName
                         const packageName = module.context.match(/[\\/]node_modules[\\/](.*?)([\\/]|$)/)[1];
+                        // if "packageName" is a namespace (i.e. @jellyfin) get the namespace + packageName
+                        if (packageName.startsWith('@')) {
+                            const parts = module.context
+                                .substring(module.context.lastIndexOf(packageName))
+                                .split('/');
+                            return `node_modules.${parts[0]}.${parts[1]}`;
+                        }
+
                         return `node_modules.${packageName}`;
                     }
                 }


### PR DESCRIPTION
**Changes**
Fixes the bundle names of node packages that are published under namespaces. i.e. `@jellyfin/libass-wasm` would currently be in a bundle named just `node_modules.@jellyfin.*.js` instead of `node_modules.@jellyfin.libass-wasm.*.js`.

**Issues**
N/A
