### PR TITLE
Fix SubtitleUploader

### DIFF
--- a/src/components/subtitleuploader/subtitleuploader.js
+++ b/src/components/subtitleuploader/subtitleuploader.js
@@ -61,7 +61,7 @@ function setFiles(page, files) {
     reader.onload = (function (theFile) {
         return function () {
             // Render file.
-            const html = '<a><span class="material-icons subtitles" aria-hidden="true" style="transform: translateY(25%);"></span><span>' + escape(theFile.name) + '</span><a/>';
+            const html = `<div><span class="material-icons subtitles" aria-hidden="true" style="transform: translateY(25%);"></span><span>${escape(theFile.name)}</span></div>`;
 
             page.querySelector('#subtitleOutput').innerHTML = html;
             page.querySelector('#fldUpload').classList.remove('hide');

--- a/src/components/subtitleuploader/subtitleuploader.js
+++ b/src/components/subtitleuploader/subtitleuploader.js
@@ -1,3 +1,5 @@
+import escapeHtml from 'escape-html';
+
 import dialogHelper from '../../components/dialogHelper/dialogHelper';
 import ServerConnections from '../ServerConnections';
 import dom from '../../scripts/dom';
@@ -61,7 +63,7 @@ function setFiles(page, files) {
     reader.onload = (function (theFile) {
         return function () {
             // Render file.
-            const html = `<div><span class="material-icons subtitles" aria-hidden="true" style="transform: translateY(25%);"></span><span>${escape(theFile.name)}</span></div>`;
+            const html = `<div><span class="material-icons subtitles" aria-hidden="true" style="transform: translateY(25%);"></span><span>${escapeHtml(theFile.name)}</span></div>`;
 
             page.querySelector('#subtitleOutput').innerHTML = html;
             page.querySelector('#fldUpload').classList.remove('hide');

--- a/src/components/subtitleuploader/subtitleuploader.template.html
+++ b/src/components/subtitleuploader/subtitleuploader.template.html
@@ -33,7 +33,7 @@
                         </label>
                     </div>
                     <div class="selectContainer flex-grow">
-                        <select is="emby-select" id="selectLanguage" required="required" label="${LabelLanguage}" autofocus></select>
+                        <select is="emby-select" id="selectLanguage" required="required" label="${LabelLanguage}"></select>
                     </div>
                     <button is="emby-button" type="submit" class="raised button-submit block">
                         <span>${Upload}</span>


### PR DESCRIPTION
Requires #4147

**Changes**
- Fix Subtitle Uploader navigation in TV mode.
  - `a` -> `div`
  - Remove `autofocus` from the language selector because it is hidden.
  FocusManager will focus on the `Browse` button.
- Fix file name escaping.
`html%3Cbr%3Etest2.en.%26.srt` -> `html<br>test2.en.&.srt`

**Issues**
N/A
