### PR TITLE
Disable multiple codec streaming on Tizen and webOS

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -366,6 +366,10 @@ import browser from './browser';
         profile.MaxStaticBitrate = 100000000;
         profile.MusicStreamingTranscodingBitrate = Math.min(bitrateSetting, 384000);
 
+        if (browser.tizen || browser.web0s) {
+            profile.EnableMultipleCodecStreaming = false;
+        }
+
         profile.DirectPlayProfiles = [];
 
         let videoAudioCodecs = [];


### PR DESCRIPTION
Requires https://github.com/jellyfin/jellyfin/pull/9016

**Changes**
Disable multiple codec streaming on Tizen and webOS.

**Issues**
Fixes https://github.com/jellyfin/jellyfin-tizen/issues/163
Fixes https://github.com/jellyfin/jellyfin-tizen/issues/5576
Fixes https://github.com/jellyfin/jellyfin-webos/issues/105

