### PR TITLE
Fix AudioContext limit exceeded

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -294,16 +294,24 @@ import browser from './browser';
                     (browser.tizen && isTizenFhd ? 20000000 : null)));
     }
 
+    let maxChannelCount = null;
+
     function getSpeakerCount() {
+        if (maxChannelCount != null) {
+            return maxChannelCount;
+        }
+
+        maxChannelCount = -1;
+
         const AudioContext = window.AudioContext || window.webkitAudioContext || false; /* eslint-disable-line compat/compat */
 
         if (AudioContext) {
             const audioCtx = new AudioContext();
 
-            return audioCtx.destination.maxChannelCount;
+            maxChannelCount = audioCtx.destination.maxChannelCount;
         }
 
-        return -1;
+        return maxChannelCount;
     }
 
     function getPhysicalAudioChannels(options, videoTestElement) {


### PR DESCRIPTION
**Changes**
Cache the `maxChannelCount` value so that `AudioContext` is created only once.

**Issues**
During testing on webOS emulators (3 and 4) this error occurs:
```
Failed to construct 'AudioContext': The number of hardware contexts provided (6) is greater than or equal to the maximum bound (6).
```

**Steps To Reproduce**
1. Load the app in the webOS 3 emulator.
2. Start music 1
3. Start music 2
4. Repeat 2-3 until an error occurs.