### PR TITLE
Fix double routing of root path

### DIFF
--- a/src/components/ConnectionRequired.tsx
+++ b/src/components/ConnectionRequired.tsx
@@ -96,6 +96,9 @@ const ConnectionRequired: FunctionComponent<ConnectionRequiredProps> = ({
                         }
                         const systemInfo = await infoResponse.json();
                         if (!systemInfo?.StartupWizardCompleted) {
+                            // Update the current ApiClient
+                            // TODO: Is there a better place to handle this?
+                            ServerConnections.setLocalApiClient(firstConnection.ApiClient);
                             // Bounce to the wizard
                             console.info('[ConnectionRequired] startup wizard is not complete, redirecting there');
                             navigate(BounceRoutes.StartWizard);

--- a/src/components/appRouter.js
+++ b/src/components/appRouter.js
@@ -412,11 +412,7 @@ class AppRouter {
         if (apiClient && apiClient.isLoggedIn()) {
             console.debug('[appRouter] user is authenticated');
 
-            if (route.isDefaultRoute) {
-                console.debug('[appRouter] loading home page');
-                this.goHome();
-                return;
-            } else if (route.roles) {
+            if (route.roles) {
                 this.#validateRoles(apiClient, route.roles).then(() => {
                     callback();
                 }, this.#beginConnectionWizard.bind(this));

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router-dom';
 
 import ConnectionRequired from '../components/ConnectionRequired';
 import UserNew from './user/usernew';
@@ -23,13 +23,18 @@ const AppRoutes = () => (
             </Route>
 
             {/* Admin routes */}
-            <Route path='/' element={<ConnectionRequired isAdminRequired={true} />}>
+            <Route path='/' element={<ConnectionRequired isAdminRequired />}>
                 <Route path='usernew.html' element={<UserNew />} />
                 <Route path='userprofiles.html' element={<UserProfiles />} />
                 <Route path='useredit.html' element={<UserEdit />} />
                 <Route path='userlibraryaccess.html' element={<UserLibraryAccess />} />
                 <Route path='userparentalcontrol.html' element={<UserParentalControl />} />
                 <Route path='userpassword.html' element={<UserPassword />} />
+            </Route>
+
+            {/* Public routes */}
+            <Route path='/' element={<ConnectionRequired isUserRequired={false} />}>
+                <Route index element={<Navigate replace to='/home.html' />} />
             </Route>
 
             {/* Suppress warnings for unhandled routes */}

--- a/src/scripts/routes.js
+++ b/src/scripts/routes.js
@@ -492,12 +492,6 @@ import { appRouter } from '../components/appRouter';
         serverRequest: true
     });
 
-    defineRoute({
-        path: '/',
-        autoFocus: false,
-        isDefaultRoute: true
-    });
-
     console.groupEnd('defining core routes');
 
 /* eslint-enable indent */


### PR DESCRIPTION
**Changes**
This moves the root path handling to react-router to fix an issue where it was being handled by both react-router and the legacy appRouter. This should fix the startup wizard (mostly). Additional work will be needed to fix this same type of double handling from happening on all other legacy routes though.

**Issues**
N/A
