### PR TITLE
Remove duplicated app elements

### DIFF
--- a/src/RootApp.tsx
+++ b/src/RootApp.tsx
@@ -3,8 +3,6 @@ import { History } from '@remix-run/router';
 import React from 'react';
 
 import StableApp from './apps/stable/App';
-import AppHeader from './components/AppHeader';
-import Backdrop from './components/Backdrop';
 import { HistoryRouter } from './components/HistoryRouter';
 import { ApiProvider } from './hooks/useApi';
 
@@ -16,17 +14,11 @@ const RootApp = ({ history }: { history: History }) => {
     return (
         <ApiProvider>
             <HistoryRouter history={history}>
-                <Backdrop />
-                <AppHeader />
-
-                <div className='mainAnimatedPages skinBody' />
-                <div className='skinBody'>
-                    {
-                        layoutMode === 'experimental' ?
-                            <ExperimentalApp /> :
-                            <StableApp />
-                    }
-                </div>
+                {
+                    layoutMode === 'experimental' ?
+                        <ExperimentalApp /> :
+                        <StableApp />
+                }
             </HistoryRouter>
         </ApiProvider>
     );


### PR DESCRIPTION
**Changes**
Removes duplicated elements that were moved to the stable/experimental app instances in #4547 but not removed from the root :sweat_smile: 

**Issues**
Fixes `ViewManagerPage` instances failing to display on master
