### PR TITLE
Support admin login in QuickConnect

### DIFF
--- a/src/controllers/session/login/index.js
+++ b/src/controllers/session/login/index.js
@@ -48,7 +48,7 @@ import './login.scss';
 
     function authenticateQuickConnect(apiClient) {
         const url = apiClient.getUrl('/QuickConnect/Initiate');
-        apiClient.getJSON(url).then(function (json) {
+        apiClient.ajax({ type: 'POST', url }, true).then(res => res.json()).then(function (json) {
             if (!json.Secret || !json.Code) {
                 console.error('Malformed quick connect response', json);
                 return false;

--- a/src/controllers/user/menu/index.js
+++ b/src/controllers/user/menu/index.js
@@ -31,7 +31,7 @@ export default function (view, params) {
         page.querySelector('.lnkHomePreferences').setAttribute('href', '#/mypreferenceshome.html?userId=' + userId);
         page.querySelector('.lnkPlaybackPreferences').setAttribute('href', '#/mypreferencesplayback.html?userId=' + userId);
         page.querySelector('.lnkSubtitlePreferences').setAttribute('href', '#/mypreferencessubtitles.html?userId=' + userId);
-        page.querySelector('.lnkQuickConnectPreferences').setAttribute('href', '#/mypreferencesquickconnect.html');
+        page.querySelector('.lnkQuickConnectPreferences').setAttribute('href', '#/mypreferencesquickconnect.html?userId=' + userId);
         page.querySelector('.lnkControlsPreferences').setAttribute('href', '#/mypreferencescontrols.html?userId=' + userId);
 
         const supportsClientSettings = appHost.supports('clientsettings');

--- a/src/controllers/user/quickConnect/helper.js
+++ b/src/controllers/user/quickConnect/helper.js
@@ -1,8 +1,8 @@
 import globalize from '../../../scripts/globalize';
 import toast from '../../../components/toast/toast';
 
-export const authorize = (code) => {
-    const url = ApiClient.getUrl('/QuickConnect/Authorize?Code=' + code);
+export const authorize = (code, userId) => {
+    const url = ApiClient.getUrl('/QuickConnect/Authorize?Code=' + code + '&UserId=' + userId);
     ApiClient.ajax({
         type: 'POST',
         url: url

--- a/src/controllers/user/quickConnect/index.js
+++ b/src/controllers/user/quickConnect/index.js
@@ -2,7 +2,9 @@ import { authorize } from './helper';
 import globalize from '../../../scripts/globalize';
 import toast from '../../../components/toast/toast';
 
-export default function (view) {
+export default function (view, params) {
+    const userId = params.userId || ApiClient.getCurrentUserId();
+
     view.addEventListener('viewshow', function () {
         const codeElement = view.querySelector('#txtQuickConnectCode');
 
@@ -17,7 +19,7 @@ export default function (view) {
 
             // Remove spaces from code
             const normalizedCode = codeElement.value.replace(/\s/g, '');
-            authorize(normalizedCode);
+            authorize(normalizedCode, userId);
         });
     });
 }


### PR DESCRIPTION
The code isn't pretty but it adheres to the existing style... Depends on (already merged) server PR jellyfin/jellyfin#8734.

**Changes**

- Use POST request when initiating QuickConnect
- Support admin login in QuickConnect
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**

Fixes #3918