### PR TITLE
Fix detection of SecondaryAudio support

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -744,7 +744,13 @@ import browser from './browser';
 
         profile.CodecProfiles = [];
 
-        const supportsSecondaryAudio = browser.tizen || videoTestElement.audioTracks;
+        // We rely on HTMLMediaElement.audioTracks
+        // It works in Chrome 79+ with "Experimental Web Platform features" enabled
+        // It doesn't work in Firefox 108 even with "media.track.enabled" enabled (it only sees the first audio track)
+        // It seems to work on Tizen 5.5+ (Chrome 69+). See https://developer.tizen.org/forums/web-application-development/video-tag-not-work-audiotracks
+        const supportsSecondaryAudio = !!videoTestElement.audioTracks
+            && !browser.firefox
+            && (browser.tizenVersion >= 5.5 || !browser.tizen);
 
         const aacCodecProfileConditions = [];
 


### PR DESCRIPTION
The existence of `HTMLMediaElement.audioTracks` that we rely on is not enough.
It works in Chrome 79+ with `Experimental Web Platform features` enabled, but it doesn't work in Firefox 108 even with `media.track.enabled` enabled (it only sees the first audio track).
It doesn't work on my Tizen 4, and according to [this](https://developer.tizen.org/forums/web-application-development/video-tag-not-work-audiotracks), it probably only works on Tizen 5.5+.

**Changes**
Fix detection of SecondaryAudio support

**Issues**
https://github.com/jellyfin/jellyfin-webos/issues/85
https://github.com/jellyfin/jellyfin-webos/issues/110
https://github.com/jellyfin/jellyfin-webos/issues/118
https://github.com/jellyfin/jellyfin-tizen/issues/48
probably https://github.com/jellyfin/jellyfin-tizen/issues/90

There is another place that relies on `audioTracks`, but it doesn't seem to be touched if secondary audio isn't supported:
https://github.com/jellyfin/jellyfin-web/blob/06c45c393e1ac17a083cc275ba1c590a9a705bbb/src/plugins/htmlVideoPlayer/plugin.js#L1547-L1554