### PR TITLE
Fix subtitles desync

### DIFF
--- a/src/components/htmlMediaHelper.js
+++ b/src/components/htmlMediaHelper.js
@@ -151,14 +151,17 @@ import { Events } from 'jellyfin-apiclient';
                 // update video player position when media is ready to be sought
                 const events = ['durationchange', 'loadeddata', 'play', 'loadedmetadata'];
                 const onMediaChange = function(e) {
-                    if (element.currentTime === 0 && element.duration >= seconds) {
-                        // seek only when video position is exactly zero,
-                        // as this is true only if video hasn't started yet or
-                        // user rewound to the very beginning
-                        // (but rewinding cannot happen as the first event with media of non-empty duration)
-                        console.debug(`seeking to ${seconds} on ${e.type} event`);
-                        setCurrentTimeIfNeeded(element, seconds);
+                    if (element.duration >= seconds) {
                         events.forEach(name => element.removeEventListener(name, onMediaChange));
+
+                        if (element.currentTime === 0) {
+                            // seek only when video position is exactly zero,
+                            // as this is true only if video hasn't started yet or
+                            // user rewound to the very beginning
+                            // (but rewinding cannot happen as the first event with media of non-empty duration)
+                            console.debug(`seeking to ${seconds} on ${e.type} event`);
+                            setCurrentTimeIfNeeded(element, seconds);
+                        }
                     }
                 };
                 events.forEach(name => element.addEventListener(name, onMediaChange));

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -845,9 +845,11 @@ function tryRemoveElement(elem) {
 
                 loading.hide();
 
-                seekOnPlaybackStart(this, e.target, this._currentPlayOptions.playerStartPositionTicks, () => {
+                const transcodingOffsetTicks = this._currentPlayOptions.transcodingOffsetTicks || 0;
+
+                seekOnPlaybackStart(this, e.target, this._currentPlayOptions.playerStartPositionTicks - transcodingOffsetTicks, () => {
                     if (this.#currentSubtitlesOctopus) {
-                        this.#currentSubtitlesOctopus.timeOffset = (this._currentPlayOptions.transcodingOffsetTicks || 0) / 10000000 + this.#currentTrackOffset;
+                        this.#currentSubtitlesOctopus.timeOffset = transcodingOffsetTicks / 10000000 + this.#currentTrackOffset;
                         this.#currentSubtitlesOctopus.resize();
                         this.#currentSubtitlesOctopus.resetRenderAheadCache(false);
                     }

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1096,7 +1096,7 @@ function tryRemoveElement(elem) {
                         onErrorInternal(htmlVideoPlayer, 'mediadecodeerror');
                     }, 0);
                 },
-                timeOffset: (this._currentPlayOptions.transcodingOffsetTicks || 0) / 10000000,
+                timeOffset: (this._currentPlayOptions.transcodingOffsetTicks || 0) / 10000000 + this.#currentTrackOffset,
 
                 // new octopus options; override all, even defaults
                 renderMode: 'wasm-blend',

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -752,7 +752,8 @@ export function canPlaySecondaryAudio(videoTestElement) {
                 VideoCodec: mp4VideoCodecs.join(','),
                 Context: 'Streaming',
                 Protocol: 'http',
-                MaxAudioChannels: physicalAudioChannels.toString()
+                MaxAudioChannels: physicalAudioChannels.toString(),
+                CopyTimestamps: true
             });
         }
 


### PR DESCRIPTION
**Changes**
- Fix MediaReady.
`onMediaReady` callback is not called if `seconds` is `0` and when using progressive streaming.
- Fix removing listeners.
They remain connected when using progressive streaming because `currentTime` is not `0` when `duration` reaches `seconds`.
- Fix subtitle desync when progressive streaming.
Copy the timestamps because the seeking is not accurate (I-frame start?).
- Fix time offset in JSO constructor _(in fact, cosmetic)_.
- Fix requested position when progressive streaming.
`seconds` must correspond to `video.currentTime` which begins with `0` relative to the transcoding offset.

**Issues**
Fixes https://github.com/jellyfin/jellyfin-web/issues/4346
