### PR TITLE
Babelify @jellyfin/libass-wasm

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -146,7 +146,25 @@ const config = {
             },
             {
                 test: /\.(js|jsx)$/,
-                exclude: /node_modules[\\/](?!@uupaa[\\/]dynamic-import-polyfill|@jellyfin[\\/]sdk|@remix-run[\\/]router|axios|blurhash|compare-versions|date-fns|dom7|epubjs|flv.js|libarchive.js|marked|react-router|screenfull|ssr-window|swiper)/,
+                include: [
+                    path.resolve(__dirname, 'node_modules/@jellyfin/sdk'),
+                    path.resolve(__dirname, 'node_modules/@remix-run/router'),
+                    path.resolve(__dirname, 'node_modules/@uupaa/dynamic-import-polyfill'),
+                    path.resolve(__dirname, 'node_modules/axios'),
+                    path.resolve(__dirname, 'node_modules/blurhash'),
+                    path.resolve(__dirname, 'node_modules/compare-versions'),
+                    path.resolve(__dirname, 'node_modules/date-fns'),
+                    path.resolve(__dirname, 'node_modules/dom7'),
+                    path.resolve(__dirname, 'node_modules/epubjs'),
+                    path.resolve(__dirname, 'node_modules/flv.js'),
+                    path.resolve(__dirname, 'node_modules/libarchive.js'),
+                    path.resolve(__dirname, 'node_modules/marked'),
+                    path.resolve(__dirname, 'node_modules/react-router'),
+                    path.resolve(__dirname, 'node_modules/screenfull'),
+                    path.resolve(__dirname, 'node_modules/ssr-window'),
+                    path.resolve(__dirname, 'node_modules/swiper'),
+                    path.resolve(__dirname, 'src')
+                ],
                 use: [{
                     loader: 'babel-loader',
                     options: {
@@ -172,7 +190,11 @@ const config = {
             },
             /* modules that Babel breaks when transforming to ESM */
             {
-                test: /node_modules[\\/](pdfjs-dist|xmldom)[\\/].*\.js$/,
+                test: /\.js$/,
+                include: [
+                    path.resolve(__dirname, 'node_modules/pdfjs-dist'),
+                    path.resolve(__dirname, 'node_modules/xmldom')
+                ],
                 use: [{
                     loader: 'babel-loader',
                     options: {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -147,6 +147,7 @@ const config = {
             {
                 test: /\.(js|jsx)$/,
                 include: [
+                    path.resolve(__dirname, 'node_modules/@jellyfin/libass-wasm'),
                     path.resolve(__dirname, 'node_modules/@jellyfin/sdk'),
                     path.resolve(__dirname, 'node_modules/@remix-run/router'),
                     path.resolve(__dirname, 'node_modules/@uupaa/dynamic-import-polyfill'),


### PR DESCRIPTION
**Changes**
- Simplify adding modules to babel-loader
- Babelify @jellyfin/libass-wasm

**Issues**
`libass-wasm` must be transpiled because of the forgotten `const`. _This will also be helpful when migrating to ES6._
https://github.com/jellyfin/jellyfin-webos/issues/31#issuecomment-1095401463
