### PR TITLE
Fix installed plugin version html

### DIFF
--- a/src/controllers/dashboard/plugins/add/index.js
+++ b/src/controllers/dashboard/plugins/add/index.js
@@ -68,7 +68,7 @@ function renderPackage(pkg, installedPlugins, page) {
 
     if (installedPlugin) {
         const currentVersionText = globalize.translate('MessageYouHaveVersionInstalled', '<strong>' + installedPlugin.Version + '</strong>');
-        $('#pCurrentVersion', page).show().text(currentVersionText);
+        $('#pCurrentVersion', page).show().html(currentVersionText);
     } else {
         $('#pCurrentVersion', page).hide().text('');
     }


### PR DESCRIPTION
**Changes**
Fixes a regression from #4269 where the installed plugin version text prints html to the screen as text. It should be safe to just use `.html()` here since the only dynamic text is the version which is a `Version` object returned by the server as a string.

![Screenshot 2023-03-06 at 16-28-48 Jellyfin](https://user-images.githubusercontent.com/3450688/223235326-0e571d4c-9f25-45ee-b648-caaf846846f4.png)

**Issues**
N/A