### PR TITLE
Trim whitespaces when entering/modifying usernames

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -57,6 +57,7 @@
  - [Meet Pandya](https://github.com/meet-k-pandya)
  - [Peter Spenler](https://github.com/peterspenler)
  - [Vankerkom](https://github.com/vankerkom)
+ - [Jxiced](https://github.com/jxiced)
 
 # Emby Contributors
 

--- a/src/controllers/session/login/index.js
+++ b/src/controllers/session/login/index.js
@@ -231,7 +231,7 @@ import './login.scss';
         view.querySelector('.manualLoginForm').addEventListener('submit', function (e) {
             appSettings.enableAutoLogin(view.querySelector('.chkRememberLogin').checked);
             const apiClient = getApiClient();
-            authenticateUserByName(view, apiClient, view.querySelector('#txtManualName').value, view.querySelector('#txtManualPassword').value);
+            authenticateUserByName(view, apiClient, view.querySelector('#txtManualName').value.trim(), view.querySelector('#txtManualPassword').value);
             e.preventDefault();
             return false;
         });

--- a/src/controllers/wizard/user/index.js
+++ b/src/controllers/wizard/user/index.js
@@ -26,7 +26,7 @@ function submit(form) {
     apiClient.ajax({
         type: 'POST',
         data: JSON.stringify({
-            Name: form.querySelector('#txtUsername').value,
+            Name: form.querySelector('#txtUsername').value.trim(),
             Password: form.querySelector('#txtManualPassword').value
         }),
         url: apiClient.getUrl('Startup/User'),

--- a/src/routes/user/usernew.tsx
+++ b/src/routes/user/usernew.tsx
@@ -108,7 +108,7 @@ const UserNew: FunctionComponent = () => {
 
         const saveUser = () => {
             const userInput: userInput = {};
-            userInput.Name = (page.querySelector('#txtUsername') as HTMLInputElement).value;
+            userInput.Name = (page.querySelector('#txtUsername') as HTMLInputElement).value.trim();
             userInput.Password = (page.querySelector('#txtPassword') as HTMLInputElement).value;
             window.ApiClient.createUser(userInput).then(function (user) {
                 if (!user.Id) {


### PR DESCRIPTION
**Changes**
Added `trim()` to the end of `value` on `form.querySelector('#txtUsername')` and `view.querySelector('#txtManualName')` to prevent whitespaces from appearing at the start or end of usernames.
This is implemented on the login page, the first-time-setup wizard, and when adding a new user.

**Issues**
Fixes [#8897](https://github.com/jellyfin/jellyfin/issues/8897)
