### PR TITLE
Use form validation to ensure required fields are filled on submission

### DIFF
--- a/src/components/mediaLibraryCreator/mediaLibraryCreator.js
+++ b/src/components/mediaLibraryCreator/mediaLibraryCreator.js
@@ -25,7 +25,7 @@ import toast from '../toast/toast';
 import alert from '../alert';
 import template from './mediaLibraryCreator.template.html';
 
-    function onAddLibrary() {
+    function onAddLibrary(e) {
         if (isCreating) {
             return false;
         }
@@ -62,7 +62,7 @@ import template from './mediaLibraryCreator.template.html';
             isCreating = false;
             loading.hide();
         });
-        return false;
+        e.preventDefault();
     }
 
     function getCollectionTypeOptionsHtml(collectionTypeOptions) {
@@ -96,7 +96,7 @@ import template from './mediaLibraryCreator.template.html';
             $('.collectionTypeFieldDescription', dlg).html(folderOption?.message || '');
         });
         page.querySelector('.btnAddFolder').addEventListener('click', onAddButtonClick);
-        page.querySelector('.btnSubmit').addEventListener('click', onAddLibrary);
+        page.querySelector('.addLibraryForm').addEventListener('submit', onAddLibrary);
         page.querySelector('.folderList').addEventListener('click', onRemoveClick);
     }
 

--- a/src/components/mediaLibraryCreator/mediaLibraryCreator.template.html
+++ b/src/components/mediaLibraryCreator/mediaLibraryCreator.template.html
@@ -1,37 +1,39 @@
-<div class="formDialogHeader">
-    <button type="button" is="paper-icon-button-light" class="btnCancel autoSize" tabindex="-1" title="${ButtonBack}"><span class="material-icons arrow_back" aria-hidden="true"></span></button>
-    <h3 class="formDialogHeaderTitle">${ButtonAddMediaLibrary}</h3>
-</div>
-
-<div class="formDialogContent scrollY" style="padding-top:2em;">
-    <div class="dialogContentInner dialog-content-centered">
-
-        <div id="fldCollectionType" class="selectContainer">
-            <select is="emby-select" id="selectCollectionType" data-mini="true" required="required" label="${LabelContentType}"></select>
-            <div class="collectionTypeFieldDescription fieldDescription">
-            </div>
-        </div>
-
-        <div class="inputContainer">
-            <input is="emby-input" type="text" id="txtValue" required="required" label="${LabelDisplayName}" />
-        </div>
-
-        <div class="folders">
-            <div style="display: flex; align-items: center;">
-                <h1 style="margin: .5em 0;">${Folders}</h1>
-                <button is="emby-button" type="button" class="fab btnAddFolder submit" title="${Add}">
-                    <span class="material-icons add" aria-hidden="true"></span>
-                </button>
-            </div>
-            <div class="paperList folderList hide" style="margin-bottom:2em;"></div>
-        </div>
-
-        <div class="libraryOptions"></div>
+<form class="addLibraryForm" style="max-width:100%;">
+    <div class="formDialogHeader">
+        <button type="button" is="paper-icon-button-light" class="btnCancel autoSize" tabindex="-1" title="${ButtonBack}"><span class="material-icons arrow_back" aria-hidden="true"></span></button>
+        <h3 class="formDialogHeaderTitle">${ButtonAddMediaLibrary}</h3>
     </div>
-</div>
 
-<div class="formDialogFooter">
-    <button is="emby-button" type="button" class="raised btnSubmit button-submit block formDialogFooterItem">
-        <span>${ButtonOk}</span>
-    </button>
-</div>
+    <div class="formDialogContent scrollY" style="padding-top:2em;">
+        <div class="dialogContentInner dialog-content-centered">
+
+            <div id="fldCollectionType" class="selectContainer">
+                <select is="emby-select" id="selectCollectionType" data-mini="true" required="required" label="${LabelContentType}"></select>
+                <div class="collectionTypeFieldDescription fieldDescription">
+                </div>
+            </div>
+
+            <div class="inputContainer">
+                <input is="emby-input" type="text" id="txtValue" required="required" label="${LabelDisplayName}" />
+            </div>
+
+            <div class="folders">
+                <div style="display: flex; align-items: center;">
+                    <h1 style="margin: .5em 0;">${Folders}</h1>
+                    <button is="emby-button" type="button" class="fab btnAddFolder submit" title="${Add}">
+                        <span class="material-icons add" aria-hidden="true"></span>
+                    </button>
+                </div>
+                <div class="paperList folderList hide" style="margin-bottom:2em;"></div>
+            </div>
+
+            <div class="libraryOptions"></div>
+        </div>
+    </div>
+
+    <div class="formDialogFooter">
+        <button is="emby-button" type="submit" class="raised btnSubmit button-submit block formDialogFooterItem">
+            <span>${ButtonOk}</span>
+        </button>
+    </div>
+</form>


### PR DESCRIPTION
I was testing library types and discovered that there's no validation on the first two required fields on the new library dialog: You can submit with no name set (results in a null error in the console) and no type selected (results in mixed, because server-side mixed is the default)

As far as I can tell it's because it's not actually in a form, so it doesn't get form checks on submission.

The inline style applied to the form feels wrong, but I couldn't figure out a different way to retain page behavior without it. I'd be happy to accept any suggestions.

**Changes**
- Wrap the new library dialog in a form for validation
