### PR TITLE
Change default timer delay

### DIFF
--- a/src/components/slideshow/slideshow.js
+++ b/src/components/slideshow/slideshow.js
@@ -613,7 +613,7 @@ export default function (options) {
      */
     function startHideTimer() {
         stopHideTimer();
-        hideTimeout = setTimeout(hideOsd, 3000);
+        hideTimeout = setTimeout(hideOsd, 7000);
     }
 
     /**


### PR DESCRIPTION
Modified default timer delay from 3 to 7 seconds.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->


