### PR TITLE
Fix HTML escaping in MediaSession and on remote page

### DIFF
--- a/src/components/nowPlayingBar/nowPlayingBar.js
+++ b/src/components/nowPlayingBar/nowPlayingBar.js
@@ -502,14 +502,14 @@ import { appRouter } from '../appRouter';
                 textLines[1].secondary = true;
                 if (textLines[1].text) {
                     const text = document.createElement('a');
-                    text.innerHTML = textLines[1].text;
+                    text.innerText = textLines[1].text;
                     secondaryText.appendChild(text);
                 }
             }
 
             if (textLines[0].text) {
                 const text = document.createElement('a');
-                text.innerHTML = textLines[0].text;
+                text.innerText = textLines[0].text;
                 itemText.appendChild(text);
             }
             nowPlayingTextElement.appendChild(itemText);

--- a/src/components/playback/nowplayinghelper.js
+++ b/src/components/playback/nowplayinghelper.js
@@ -1,5 +1,3 @@
-import escapeHtml from 'escape-html';
-
 export function getNowPlayingNames(nowPlayingItem, includeNonNameInfo) {
     let topItem = nowPlayingItem;
     let bottomItem = null;
@@ -61,13 +59,13 @@ export function getNowPlayingNames(nowPlayingItem, includeNonNameInfo) {
     const list = [];
 
     list.push({
-        text: escapeHtml(topText),
+        text: topText,
         item: topItem
     });
 
     if (bottomText) {
         list.push({
-            text: escapeHtml(bottomText),
+            text: bottomText,
             item: bottomItem
         });
     }


### PR DESCRIPTION
**Changes**
- Remove extra `escapeHtml` in `getNowPlayingNames`.
- Use `innerText` in `updateNowPlayingInfo`.

**Issues**
- MediaSession has escaped artist and track title (https://github.com/jellyfin/jellyfin-web/pull/4125#issuecomment-1297505471).
- Remote page has escaped movie title (#4125).
