### PR TITLE
Fix subtitle offset reset when seeking progressive stream

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -1677,6 +1677,7 @@ class PlaybackManager {
                         const streamInfo = createStreamInfo(apiClient, currentItem.MediaType, currentItem, currentMediaSource, ticks, player);
                         streamInfo.fullscreen = currentPlayOptions.fullscreen;
                         streamInfo.lastMediaInfoQuery = lastMediaInfoQuery;
+                        streamInfo.resetSubtitleOffset = false;
 
                         if (!streamInfo.url) {
                             showPlaybackInfoErrorMessage(self, 'PlaybackErrorNoCompatibleStream');

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -365,7 +365,7 @@ function tryRemoveElement(elem) {
 
             this.#currentTime = null;
 
-            this.resetSubtitleOffset();
+            if (options.resetSubtitleOffset !== false) this.resetSubtitleOffset();
 
             return this.createMediaElement(options).then(elem => {
                 return this.updateVideoUrl(options).then(() => {


### PR DESCRIPTION
**Changes**
Add an option to prevent the subtitle offset from being reset.

**Issues**
Subtitle offset resets when seeking progressive stream.
See https://github.com/jellyfin/jellyfin-web/pull/613