### PR TITLE
Fix images sometimes not un-blurring

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -52,6 +52,7 @@
  - [MinecraftPlaye](https://github.com/MinecraftPlaye)
  - [Matthew Jones](https://github.com/matthew-jones-uk)
  - [taku0](https://github.com/taku0)
+ - [Peter Spenler](https://github.com/peterspenler)
 
 # Emby Contributors
 

--- a/src/components/images/imageLoader.js
+++ b/src/components/images/imageLoader.js
@@ -83,7 +83,7 @@ worker.addEventListener(
             source = entry;
         }
 
-        if (entry.intersectionRatio > 0) {
+        if (entry.isIntersecting) {
             if (source) {
                 fillImageElement(target, source);
             }


### PR DESCRIPTION
**Changes**
Updates the image loader to use `isIntersecting` instead of `intersectionRatio` to determine if an image intersects the intersection area for lazy loading. If we use the `intersectionRatio` property to determine if an image is in the intersection area there is a case where the IntersectionObserver calls the callback exactly as the image enters the area. This means that the `intersectionRatio` property will still be 0, which is what we would expect when the image is outside of the area, even though the image has just entered the area. When this happens the full images never load to replace the blurred image, since the intersection callback is only called when the image leaves or enters the intersection area. By using the `isIntersecting` property instead we can reliably determine whether or not an image is in the intersection area.

**Issues**
Fixes #3693 
Fixes #3542 
