### PR TITLE
Fix changing audio stream on Firefox/Chrome

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -1320,7 +1320,7 @@ class PlaybackManager {
             }
 
             if (self.playMethod(player) === 'Transcode' || !player.canSetAudioStreamIndex()) {
-                changeStream(player, getCurrentTicks(player), { AudioStreamIndex: index });
+                changeStream(player, getCurrentTicks(player), { AudioStreamIndex: index, EnableDirectPlay: false });
                 getPlayerData(player).audioStreamIndex = index;
             } else {
                 // See if the player supports the track without transcoding


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
If the audio stream is changes and the web client detects that the player cannot set the audio stream by itself, a new stream is requested from the server. The new stream must be remuxed to allow switching the audio track. To force the server to do so, we can set the `EnableDirectPlay` to false.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #4044