### PR TITLE
feat: search bar for installed plugins

### DIFF
--- a/src/controllers/dashboard/plugins/installed/index.html
+++ b/src/controllers/dashboard/plugins/installed/index.html
@@ -1,6 +1,10 @@
 <div id="pluginsPage" data-role="page" class="page type-interior pluginConfigurationPage withTabs fullWidthContent">
     <div>
         <div class="content-primary">
+            <div class="inputContainer">
+                <label class="inputLabel" for="txtSearchPlugins">${Search}</label>
+                <input id="txtSearchPlugins" name="txtSearchPlugins" type="text" is="emby-input" class="emby-input">
+            </div>
             <div class="installedPlugins"></div>
         </div>
     </div>

--- a/src/controllers/dashboard/plugins/installed/index.js
+++ b/src/controllers/dashboard/plugins/installed/index.js
@@ -112,7 +112,6 @@ function populateList(page, plugins, pluginConfigurationPages) {
         if (plugin1.Name > plugin2.Name) {
             return 1;
         }
-
         return -1;
     });
 
@@ -134,6 +133,12 @@ function populateList(page, plugins, pluginConfigurationPages) {
         html += globalize.translate('MessageBrowsePluginCatalog');
         html += '</a></p>';
         html += '</div>';
+    }
+
+    // add search box listener
+    const searchBar = page.querySelector('#txtSearchPlugins');
+    if (searchBar) {
+        searchBar.addEventListener('input', () => onFilterType(page, searchBar));
     }
 
     installedPluginsElement.innerHTML = html;
@@ -235,6 +240,17 @@ function onInstalledPluginsClick(e) {
         const btnCardMenu = dom.parentWithClass(e.target, 'btnCardMenu');
         if (btnCardMenu) {
             showPluginMenu(dom.parentWithClass(btnCardMenu, 'page'), btnCardMenu);
+        }
+    }
+}
+
+function onFilterType(page, searchBar) {
+    const filter = searchBar.value.toLowerCase();
+    for (const card of page.querySelectorAll('.card')) {
+        if (filter && filter != '' && !card.textContent.toLowerCase().includes(filter)) {
+            card.style.display = 'none';
+        } else {
+            card.style.display = 'unset';
         }
     }
 }


### PR DESCRIPTION
**Changes**

Adds a search bar to the `My Plugins` section, allowing you to filter the installed plugins.
Title, version and status can be searched (the whole text of a plugin-card).
I tried to make it as less intrusive as possible by adding `display: none` to plugins that do not match the filter.

![msedge_XJPDY45ppY](https://user-images.githubusercontent.com/71837281/197068486-00cce571-1126-4562-9c3f-96206c07a997.gif)
