### PR TITLE
Allow zero as MaxParentalRating value

### DIFF
--- a/src/routes/user/userparentalcontrol.tsx
+++ b/src/routes/user/userparentalcontrol.tsx
@@ -224,7 +224,7 @@ const UserParentalControl: FunctionComponent = () => {
             }
 
             const parentalRating = parseInt((page.querySelector('#selectMaxParentalRating') as HTMLSelectElement).value || '0', 10);
-            user.Policy.MaxParentalRating = parentalRating !== undefined ? parentalRating : null;
+            user.Policy.MaxParentalRating = Number.isNaN(parentalRating) ? null : parentalRating;
             user.Policy.BlockUnratedItems = Array.prototype.filter.call(page.querySelectorAll('.chkUnratedItem'), function (i) {
                 return i.checked;
             }).map(function (i) {

--- a/src/routes/user/userparentalcontrol.tsx
+++ b/src/routes/user/userparentalcontrol.tsx
@@ -168,7 +168,7 @@ const UserParentalControl: FunctionComponent = () => {
         populateRatings(allParentalRatings);
         let ratingValue = '';
 
-        if (user.Policy.MaxParentalRating) {
+        if (user.Policy.MaxParentalRating != null) {
             for (let i = 0, length = allParentalRatings.length; i < length; i++) {
                 const rating = allParentalRatings[i];
 
@@ -223,7 +223,8 @@ const UserParentalControl: FunctionComponent = () => {
                 throw new Error('Unexpected null user.Policy');
             }
 
-            user.Policy.MaxParentalRating = parseInt((page.querySelector('#selectMaxParentalRating') as HTMLSelectElement).value || '0', 10) || null;
+            const parentalRating = parseInt((page.querySelector('#selectMaxParentalRating') as HTMLSelectElement).value || '0', 10);
+            user.Policy.MaxParentalRating = parentalRating !== undefined ? parentalRating : null;
             user.Policy.BlockUnratedItems = Array.prototype.filter.call(page.querySelectorAll('.chkUnratedItem'), function (i) {
                 return i.checked;
             }).map(function (i) {


### PR DESCRIPTION
jellyfin/jellyfin#8526 allows zero to be a valid content rating level and the current code does not respect that.

**Changes**
Allow zero as value for `MaxParentalRating`.