### PR TITLE
Fix missing invalid issue number for rebase failed comment

### DIFF
--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -31,6 +31,6 @@ jobs:
         uses: peter-evans/create-or-update-comment@3383acd359705b10cb1eeef05c0e88c056ea4666 # v3.0.0
         with:
           token: ${{ secrets.JF_BOT_TOKEN }}
-          issue-number: ${{ github.event.issue.id }}
+          issue-number: ${{ github.event.issue.number }}
           body: |
             I'm sorry @${{ github.event.comment.user.login }}, I'm afraid I can't do that.


### PR DESCRIPTION
**Changes**
TIL issue id is not the same as an issue number on GH

**Issues**
N/A