### PR TITLE
Fix unlimited pagination

### DIFF
--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -16,7 +16,7 @@ const Pagination: FC<PaginationProps> = ({ viewQuerySettings, setViewQuerySettin
     const totalRecordCount = itemsResult.TotalRecordCount || 0;
     const startIndex = viewQuerySettings.StartIndex || 0;
     const recordsEnd = Math.min(startIndex + limit, totalRecordCount);
-    const showControls = limit < totalRecordCount;
+    const showControls = limit > 0 && limit < totalRecordCount;
     const element = useRef<HTMLDivElement>(null);
 
     const onNextPageClick = useCallback(() => {

--- a/src/components/common/ViewItemsContainer.tsx
+++ b/src/components/common/ViewItemsContainer.tsx
@@ -274,7 +274,7 @@ const ViewItemsContainer: FC<ViewItemsContainerProps> = ({
             Fields: fields,
             ImageTypeLimit: 1,
             EnableImageTypes: 'Primary,Backdrop,Banner,Thumb,Disc,Logo',
-            Limit: userSettings.libraryPageSize(undefined),
+            Limit: userSettings.libraryPageSize(undefined) || undefined,
             IsFavorite: getBasekey() === 'favorites' ? true : null,
             VideoTypes: viewQuerySettings.VideoTypes,
             GenreIds: viewQuerySettings.GenreIds,


### PR DESCRIPTION
**Changes**
Setting page size to 0 in settings disables pagination (expected). Most current master commit sends 0 as an actual page size in the query. This breaks views for those who have pagination disabled (effectively showing empty library).

PR has small change that removes the query limit and disables pagination controls if page size is set to 0.
