### PR TITLE
Tweak navigation sizing

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -56,6 +56,7 @@
  - [is343](https://github.com/is343)
  - [Meet Pandya](https://github.com/meet-k-pandya)
  - [Peter Spenler](https://github.com/peterspenler)
+ - [Vankerkom](https://github.com/vankerkom)
 
 # Emby Contributors
 

--- a/src/assets/css/librarybrowser.scss
+++ b/src/assets/css/librarybrowser.scss
@@ -273,20 +273,21 @@
     flex-shrink: 0;
 
     [dir="ltr"] & {
-        margin-right: 1.2em;
+        margin-right: 1em;
     }
 
     [dir="rtl"] & {
-        margin-left: 1.2em;
+        margin-left: 1em;
     }
 }
 
 .navMenuOptionText {
+    line-height: 1.35em;
     white-space: nowrap;
-    margin-top: 0.25em;
 }
 
 .sidebarHeader {
+    font-size: 1em;
     margin: 1em 0 0.5em;
 
     [dir="ltr"] & {

--- a/src/components/listview/listview.scss
+++ b/src/components/listview/listview.scss
@@ -122,10 +122,11 @@
     padding: 0.1em 0;
     overflow: hidden;
     text-overflow: ellipsis;
+    font-weight: 400;
 }
 
 .layout-desktop .listItemBodyText {
-    margin: 0.25em 0 0 0;
+    line-height: 1.2em;
 }
 
 .listItemBodyText-nowrap {


### PR DESCRIPTION
**Changes**
Changed the alignments, font-sizes and weights of the side navigation drawer and the my preferences menu to match each other.

Side Navigation Before
![Side Nav Before](https://user-images.githubusercontent.com/16082198/200899857-9a5964b9-0064-4520-bc7f-2236ebc33929.png)

Side Navigation After
![Side Nav After](https://user-images.githubusercontent.com/16082198/200899868-271c990d-7368-4290-a9db-7d439eef3048.png)

Profile Navigation Before
![Profile Nav Before](https://user-images.githubusercontent.com/16082198/200899911-884c6ef3-349f-4e4a-bd81-27acb7a077e5.png)

Profile Navigation After
![Profile Nav After](https://user-images.githubusercontent.com/16082198/200899918-5c0e3ad7-be36-4e1c-afe1-ce4b6cbad18b.png)


**Issues**
None
