### PR TITLE
Audio boost when downmixing should be 0 - 3

### DIFF
--- a/src/controllers/dashboard/encodingsettings.html
+++ b/src/controllers/dashboard/encodingsettings.html
@@ -254,7 +254,7 @@
                     <div class="fieldDescription checkboxFieldDescription">${EnableFallbackFontHelp}</div>
                 </div>
                 <div class="inputContainer">
-                    <input is="emby-input" type="number" id="txtDownMixAudioBoost" pattern="[0-9]*" required="required" min=".5" max="3" step=".1" label="${LabelDownMixAudioScale}" />
+                    <input is="emby-input" type="number" id="txtDownMixAudioBoost" pattern="[0-9]*" required="required" min="0" max="3" step=".1" label="${LabelDownMixAudioScale}" />
                     <div class="fieldDescription">${LabelDownMixAudioScaleHelp}</div>
                 </div>
                 <div class="inputContainer">


### PR DESCRIPTION
This number input should have a range down to `0`

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
Changed minimum excepted value for downmixing to `0` from `0.5`
Please let me know if this requires changes, this is my first MR here/I just wanted to resolve this issue quick if it doesn't go too deep.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
https://github.com/jellyfin/jellyfin-web/issues/4265