### PR TITLE
Fix resolving of the history back Promise

### DIFF
--- a/src/components/appRouter.js
+++ b/src/components/appRouter.js
@@ -63,7 +63,11 @@ class AppRouter {
         if (this.promiseShow) await this.promiseShow;
 
         this.promiseShow = new Promise((resolve) => {
-            this.resolveOnNextShow = resolve;
+            const unlisten = history.listen(() => {
+                unlisten();
+                this.promiseShow = null;
+                resolve();
+            });
             history.back();
         });
 


### PR DESCRIPTION
**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Fix resolving of the history back Promise

**Issues**
Another regression after #4095
When dialog is closed with the `Escape` button (TV mode), `promiseShow` remains unresolved and the next dialog cannot be closed.
That's because this block is not called by the new router:
https://github.com/jellyfin/jellyfin-web/blob/7f1823ade4b385293c3edcb5bebfeb31662884e7/src/components/appRouter.js#L482-L487