### PR TITLE
Remove string replaceAll implementations

### DIFF
--- a/src/components/alert.js
+++ b/src/components/alert.js
@@ -5,11 +5,6 @@ import globalize from '../scripts/globalize';
 
 /* eslint-disable indent */
 
-    function replaceAll(originalString, strReplace, strWith) {
-        const reg = new RegExp(strReplace, 'ig');
-        return originalString.replace(reg, strWith);
-    }
-
     function useNativeAlert() {
         // webOS seems to block modals
         // Tizen 2.x seems to block modals
@@ -33,7 +28,7 @@ import globalize from '../scripts/globalize';
         await appRouter.ready();
 
         if (useNativeAlert()) {
-            alert(replaceAll(options.text || '', '<br/>', '\n'));
+            alert((options.text || '').replaceAll('<br/>', '\n'));
             return Promise.resolve();
         } else {
             const items = [];

--- a/src/components/apphost.js
+++ b/src/components/apphost.js
@@ -63,23 +63,13 @@ function getDeviceProfile(item) {
     });
 }
 
-function escapeRegExp(str) {
-    return str.replace(/([.*+?^=!:${}()|[\]/\\])/g, '\\$1');
-}
-
-function replaceAll(originalString, strReplace, strWith) {
-    const strReplace2 = escapeRegExp(strReplace);
-    const reg = new RegExp(strReplace2, 'ig');
-    return originalString.replace(reg, strWith);
-}
-
 function generateDeviceId() {
     const keys = [];
 
     keys.push(navigator.userAgent);
     keys.push(new Date().getTime());
     if (window.btoa) {
-        return replaceAll(btoa(keys.join('|')), '=', '1');
+        return btoa(keys.join('|')).replaceAll('=', '1');
     }
 
     return new Date().getTime();

--- a/src/components/confirm/confirm.js
+++ b/src/components/confirm/confirm.js
@@ -3,10 +3,6 @@ import browser from '../../scripts/browser';
 import dialog from '../dialog/dialog';
 import globalize from '../../scripts/globalize';
 
-function replaceAll(str, find, replace) {
-    return str.split(find).join(replace);
-}
-
 function useNativeConfirm() {
     // webOS seems to block modals
     // Tizen 2.x seems to block modals
@@ -24,7 +20,7 @@ async function nativeConfirm(options) {
         };
     }
 
-    const text = replaceAll(options.text || '', '<br/>', '\n');
+    const text = (options.text || '').replaceAll('<br/>', '\n');
     await appRouter.ready();
     const result = window.confirm(text);
 

--- a/src/components/prompt/prompt.js
+++ b/src/components/prompt/prompt.js
@@ -12,10 +12,6 @@ import '../formdialog.scss';
 import template from './prompt.template.html';
 
 export default (() => {
-    function replaceAll(str, find, replace) {
-        return str.split(find).join(replace);
-    }
-
     function setInputProperties(dlg, options) {
         const txtInput = dlg.querySelector('#txtInput');
 
@@ -105,7 +101,7 @@ export default (() => {
                 };
             }
 
-            const label = replaceAll(options.label || '', '<br/>', '\n');
+            const label = (options.label || '').replaceAll('<br/>', '\n');
             const result = prompt(label, options.text || '');
 
             if (result) {

--- a/src/components/viewContainer.js
+++ b/src/components/viewContainer.js
@@ -112,14 +112,11 @@ import Dashboard from '../utils/dashboard';
         }
     }
 
-    function replaceAll(str, find, replace) {
-        return str.split(find).join(replace);
-    }
-
     function parseHtml(html, hasScript) {
         if (hasScript) {
-            html = replaceAll(html, '\x3c!--<script', '<script');
-            html = replaceAll(html, '</script>--\x3e', '</script>');
+            html = html
+                .replaceAll('\x3c!--<script', '<script')
+                .replaceAll('</script>--\x3e', '</script>');
         }
 
         const wrapper = document.createElement('div');

--- a/src/scripts/globalize.js
+++ b/src/scripts/globalize.js
@@ -232,14 +232,10 @@ const Direction = {
         return key;
     }
 
-    function replaceAll(str, find, replace) {
-        return str.split(find).join(replace);
-    }
-
     export function translate(key) {
         let val = translateKey(key);
         for (let i = 1; i < arguments.length; i++) {
-            val = replaceAll(val, '{' + (i - 1) + '}', arguments[i].toLocaleString(currentCulture));
+            val = val.replaceAll('{' + (i - 1) + '}', arguments[i].toLocaleString(currentCulture));
         }
         return val;
     }


### PR DESCRIPTION
**Changes**
Removes all the different implementations of replaceAll functions for strings. This functionality is included in modern browsers and the core-js polyfills we ship, so there is no need for another implementation(s).

**Issues**
N/A
