### PR TITLE
Exclude location.state from effect dependencies

### DIFF
--- a/src/components/viewManager/ViewManagerPage.tsx
+++ b/src/components/viewManager/ViewManagerPage.tsx
@@ -70,8 +70,9 @@ const ViewManagerPage: FunctionComponent<ViewManagerPageProps> = ({
         isThemeMediaSupported,
         transition,
         location.pathname,
-        location.search,
-        location.state
+        location.search
+        // location.state is NOT included as a dependency here since dialogs will update state while the current view
+        // stays the same
     ]);
 
     return <></>;


### PR DESCRIPTION
**Changes**
Including the state here causes the current view to try to be restored when dialogs that modify location state are activated

**Issues**
Fixes https://github.com/jellyfin/jellyfin-tizen/issues/149
