### PR TITLE
Add Collections list to Item Details

### DIFF
--- a/src/controllers/itemDetails/index.html
+++ b/src/controllers/itemDetails/index.html
@@ -231,6 +231,13 @@
                     </div>
                 </div>
 
+                <div id="collectionsItemIsInCollapsible" class="verticalSection detailVerticalSection hide">
+                    <h2 class="sectionTitle sectionTitle-cards padded-right">${Collections}</h2>
+                    <div is="emby-scroller" class="padded-top-focusscale padded-bottom-focusscale" data-centerfocus="true">
+                        <div is="emby-itemscontainer" class="scrollSlider focuscontainer-x itemsContainer collectionsItemIsInContent"></div>
+                    </div>
+                </div>
+
                 <div id="similarCollapsible" class="verticalSection detailVerticalSection verticalSection-extrabottompadding hide">
                     <h2 class="sectionTitle sectionTitle-cards padded-right">${HeaderMoreLikeThis}</h2>
                     <div is="emby-scroller" class="padded-top-focusscale padded-bottom-focusscale" data-centerfocus="true">


### PR DESCRIPTION
**Changes**
Adds Collections to an Item detail page. I saw this todo and started messing around with it (and with it learning a bit of the API client). 

So I tried to get a list of BoxSets with the parent ID set to the item being rendered however that didn't work and just returned all box sets so I just looped through them, if this is something we want to wait for on the server side so that getting this information is easier and not have to do a bunch of API calls on the client to search through the collections then let me know and I can close this PR until that is done.

I also assumed that only Movies, Trailers, Series, Programs, Recordings, MusicAlbums, MusicArtists, and Playlists were what you can add to a collection, let me know if I need to add or remove any content types

**Issues**
[Roadmap Issue](https://trello.com/c/cH7IMbst/47-add-collections-to-item-details-screen)
[Feature Request](https://features.jellyfin.org/posts/540/list-all-collections-that-a-movie-belong-to-in-movie-details)
