### PR TITLE
Fix html lang attribute

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -74,6 +74,7 @@ function init() {
         autoFocuser.enable();
 
         Events.on(ServerConnections, 'localusersignedin', globalize.updateCurrentCulture);
+        Events.on(ServerConnections, 'localusersignedout', globalize.updateCurrentCulture);
     });
 }
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -227,15 +227,8 @@ async function onAppReady() {
             }
         };
 
-        const handleLanguageChange = () => {
-            const locale = globalize.getCurrentLocale();
-
-            document.documentElement.setAttribute('lang', locale);
-        };
-
         const handleUserChange = () => {
             handleStyleChange();
-            handleLanguageChange();
         };
 
         Events.on(ServerConnections, 'localusersignedin', handleUserChange);
@@ -243,8 +236,6 @@ async function onAppReady() {
         Events.on(currentSettings, 'change', (e, prop) => {
             if (prop == 'disableCustomCss' || prop == 'customCss') {
                 handleStyleChange();
-            } else if (prop == 'language') {
-                handleLanguageChange();
             }
         });
 

--- a/src/scripts/globalize.js
+++ b/src/scripts/globalize.js
@@ -89,6 +89,8 @@ const Direction = {
 
         currentCulture = normalizeLocaleName(culture);
 
+        document.documentElement.setAttribute('lang', currentCulture);
+
         let dateTimeCulture;
         try {
             dateTimeCulture = userSettings.dateTimeLocale();


### PR DESCRIPTION
**Changes**
- Move the `lang` attribute update code to `globalize.js`.
- Update language when logging out. This makes it equal to the browser language.
We don't do this in the release branch, but `lang` is updated on refresh.

**Issues**
With React Router, the `localusersignedin` event is triggered before we subscribe to it, and the `lang` attribute isn't set.
