### PR TITLE
Fix missing port number in German translation

### DIFF
--- a/src/strings/de.json
+++ b/src/strings/de.json
@@ -634,7 +634,7 @@
     "LabelSerialNumber": "Seriennummer:",
     "LabelSeriesRecordingPath": "Serien Aufnahmepfad:",
     "LabelServerHost": "Adresse:",
-    "LabelServerHostHelp": "192.168.1.100 oder https://myserver.com",
+    "LabelServerHostHelp": "192.168.1.100:8096 oder https://myserver.com",
     "LabelSimultaneousConnectionLimit": "Paralleler Streamlimit:",
     "LabelSkipBackLength": "Sprungweite rückwärts:",
     "LabelSkipForwardLength": "Sprungweite vorwärts:",


### PR DESCRIPTION
See https://github.com/jellyfin/jellyfin-media-player/issues/288#issuecomment-1474852988