### PR TITLE
Show total count when no pagination is applied

### DIFF
--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -15,7 +15,8 @@ const Pagination: FC<PaginationProps> = ({ viewQuerySettings, setViewQuerySettin
     const limit = userSettings.libraryPageSize(undefined);
     const totalRecordCount = itemsResult.TotalRecordCount || 0;
     const startIndex = viewQuerySettings.StartIndex || 0;
-    const recordsEnd = Math.min(startIndex + limit, totalRecordCount);
+    const recordsStart = totalRecordCount ? startIndex + 1 : 0;
+    const recordsEnd = limit ? Math.min(startIndex + limit, totalRecordCount) : totalRecordCount;
     const showControls = limit > 0 && limit < totalRecordCount;
     const element = useRef<HTMLDivElement>(null);
 
@@ -71,7 +72,7 @@ const Pagination: FC<PaginationProps> = ({ viewQuerySettings, setViewQuerySettin
             <div className='paging'>
                 <div className='listPaging' style={{ display: 'flex', alignItems: 'center' }}>
                     <span>
-                        {globalize.translate('ListPaging', (totalRecordCount ? startIndex + 1 : 0), recordsEnd || totalRecordCount, totalRecordCount)}
+                        {globalize.translate('ListPaging', recordsStart, recordsEnd, totalRecordCount)}
                     </span>
                     {showControls && (
                         <>

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -74,7 +74,7 @@ const Pagination: FC<PaginationProps> = ({ viewQuerySettings, setViewQuerySettin
                         {globalize.translate('ListPaging', (totalRecordCount ? startIndex + 1 : 0), recordsEnd || totalRecordCount, totalRecordCount)}
                     </span>
                     {showControls && (
-                        <div style={{ display: 'inline-flex' }}>
+                        <>
                             <IconButtonElement
                                 is='paper-icon-button-light'
                                 className='btnPreviousPage autoSize'
@@ -85,7 +85,7 @@ const Pagination: FC<PaginationProps> = ({ viewQuerySettings, setViewQuerySettin
                                 className='btnNextPage autoSize'
                                 icon='material-icons arrow_forward'
                             />
-                        </div>
+                        </>
                     )}
                 </div>
             </div>

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -69,34 +69,25 @@ const Pagination: FC<PaginationProps> = ({ viewQuerySettings, setViewQuerySettin
     return (
         <div ref={element}>
             <div className='paging'>
-                {showControls && (
-                    <div className='listPaging' style={{ display: 'flex', alignItems: 'center' }}>
-
-                        <span>
-                            {globalize.translate('ListPaging', (totalRecordCount ? startIndex + 1 : 0), recordsEnd, totalRecordCount)}
-                        </span>
-
-                        <IconButtonElement
-                            is='paper-icon-button-light'
-                            className='btnPreviousPage autoSize'
-                            icon='material-icons arrow_back'
-                        />
-                        <IconButtonElement
-                            is='paper-icon-button-light'
-                            className='btnNextPage autoSize'
-                            icon='material-icons arrow_forward'
-                        />
-                    </div>
-                )}
-                {!showControls && (
-                    <div className='listPaging' style={{ display: 'flex', alignItems: 'center' }}>
-
-                        <span>
-                            {globalize.translate('ListPaging', (totalRecordCount ? startIndex + 1 : 0), totalRecordCount, totalRecordCount)}
-                        </span>
-
-                    </div>
-                )}
+                <div className='listPaging' style={{ display: 'flex', alignItems: 'center' }}>
+                    <span>
+                        {globalize.translate('ListPaging', (totalRecordCount ? startIndex + 1 : 0), recordsEnd || totalRecordCount, totalRecordCount)}
+                    </span>
+                    {showControls && (
+                        <div style={{ display: 'inline-flex' }}>
+                            <IconButtonElement
+                                is='paper-icon-button-light'
+                                className='btnPreviousPage autoSize'
+                                icon='material-icons arrow_back'
+                            />
+                            <IconButtonElement
+                                is='paper-icon-button-light'
+                                className='btnNextPage autoSize'
+                                icon='material-icons arrow_forward'
+                            />
+                        </div>
+                    )}
+                </div>
             </div>
         </div>
     );

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -88,6 +88,15 @@ const Pagination: FC<PaginationProps> = ({ viewQuerySettings, setViewQuerySettin
                         />
                     </div>
                 )}
+                {!showControls && (
+                    <div className='listPaging' style={{ display: 'flex', alignItems: 'center' }}>
+
+                        <span>
+                            {globalize.translate('ListPaging', (totalRecordCount ? startIndex + 1 : 0), totalRecordCount, totalRecordCount)}
+                        </span>
+
+                    </div>
+                )}
             </div>
         </div>
     );

--- a/src/scripts/libraryBrowser.js
+++ b/src/scripts/libraryBrowser.js
@@ -81,13 +81,14 @@ export function getQueryPagingHtml (options) {
     const limit = options.limit;
     const totalRecordCount = options.totalRecordCount;
     let html = '';
-    const recordsEnd = Math.min(startIndex + limit, totalRecordCount);
-    const showControls = limit < totalRecordCount;
+    const recordsStart = totalRecordCount ? startIndex + 1 : 0;
+    const recordsEnd = limit ? Math.min(startIndex + limit, totalRecordCount) : totalRecordCount;
+    const showControls = limit > 0 && limit < totalRecordCount;
 
     html += '<div class="listPaging">';
 
     html += '<span style="vertical-align:middle;">';
-    html += globalize.translate('ListPaging', totalRecordCount ? startIndex + 1 : 0, recordsEnd || totalRecordCount, totalRecordCount);
+    html += globalize.translate('ListPaging', recordsStart, recordsEnd, totalRecordCount);
     html += '</span>';
 
     if (showControls || options.viewButton || options.filterButton || options.sortButton || options.addLayoutButton) {

--- a/src/scripts/libraryBrowser.js
+++ b/src/scripts/libraryBrowser.js
@@ -86,15 +86,9 @@ export function getQueryPagingHtml (options) {
 
     html += '<div class="listPaging">';
 
-    if (showControls) {
-        html += '<span style="vertical-align:middle;">';
-        html += globalize.translate('ListPaging', totalRecordCount ? startIndex + 1 : 0, recordsEnd, totalRecordCount);
-        html += '</span>';
-    } else {
-        html += '<span style="vertical-align:middle;">';
-        html += globalize.translate('ListPaging', totalRecordCount ? startIndex + 1 : 0, totalRecordCount, totalRecordCount);
-        html += '</span>';
-    }
+    html += '<span style="vertical-align:middle;">';
+    html += globalize.translate('ListPaging', totalRecordCount ? startIndex + 1 : 0, recordsEnd || totalRecordCount, totalRecordCount);
+    html += '</span>';
 
     if (showControls || options.viewButton || options.filterButton || options.sortButton || options.addLayoutButton) {
         html += '<div style="display:inline-block;">';

--- a/src/scripts/libraryBrowser.js
+++ b/src/scripts/libraryBrowser.js
@@ -90,6 +90,10 @@ export function getQueryPagingHtml (options) {
         html += '<span style="vertical-align:middle;">';
         html += globalize.translate('ListPaging', totalRecordCount ? startIndex + 1 : 0, recordsEnd, totalRecordCount);
         html += '</span>';
+    } else {
+        html += '<span style="vertical-align:middle;">';
+        html += globalize.translate('ListPaging', totalRecordCount ? startIndex + 1 : 0, totalRecordCount, totalRecordCount);
+        html += '</span>';
     }
 
     if (showControls || options.viewButton || options.filterButton || options.sortButton || options.addLayoutButton) {


### PR DESCRIPTION
If no pagination is applied (or disabled in the settings), there is no view on how many items you have in your library. By showing the pagination text (without the pagination buttons) it's still visible for the user how many items are listed in the library.

Without paging enabled (or you don't reach the configured amount of items for paging):
![image](https://user-images.githubusercontent.com/1945295/206919599-02dda295-c71d-459b-a00f-307a79998508.png)

With paging enabled (as-is):
![image](https://user-images.githubusercontent.com/1945295/206919662-19c888bc-279f-48a6-8d5e-de4cc8d237a1.png)

