### PR TITLE
Refactor ConnectionState to a shared enum

### DIFF
--- a/src/apiclient.d.ts
+++ b/src/apiclient.d.ts
@@ -68,6 +68,7 @@ declare module 'jellyfin-apiclient' {
         UtcTimeResponse,
         VirtualFolderInfo
     } from '@jellyfin/sdk/lib/generated-client';
+    import { ConnectionState } from './utils/jellyfin-apiclient/ConnectionState';
 
     class ApiClient {
         constructor(serverAddress: string, appName: string, appVersion: string, deviceName: string, deviceId: string);
@@ -310,12 +311,18 @@ declare module 'jellyfin-apiclient' {
         setItem(name: string, value: string): void;
     }
 
+    interface ConnectResponse {
+        ApiClient: ApiClient
+        Servers: any[]
+        State: ConnectionState
+    }
+
     class ConnectionManager {
         constructor(credentialProvider: Credentials, appName: string, appVersion: string, deviceName: string, deviceId: string, capabilities: ClientCapabilities);
 
         addApiClient(apiClient: ApiClient): void;
         clearData(): void;
-        connect(options?: any): Promise<any>;
+        connect(options?: any): Promise<ConnectResponse>;
         connectToAddress(address: string, options?: any): Promise<any>;
         connectToServer(server: any, options?: any): Promise<any>;
         connectToServers(servers: any[], options?: any): Promise<any>;

--- a/src/components/ConnectionRequired.tsx
+++ b/src/components/ConnectionRequired.tsx
@@ -1,25 +1,19 @@
 import React, { FunctionComponent, useEffect, useState } from 'react';
 import { Outlet, useNavigate } from 'react-router-dom';
+import type { ConnectResponse } from 'jellyfin-apiclient';
 
 import alert from './alert';
 import { appRouter } from './appRouter';
 import loading from './loading/loading';
 import ServerConnections from './ServerConnections';
 import globalize from '../scripts/globalize';
+import { ConnectionState } from '../utils/jellyfin-apiclient/ConnectionState';
 
 enum BounceRoutes {
     Home = '/home.html',
     Login = '/login.html',
     SelectServer = '/selectserver.html',
     StartWizard = '/wizardstart.html'
-}
-
-// TODO: This should probably be in the SDK
-enum ConnectionState {
-    SignedIn = 'SignedIn',
-    ServerSignIn = 'ServerSignIn',
-    ServerSelection = 'ServerSelection',
-    ServerUpdateNeeded = 'ServerUpdateNeeded'
 }
 
 type ConnectionRequiredProps = {
@@ -42,7 +36,7 @@ const ConnectionRequired: FunctionComponent<ConnectionRequiredProps> = ({
 
     useEffect(() => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const bounce = async (connectionResponse: any) => {
+        const bounce = async (connectionResponse: ConnectResponse) => {
             switch (connectionResponse.State) {
                 case ConnectionState.SignedIn:
                     // Already logged in, bounce to the home page

--- a/src/components/appRouter.js
+++ b/src/components/appRouter.js
@@ -9,6 +9,7 @@ import loading from './loading/loading';
 import viewManager from './viewManager/viewManager';
 import ServerConnections from './ServerConnections';
 import alert from './alert';
+import { ConnectionState } from '../utils/jellyfin-apiclient/ConnectionState.ts';
 
 export const history = createHashHistory();
 
@@ -201,17 +202,17 @@ class AppRouter {
 
     #handleConnectionResult(result) {
         switch (result.State) {
-            case 'SignedIn':
+            case ConnectionState.SignedIn:
                 loading.hide();
                 this.goHome();
                 break;
-            case 'ServerSignIn':
+            case ConnectionState.ServerSignIn:
                 this.showLocalLogin(result.ApiClient.serverId());
                 break;
-            case 'ServerSelection':
+            case ConnectionState.ServerSelection:
                 this.showSelectServer();
                 break;
-            case 'ServerUpdateNeeded':
+            case ConnectionState.ServerUpdateNeeded:
                 alert({
                     text: globalize.translate('ServerUpdateNeeded', 'https://github.com/jellyfin/jellyfin'),
                     html: globalize.translate('ServerUpdateNeeded', '<a href="https://github.com/jellyfin/jellyfin">https://github.com/jellyfin/jellyfin</a>')
@@ -365,7 +366,7 @@ class AppRouter {
 
         this.firstConnectionResult = null;
         if (firstResult) {
-            if (firstResult.State === 'ServerSignIn') {
+            if (firstResult.State === ConnectionState.ServerSignIn) {
                 const url = firstResult.ApiClient.serverAddress() + '/System/Info/Public';
                 fetch(url).then(response => {
                     if (!response.ok) return Promise.reject('fetch failed');
@@ -382,7 +383,7 @@ class AppRouter {
                 });
 
                 return;
-            } else if (firstResult.State !== 'SignedIn') {
+            } else if (firstResult.State !== ConnectionState.SignedIn) {
                 this.#handleConnectionResult(firstResult);
                 return;
             }

--- a/src/controllers/session/addServer/index.js
+++ b/src/controllers/session/addServer/index.js
@@ -4,30 +4,31 @@ import globalize from '../../../scripts/globalize';
 import '../../../elements/emby-button/emby-button';
 import Dashboard from '../../../utils/dashboard';
 import ServerConnections from '../../../components/ServerConnections';
+import { ConnectionState } from '../../../utils/jellyfin-apiclient/ConnectionState.ts';
 
 /* eslint-disable indent */
 
     function handleConnectionResult(page, result) {
         loading.hide();
         switch (result.State) {
-            case 'SignedIn': {
+            case ConnectionState.SignedIn: {
                 const apiClient = result.ApiClient;
                 Dashboard.onServerChanged(apiClient.getCurrentUserId(), apiClient.accessToken(), apiClient);
                 Dashboard.navigate('home.html');
                 break;
             }
-            case 'ServerSignIn':
+            case ConnectionState.ServerSignIn:
                 Dashboard.navigate('login.html?serverid=' + result.Servers[0].Id, false, 'none');
                 break;
-            case 'ServerSelection':
+            case ConnectionState.ServerSelection:
                 Dashboard.navigate('selectserver.html', false, 'none');
                 break;
-            case 'ServerUpdateNeeded':
+            case ConnectionState.ServerUpdateNeeded:
                 Dashboard.alert({
                     message: globalize.translate('ServerUpdateNeeded', '<a href="https://github.com/jellyfin/jellyfin">https://github.com/jellyfin/jellyfin</a>')
                 });
                 break;
-            case 'Unavailable':
+            case ConnectionState.Unavailable:
                 Dashboard.alert({
                     message: globalize.translate('MessageUnableToConnectToServer'),
                     title: globalize.translate('HeaderConnectionFailure')
@@ -44,7 +45,7 @@ import ServerConnections from '../../../components/ServerConnections';
             handleConnectionResult(page, result);
         }, function() {
             handleConnectionResult(page, {
-                State: 'Unavailable'
+                State: ConnectionState.Unavailable
             });
         });
     }

--- a/src/controllers/session/selectServer/index.js
+++ b/src/controllers/session/selectServer/index.js
@@ -19,6 +19,7 @@ import Dashboard from '../../../utils/dashboard';
 import ServerConnections from '../../../components/ServerConnections';
 import alert from '../../../components/alert';
 import cardBuilder from '../../../components/cardbuilder/cardBuilder';
+import { ConnectionState } from '../../../utils/jellyfin-apiclient/ConnectionState.ts';
 
 /* eslint-disable indent */
 
@@ -113,17 +114,17 @@ import cardBuilder from '../../../components/cardbuilder/cardBuilder';
                 const apiClient = result.ApiClient;
 
                 switch (result.State) {
-                    case 'SignedIn':
+                    case ConnectionState.SignedIn:
                         Dashboard.onServerChanged(apiClient.getCurrentUserId(), apiClient.accessToken(), apiClient);
                         Dashboard.navigate('home.html');
                         break;
 
-                    case 'ServerSignIn':
+                    case ConnectionState.ServerSignIn:
                         Dashboard.onServerChanged(null, null, apiClient);
                         Dashboard.navigate('login.html?serverid=' + result.Servers[0].Id);
                         break;
 
-                    case 'ServerUpdateNeeded':
+                    case ConnectionState.ServerUpdateNeeded:
                         alertTextWithOptions({
                             text: globalize.translate('core#ServerUpdateNeeded', 'https://github.com/jellyfin/jellyfin'),
                             html: globalize.translate('core#ServerUpdateNeeded', '<a href="https://github.com/jellyfin/jellyfin">https://github.com/jellyfin/jellyfin</a>')

--- a/src/utils/jellyfin-apiclient/ConnectionState.ts
+++ b/src/utils/jellyfin-apiclient/ConnectionState.ts
@@ -1,0 +1,10 @@
+/**
+ * Server state values for a connected server used by jellyfin-apiclient.
+ */
+export enum ConnectionState {
+    SignedIn = 'SignedIn',
+    ServerSignIn = 'ServerSignIn',
+    ServerSelection = 'ServerSelection',
+    ServerUpdateNeeded = 'ServerUpdateNeeded',
+    Unavailable = 'Unavailable'
+}


### PR DESCRIPTION
**Changes**
Refactors the ConnectionState values to a shared enum. These `ConnectionState` values are an invention of the apiclient, so they will not exist in the new sdk.

**Issues**
N/A
