### PR TITLE
Fix AlphaPicker padding

### DIFF
--- a/src/assets/css/librarybrowser.scss
+++ b/src/assets/css/librarybrowser.scss
@@ -1415,7 +1415,7 @@ div:not(.sectionTitleContainer-cards) > .sectionTitle-cards {
 @media all and (min-height: 31.25em) {
     .padded-right-withalphapicker {
         padding-right: 7.5%;
-        padding-right: max(env(safe-area-inset-left), 7.5%);
+        padding-right: max(env(safe-area-inset-right), 7.5%);
     }
 }
 

--- a/src/assets/css/librarybrowser.scss
+++ b/src/assets/css/librarybrowser.scss
@@ -1413,9 +1413,14 @@ div:not(.sectionTitleContainer-cards) > .sectionTitle-cards {
 }
 
 @media all and (min-height: 31.25em) {
-    .padded-right-withalphapicker {
+    [dir="ltr"] .padded-right-withalphapicker {
         padding-right: 7.5%;
         padding-right: max(env(safe-area-inset-right), 7.5%);
+    }
+
+    [dir="rtl"] .padded-right-withalphapicker {
+        padding-left: 7.5%;
+        padding-left: max(env(safe-area-inset-left), 7.5%);
     }
 }
 


### PR DESCRIPTION
**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
- Fix safe-area padding-right.
- Fix RTL padding with AlphaPicker.

**Issues**
No padding with AlphaPicker - CSS path has low priority and padding is overridden.
Also doesn't work with RTL mode.
