### PR TITLE
Update docs - gamepad requirement

### DIFF
--- a/src/strings/en-gb.json
+++ b/src/strings/en-gb.json
@@ -1518,7 +1518,7 @@
     "MessageChromecastConnectionError": "Your Google Cast receiver is unable to contact the Jellyfin server. Please check the connection and try again.",
     "Framerate": "Framerate",
     "DirectPlayHelp": "The source file is entirely compatible with this client, and the session is receiving the file without modifications.",
-    "EnableGamepadHelp": "Listen for input from any connected controllers.",
+    "EnableGamepadHelp": "Listen for input from any connected controllers. (Requires: 'TV' Display Mode)",
     "LabelEnableGamepad": "Enable Gamepad",
     "Controls": "Controls",
     "TextSent": "Text sent.",

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1616,7 +1616,7 @@
     "AllowVppTonemappingHelp": "Full Intel driver based tone-mapping. Currently works only on certain hardware with HDR10 videos. This has a higher priority compared to another OpenCL implementation.",
     "Controls": "Controls",
     "LabelEnableGamepad": "Enable Gamepad",
-    "EnableGamepadHelp": "Listen for input from any connected controllers.",
+    "EnableGamepadHelp": "Listen for input from any connected controllers. (Requires: 'TV' Display Mode)",
     "AudioCodecNotSupported": "The audio codec is not supported",
     "ContainerNotSupported": "The container is not supported",
     "SubtitleCodecNotSupported": "The subtitle codec is not supported",


### PR DESCRIPTION
It was found that Jellyfin-web does not automatically identify the steam deck as a game console so the 'Display -> Display Mode' setting needs to be changes from 'Auto' to 'TV' explicitly for the gamepad control (even if already enabled) to work. 

Note: webpage needs manual refresh after setting to TV and enabling gamepad control for the changes to be applied.

At this time, it is unclear on how to have javascript auto-detect the steam deck since it is technically a linux desktop system, so for now, a small note is being added to the "Enable gamepad" setting that TV display mode is required.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
Update en-us.json & en-gb.json to include "gamepad enable" setting requires TV display mode.

**Issues**
Reference Issue #4296 Gamepad support broken on Steam Deck
