### PR TITLE
Add search bar for plugin catalogue

### DIFF
--- a/src/controllers/dashboard/plugins/available/index.html
+++ b/src/controllers/dashboard/plugins/available/index.html
@@ -2,8 +2,7 @@
     <div>
         <div class="content-primary">
             <div class="inputContainer">
-                <label class="inputLabel" for="txtSearchPlugins">${Search}</label>
-                <input id="txtSearchPlugins" name="txtSearchPlugins" type="text" is="emby-input" class="emby-input">
+                <input id="txtSearchPlugins" name="txtSearchPlugins" type="text" is="emby-input" label="${Search}" />
             </div>
             <div id="noPlugins" class="hide">${MessageNoAvailablePlugins}</div>
             <div id="pluginTiles" style="text-align:left;"></div>

--- a/src/controllers/dashboard/plugins/available/index.html
+++ b/src/controllers/dashboard/plugins/available/index.html
@@ -1,6 +1,10 @@
 <div id="pluginCatalogPage" data-role="page" class="page type-interior pluginConfigurationPage withTabs fullWidthContent">
     <div>
         <div class="content-primary">
+            <div class="inputContainer">
+                <label class="inputLabel" for="txtSearchPlugins">${Search}</label>
+                <input id="txtSearchPlugins" name="txtSearchPlugins" type="text" is="emby-input" class="emby-input">
+            </div>
             <div id="noPlugins" class="hide">${MessageNoAvailablePlugins}</div>
             <div id="pluginTiles" style="text-align:left;"></div>
         </div>

--- a/src/controllers/dashboard/plugins/available/index.js
+++ b/src/controllers/dashboard/plugins/available/index.js
@@ -105,7 +105,7 @@ function onSearchBarType(searchBar) {
                 card.style.display = 'none';
             } else {
                 card.style.display = 'unset';
-                shown += 1;
+                shown++;
             }
         }
         // hide title if no cards are shown

--- a/src/controllers/dashboard/plugins/available/index.js
+++ b/src/controllers/dashboard/plugins/available/index.js
@@ -97,10 +97,10 @@ function populateList(options) {
 
 function onSearchBarType(searchBar) {
     const filter = searchBar.value.toLowerCase();
-    for (const header of document.querySelectorAll("div .verticalSection")) {
+    for (const header of document.querySelectorAll('div .verticalSection')) {
         // keep track of shown cards after each search
         let shown = 0;
-        for (const card of header.querySelectorAll("div .card")) {
+        for (const card of header.querySelectorAll('div .card')) {
             if (filter && filter != '' && !card.textContent.toLowerCase().includes(filter)) {
                 card.style.display = 'none';
             } else {

--- a/src/controllers/dashboard/plugins/available/index.js
+++ b/src/controllers/dashboard/plugins/available/index.js
@@ -86,8 +86,35 @@ function populateList(options) {
         options.noItemsElement.classList.remove('hide');
     }
 
+    const searchBar = document.getElementById('txtSearchPlugins');
+    if (searchBar) {
+        searchBar.addEventListener('input', () => onSearchBarType(searchBar));
+    }
+
     options.catalogElement.innerHTML = html;
     loading.hide();
+}
+
+function onSearchBarType(searchBar) {
+    const filter = searchBar.value.toLowerCase();
+    for (const header of document.querySelectorAll("div .verticalSection")) {
+        // keep track of shown cards after each search
+        let shown = 0;
+        for (const card of header.querySelectorAll("div .card")) {
+            if (filter && filter != '' && !card.textContent.toLowerCase().includes(filter)) {
+                card.style.display = 'none';
+            } else {
+                card.style.display = 'unset';
+                shown += 1;
+            }
+        }
+        // hide title if no cards are shown
+        if (shown <= 0) {
+            header.style.display = 'none';
+        } else {
+            header.style.display = 'unset';
+        }
+    }
 }
 
 function getPluginHtml(plugin, options, installedPlugins) {


### PR DESCRIPTION
**Changes**

Adds a search bar to the `Catalogue` section, allowing you to filter the available plugins.

This PR differs from #4079 in that, on the one hand, the plugin catalog can be searched (available plugins, not already installed ones) and, on the other hand, the category headings are also hidden.

I tried to make it as less intrusive as possible by adding `display: none` to cards and headers that do not match the filter.

https://user-images.githubusercontent.com/71837281/197134209-3ff4d6f1-c343-414b-b82a-a04bc0e54ff5.mov

