### PR TITLE
Fix label creation for plugin search input (#4079)

### DIFF
--- a/src/controllers/dashboard/plugins/installed/index.html
+++ b/src/controllers/dashboard/plugins/installed/index.html
@@ -2,8 +2,7 @@
     <div>
         <div class="content-primary">
             <div class="inputContainer">
-                <label class="inputLabel" for="txtSearchPlugins">${Search}</label>
-                <input id="txtSearchPlugins" name="txtSearchPlugins" type="text" is="emby-input" class="emby-input">
+                <input id="txtSearchPlugins" name="txtSearchPlugins" type="text" is="emby-input" label="${Search}" />
             </div>
             <div class="installedPlugins"></div>
         </div>


### PR DESCRIPTION
**Changes**

Fixes #4079: The label for the search input was created manually which causes errors to be thrown in the console.

cc/ @thornbill 