### PR TITLE
Fix XSS vulnerability in router

### DIFF
--- a/src/components/appRouter.js
+++ b/src/components/appRouter.js
@@ -59,25 +59,11 @@ class AppRouter {
             this.baseRoute = this.baseRoute.substring(0, this.baseRoute.length - 1);
         }
 
-        this.setBaseRoute();
-
         // paths that start with a hashbang (i.e. /#!/page.html) get transformed to starting with //
         // we need to strip one "/" for our routes to work
         page('//*', (ctx) => {
             page.redirect(ctx.path.substring(1));
         });
-    }
-
-    /**
-     * @private
-     */
-    setBaseRoute() {
-        let baseRoute = window.location.pathname.replace(this.getRequestFile(), '');
-        if (baseRoute.lastIndexOf('/') === baseRoute.length - 1) {
-            baseRoute = baseRoute.substring(0, baseRoute.length - 1);
-        }
-        console.debug('setting page base to ' + baseRoute);
-        page.base(baseRoute);
     }
 
     addRoute(path, newRoute) {


### PR DESCRIPTION
**Changes**
Fixes a XSS vulnerability caused by a misconfiguration of pages.js combined with a feature of the default unhandled route handler.

Proof of concept can be viewed on the stable demo server: https://demo.jellyfin.org/stable/web/index.html#!javascript:alert(%22XSS%20Found%20!!!!%22)

We are configuring a base url for pages.js which does not seem to be valid. The base url seems to only be needed if there is a base url as part of the hash route url and **NOT** as part of the main page url. Currently we are setting the base url to `/web` in our default server configuration since the main page is hosted at `/web/index.html`. In this case when pages.js hits an unhandled route, it compares the requested path with the base url + the current hash route. In the case of the example above the requested path would be `javascript:alert(%22XSS%20Found%20!!!!%22)` which would be compared to `/web/#!javascript:alert(%22XSS%20Found%20!!!!%22)` and since these differ, pages.js sets the current url to `javascript:alert(%22XSS%20Found%20!!!!%22)`.

Relevant code in pages.js: https://github.com/visionmedia/page.js/blob/master/page.js#L1040-L1049

**Issues**
XSS vulnerability reported via email
