### PR TITLE
Remove error logs for checks expected to fail

### DIFF
--- a/src/components/scrollManager.js
+++ b/src/components/scrollManager.js
@@ -46,8 +46,8 @@ try {
     });
 
     elem.scrollTo(opts);
-} catch (e) {
-    console.error('error checking ScrollToOptions support');
+} catch {
+    // no scroll to options support
 }
 
 /**

--- a/src/legacy/focusPreventScroll.js
+++ b/src/legacy/focusPreventScroll.js
@@ -19,8 +19,8 @@ if (HTMLElement.prototype.nativeFocus === undefined) {
             });
 
             focusElem.focus(opts);
-        } catch (e) {
-            console.error('error checking preventScroll support');
+        } catch {
+            // no preventScroll supported
         }
 
         if (!supportsPreventScrollOption) {

--- a/src/scripts/dom.js
+++ b/src/scripts/dom.js
@@ -93,8 +93,8 @@ try {
         }
     });
     window.addEventListener('test', null, opts);
-} catch (e) {
-    console.debug('error checking capture support');
+} catch {
+    // no capture support
 }
 
 /**


### PR DESCRIPTION
**Changes**
These checks are expected to fail if browser support is not present, so logging an error doesn't make sense imo.

**Issues**
N/A
