### PR TITLE
fix(hls): playback should work without bundling hls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "flv.js": "1.6.2",
         "headroom.js": "0.12.0",
         "history": "5.3.0",
-        "hls.js": "1.3.4",
+        "hls.js": "1.2.4",
         "intersection-observer": "0.12.2",
         "jellyfin-apiclient": "1.10.0",
         "jquery": "3.6.3",
@@ -8468,9 +8468,9 @@
       }
     },
     "node_modules/hls.js": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.3.4.tgz",
-      "integrity": "sha512-iFEwVqtEDk6sKotcTwtJ5OMo/nuDTk9PrpB8FI2J2WYf8EriTVfR4FaK0aNyYtwbYeRSWCXJKlz23xeREdlNYg=="
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.2.4.tgz",
+      "integrity": "sha512-yC3K79Kzq1W+OgjT12JxKMDXv9DbfvulppxmPBl7D04SaTyd2IwWk5eNASQV1mUaPlKbjr16yI9292qpSGo0ig=="
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
@@ -25398,9 +25398,9 @@
       }
     },
     "hls.js": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.3.4.tgz",
-      "integrity": "sha512-iFEwVqtEDk6sKotcTwtJ5OMo/nuDTk9PrpB8FI2J2WYf8EriTVfR4FaK0aNyYtwbYeRSWCXJKlz23xeREdlNYg=="
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.2.4.tgz",
+      "integrity": "sha512-yC3K79Kzq1W+OgjT12JxKMDXv9DbfvulppxmPBl7D04SaTyd2IwWk5eNASQV1mUaPlKbjr16yI9292qpSGo0ig=="
     },
     "hoist-non-react-statics": {
       "version": "3.3.2",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "flv.js": "1.6.2",
     "headroom.js": "0.12.0",
     "history": "5.3.0",
-    "hls.js": "1.3.4",
+    "hls.js": "1.2.4",
     "intersection-observer": "0.12.2",
     "jellyfin-apiclient": "1.10.0",
     "jquery": "3.6.3",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -158,7 +158,6 @@ const config = {
                     path.resolve(__dirname, 'node_modules/dom7'),
                     path.resolve(__dirname, 'node_modules/epubjs'),
                     path.resolve(__dirname, 'node_modules/flv.js'),
-                    path.resolve(__dirname, 'node_modules/hls.js'),
                     path.resolve(__dirname, 'node_modules/libarchive.js'),
                     path.resolve(__dirname, 'node_modules/marked'),
                     path.resolve(__dirname, 'node_modules/react-router'),


### PR DESCRIPTION
**Changes**
Revert the webpack change to bundle hls.js from #4399 

**Issues**
Playback didn't work and raised a `_typeof` error.

video-dev/hls.js#1939 gave me the correct hint.
