### PR TITLE
Fix library options missing when editing an existing Mixed-type library

### DIFF
--- a/src/components/libraryoptionseditor/libraryoptionseditor.js
+++ b/src/components/libraryoptionseditor/libraryoptionseditor.js
@@ -398,7 +398,7 @@ import template from './libraryoptionseditor.template.html';
             parent.querySelector('.chkEnablePhotosContainer').classList.add('hide');
         }
 
-        if (contentType !== 'tvshows' && contentType !== 'movies' && contentType !== 'homevideos' && contentType !== 'musicvideos' && contentType !== 'mixed') {
+        if (contentType !== 'tvshows' && contentType !== 'movies' && contentType !== 'homevideos' && contentType !== 'musicvideos' && contentType !== 'mixed' && contentType !== undefined) {
             parent.querySelector('.chapterSettingsSection').classList.add('hide');
         } else {
             parent.querySelector('.chapterSettingsSection').classList.remove('hide');
@@ -430,13 +430,13 @@ import template from './libraryoptionseditor.template.html';
             parent.querySelector('.chkEnableEmbeddedEpisodeInfosContainer').classList.add('hide');
         }
 
-        if (contentType === 'tvshows' || contentType === 'movies' || contentType === 'musicvideos' || contentType === 'mixed') {
+        if (contentType === 'tvshows' || contentType === 'movies' || contentType === 'musicvideos' || contentType === 'mixed' || contentType === undefined) {
             parent.querySelector('.fldAllowEmbeddedSubtitlesContainer').classList.remove('hide');
         } else {
             parent.querySelector('.fldAllowEmbeddedSubtitlesContainer').classList.add('hide');
         }
 
-        parent.querySelector('.chkAutomaticallyAddToCollectionContainer').classList.toggle('hide', contentType !== 'movies' && contentType !== 'mixed');
+        parent.querySelector('.chkAutomaticallyAddToCollectionContainer').classList.toggle('hide', contentType !== 'movies' && contentType !== 'mixed' && contentType !== undefined);
 
         return populateMetadataSettings(parent, contentType);
     }


### PR DESCRIPTION
**Changes**
- Add checks for `undefined` `contentType` and treat it the same as 'mixed'

On library creation the dialog sees the type as 'mixed' but when queried for existing libraries the server provides mixed-type libraries with a null `CollectionType`, which doesn't populate on the javascript side and fails the check when only testing for 'mixed'.

**Issues**
Fixes jellyfin/jellyfin#8538
