### PR TITLE
Fix sortby Releasedate (Release 10.8.8)

### DIFF
--- a/src/controllers/list.js
+++ b/src/controllers/list.js
@@ -1041,7 +1041,7 @@ class ItemsView {
 
         sortBy.push({
             name: globalize.translate('ReleaseDate'),
-            value: 'ProductionYear,PremiereDate,SortName'
+            value: 'PremiereDate,SortName'
         });
         sortBy.push({
             name: globalize.translate('Runtime'),


### PR DESCRIPTION
It found it misleading that when sorting by "Release Date" in fact the programs get sorted by "Production Date" first and as a second criteria sorted by primieredate. Since my "Production Date" values where not correct (they are not set by the TVHeadend plugin) I got an absolute strange ordering.

**Changes**
Simply removed ProductionYear from sorty query since the purpose was not clear to me.
