### PR TITLE
Fix Blurred pdf

### DIFF
--- a/src/plugins/pdfPlayer/plugin.js
+++ b/src/plugins/pdfPlayer/plugin.js
@@ -278,16 +278,22 @@ export class PdfPlayer {
 
     renderPage(canvas, number) {
         this.book.getPage(number).then(page => {
-            const original = page.getViewport({ scale: 1 });
+            const width = dom.getWindowSize().innerWidth;
+            const height = dom.getWindowSize().innerHeight;
+			
+            const viewport = page.getViewport({ scale: 5 });
             const context = canvas.getContext('2d');
-
-            const widthRatio = dom.getWindowSize().innerWidth / original.width;
-            const heightRatio = dom.getWindowSize().innerHeight / original.height;
-            const scale = Math.min(heightRatio, widthRatio);
-            const viewport = page.getViewport({ scale: scale });
-
             canvas.width = viewport.width;
             canvas.height = viewport.height;
+			
+			if (width<height) {
+                canvas.style.width = "100%";
+				canvas.style.height = "auto"; 
+            } else {
+				canvas.style.height = "100%";
+				canvas.style.width = "auto"; 
+			}
+		 
             const renderContext = {
                 canvasContext: context,
                 viewport: viewport


### PR DESCRIPTION
Blurred pdf may happen if the screen is small. I modified pdfPlayer to avoid it.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
I modified pdfPlayer / renderPage so the issue I found is fixed. I increased the scale and changed the canvas size to render the PDF within the size of the screen.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes jellyfin-android  Books (pdf) #977 

