### PR TITLE
Fix white background on video refresh

### DIFF
--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1496,6 +1496,7 @@ export default function (view) {
                 dom.addEventListener(document, 'click', onClickCapture, { capture: true });
             }
         } catch (e) {
+            setBackdropTransparency(TRANSPARENCY_LEVEL.None); // reset state set in viewbeforeshow
             appRouter.goHome();
         }
     });


### PR DESCRIPTION
When refreshing a /video page, since no player is available, `getCurrentPlayer` will be empty and `bindToPlayer` will crash leading to a redirect with `appRouter.goHome();`
This is also visible when doing back then next in the browser.

Before that that, the background is set in `viewbeforeshow` using `setBackdropTransparency(TRANSPARENCY_LEVEL.Full);`

This will leave unexpected classes in the dom leading to a white background on the main page.

This fixes proposes to reset the transparency before going to home using `setBackdropTransparency(TRANSPARENCY_LEVEL.None);` Anyway, this looks a little fragile and a deeper fix may be preferable in the future.

Another solution would be to move the
`setBackdropTransparency(TRANSPARENCY_LEVEL.Full);` when the player is ready but my understanding of the flow is not enough to now if it would have any unexpected results.