### PR TITLE
Reduce tv card scaling

### DIFF
--- a/src/components/cardbuilder/card.scss
+++ b/src/components/cardbuilder/card.scss
@@ -114,7 +114,7 @@ button::-moz-focus-inner {
 }
 
 .card.show-animation:focus > .cardBox {
-    transform: scale(1.18, 1.18);
+    transform: scale(1.07, 1.07);
 }
 
 .cardBox-bottompadded {


### PR DESCRIPTION
**Changes**
Reduced the transform scale from 18% to 7% to fix the readability of heading text on focus.

![tv-card-size](https://user-images.githubusercontent.com/16082198/200900156-bf6fda5f-c49d-41ee-893b-72a2cd2ccad4.png)

**Issues**
None
