### PR TITLE
Update SyncPlay references to use plugin

### DIFF
--- a/src/components/playerstats/playerstats.js
+++ b/src/components/playerstats/playerstats.js
@@ -4,7 +4,8 @@ import Events from '../../utils/events.ts';
 import layoutManager from '../layoutManager';
 import { playbackManager } from '../playback/playbackmanager';
 import playMethodHelper from '../playback/playmethodhelper';
-import SyncPlay from '../../plugins/syncPlay/core';
+import { pluginManager } from '../pluginManager';
+import { PluginType } from '../../types/plugin.ts';
 import './playerstats.scss';
 import ServerConnections from '../ServerConnections';
 
@@ -325,6 +326,12 @@ import ServerConnections from '../ServerConnections';
     }
 
     function getSyncPlayStats() {
+        const SyncPlay = pluginManager.firstOfType(PluginType.SyncPlay)?.instance;
+
+        if (!SyncPlay?.Manager.isSyncPlayEnabled()) {
+            return [];
+        }
+
         const syncStats = [];
         const stats = SyncPlay.Manager.getStats();
 
@@ -422,10 +429,10 @@ import ServerConnections from '../ServerConnections';
                 name: globalize.translate('LabelOriginalMediaInfo')
             });
 
-            const apiClient = ServerConnections.getApiClient(playbackManager.currentItem(player).ServerId);
-            if (SyncPlay.Manager.isSyncPlayEnabled() && apiClient.isMinServerVersion('10.6.0')) {
+            const syncPlayStats = getSyncPlayStats();
+            if (syncPlayStats.length > 0) {
                 categories.push({
-                    stats: getSyncPlayStats(),
+                    stats: syncPlayStats,
                     name: globalize.translate('LabelSyncPlayInfo')
                 });
             }

--- a/src/components/playlisteditor/playlisteditor.js
+++ b/src/components/playlisteditor/playlisteditor.js
@@ -4,10 +4,12 @@ import dialogHelper from '../dialogHelper/dialogHelper';
 import loading from '../loading/loading';
 import layoutManager from '../layoutManager';
 import { playbackManager } from '../playback/playbackmanager';
-import SyncPlay from '../../plugins/syncPlay/core';
+import { pluginManager } from '../pluginManager';
 import * as userSettings from '../../scripts/settings/userSettings';
 import { appRouter } from '../appRouter';
 import globalize from '../../scripts/globalize';
+import { PluginType } from '../../types/plugin.ts';
+
 import '../../elements/emby-button/emby-button';
 import '../../elements/emby-input/emby-input';
 import '../../elements/emby-button/paper-icon-button-light';
@@ -117,10 +119,12 @@ import ServerConnections from '../ServerConnections';
         };
 
         const apiClient = ServerConnections.getApiClient(currentServerId);
+        const SyncPlay = pluginManager.firstOfType(PluginType.SyncPlay)?.instance;
+
         apiClient.getItems(apiClient.getCurrentUserId(), options).then(result => {
             let html = '';
 
-            if ((editorOptions.enableAddToPlayQueue !== false && playbackManager.isPlaying()) || SyncPlay.Manager.isSyncPlayEnabled()) {
+            if ((editorOptions.enableAddToPlayQueue !== false && playbackManager.isPlaying()) || SyncPlay?.Manager.isSyncPlayEnabled()) {
                 html += `<option value="queue">${globalize.translate('AddToPlayQueue')}</option>`;
             }
 

--- a/src/components/pluginManager.js
+++ b/src/components/pluginManager.js
@@ -119,9 +119,14 @@ class PluginManager {
     }
 
     ofType(type) {
-        return this.pluginsList.filter((o) => {
-            return o.type === type;
-        });
+        return this.pluginsList.filter(plugin => plugin.type === type);
+    }
+
+    firstOfType(type) {
+        // Get all plugins of the specified type
+        return this.ofType(type)
+            // Return the plugin with the "highest" (lowest numeric value) priority
+            .sort((p1, p2) => (p1.priority || 0) - (p2.priority || 0))[0];
     }
 
     #mapRoute(plugin, route) {

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1,6 +1,5 @@
 import escapeHtml from 'escape-html';
 import { playbackManager } from '../../../components/playback/playbackmanager';
-import SyncPlay from '../../../plugins/syncPlay/core';
 import browser from '../../../scripts/browser';
 import dom from '../../../scripts/dom';
 import inputManager from '../../../scripts/inputManager';
@@ -25,6 +24,8 @@ import SubtitleSync from '../../../components/subtitlesync/subtitlesync';
 import { appRouter } from '../../../components/appRouter';
 import LibraryMenu from '../../../scripts/libraryMenu';
 import { setBackdropTransparency, TRANSPARENCY_LEVEL } from '../../../components/backdrop/backdrop';
+import { pluginManager } from '../../../components/pluginManager';
+import { PluginType } from '../../../types/plugin.ts';
 
 /* eslint-disable indent */
     const TICKS_PER_MINUTE = 600000000;
@@ -1774,38 +1775,39 @@ import { setBackdropTransparency, TRANSPARENCY_LEVEL } from '../../../components
             }, iconVisibilityTime);
         };
 
