### PR TITLE
Add dashboard to plugin manager.

### DIFF
--- a/src/components/pluginManager.js
+++ b/src/components/pluginManager.js
@@ -8,6 +8,7 @@ import { appRouter } from '../components/appRouter';
 import * as inputManager from '../scripts/inputManager';
 import toast from '../components/toast/toast';
 import confirm from '../components/confirm/confirm';
+import * as dashboard from '../utils/dashboard';
 
 // TODO: replace with each plugin version
 const cacheParam = new Date().getTime();
@@ -86,7 +87,8 @@ class PluginManager {
                     appRouter,
                     inputManager,
                     toast,
-                    confirm
+                    confirm,
+                    dashboard
                 });
             } else {
                 console.debug(`Loading plugin (via dynamic import): ${pluginSpec}`);

--- a/src/components/pluginManager.js
+++ b/src/components/pluginManager.js
@@ -9,6 +9,7 @@ import * as inputManager from '../scripts/inputManager';
 import toast from '../components/toast/toast';
 import confirm from '../components/confirm/confirm';
 import * as dashboard from '../utils/dashboard';
+import ServerConnections from '../components/ServerConnections';
 
 // TODO: replace with each plugin version
 const cacheParam = new Date().getTime();
@@ -88,7 +89,8 @@ class PluginManager {
                     inputManager,
                     toast,
                     confirm,
-                    dashboard
+                    dashboard,
+                    ServerConnections
                 });
             } else {
                 console.debug(`Loading plugin (via dynamic import): ${pluginSpec}`);


### PR DESCRIPTION
**Changes**
 - Add `dashboard` util to `pluginManager`. This allows using the new setTransparency method.
 - Add `ServerConnections` component to `pluginManager`. This allows accessing the api client without relying on `window.ApiClient`.

**Issues**
Relates to: #3560
Relates to: https://github.com/jellyfin/jellyfin-media-player/commit/ac1e4593564872d5aab333e1ed2025694cfeec49

Note: I left the deprecated function in place so that people can continue to test `jellyfin-web` in JMP before I do a release that contains the migration code.