### PR TITLE
Fix null being a valid parental control level

### DIFF
--- a/src/routes/user/userparentalcontrol.tsx
+++ b/src/routes/user/userparentalcontrol.tsx
@@ -223,7 +223,7 @@ const UserParentalControl: FunctionComponent = () => {
                 throw new Error('Unexpected null user.Policy');
             }
 
-            const parentalRating = parseInt((page.querySelector('#selectMaxParentalRating') as HTMLSelectElement).value || '0', 10);
+            const parentalRating = parseInt((page.querySelector('#selectMaxParentalRating') as HTMLSelectElement).value, 10);
             user.Policy.MaxParentalRating = Number.isNaN(parentalRating) ? null : parentalRating;
             user.Policy.BlockUnratedItems = Array.prototype.filter.call(page.querySelectorAll('.chkUnratedItem'), function (i) {
                 return i.checked;


### PR DESCRIPTION
Seems like #4033 didn't really fix it. This works with https://github.com/jellyfin/jellyfin/pull/8526