### PR TITLE
Babelify @jellyfin/libass-wasm

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -97,6 +97,7 @@ module.exports = {
             {
                 test: /\.(js|jsx)$/,
                 include: [
+                    path.resolve(__dirname, 'node_modules/@jellyfin/libass-wasm'),
                     path.resolve(__dirname, 'node_modules/@uupaa/dynamic-import-polyfill'),
                     path.resolve(__dirname, 'node_modules/blurhash'),
                     path.resolve(__dirname, 'node_modules/date-fns'),

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -96,7 +96,17 @@ module.exports = {
             },
             {
                 test: /\.(js|jsx)$/,
-                exclude: /node_modules[\\/](?!@uupaa[\\/]dynamic-import-polyfill|blurhash|date-fns|epubjs|flv.js|libarchive.js|marked|screenfull)/,
+                include: [
+                    path.resolve(__dirname, 'node_modules/@uupaa/dynamic-import-polyfill'),
+                    path.resolve(__dirname, 'node_modules/blurhash'),
+                    path.resolve(__dirname, 'node_modules/date-fns'),
+                    path.resolve(__dirname, 'node_modules/epubjs'),
+                    path.resolve(__dirname, 'node_modules/flv.js'),
+                    path.resolve(__dirname, 'node_modules/libarchive.js'),
+                    path.resolve(__dirname, 'node_modules/marked'),
+                    path.resolve(__dirname, 'node_modules/screenfull'),
+                    path.resolve(__dirname, 'src')
+                ],
                 use: [{
                     loader: 'babel-loader'
                 }]
@@ -118,7 +128,11 @@ module.exports = {
             },
             /* modules that Babel breaks when transforming to ESM */
             {
-                test: /node_modules[\\/](pdfjs-dist|xmldom)[\\/].*\.js$/,
+                test: /\.js$/,
+                include: [
+                    path.resolve(__dirname, 'node_modules/pdfjs-dist'),
+                    path.resolve(__dirname, 'node_modules/xmldom')
+                ],
                 use: [{
                     loader: 'babel-loader',
                     options: {


### PR DESCRIPTION
**Changes**
- Simplify adding modules to babel-loader
- Babelify @jellyfin/libass-wasm

**Issues**
`libass-wasm` must be transpiled because of the forgotten `const`. _This will also be helpful when migrating to ES6._
https://github.com/jellyfin/jellyfin-webos/issues/31#issuecomment-1095401463
