### PR TITLE
Update all documentation links to new website

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -7,7 +7,7 @@ When looking for support or information, please first search for your
 question in these venues:
 
 * [Jellyfin Forum](https://forum.jellyfin.org)
-* [Jellyfin Documentation](https://docs.jellyfin.org)
+* [Jellyfin Documentation](https://jellyfin.org/docs/)
 * [Open or **closed** issues in the organization](https://github.com/issues?q=sort%3Aupdated-desc+org%3Ajellyfin+is%3Aissue+)
 
 If you didn't find an answer in the resources above, contributors and other

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 <!--
 Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
-For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
+For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
 -->
 
 **Changes**

--- a/.github/workflows/repo-stale.yaml
+++ b/.github/workflows/repo-stale.yaml
@@ -21,7 +21,7 @@ jobs:
           stale-issue-label: stale
           stale-issue-message: |-
             This issue has gone 120 days without comment. To avoid abandoned issues, it will be closed in 21 days if there are no new comments.
-            
+
             If you're the original submitter of this issue, please comment confirming if this issue still affects you in the latest release or master branch, or close the issue if it has been fixed. If you're another user also affected by this bug, please comment confirming so. Either action will remove the stale label.
-            
-            This bot exists to prevent issues from becoming stale and forgotten. Jellyfin is always moving forward, and bugs are often fixed as side effects of other changes. We therefore ask that bug report authors remain vigilant about their issues to ensure they are closed if fixed, or re-confirmed - perhaps with fresh logs or reproduction examples - regularly. If you have any questions you can reach us on [Matrix or Social Media](https://docs.jellyfin.org/general/getting-help.html).
+
+            This bot exists to prevent issues from becoming stale and forgotten. Jellyfin is always moving forward, and bugs are often fixed as side effects of other changes. We therefore ask that bug report authors remain vigilant about their issues to ensure they are closed if fixed, or re-confirmed - perhaps with fresh logs or reproduction examples - regularly. If you have any questions you can reach us on [Matrix or Social Media](https://jellyfin.org/contact).

--- a/src/components/subtitleeditor/subtitleeditor.template.html
+++ b/src/components/subtitleeditor/subtitleeditor.template.html
@@ -2,7 +2,7 @@
     <button is="paper-icon-button-light" class="btnCancel autoSize" tabindex="-1" title="${ButtonBack}"><span class="material-icons arrow_back" aria-hidden="true"></span></button>
     <h3 class="formDialogHeaderTitle">${Subtitles}</h3>
 
-    <a is="emby-linkbutton" rel="noopener noreferrer" data-autohide="true" class="button-link btnHelp flex align-items-center" href="https://jellyfin.org/docs/general/server/media/external-files.html" target="_blank" style="margin-left:auto;margin-right:.5em;padding:.25em;" title="${Help}"><span class="material-icons info" aria-hidden="true"></span><span style="margin-left:.25em;">${Help}</span></a>
+    <a is="emby-linkbutton" rel="noopener noreferrer" data-autohide="true" class="button-link btnHelp flex align-items-center" href="https://jellyfin.org/docs/general/server/media/external-files" target="_blank" style="margin-left:auto;margin-right:.5em;padding:.25em;" title="${Help}"><span class="material-icons info" aria-hidden="true"></span><span style="margin-left:.25em;">${Help}</span></a>
 </div>
 <div class="formDialogContent smoothScrollY">
     <div class="dialogContentInner dialog-content-centered">

--- a/src/components/tvproviders/schedulesdirect.template.html
+++ b/src/components/tvproviders/schedulesdirect.template.html
@@ -1,7 +1,7 @@
 <div class="verticalSection">
     <div class="sectionTitleContainer flex align-items-center">
         <h1 class="sectionTitle">Schedules Direct</h1>
-        <a is="emby-linkbutton" rel="noopener noreferrer" class="raised button-alt headerHelpButton" target="_blank" href="https://docs.jellyfin.org/general/server/live-tv/setup-guide.html#adding-guide-data">${Help}</a>
+        <a is="emby-linkbutton" rel="noopener noreferrer" class="raised button-alt headerHelpButton" target="_blank" href="https://jellyfin.org/docs/general/server/live-tv/setup-guide#adding-guide-data">${Help}</a>
     </div>
     <p class="createAccountHelp"></p>
 </div>

--- a/src/components/tvproviders/xmltv.template.html
+++ b/src/components/tvproviders/xmltv.template.html
@@ -1,7 +1,7 @@
 <div class="verticalSection">
     <div class="sectionTitleContainer flex align-items-center">
         <h1 class="sectionTitle">Xml TV</h1>
-        <a is="emby-linkbutton" rel="noopener noreferrer" class="raised button-alt headerHelpButton" target="_blank" href="https://docs.jellyfin.org/general/server/live-tv/setup-guide.html#adding-guide-data">${Help}</a>
+        <a is="emby-linkbutton" rel="noopener noreferrer" class="raised button-alt headerHelpButton" target="_blank" href="https://jellyfin.org/docs/general/server/live-tv/setup-guide#adding-guide-data">${Help}</a>
     </div>
 </div>
 

--- a/src/controllers/dashboard/devices/device.html
+++ b/src/controllers/dashboard/devices/device.html
@@ -5,7 +5,7 @@
                 <div class="verticalSection verticalSection-extrabottompadding">
                     <div class="sectionTitleContainer flex align-items-center">
                         <h2 class="sectionTitle reportedName"></h2>
-                        <a is="emby-linkbutton" rel="noopener noreferrer" class="raised button-alt headerHelpButton" target="_blank" href="https://docs.jellyfin.org/general/server/devices.html">${Help}</a>
+                        <a is="emby-linkbutton" rel="noopener noreferrer" class="raised button-alt headerHelpButton" target="_blank" href="https://jellyfin.org/docs/general/server/devices">${Help}</a>
                     </div>
 
                     <div class="inputContainer">

--- a/src/controllers/dashboard/devices/devices.html
+++ b/src/controllers/dashboard/devices/devices.html
@@ -4,7 +4,7 @@
             <div class="verticalSection verticalSection">
                 <div class="sectionTitleContainer sectionTitleContainer-cards flex align-items-center">
                     <h2 class="sectionTitle sectionTitle-cards">${HeaderDevices}</h2>
-                    <a is="emby-linkbutton" rel="noopener noreferrer" class="raised button-alt headerHelpButton" target="_blank" href="https://docs.jellyfin.org/general/server/devices.html">${Help}</a>
+                    <a is="emby-linkbutton" rel="noopener noreferrer" class="raised button-alt headerHelpButton" target="_blank" href="https://jellyfin.org/docs/general/server/devices">${Help}</a>
                     <button id="deviceDeleteAll" is="emby-button" type="button" class="raised button-alt headerHelpButton">${DeleteAll}</button>
                 </div>
             </div>

--- a/src/controllers/dashboard/dlna/settings.html
+++ b/src/controllers/dashboard/dlna/settings.html
@@ -8,7 +8,7 @@
                 <div class="verticalSection">
                     <div class="sectionTitleContainer flex align-items-center">
                         <h2 class="sectionTitle">${Settings}</h2>
-                        <a is="emby-linkbutton" rel="noopener noreferrer" class="raised button-alt headerHelpButton" target="_blank" href="https://docs.jellyfin.org/general/networking/dlna.html">${Help}</a>
+                        <a is="emby-linkbutton" rel="noopener noreferrer" class="raised button-alt headerHelpButton" target="_blank" href="https://jellyfin.org/docs/general/networking/dlna">${Help}</a>
                     </div>
                 </div>
 

--- a/src/controllers/dashboard/encodingsettings.html
+++ b/src/controllers/dashboard/encodingsettings.html
@@ -5,7 +5,7 @@
                 <div class="verticalSection">
                     <div class="sectionTitleContainer flex align-items-center">
                         <h2 class="sectionTitle">${Transcoding}</h2>
-                        <a is="emby-linkbutton" rel="noopener noreferrer" class="raised button-alt headerHelpButton" target="_blank" href="https://docs.jellyfin.org/general/server/transcoding.html">${Help}</a>
+                        <a is="emby-linkbutton" rel="noopener noreferrer" class="raised button-alt headerHelpButton" target="_blank" href="https://jellyfin.org/docs/general/server/transcoding">${Help}</a>
                     </div>
                 </div>
 
@@ -20,7 +20,7 @@
                         <option value="v4l2m2m">Video4Linux2 (V4L2)</option>
                     </select>
                     <div class="fieldDescription">
-                        <a is="emby-linkbutton" rel="noopener noreferrer" class="button-link" href="https://docs.jellyfin.org/general/administration/hardware-acceleration.html" target="_blank">${LabelHardwareAccelerationTypeHelp}</a>
+                        <a is="emby-linkbutton" rel="noopener noreferrer" class="button-link" href="https://jellyfin.org/docs/general/administration/hardware-acceleration" target="_blank">${LabelHardwareAccelerationTypeHelp}</a>
                     </div>
                 </div>
 

--- a/src/controllers/dashboard/general.html
+++ b/src/controllers/dashboard/general.html
@@ -5,7 +5,7 @@
                 <div class="verticalSection">
                     <div class="sectionTitleContainer flex align-items-center">
                         <h2 class="sectionTitle">${Settings}</h2>
-                        <a is="emby-linkbutton" rel="noopener noreferrer" class="raised button-alt headerHelpButton" target="_blank" href="https://docs.jellyfin.org/general/server/settings.html">${Help}</a>
+                        <a is="emby-linkbutton" rel="noopener noreferrer" class="raised button-alt headerHelpButton" target="_blank" href="https://jellyfin.org/docs/general/server/settings">${Help}</a>
                     </div>
                 </div>
 
@@ -19,7 +19,7 @@
                         <div class="fieldDescription">
                             <div>${LabelDisplayLanguageHelp}</div>
                             <div style="margin-top: .25em;">
-                                <a is="emby-linkbutton" rel="noopener noreferrer" class="button-link" href="https://docs.jellyfin.org/general/contributing/index.html" target="_blank">${LearnHowYouCanContribute}</a>
+                                <a is="emby-linkbutton" rel="noopener noreferrer" class="button-link" href="https://jellyfin.org/docs/general/contributing/#translating" target="_blank">${LearnHowYouCanContribute}</a>
                             </div>
                         </div>
                     </div>

--- a/src/controllers/dashboard/library.html
+++ b/src/controllers/dashboard/library.html
@@ -6,7 +6,7 @@
                     <span>${ButtonScanAllLibraries}</span>
                 </button>
                 <progress max="100" min="0" style="display: inline-block; vertical-align: middle;" class="refreshProgress"></progress>
-                <a is="emby-linkbutton" rel="noopener noreferrer" class="raised button-alt" target="_blank" href="https://docs.jellyfin.org/general/server/libraries.html">${Help}</a>
+                <a is="emby-linkbutton" rel="noopener noreferrer" class="raised button-alt" target="_blank" href="https://jellyfin.org/docs/general/server/libraries">${Help}</a>
             </div>
 
             <div id="divVirtualFolders"></div>

--- a/src/controllers/dashboard/library.js
+++ b/src/controllers/dashboard/library.js
@@ -223,19 +223,19 @@ import cardBuilder from '../../components/cardbuilder/cardBuilder';
         }, {
             name: globalize.translate('Movies'),
             value: 'movies',
-            message: getLink('MovieLibraryHelp', 'https://docs.jellyfin.org/general/server/media/movies.html')
+            message: getLink('MovieLibraryHelp', 'https://jellyfin.org/docs/general/server/media/movies')
         }, {
             name: globalize.translate('TabMusic'),
             value: 'music',
-            message: getLink('MusicLibraryHelp', 'https://docs.jellyfin.org/general/server/media/music.html')
+            message: getLink('MusicLibraryHelp', 'https://jellyfin.org/docs/general/server/media/music')
         }, {
             name: globalize.translate('Shows'),
             value: 'tvshows',
-            message: getLink('TvLibraryHelp', 'https://docs.jellyfin.org/general/server/media/shows.html')
+            message: getLink('TvLibraryHelp', 'https://jellyfin.org/docs/general/server/media/shows')
         }, {
             name: globalize.translate('Books'),
             value: 'books',
-            message: getLink('BookLibraryHelp', 'https://docs.jellyfin.org/general/server/media/books.html')
+            message: getLink('BookLibraryHelp', 'https://jellyfin.org/docs/general/server/media/books')
         }, {
             name: globalize.translate('HomeVideosPhotos'),
             value: 'homevideos'

--- a/src/controllers/dashboard/networking.html
+++ b/src/controllers/dashboard/networking.html
@@ -5,7 +5,7 @@
                 <div class="verticalSection verticalSection-extrabottompadding">
                     <div class="sectionTitleContainer flex align-items-center">
                         <h2 class="sectionTitle">${TabNetworking}</h2>
-                        <a is="emby-linkbutton" rel="noopener noreferrer" class="raised button-alt headerHelpButton" target="_blank" href="https://docs.jellyfin.org/general/networking/index.html">${Help}</a>
+                        <a is="emby-linkbutton" rel="noopener noreferrer" class="raised button-alt headerHelpButton" target="_blank" href="https://jellyfin.org/docs/general/networking/">${Help}</a>
                     </div>
 
                     <fieldset class='verticalSection verticalSection-extrabottompadding'>

--- a/src/controllers/dashboard/notifications/notification/index.html
+++ b/src/controllers/dashboard/notifications/notification/index.html
@@ -8,7 +8,7 @@
                 <div class="verticalSection">
                     <div class="sectionTitleContainer flex align-items-center">
                         <h2 class="notificationType sectionTitle"></h2>
-                        <a is="emby-linkbutton" rel="noopener noreferrer" class="raised button-alt headerHelpButton" target="_blank" href="https://docs.jellyfin.org/general/server/notifications.html">${Help}</a>
+                        <a is="emby-linkbutton" rel="noopener noreferrer" class="raised button-alt headerHelpButton" target="_blank" href="https://jellyfin.org/docs/general/server/notifications">${Help}</a>
                     </div>
                 </div>
 

--- a/src/controllers/dashboard/notifications/notifications/index.js
+++ b/src/controllers/dashboard/notifications/notifications/index.js
@@ -24,7 +24,7 @@ function reload(page) {
                 itemHtml += '</h2>';
                 if (showHelp) {
                     showHelp = false;
-                    itemHtml += '<a is="emby-linkbutton" class="raised button-alt headerHelpButton" target="_blank" href="https://docs.jellyfin.org/general/server/notifications.html">';
+                    itemHtml += '<a is="emby-linkbutton" class="raised button-alt headerHelpButton" target="_blank" href="https://jellyfin.org/docs/general/server/notifications">';
                     itemHtml += globalize.translate('Help');
                     itemHtml += '</a>';
                 }

--- a/src/controllers/dashboard/plugins/add/index.html
+++ b/src/controllers/dashboard/plugins/add/index.html
@@ -5,7 +5,7 @@
                 <div class="verticalSection">
                     <div class="sectionTitleContainer flex align-items-center">
                         <h1 class="sectionTitle pluginName"></h1>
-                        <a is="emby-linkbutton" rel="noopener noreferrer" class="raised button-alt headerHelpButton" target="_blank" href="https://docs.jellyfin.org/general/server/plugins/index.html">${Help}</a>
+                        <a is="emby-linkbutton" rel="noopener noreferrer" class="raised button-alt headerHelpButton" target="_blank" href="https://jellyfin.org/docs/general/server/plugins/">${Help}</a>
                     </div>
 
                     <p id="overview" style="font-style: italic;"></p>

--- a/src/controllers/dashboard/plugins/repositories/index.html
+++ b/src/controllers/dashboard/plugins/repositories/index.html
@@ -6,7 +6,7 @@
                 <button is="emby-button" type="button" class="fab btnNewRepository submit" style="margin-left:1em;" title="${Add}">
                     <span class="material-icons add" aria-hidden="true"></span>
                 </button>
-                <a is="emby-linkbutton" rel="noopener noreferrer" class="raised button-alt headerHelpButton" target="_blank" href="https://jellyfin.org/docs/general/server/plugins/index.html#repositories">
+                <a is="emby-linkbutton" rel="noopener noreferrer" class="raised button-alt headerHelpButton" target="_blank" href="https://jellyfin.org/docs/general/server/plugins/#repositories">
                     ${Help}
                 </a>
             </div>

--- a/src/controllers/dashboard/scheduledtasks/scheduledtask.html
+++ b/src/controllers/dashboard/scheduledtasks/scheduledtask.html
@@ -4,7 +4,7 @@
             <div class="verticalSection">
                 <div class="sectionTitleContainer flex align-items-center">
                     <h2 class="sectionTitle taskName"></h2>
-                    <a is="emby-linkbutton" rel="noopener noreferrer" class="raised button-alt headerHelpButton" target="_blank" href="https://docs.jellyfin.org/general/server/tasks.html">${Help}</a>
+                    <a is="emby-linkbutton" rel="noopener noreferrer" class="raised button-alt headerHelpButton" target="_blank" href="https://jellyfin.org/docs/general/server/tasks">${Help}</a>
                 </div>
                 <p id="pTaskDescription"></p>
             </div>

--- a/src/controllers/dashboard/scheduledtasks/scheduledtasks.js
+++ b/src/controllers/dashboard/scheduledtasks/scheduledtasks.js
@@ -49,7 +49,7 @@ import '../../../elements/emby-button/emby-button';
                 html += currentCategory;
                 html += '</h2>';
                 if (i === 0) {
-                    html += '<a is="emby-linkbutton" class="raised button-alt headerHelpButton" target="_blank" href="https://docs.jellyfin.org/general/server/tasks.html">' + globalize.translate('Help') + '</a>';
+                    html += '<a is="emby-linkbutton" class="raised button-alt headerHelpButton" target="_blank" href="https://jellyfin.org/docs/general/server/tasks">' + globalize.translate('Help') + '</a>';
                 }
                 html += '</div>';
                 html += '<div class="paperList">';

--- a/src/controllers/livetvsettings.html
+++ b/src/controllers/livetvsettings.html
@@ -4,7 +4,7 @@
             <div class="verticalSection">
                 <div class="sectionTitleContainer flex align-items-center">
                     <h2 class="sectionTitle">${HeaderDVR}</h2>
-                    <a is="emby-linkbutton" rel="noopener noreferrer" class="raised button-alt headerHelpButton" target="_blank" href="https://docs.jellyfin.org/general/server/live-tv/index.html">${Help}</a>
+                    <a is="emby-linkbutton" rel="noopener noreferrer" class="raised button-alt headerHelpButton" target="_blank" href="https://jellyfin.org/docs/general/server/live-tv/">${Help}</a>
                 </div>
             </div>
 

--- a/src/controllers/livetvstatus.html
+++ b/src/controllers/livetvstatus.html
@@ -10,7 +10,7 @@
                         <button is="emby-button" type="button" class="fab btnAddDevice submit sectionTitleButton" style="margin-left:1em;" title="${Add}">
                             <span class="material-icons add" aria-hidden="true"></span>
                         </button>
-                        <a is="emby-linkbutton" rel="noopener noreferrer" style="margin-left:2em!important;" class="raised button-alt headerHelpButton" target="_blank" href="https://docs.jellyfin.org/general/server/live-tv/index.html">${Help}</a>
+                        <a is="emby-linkbutton" rel="noopener noreferrer" style="margin-left:2em!important;" class="raised button-alt headerHelpButton" target="_blank" href="https://jellyfin.org/docs/general/server/live-tv/">${Help}</a>
                     </div>
                     <div class="devicesList itemsContainer vertical-wrap" data-hovermenu="false" data-multiselect="false" style="margin-top: .5em;"></div>
                 </div>

--- a/src/controllers/livetvtuner.html
+++ b/src/controllers/livetvtuner.html
@@ -5,7 +5,7 @@
                 <div class="verticalSection">
                     <div class="sectionTitleContainer flex align-items-center">
                         <h1 class="sectionTitle">${HeaderLiveTvTunerSetup}</h1>
-                        <a is="emby-linkbutton" rel="noopener noreferrer" class="raised button-alt headerHelpButton" target="_blank" href="https://docs.jellyfin.org/general/server/live-tv/index.html">${Help}</a>
+                        <a is="emby-linkbutton" rel="noopener noreferrer" class="raised button-alt headerHelpButton" target="_blank" href="https://jellyfin.org/docs/general/server/live-tv/">${Help}</a>
                     </div>
                 </div>
 

--- a/src/controllers/wizard/library.html
+++ b/src/controllers/wizard/library.html
@@ -3,7 +3,7 @@
         <div class="ui-corner-all ui-shadow wizardContent">
             <div>
                 <h1 style="display:inline-block;">${HeaderSetupLibrary}</h1>
-                <a href="https://docs.jellyfin.org/general/server/libraries.html" rel="noopener noreferrer" target="_blank" class="clearLink" style="margin-top:-10px;display:inline-block;vertical-align:middle;margin-left:2em;"><button is="emby-button" type="button" class="raised"><span class="material-icons info" aria-hidden="true"></span><span>${Help}</span></button></a>
+                <a href="https://jellyfin.org/docs/general/server/libraries" rel="noopener noreferrer" target="_blank" class="clearLink" style="margin-top:-10px;display:inline-block;vertical-align:middle;margin-left:2em;"><button is="emby-button" type="button" class="raised"><span class="material-icons info" aria-hidden="true"></span><span>${Help}</span></button></a>
             </div>
             <br />
             <div id="divVirtualFolders"></div>

--- a/src/controllers/wizard/start/index.html
+++ b/src/controllers/wizard/start/index.html
@@ -4,7 +4,7 @@
             <form class="wizardStartForm">
                 <div>
                     <h1 style="float:left;">${WelcomeToProject}</h1>
-                    <a is="emby-linkbutton" rel="noopener noreferrer" href="https://docs.jellyfin.org/general/quick-start.html" target="_blank" class="raised raised-alt" style="float:right;margin-top:20px;">
+                    <a is="emby-linkbutton" rel="noopener noreferrer" href="https://jellyfin.org/docs/general/quick-start" target="_blank" class="raised raised-alt" style="float:right;margin-top:20px;">
                         <span>${ButtonQuickStartGuide}</span>
                     </a>
                 </div>

--- a/src/index.html
+++ b/src/index.html
@@ -14,7 +14,7 @@
     <meta name="referrer" content="no-referrer">
     <meta property="og:title" content="Jellyfin">
     <meta property="og:site_name" content="Jellyfin">
-    <meta property="og:url" content="http://jellyfin.org">
+    <meta property="og:url" content="https://jellyfin.org">
     <meta property="og:description" content="The Free Software Media System">
     <meta property="og:type" content="article">
 

--- a/src/routes/user/useredit.tsx
+++ b/src/routes/user/useredit.tsx
@@ -305,7 +305,7 @@ const UserEdit: FunctionComponent = () => {
                 <div className='verticalSection'>
                     <SectionTitleContainer
                         title={userName}
-                        url='https://docs.jellyfin.org/general/server/users/'
+                        url='https://jellyfin.org/docs/general/server/users/'
                     />
                 </div>
 

--- a/src/routes/user/userlibraryaccess.tsx
+++ b/src/routes/user/userlibraryaccess.tsx
@@ -235,7 +235,7 @@ const UserLibraryAccess: FunctionComponent = () => {
                 <div className='verticalSection'>
                     <SectionTitleContainer
                         title={userName}
-                        url='https://docs.jellyfin.org/general/server/users/'
+                        url='https://jellyfin.org/docs/general/server/users/'
                     />
                 </div>
                 <SectionTabs activeTab='userlibraryaccess'/>

--- a/src/routes/user/usernew.tsx
+++ b/src/routes/user/usernew.tsx
@@ -184,7 +184,7 @@ const UserNew: FunctionComponent = () => {
                 <div className='verticalSection'>
                     <SectionTitleContainer
                         title={globalize.translate('HeaderAddUser')}
-                        url='https://docs.jellyfin.org/general/server/users/'
+                        url='https://jellyfin.org/docs/general/server/users/'
                     />
                 </div>
 

--- a/src/routes/user/userparentalcontrol.tsx
+++ b/src/routes/user/userparentalcontrol.tsx
@@ -332,7 +332,7 @@ const UserParentalControl: FunctionComponent = () => {
                 <div className='verticalSection'>
                     <SectionTitleContainer
                         title={userName}
-                        url='https://docs.jellyfin.org/general/server/users/'
+                        url='https://jellyfin.org/docs/general/server/users/'
                     />
                 </div>
                 <SectionTabs activeTab='userparentalcontrol'/>

--- a/src/routes/user/userpassword.tsx
+++ b/src/routes/user/userpassword.tsx
@@ -33,7 +33,7 @@ const UserPassword: FunctionComponent = () => {
                 <div className='verticalSection'>
                     <SectionTitleContainer
                         title={userName}
-                        url='https://docs.jellyfin.org/general/server/users/'
+                        url='https://jellyfin.org/docs/general/server/users/'
                     />
                 </div>
                 <SectionTabs activeTab='userpassword'/>

--- a/src/routes/user/userprofiles.tsx
+++ b/src/routes/user/userprofiles.tsx
@@ -144,7 +144,7 @@ const UserProfiles: FunctionComponent = () => {
                         btnClassName='fab submit sectionTitleButton'
                         btnTitle='ButtonAddUser'
                         btnIcon='add'
-                        url='https://docs.jellyfin.org/general/server/users/adding-managing-users.html'
+                        url='https://jellyfin.org/docs/general/server/users/adding-managing-users'
                     />
                 </div>
 


### PR DESCRIPTION
**Changes**
- Update all docs.jellyfin.org links to jellyfin.org/docs
- Update all jellyfin.org/docs links to new link format (mostly removing the .html suffix)
- Update a http link to https in index.html

The links are always the same as the menu on the new website, this means that they don't end with a `/` when there is no subpage. The website itself does add this slash when the page is opened.

Also, vscode automatically trimmed whitespace in the repo-stale.yaml file but the yaml is still valid.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
