### PR TITLE
removed disclaimer target _blank enforcement

### DIFF
--- a/src/controllers/session/login/index.js
+++ b/src/controllers/session/login/index.js
@@ -290,7 +290,9 @@ import './login.scss';
 
                 for (const elem of disclaimer.querySelectorAll('a')) {
                     elem.rel = 'noopener noreferrer';
-                    elem.target = '_blank';
+                    if( typeof elem.target === 'undefined' || !(elem.target)) {
+                        elem.target = '_blank';
+                    }
                     elem.classList.add('button-link');
                     elem.setAttribute('is', 'emby-linkbutton');
 


### PR DESCRIPTION
My blind try to change the JS code. It's untested. I want to allow "target" attribute on "a" Elements in the disclaimer.

**Changes**
changed session/login/index.js to check if the "target" property on an "<a>" element is present, if not it will be set to "_blank" as it used to be.


