### PR TITLE
Increasing limit of returned results from searches

### DIFF
--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -49,7 +49,7 @@ const SearchResults: FunctionComponent<SearchResultsProps> = ({ serverId = windo
     const getDefaultParameters = useCallback(() => ({
         ParentId: parentId,
         searchTerm: query,
-        Limit: 24,
+        Limit: 100,
         Fields: 'PrimaryImageAspectRatio,CanDelete,BasicSyncInfo,MediaSourceCount',
         Recursive: true,
         EnableTotalRecordCount: false,


### PR DESCRIPTION
**Changes**
In the context of https://github.com/jellyfin/jellyfin/pull/8842, many more than 24 items might be relevant. This PR increases the number of returned results per category to accommodate this (e.g. searching for movies with the tag `christmas`).

**Issues**
While this isn't a complete solution to https://github.com/jellyfin/jellyfin-web/issues/1752 (which would likely require infinite horizontal scroll), it's a sufficient short-term measure to relieve the pressure some users might feel.