### PR TITLE
Fix item details banner image alignment

### DIFF
--- a/src/assets/css/librarybrowser.scss
+++ b/src/assets/css/librarybrowser.scss
@@ -439,7 +439,7 @@
 .itemBackdrop {
     background-size: cover;
     background-repeat: no-repeat;
-    background-position: center 0;
+    background-position: center center;
     background-attachment: fixed;
     height: 40vh;
     position: relative;

--- a/src/assets/css/librarybrowser.scss
+++ b/src/assets/css/librarybrowser.scss
@@ -447,6 +447,7 @@
 
     .layout-mobile & {
         background-attachment: initial;
+        background-position: top center;
         margin-top: 3rem;
 
         @media all and (orientation: portrait) and (max-width: 40em) {


### PR DESCRIPTION
**Changes**
Fixes the alignment issue with the item details screen banner and the full backdrop

Matches the backdrop positioning [here](https://github.com/jellyfin/jellyfin-web/blob/master/src/components/backdrop/backdrop.scss#L7).

| Desktop | Mobile Portrait | Mobile Landscape |
|---|---|---|
| ![Screenshot 2022-11-15 at 13-26-55 Jellyfin](https://user-images.githubusercontent.com/3450688/201998438-b54a6353-c2c8-4a7a-9089-e9517e9648cf.png) | ![Screenshot 2022-11-15 at 13-30-22 Jellyfin](https://user-images.githubusercontent.com/3450688/201998860-35528ee0-cf38-4b50-9615-9ae27132cbb8.png) | ![Screen Shot 2022-11-15 at 13 31 02](https://user-images.githubusercontent.com/3450688/201998608-b62e6859-5d5a-429c-976f-a95919ccf131.png) |

**Issues**
Fixes #3723
