### PR TITLE
Use typescript eslint parser for all files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,8 +2,9 @@ const restrictedGlobals = require('confusing-browser-globals');
 
 module.exports = {
     root: true,
+    parser: '@typescript-eslint/parser',
     plugins: [
-        '@babel',
+        '@typescript-eslint',
         'react',
         'promise',
         'import',
@@ -15,14 +16,6 @@ module.exports = {
         es6: true,
         es2017: true,
         es2020: true
-    },
-    parserOptions: {
-        ecmaVersion: 2020,
-        sourceType: 'module',
-        ecmaFeatures: {
-            impliedStrict: true,
-            jsx: true
-        }
     },
     extends: [
         'eslint:recommended',
@@ -53,14 +46,19 @@ module.exports = {
         'no-multi-spaces': ['error'],
         'no-multiple-empty-lines': ['error', { 'max': 1 }],
         'no-nested-ternary': ['error'],
+        'no-redeclare': ['off'],
+        '@typescript-eslint/no-redeclare': ['error', { builtinGlobals: false }],
         'no-restricted-globals': ['error'].concat(restrictedGlobals),
         'no-return-assign': ['error'],
         'no-return-await': ['error'],
         'no-sequences': ['error', { 'allowInParentheses': false }],
-        'no-shadow': ['error'],
+        'no-shadow': ['off'],
+        '@typescript-eslint/no-shadow': ['error'],
         'no-trailing-spaces': ['error'],
-        '@babel/no-unused-expressions': ['error', { 'allowShortCircuit': true, 'allowTernary': true, 'allowTaggedTemplates': true }],
-        'no-useless-constructor': ['error'],
+        'no-unused-expressions': ['off'],
+        '@typescript-eslint/no-unused-expressions': ['error', { 'allowShortCircuit': true, 'allowTernary': true, 'allowTaggedTemplates': true }],
+        'no-useless-constructor': ['off'],
+        '@typescript-eslint/no-useless-constructor': ['error'],
         'no-var': ['error'],
         'no-void': ['error', { 'allowAsStatement': true }],
         'no-warning-comments': ['warn', { 'terms': ['fixme', 'hack', 'xxx'] }],
@@ -71,7 +69,7 @@ module.exports = {
         'prefer-const': ['error', { 'destructuring': 'all' }],
         'quotes': ['error', 'single', { 'avoidEscape': true, 'allowTemplateLiterals': false }],
         'radix': ['error'],
-        '@babel/semi': ['error'],
+        '@typescript-eslint/semi': ['error'],
         'space-before-blocks': ['error'],
         'space-infix-ops': 'error',
         'yoda': 'error',
@@ -201,9 +199,9 @@ module.exports = {
             files: [
                 './src/**/*.js',
                 './src/**/*.jsx',
-                './src/**/*.ts'
+                './src/**/*.ts',
+                './src/**/*.tsx'
             ],
-            parser: '@babel/eslint-parser',
             env: {
                 node: false,
                 amd: true,
@@ -241,8 +239,6 @@ module.exports = {
                 'TaskButton': 'writable',
                 'UserParentalControlPage': 'writable',
                 'Windows': 'readonly'
-            },
-            rules: {
             }
         },
         // TypeScript source files
@@ -251,8 +247,6 @@ module.exports = {
                 './src/**/*.ts',
                 './src/**/*.tsx'
             ],
-            parser: '@typescript-eslint/parser',
-            plugins: ['@typescript-eslint'],
             extends: [
                 'eslint:recommended',
                 'plugin:import/typescript',
@@ -263,12 +257,6 @@ module.exports = {
                 'plugin:jsx-a11y/recommended'
             ],
             rules: {
-                // Use TypeScript equivalent rules when required
-                'no-shadow': ['off'],
-                '@typescript-eslint/no-shadow': ['error'],
-                'no-useless-constructor': ['off'],
-                '@typescript-eslint/no-useless-constructor': ['error'],
-
                 'sonarjs/cognitive-complexity': ['warn']
             }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,8 +56,6 @@
       },
       "devDependencies": {
         "@babel/core": "7.21.4",
-        "@babel/eslint-parser": "7.21.3",
-        "@babel/eslint-plugin": "7.19.1",
         "@babel/plugin-proposal-class-properties": "7.18.6",
         "@babel/plugin-proposal-private-methods": "7.18.6",
         "@babel/plugin-transform-modules-umd": "7.18.6",
@@ -223,40 +221,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@babel/eslint-parser": {
-      "version": "7.21.3",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.21.3.tgz",
-      "integrity": "sha512-kfhmPimwo6k4P8zxNs8+T7yR44q1LdpsZdE1NkCsVlfiuTPRfnGgjaF8Qgug9q9Pou17u6wneYF0lDCZJATMFg==",
-      "dev": true,
-      "dependencies": {
-        "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
-        "eslint-visitor-keys": "^2.1.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": ">=7.11.0",
-        "eslint": "^7.5.0 || ^8.0.0"
-      }
-    },
-    "node_modules/@babel/eslint-plugin": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-plugin/-/eslint-plugin-7.19.1.tgz",
-      "integrity": "sha512-ElGPkQPapKMa3zVqXHkZYzuL7I5LbRw9UWBUArgWsdWDDb9XcACqOpBib5tRPA9XvbVZYrFUkoQPbiJ4BFvu4w==",
-      "dev": true,
-      "dependencies": {
-        "eslint-rule-composer": "^0.3.0"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
-      },
-      "peerDependencies": {
-        "@babel/eslint-parser": ">=7.11.0",
-        "eslint": ">=7.5.0"
       }
     },
     "node_modules/@babel/generator": {
@@ -2900,15 +2864,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
-      "version": "5.1.1-v1",
-      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
-      "integrity": "sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==",
-      "dev": true,
-      "dependencies": {
-        "eslint-scope": "5.1.1"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -7232,15 +7187,6 @@
         "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/eslint-rule-composer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
-      "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -7252,15 +7198,6 @@
       },
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/eslint-visitor-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/eslint/node_modules/ajv": {
@@ -20171,26 +20108,6 @@
         "semver": "^6.3.0"
       }
     },
-    "@babel/eslint-parser": {
-      "version": "7.21.3",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.21.3.tgz",
-      "integrity": "sha512-kfhmPimwo6k4P8zxNs8+T7yR44q1LdpsZdE1NkCsVlfiuTPRfnGgjaF8Qgug9q9Pou17u6wneYF0lDCZJATMFg==",
-      "dev": true,
-      "requires": {
-        "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
-        "eslint-visitor-keys": "^2.1.0",
-        "semver": "^6.3.0"
-      }
-    },
-    "@babel/eslint-plugin": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-plugin/-/eslint-plugin-7.19.1.tgz",
-      "integrity": "sha512-ElGPkQPapKMa3zVqXHkZYzuL7I5LbRw9UWBUArgWsdWDDb9XcACqOpBib5tRPA9XvbVZYrFUkoQPbiJ4BFvu4w==",
-      "dev": true,
-      "requires": {
-        "eslint-rule-composer": "^0.3.0"
-      }
-    },
     "@babel/generator": {
       "version": "7.21.4",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.4.tgz",
@@ -21936,15 +21853,6 @@
       "requires": {
         "call-me-maybe": "^1.0.1",
         "glob-to-regexp": "^0.3.0"
-      }
-    },
-    "@nicolo-ribaudo/eslint-scope-5-internals": {
-      "version": "5.1.1-v1",
-      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
-      "integrity": "sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==",
-      "dev": true,
-      "requires": {
-        "eslint-scope": "5.1.1"
       }
     },
     "@nodelib/fs.scandir": {
@@ -25452,12 +25360,6 @@
       "dev": true,
       "requires": {}
     },
-    "eslint-rule-composer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
-      "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
-      "dev": true
-    },
     "eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -25467,12 +25369,6 @@
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
       }
-    },
-    "eslint-visitor-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-      "dev": true
     },
     "espree": {
       "version": "9.5.1",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,6 @@
   "license": "GPL-2.0-or-later",
   "devDependencies": {
     "@babel/core": "7.21.4",
-    "@babel/eslint-parser": "7.21.3",
-    "@babel/eslint-plugin": "7.19.1",
     "@babel/plugin-proposal-class-properties": "7.18.6",
     "@babel/plugin-proposal-private-methods": "7.18.6",
     "@babel/plugin-transform-modules-umd": "7.18.6",

--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -1118,7 +1118,6 @@ let refreshIndicatorLoaded;
 function importRefreshIndicator() {
     if (!refreshIndicatorLoaded) {
         refreshIndicatorLoaded = true;
-        /* eslint-disable-next-line  @babel/no-unused-expressions */
         import('../../elements/emby-itemrefreshindicator/emby-itemrefreshindicator');
     }
 }
@@ -1469,7 +1468,6 @@ function getHoverMenuHtml(item, action) {
     const userData = item.UserData || {};
 
     if (itemHelper.canMarkPlayed(item)) {
-        /* eslint-disable-next-line  @babel/no-unused-expressions */
         import('../../elements/emby-playstatebutton/emby-playstatebutton');
         html += '<button is="emby-playstatebutton" type="button" data-action="none" class="' + btnCssClass + '" data-id="' + item.Id + '" data-serverid="' + item.ServerId + '" data-itemtype="' + item.Type + '" data-played="' + (userData.Played) + '"><span class="material-icons cardOverlayButtonIcon cardOverlayButtonIcon-hover check" aria-hidden="true"></span></button>';
     }
@@ -1477,7 +1475,6 @@ function getHoverMenuHtml(item, action) {
     if (itemHelper.canRate(item)) {
         const likes = userData.Likes == null ? '' : userData.Likes;
 
-        /* eslint-disable-next-line  @babel/no-unused-expressions */
         import('../../elements/emby-ratingbutton/emby-ratingbutton');
         html += '<button is="emby-ratingbutton" type="button" data-action="none" class="' + btnCssClass + '" data-id="' + item.Id + '" data-serverid="' + item.ServerId + '" data-itemtype="' + item.Type + '" data-likes="' + likes + '" data-isfavorite="' + (userData.IsFavorite) + '"><span class="material-icons cardOverlayButtonIcon cardOverlayButtonIcon-hover favorite" aria-hidden="true"></span></button>';
     }

--- a/src/scripts/editorsidebar.js
+++ b/src/scripts/editorsidebar.js
@@ -300,7 +300,6 @@ let selectedNodeId;
 $(document).on('itemsaved', '.metadataEditorPage', function (e, item) {
     updateEditorNode(this, item);
 }).on('pagebeforeshow', '.metadataEditorPage', function () {
-    /* eslint-disable-next-line  @babel/no-unused-expressions */
     import('../styles/metadataeditor.scss');
 }).on('pagebeforeshow', '.metadataEditorPage', function () {
     const page = this;

--- a/src/scripts/keyboardNavigation.js
+++ b/src/scripts/keyboardNavigation.js
@@ -202,7 +202,6 @@ export function enable() {
 function attachGamepadScript() {
     console.log('Gamepad connected! Attaching gamepadtokey.js script');
     window.removeEventListener('gamepadconnected', attachGamepadScript);
-    /* eslint-disable-next-line  @babel/no-unused-expressions */
     import('./gamepadtokey');
 }
 


### PR DESCRIPTION
**Changes**
Changes our eslint config to use the typescript parser for all files. This allows us to better match rules in sonar that are flagging issues in our javascript files.

**Issues**
N/A
