### PR TITLE
Fix the stale action removing the merge conflict label when not fixed

### DIFF
--- a/.github/workflows/repo-stale.yaml
+++ b/.github/workflows/repo-stale.yaml
@@ -41,6 +41,8 @@ jobs:
         with:
           repo-token: ${{ secrets.JF_BOT_TOKEN }}
           operations-per-run: 75
+          # The merge conflict action will remove the label when updated
+          remove-stale-when-updated: false
           days-before-stale: -1
           days-before-close: 90
           days-before-issue-close: -1


### PR DESCRIPTION
**Changes**
Fixes an issue where the stale action was removing the "merge conflict" label when conflicts still exist

See: https://github.com/jellyfin/jellyfin-web/pull/4390#issuecomment-1479904358

**Issues**
N/A