### PR TITLE
Fix for position time bug for remote control player

### DIFF
--- a/src/components/remotecontrol/remotecontrol.js
+++ b/src/components/remotecontrol/remotecontrol.js
@@ -472,8 +472,8 @@ export default function () {
             }
         }
 
-        context.querySelector('.positionTime').innerHTML = positionTicks == null ? '--:--' : datetime.getDisplayRunningTime(positionTicks);
-        context.querySelector('.runtime').innerHTML = runtimeTicks != null ? datetime.getDisplayRunningTime(runtimeTicks) : '--:--';
+        context.querySelector('.positionTime').innerHTML = Number.isFinite(positionTicks) ? datetime.getDisplayRunningTime(positionTicks) : '--:--';
+        context.querySelector('.runtime').innerHTML = Number.isFinite(runtimeTicks) ? datetime.getDisplayRunningTime(runtimeTicks) : '--:--';
     }
 
     function getPlaylistItems(player) {


### PR DESCRIPTION
Fix for bug whereby the position time in the remote control would display NaN if nothing was playing.

**Changes**
Previously, it only checked if the ticks variables were different than null. Now using Number.isFinite to check for NaN as well.

**Issues**
Fixes #4522
