### PR TITLE
Add "AllowedTags" option to parental controls

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -60,6 +60,7 @@
  - [edvwib](https://github.com/edvwib)
  - [Rob Farraher](https://github.com/farraherbg)
  - [Pier-Luc Ducharme](https://github.com/pl-ducharme)
+ - [JPUC1143](https://github.com/Jpuc1143/)
 
 # Emby Contributors
 

--- a/src/components/dashboard/users/TagList.tsx
+++ b/src/components/dashboard/users/TagList.tsx
@@ -2,10 +2,11 @@ import React, { FunctionComponent } from 'react';
 import IconButtonElement from '../../../elements/IconButtonElement';
 
 type IProps = {
-    tag?: string;
+    tag?: string,
+    tagType?: string;
 }
 
-const BlockedTagList: FunctionComponent<IProps> = ({tag}: IProps) => {
+const TagList: FunctionComponent<IProps> = ({tag, tagType}: IProps) => {
     return (
         <div className='paperList'>
             <div className='listItem'>
@@ -16,7 +17,7 @@ const BlockedTagList: FunctionComponent<IProps> = ({tag}: IProps) => {
                 </div>
                 <IconButtonElement
                     is='paper-icon-button-light'
-                    className='blockedTag btnDeleteTag listItemButton'
+                    className={`${tagType} btnDeleteTag listItemButton`}
                     title='Delete'
                     icon='delete'
                     dataTag={tag}
@@ -26,4 +27,4 @@ const BlockedTagList: FunctionComponent<IProps> = ({tag}: IProps) => {
     );
 };
 
-export default BlockedTagList;
+export default TagList;

--- a/src/strings/en-gb.json
+++ b/src/strings/en-gb.json
@@ -1007,6 +1007,7 @@
     "LabelArtistsHelp": "Separate multiple artists with a semicolon.",
     "LabelArtists": "Artists:",
     "LabelAppName": "App name",
+    "LabelAllowContentWithTags": "Allow items with tags:",
     "LabelAllowedRemoteAddressesMode": "Remote IP address filter mode:",
     "LabelAllowedRemoteAddresses": "Remote IP address filter:",
     "LabelAllowHWTranscoding": "Allow hardware transcoding",

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -538,6 +538,7 @@
     "LabelAlbumArtMaxResHelp": "Maximum resolution of album art exposed via the 'upnp:albumArtURI' property.",
     "LabelAlbumArtMaxWidth": "Album art max width:",
     "LabelAlbumArtPN": "Album art PN:",
+    "LabelAllowContentWithTags": "Allow items with tags:",
     "LabelAllowedRemoteAddresses": "Remote IP address filter:",
     "LabelAllowedRemoteAddressesMode": "Remote IP address filter mode:",
     "LabelAllowHWTranscoding": "Allow hardware transcoding",

--- a/src/strings/es.json
+++ b/src/strings/es.json
@@ -370,6 +370,7 @@
     "LabelAlbumArtMaxWidth": "Anchura máxima de la carátula del album:",
     "LabelAlbumArtPN": "Carátula del album PN:",
     "LabelAlbumArtists": "Artistas de los álbumes:",
+    "LabelAllowContentWithTags": "Permitir artículos con etiquetas:",
     "LabelAllowHWTranscoding": "Activar la conversión acelerada por hardware",
     "LabelAllowedRemoteAddresses": "Filtro de dirección IP remota:",
     "LabelAllowedRemoteAddressesMode": "Modo de filtro de dirección IP remota:",


### PR DESCRIPTION
**Changes**
Adds an option in Parental Controls to only allow media with selected tags for viewing.

**Issues**
Client side configuration of jellyfin/jellyfin#9139