### PR TITLE
Fix rewind and fast forward buttons not showing on audio books in mobile layout

### DIFF
--- a/src/components/remotecontrol/remotecontrol.js
+++ b/src/components/remotecontrol/remotecontrol.js
@@ -325,10 +325,11 @@ export default function () {
         if (layoutManager.mobile) {
             const playingVideo = playbackManager.isPlayingVideo() && item !== null;
             const playingAudio = !playbackManager.isPlayingVideo() && item !== null;
-            buttonVisible(context.querySelector('.btnRepeat'), playingAudio);
-            buttonVisible(context.querySelector('.btnShuffleQueue'), playingAudio);
-            buttonVisible(context.querySelector('.btnRewind'), playingVideo);
-            buttonVisible(context.querySelector('.btnFastForward'), playingVideo);
+            const playingAudioBook = playingAudio && item.Type == 'AudioBook';
+            buttonVisible(context.querySelector('.btnRepeat'), playingAudio && !playingAudioBook);
+            buttonVisible(context.querySelector('.btnShuffleQueue'), playingAudio && !playingAudioBook);
+            buttonVisible(context.querySelector('.btnRewind'), playingVideo || playingAudioBook);
+            buttonVisible(context.querySelector('.btnFastForward'), playingVideo || playingAudioBook);
             buttonVisible(context.querySelector('.nowPlayingSecondaryButtons .btnShuffleQueue'), playingVideo);
             buttonVisible(context.querySelector('.nowPlayingSecondaryButtons .btnRepeat'), playingVideo);
         } else {


### PR DESCRIPTION
**Changes**
In mobile view make the rewind and fast forward 10 seconds buttons visible on audiobook content, and hid shuffle and repeat on audiobook content, other audio type content will be unaffected

**Issues**
Fixes #4319 

**Screenshots**
Audio Book Mobile Controls (changed)
![image](https://user-images.githubusercontent.com/18491002/232248844-6ee4ab59-d6c9-443e-abc1-cebddbfdb472.png)
Music Mobile Controls (not changed)
![image](https://user-images.githubusercontent.com/18491002/232248820-2c1f3635-17ab-4658-810a-b02a3e492633.png)