-        Events.on(SyncPlay.Manager, 'enabled', (event, enabled) => {
-            if (enabled) {
-                // SyncPlay enabled
-            } else {
-                const syncPlayIcon = view.querySelector('#syncPlayIcon');
-                syncPlayIcon.style.visibility = 'hidden';
-            }
-        });
+        const SyncPlay = pluginManager.firstOfType(PluginType.SyncPlay)?.instance;
+        if (SyncPlay) {
+            Events.on(SyncPlay.Manager, 'enabled', (_event, enabled) => {
+                if (!enabled) {
+                    const syncPlayIcon = view.querySelector('#syncPlayIcon');
+                    syncPlayIcon.style.visibility = 'hidden';
+                }
+            });
 
-        Events.on(SyncPlay.Manager, 'notify-osd', (event, action) => {
-            showIcon(action);
-        });
+            Events.on(SyncPlay.Manager, 'notify-osd', (_event, action) => {
+                showIcon(action);
+            });
 
-        Events.on(SyncPlay.Manager, 'group-state-update', (event, state, reason) => {
-            if (state === 'Playing' && reason === 'Unpause') {
-                showIcon('schedule-play');
-            } else if (state === 'Playing' && reason === 'Ready') {
-                showIcon('schedule-play');
-            } else if (state === 'Paused' && reason === 'Pause') {
-                showIcon('pause');
-            } else if (state === 'Paused' && reason === 'Ready') {
-                showIcon('clear');
-            } else if (state === 'Waiting' && reason === 'Seek') {
-                showIcon('seek');
-            } else if (state === 'Waiting' && reason === 'Buffer') {
-                showIcon('buffering');
-            } else if (state === 'Waiting' && reason === 'Pause') {
-                showIcon('wait-pause');
-            } else if (state === 'Waiting' && reason === 'Unpause') {
-                showIcon('wait-unpause');
-            }
-        });
+            Events.on(SyncPlay.Manager, 'group-state-update', (_event, state, reason) => {
+                if (state === 'Playing' && reason === 'Unpause') {
+                    showIcon('schedule-play');
+                } else if (state === 'Playing' && reason === 'Ready') {
+                    showIcon('schedule-play');
+                } else if (state === 'Paused' && reason === 'Pause') {
+                    showIcon('pause');
+                } else if (state === 'Paused' && reason === 'Ready') {
+                    showIcon('clear');
+                } else if (state === 'Waiting' && reason === 'Seek') {
+                    showIcon('seek');
+                } else if (state === 'Waiting' && reason === 'Buffer') {
+                    showIcon('buffering');
+                } else if (state === 'Waiting' && reason === 'Pause') {
+                    showIcon('wait-pause');
+                } else if (state === 'Waiting' && reason === 'Unpause') {
+                    showIcon('wait-unpause');
+                }
+            });
+        }
     }
 
 /* eslint-enable indent */

