### PR TITLE
Fix card cropping on item details page

### DIFF
--- a/src/assets/css/librarybrowser.scss
+++ b/src/assets/css/librarybrowser.scss
@@ -738,6 +738,8 @@
         left: 3.3%;
         top: -80%;
         width: 25vw;
+        // FIXME: the fixed width + max height cause the card to be cropped this needs a proper fix
+        max-height: none;
     }
 
     .layout-tv & {


### PR DESCRIPTION
**Changes**
Fixes an issue where the card is cropped at wide screen sizes. Not entirely sure how we didn't notice this one before. :sweat_smile: 

**Issues**
https://old.reddit.com/r/jellyfin/comments/xo0mw3/could_someone_please_explain_to_a_noob_how_to_fix/

