### PR TITLE
Fix pointer events not propogating to dashboard pages

### DIFF
--- a/src/assets/css/librarybrowser.scss
+++ b/src/assets/css/librarybrowser.scss
@@ -305,9 +305,15 @@
     right: 0;
     bottom: 0;
     left: 0;
+    pointer-events: none;
 
     [dir="rtl"] & {
         transition: right ease-in-out 0.3s, padding ease-in-out 0.3s;
+    }
+
+    > .page {
+        // Fix pointer events being swallowed by the react root when a dashboard page is not rendered by react
+        pointer-events: all;
     }
 }
 


### PR DESCRIPTION
**Changes**
Fixes a bug where dashboard pages cannot be interacted with because the `reactRoot` div is absolutely positioned over the legacy views. This was probably introduced by https://github.com/jellyfin/jellyfin-web/pull/4036

**Issues**
N/A
