### PR TITLE
Add toggle to show/hide remaining video time in video player

### DIFF
--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -787,12 +787,18 @@ import { setBackdropTransparency, TRANSPARENCY_LEVEL } from '../../../components
                     nowPlayingPositionText.classList.add('hide');
                 }
 
-                const leftTicks = runtimeTicks - positionTicks;
-                if (leftTicks >= 0) {
-                    updateTimeText(nowPlayingDurationText, leftTicks);
-                    nowPlayingDurationText.classList.remove('hide');
+                if (userSettings.enableVideoRemainingTime()) {
+                    const leftTicks = runtimeTicks - positionTicks;
+                    if (leftTicks >= 0) {
+                        updateTimeText(nowPlayingDurationText, leftTicks);
+                        nowPlayingDurationText.innerHTML = '-' + nowPlayingDurationText.innerHTML;
+                        nowPlayingDurationText.classList.remove('hide');
+                    } else {
+                        nowPlayingPositionText.classList.add('hide');
+                    }
                 } else {
-                    nowPlayingPositionText.classList.add('hide');
+                    updateTimeText(nowPlayingDurationText, runtimeTicks);
+                    nowPlayingDurationText.classList.remove('hide');
                 }
             }
         }
@@ -869,6 +875,19 @@ import { setBackdropTransparency, TRANSPARENCY_LEVEL } from '../../../components
             }
 
             elem.innerHTML = html;
+        }
+
+        function nowPlayingDurationTextClick() {
+            if (userSettings.enableVideoRemainingTime()) {
+                userSettings.enableVideoRemainingTime(false);
+            } else {
+                userSettings.enableVideoRemainingTime(true);
+            }
+            // immediately update the text, without waiting for the next tick update or if the player is paused
+            const state = playbackManager.getPlayerState(currentPlayer);
+            const playState = state.PlayState;
+            const nowPlayingItem = state.NowPlayingItem;
+            updateTimeDisplay(playState.PositionTicks, nowPlayingItem.RunTimeTicks, playState.PlaybackStartTimeTicks, playState.PlaybackRate, playState.BufferedRanges || []);
         }
 
         function onSettingsButtonClick() {
@@ -1329,6 +1348,8 @@ import { setBackdropTransparency, TRANSPARENCY_LEVEL } from '../../../components
         if (layoutManager.tv) {
             nowPlayingPositionSlider.classList.add('focusable');
         }
+
+        nowPlayingDurationText.addEventListener('click', nowPlayingDurationTextClick);
 
         view.addEventListener('viewbeforeshow', function () {
             headerElement.classList.add('osdHeader');

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -878,11 +878,7 @@ import { setBackdropTransparency, TRANSPARENCY_LEVEL } from '../../../components
         }
 
         function nowPlayingDurationTextClick() {
-            if (userSettings.enableVideoRemainingTime()) {
-                userSettings.enableVideoRemainingTime(false);
-            } else {
-                userSettings.enableVideoRemainingTime(true);
-            }
+            userSettings.enableVideoRemainingTime(!userSettings.enableVideoRemainingTime());
             // immediately update the text, without waiting for the next tick update or if the player is paused
             const state = playbackManager.getPlayerState(currentPlayer);
             const playState = state.PlayState;

--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -170,6 +170,19 @@ export class UserSettings {
     }
 
     /**
+     * Get or set 'Video Remaining/Total Time' state.
+     * @param {boolean|undefined} val - Flag to enable 'Video Remaining/Total Time' or undefined.
+     * @return {boolean} 'Video Remaining/Total Time' state.
+     */
+    enableVideoRemainingTime(val) {
+        if (val !== undefined) {
+            return this.set('enableVideoRemainingTime', val.toString());
+        }
+
+        return toBoolean(this.get('enableVideoRemainingTime', false), true);
+    }
+
+    /**
      * Get or set 'Theme Songs' state.
      * @param {boolean|undefined} val - Flag to enable 'Theme Songs' or undefined.
      * @return {boolean} 'Theme Songs' state.
@@ -580,6 +593,7 @@ export const allowedAudioChannels = currentSettings.allowedAudioChannels.bind(cu
 export const preferFmp4HlsContainer = currentSettings.preferFmp4HlsContainer.bind(currentSettings);
 export const enableCinemaMode = currentSettings.enableCinemaMode.bind(currentSettings);
 export const enableNextVideoInfoOverlay = currentSettings.enableNextVideoInfoOverlay.bind(currentSettings);
+export const enableVideoRemainingTime = currentSettings.enableVideoRemainingTime.bind(currentSettings);
 export const enableThemeSongs = currentSettings.enableThemeSongs.bind(currentSettings);
 export const enableThemeVideos = currentSettings.enableThemeVideos.bind(currentSettings);
 export const enableFastFadein = currentSettings.enableFastFadein.bind(currentSettings);


### PR DESCRIPTION
**Changes**
Added a click listener to the remaining time label that toggles between show the total video length and the remaining video time.

When toggle is in remaining video time mode, `-` is added as a prefix.

It imitates the same behavior in VLC.

Toggle preference as local storage user setting.

