### PR TITLE
Drop progressive transcoding in web client

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -689,30 +689,6 @@ export function canPlaySecondaryAudio(videoTestElement) {
             });
         });
 
-        if (canPlayMkv && !browser.tizen && options.enableMkvProgressive !== false) {
-            profile.TranscodingProfiles.push({
-                Container: 'mkv',
-                Type: 'Video',
-                AudioCodec: videoAudioCodecs.join(','),
-                VideoCodec: mp4VideoCodecs.join(','),
-                Context: 'Streaming',
-                MaxAudioChannels: physicalAudioChannels.toString(),
-                CopyTimestamps: true
-            });
-        }
-
-        if (canPlayMkv) {
-            profile.TranscodingProfiles.push({
-                Container: 'mkv',
-                Type: 'Video',
-                AudioCodec: videoAudioCodecs.join(','),
-                VideoCodec: mp4VideoCodecs.join(','),
-                Context: 'Static',
-                MaxAudioChannels: physicalAudioChannels.toString(),
-                CopyTimestamps: true
-            });
-        }
-
         if (canPlayHls() && options.enableHls !== false) {
             if (hlsInFmp4VideoCodecs.length && hlsInFmp4VideoAudioCodecs.length && userSettings.preferFmp4HlsContainer() && (browser.safari || browser.tizen || browser.web0s)) {
                 profile.TranscodingProfiles.push({
@@ -742,28 +718,6 @@ export function canPlaySecondaryAudio(videoTestElement) {
                 });
             }
         }
-
-        // Progressive mp4 transcoding
-        if (mp4VideoCodecs.length && videoAudioCodecs.length) {
-            profile.TranscodingProfiles.push({
-                Container: 'mp4',
-                Type: 'Video',
-                AudioCodec: videoAudioCodecs.join(','),
-                VideoCodec: mp4VideoCodecs.join(','),
-                Context: 'Streaming',
-                Protocol: 'http',
-                MaxAudioChannels: physicalAudioChannels.toString()
-            });
-        }
-
-        profile.TranscodingProfiles.push({
-            Container: 'mp4',
-            Type: 'Video',
-            AudioCodec: videoAudioCodecs.join(','),
-            VideoCodec: 'h264',
-            Context: 'Static',
-            Protocol: 'http'
-        });
 
         profile.ContainerProfiles = [];
 


### PR DESCRIPTION
For HEVC playback in Chrome without transcoding:
use compatible audio codecs (e.g. AAC, MP3) and MP4 container or try the Shaka-player fMP4 PR #4041

**Changes**
- Drop progressive transcoding in web client

**Issues**
- Progressive remuxing/transcoding is not reliable when seeking in browsers.
- Some changes were made on the server side to raise the priority of progressive remuxing/transcoding but didn't fully test it in various browsers and codecs such as the newly added HEVC hardware decoder in Chrome.

Fixes https://github.com/jellyfin/jellyfin/issues/9196
Fixes https://github.com/jellyfin/jellyfin/issues/9241
Fixes https://github.com/jellyfin/jellyfin/issues/9330