### PR TITLE
Set minimum version of npm

### DIFF
--- a/fedora/jellyfin-web.spec
+++ b/fedora/jellyfin-web.spec
@@ -15,6 +15,8 @@ BuildRequires:	nodejs
 %else
 BuildRequires:	git
 # Nodejs 16 is required and npm >= 8 should bring in NodeJS 16
+# This requires the build environment to use the nodejs:16 module stream:
+# dnf module {install|switch-to}:web nodejs:16
 BuildRequires:	npm >= 8
 %endif
 

--- a/fedora/jellyfin-web.spec
+++ b/fedora/jellyfin-web.spec
@@ -2,7 +2,7 @@
 
 Name:           jellyfin-web
 Version:        10.8.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        The Free Software Media System web client
 License:        GPLv2
 URL:            https://jellyfin.org
@@ -14,7 +14,8 @@ BuildArch:		noarch
 BuildRequires:	nodejs
 %else
 BuildRequires:	git
-BuildRequires:	npm
+# Nodejs 16 is required and npm >= 8 should bring in NodeJS 16
+BuildRequires:	npm >= 8
 %endif
 
 %description


### PR DESCRIPTION
**Changes**
To imply a minimum version of NodeJS which is now 16 and prevent people from trying to build with a NodeJS/npm that is too old.

Fixes: #4129