### PR TITLE
Accept arbitrary precision for community rating

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -120,3 +120,4 @@
  - [SvenVandenbrande](https://github.com/SvenVandenbrande)
  - [jomp16](https://github.com/jomp16)
  - [Leon de Klerk](https://github.com/leondeklerk)
+ - [CrispyBaguette](https://github.com/CrispyBaguette)

--- a/src/components/metadataEditor/metadataEditor.template.html
+++ b/src/components/metadataEditor/metadataEditor.template.html
@@ -69,7 +69,7 @@
                     </div>
                 </div>
                 <div id="fldCommunityRating" class="hide inputContainer">
-                    <input is="emby-input" id="txtCommunityRating" type="number" step=".1" min="0" max="10" label="${LabelCommunityRating}" />
+                    <input is="emby-input" id="txtCommunityRating" type="number" step="any" min="0" max="10" label="${LabelCommunityRating}" />
                 </div>
                 <div id="fldCriticRating" class="hide inputContainer">
                     <input is="emby-input" id="txtCriticRating" type="number" step=".1" label="${LabelCriticRating}" />


### PR DESCRIPTION
**Changes**
Changed form validation rule in the metadata editor component to accept any number of decimal places..

**Issues**
Fixes #4093 
