### PR TITLE
Migrate Usernames to Remove Whitespaces

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -57,6 +57,7 @@
  - [Meet Pandya](https://github.com/meet-k-pandya)
  - [Peter Spenler](https://github.com/peterspenler)
  - [Vankerkom](https://github.com/vankerkom)
+ - [Jxiced](https://github.com/jxiced)
 
 # Emby Contributors
 

--- a/src/controllers/wizard/user/index.js
+++ b/src/controllers/wizard/user/index.js
@@ -26,7 +26,7 @@ function submit(form) {
     apiClient.ajax({
         type: 'POST',
         data: JSON.stringify({
-            Name: form.querySelector('#txtUsername').value,
+            Name: form.querySelector('#txtUsername').value.trim(),
             Password: form.querySelector('#txtManualPassword').value
         }),
         url: apiClient.getUrl('Startup/User'),

--- a/src/routes/user/useredit.tsx
+++ b/src/routes/user/useredit.tsx
@@ -212,7 +212,7 @@ const UserEdit: FunctionComponent = () => {
                 throw new Error('Unexpected null user.Policy');
             }
 
-            user.Name = (page.querySelector('#txtUserName') as HTMLInputElement).value;
+            user.Name = (page.querySelector('#txtUserName') as HTMLInputElement).value.trim();
             user.Policy.IsAdministrator = (page.querySelector('.chkIsAdmin') as HTMLInputElement).checked;
             user.Policy.IsHidden = (page.querySelector('.chkIsHidden') as HTMLInputElement).checked;
             user.Policy.IsDisabled = (page.querySelector('.chkDisabled') as HTMLInputElement).checked;

--- a/src/routes/user/usernew.tsx
+++ b/src/routes/user/usernew.tsx
@@ -108,7 +108,7 @@ const UserNew: FunctionComponent = () => {
 
         const saveUser = () => {
             const userInput: userInput = {};
-            userInput.Name = (page.querySelector('#txtUsername') as HTMLInputElement).value;
+            userInput.Name = (page.querySelector('#txtUsername') as HTMLInputElement).value.trim();
             userInput.Password = (page.querySelector('#txtPassword') as HTMLInputElement).value;
             window.ApiClient.createUser(userInput).then(function (user) {
                 if (!user.Id) {


### PR DESCRIPTION
**Changes**
Added trim() to the end of value on form.querySelector('#txtUsername') and view.querySelector('#txtManualName') to prevent whitespaces from appearing at the start or end of usernames.
This is implemented on the login page, the first-time-setup wizard, and when editing or adding a user.
Created dialogs to allow the user to migrate to a new username if one is already taken, otherwise whitespaces will just be removed.

**Issues**
Addresses [#8897](https://github.com/jellyfin/jellyfin/issues/8897)