### PR TITLE
Remove node max space setting

### DIFF
--- a/.ci/azure-pipelines-build.yml
+++ b/.ci/azure-pipelines-build.yml
@@ -28,10 +28,14 @@ jobs:
     displayName: 'Install Dependencies'
 
   - script: 'npm run build:development'
+    env:
+        NODE_OPTIONS: --max_old_space_size=6144
     displayName: 'Build Development'
     condition: eq(variables['BuildConfiguration'], 'development')
 
   - script: 'npm run build:production'
+    env:
+        NODE_OPTIONS: --max_old_space_size=6144
     displayName: 'Build Production'
     condition: eq(variables['BuildConfiguration'], 'production')
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,8 @@ jobs:
         run: npm ci --no-audit
 
       - name: Run a production build
+        env:
+            NODE_OPTIONS: --max_old_space_size=6144
         run: npm run build:production
 
       - name: Run es-check

--- a/package.json
+++ b/package.json
@@ -132,8 +132,8 @@
   "scripts": {
     "start": "npm run serve",
     "serve": "webpack serve --config webpack.dev.js",
-    "build:development": "cross-env NODE_OPTIONS=\"--max_old_space_size=6144\" webpack --config webpack.dev.js",
-    "build:production": "cross-env NODE_ENV=\"production\" NODE_OPTIONS=\"--max_old_space_size=6144\" webpack --config webpack.prod.js",
+    "build:development": "cross-env webpack --config webpack.dev.js",
+    "build:production": "cross-env NODE_ENV=\"production\" webpack --config webpack.prod.js",
     "build:check": "tsc --noEmit",
     "escheck": "es-check",
     "lint": "eslint \"./\"",


### PR DESCRIPTION
**Changes**
Removes the configuration of the `max_old_space_size` from the node build scripts and adds it to CI configuration as needed. This should be set locally based on the available ram of an individual system if needed.

**Issues**
N/A