### PR TITLE
Add support for absolute imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -88,14 +88,22 @@ module.exports = {
         react: {
             version: 'detect'
         },
-        'import/extensions': [
-            '.js',
-            '.ts',
-            '.jsx',
-            '.tsx'
-        ],
         'import/parsers': {
             '@typescript-eslint/parser': [ '.ts', '.tsx' ]
+        },
+        'import/resolver': {
+            node: {
+                extensions: [
+                    '.js',
+                    '.ts',
+                    '.jsx',
+                    '.tsx'
+                ],
+                moduleDirectory: [
+                    'node_modules',
+                    'src'
+                ]
+            }
         },
         polyfills: [
             // Native Promises Only

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": "src",
     "target": "ES5",
     "lib": ["DOM", "DOM.Iterable", "ES2015"],
     "allowJs": true,

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -31,6 +31,7 @@ const config = {
     resolve: {
         extensions: ['.tsx', '.ts', '.js'],
         modules: [
+            path.resolve(__dirname, 'src'),
             path.resolve(__dirname, 'node_modules')
         ]
     },


### PR DESCRIPTION
**Changes**
Adds support for absolute imports from the `src/` directory, so instead of having something like `import foo from '../../../../utils/foo';`, we can just use `import foo from 'utils/foo';`.

**Issues**
N/A
