### PR TITLE
Stop sending unnecessary `Sessions/Playing/Progress` requests to the backend

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -3157,11 +3157,13 @@ class PlaybackManager {
         function onPlaybackPause() {
             const player = this;
             sendProgressUpdate(player, 'pause');
+            stopPlaybackProgressTimer(player);
         }
 
         function onPlaybackUnpause() {
             const player = this;
             sendProgressUpdate(player, 'unpause');
+            startPlaybackProgressTimer(player);
         }
 
         function onPlaybackVolumeChange() {


### PR DESCRIPTION
Currently the client keeps sending these requests on an interval of 10 seconds even when there's no progress being made.