--- a/src/plugins/syncPlay/plugin.ts
+++ b/src/plugins/syncPlay/plugin.ts
@@ -12,6 +12,7 @@ class SyncPlayPlugin implements Plugin {
     id: string;
     type: string;
     priority: number;
+    instance: typeof SyncPlay;
 
     constructor() {
         this.name = 'SyncPlay Plugin';
@@ -20,6 +21,8 @@ class SyncPlayPlugin implements Plugin {
         // SyncPlay needs refactored so it does not have an independent playback manager.
         this.type = PluginType.SyncPlay;
         this.priority = 1;
+
+        this.instance = SyncPlay;
 
         this.init();
     }

--- a/src/plugins/syncPlay/ui/settings/SettingsEditor.js
+++ b/src/plugins/syncPlay/ui/settings/SettingsEditor.js
@@ -3,13 +3,14 @@
  * @module components/syncPlay/settings/SettingsEditor
  */
 
-import SyncPlay from '../../core';
 import { setSetting } from '../../core/Settings';
 import dialogHelper from '../../../../components/dialogHelper/dialogHelper';
 import layoutManager from '../../../../components/layoutManager';
+import { pluginManager } from '../../../../components/pluginManager';
 import loading from '../../../../components/loading/loading';
 import toast from '../../../../components/toast/toast';
 import globalize from '../../../../scripts/globalize';
+import { PluginType } from '../../../../types/plugin.ts';
 import Events from '../../../../utils/events.ts';
 
 import 'material-design-icons-iconfont';
@@ -36,6 +37,7 @@ class SettingsEditor {
         this.apiClient = apiClient;
         this.timeSyncCore = timeSyncCore;
         this.options = options;
+        this.SyncPlay = pluginManager.firstOfType(PluginType.SyncPlay)?.instance;
     }
 
     async embed() {
@@ -95,14 +97,14 @@ class SettingsEditor {
     async initEditor() {
         const { context } = this;
 
-        context.querySelector('#txtExtraTimeOffset').value = SyncPlay.Manager.timeSyncCore.extraTimeOffset;
-        context.querySelector('#chkSyncCorrection').checked = SyncPlay.Manager.playbackCore.enableSyncCorrection;
-        context.querySelector('#txtMinDelaySpeedToSync').value = SyncPlay.Manager.playbackCore.minDelaySpeedToSync;
-        context.querySelector('#txtMaxDelaySpeedToSync').value = SyncPlay.Manager.playbackCore.maxDelaySpeedToSync;
-        context.querySelector('#txtSpeedToSyncDuration').value = SyncPlay.Manager.playbackCore.speedToSyncDuration;
-        context.querySelector('#txtMinDelaySkipToSync').value = SyncPlay.Manager.playbackCore.minDelaySkipToSync;
-        context.querySelector('#chkSpeedToSync').checked = SyncPlay.Manager.playbackCore.useSpeedToSync;
-        context.querySelector('#chkSkipToSync').checked = SyncPlay.Manager.playbackCore.useSkipToSync;
+        context.querySelector('#txtExtraTimeOffset').value = this.SyncPlay?.Manager.timeSyncCore.extraTimeOffset;
+        context.querySelector('#chkSyncCorrection').checked = this.SyncPlay?.Manager.playbackCore.enableSyncCorrection;
+        context.querySelector('#txtMinDelaySpeedToSync').value = this.SyncPlay?.Manager.playbackCore.minDelaySpeedToSync;
+        context.querySelector('#txtMaxDelaySpeedToSync').value = this.SyncPlay?.Manager.playbackCore.maxDelaySpeedToSync;
+        context.querySelector('#txtSpeedToSyncDuration').value = this.SyncPlay?.Manager.playbackCore.speedToSyncDuration;
+        context.querySelector('#txtMinDelaySkipToSync').value = this.SyncPlay?.Manager.playbackCore.minDelaySkipToSync;
+        context.querySelector('#chkSpeedToSync').checked = this.SyncPlay?.Manager.playbackCore.useSpeedToSync;
+        context.querySelector('#chkSkipToSync').checked = this.SyncPlay?.Manager.playbackCore.useSkipToSync;
     }
 
     onSubmit() {
@@ -139,7 +141,7 @@ class SettingsEditor {
         setSetting('useSpeedToSync', useSpeedToSync);
         setSetting('useSkipToSync', useSkipToSync);
 
-        Events.trigger(SyncPlay.Manager, 'settings-update');
+        Events.trigger(this.SyncPlay?.Manager, 'settings-update');
     }
 }
 

--- a/src/scripts/serverNotifications.js
+++ b/src/scripts/serverNotifications.js
@@ -1,5 +1,5 @@
 import { playbackManager } from '../components/playback/playbackmanager';
-import SyncPlay from '../plugins/syncPlay/core';
+import { pluginManager } from '../components/pluginManager';
 import inputManager from '../scripts/inputManager';
 import focusManager from '../components/focusManager';
 import { appRouter } from '../components/appRouter';
@@ -7,6 +7,7 @@ import ServerConnections from '../components/ServerConnections';
 import toast from '../components/toast/toast';
 import alert from '../components/alert';
 import Events from '../utils/events.ts';
+import { PluginType } from '../types/plugin.ts';
 
 const serverNotifications = {};
 
@@ -140,6 +141,8 @@ function processGeneralCommand(cmd, apiClient) {
 
 function onMessageReceived(e, msg) {
     const apiClient = this;
+    const SyncPlay = pluginManager.firstOfType(PluginType.SyncPlay)?.instance;
+
     if (msg.MessageType === 'Play') {
         notifyApp();
         const serverId = apiClient.serverInfo().Id;
@@ -186,9 +189,9 @@ function onMessageReceived(e, msg) {
             }
         }
     } else if (msg.MessageType === 'SyncPlayCommand') {
-        SyncPlay.Manager.processCommand(msg.Data, apiClient);
+        SyncPlay?.Manager.processCommand(msg.Data, apiClient);
     } else if (msg.MessageType === 'SyncPlayGroupUpdate') {
-        SyncPlay.Manager.processGroupUpdate(msg.Data, apiClient);
+        SyncPlay?.Manager.processGroupUpdate(msg.Data, apiClient);
     } else {
         Events.trigger(serverNotifications, msg.MessageType, [apiClient, msg.Data]);
     }

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -9,5 +9,5 @@ export interface Plugin {
     name: string
     id: string
     type: PluginType | string
-    priority: number
+    priority?: number
 }


### PR DESCRIPTION
**Changes**
Use plugin manager for all SyncPlay references. This makes SyncPlay completely isolated to a plugin... at least as much as possible currently.

**Issues**
N/A