### PR TITLE
Fix going to parent folder in directory browser

### DIFF
--- a/src/components/directorybrowser/directorybrowser.js
+++ b/src/components/directorybrowser/directorybrowser.js
@@ -43,7 +43,7 @@ function refreshDirectoryBrowser(page, path, fileOptions, updatePathOnError) {
     Promise.all(promises).then(
         responses => {
             const folders = responses[0];
-            const parentPath = responses[1] ? JSON.parse(responses[1]) || '' : '';
+            const parentPath = (responses[1] ? JSON.parse(responses[1]) : '') || '';
             let html = '';
 
             page.querySelector('.results').scrollTop = 0;

--- a/src/components/directorybrowser/directorybrowser.js
+++ b/src/components/directorybrowser/directorybrowser.js
@@ -43,7 +43,7 @@ function refreshDirectoryBrowser(page, path, fileOptions, updatePathOnError) {
     Promise.all(promises).then(
         responses => {
             const folders = responses[0];
-            const parentPath = responses[1] || '';
+            const parentPath = responses[1] ? JSON.parse(responses[1]) || '' : '';
             let html = '';
 
             page.querySelector('.results').scrollTop = 0;


### PR DESCRIPTION
The API response is JSON so the response string is wrapped in quotes. Use JSON.parse to fix that.

**Changes**
- Fix going to parent folder in directory browser

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
