### PR TITLE
Fix bottom video controls don't auto-hide

### DIFF
--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -510,11 +510,11 @@ import { appRouter } from '../../../components/appRouter';
         }
 
         function onBeginFetch() {
-            document.querySelector('.osdMediaStatus').classList.remove('hide');
+            view.querySelector('.osdMediaStatus').classList.remove('hide');
         }
 
         function onEndFetch() {
-            document.querySelector('.osdMediaStatus').classList.add('hide');
+            view.querySelector('.osdMediaStatus').classList.add('hide');
         }
 
         function bindToPlayer(player) {
@@ -1308,7 +1308,7 @@ import { appRouter } from '../../../components/appRouter';
         const btnFastForward = view.querySelector('.btnFastForward');
         const transitionEndEventName = dom.whichTransitionEvent();
         const headerElement = document.querySelector('.skinHeader');
-        const osdBottomElement = document.querySelector('.videoOsdBottom-maincontrols');
+        const osdBottomElement = view.querySelector('.videoOsdBottom-maincontrols');
 
         nowPlayingPositionSlider.enableKeyboardDragging();
         nowPlayingVolumeSlider.enableKeyboardDragging();


### PR DESCRIPTION
Following the steps from https://github.com/jellyfin/jellyfin-web/issues/1865#issuecomment-1531340243, there are 2 `videoOsd` views. The [query selector](https://github.com/jellyfin/jellyfin-web/blob/c0012de9277fafe0a53ea1e9f1112fabbe9259fa/src/controllers/playback/video/index.js#L1440) targets `document`, and it retrieves the first available element - from the previous view instead of the actual one.

**Changes**
Fix query selector target.

**Issues**
#1865 (https://github.com/jellyfin/jellyfin-web/issues/1865#issuecomment-1531340243)
