### PR TITLE
Fix centos build

### DIFF
--- a/deployment/Dockerfile.centos
+++ b/deployment/Dockerfile.centos
@@ -1,4 +1,4 @@
-FROM centos:stream8
+FROM quay.io/centos/centos:stream8
 
 # Docker build arguments
 ARG SOURCE_DIR=/jellyfin


### PR DESCRIPTION
#4464 didn't work because centos no longer uses dockerhub - they use quay.io

**Changes**
- Update centos image so build passes CI

