### PR TITLE
Fix Time Until Next Episode Text Overflow

### DIFF
--- a/src/components/upnextdialog/upnextdialog.scss
+++ b/src/components/upnextdialog/upnextdialog.scss
@@ -28,9 +28,9 @@
 
 .upNextDialog-countdownText {
     font-weight: 500;
+    white-space: nowrap;
 }
 
-.upNextDialog-nextVideoText,
 .upNextDialog-title {
     width: 25.5em;
     white-space: nowrap;


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
1. Removes Css for .upNextDialog-nextVideoText
    This stops the text "Next Episode Playing in 20 Seconds" from overflowing off the screen, and it takes up a new line underneath
"Next Episode Playing in 
20 Seconds"

2. Add Css to .upNextDialog-countdownText
    This stops the span containing the time remaining i.e "20 seconds" from overflowing.
     This forces the text to be shown on the same line. 
It Avoids this behaviour: 
"Next Episode Playing in 20 
Seconds"

<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
Fixes [4342](https://github.com/jellyfin/jellyfin-web/issues/4342)
