### PR TITLE
Fix config.json using cache when changed

### DIFF
--- a/src/hooks/useWebConfig.tsx
+++ b/src/hooks/useWebConfig.tsx
@@ -13,7 +13,7 @@ export const WebConfigProvider: FC = ({ children }) => {
     useEffect(() => {
         const fetchConfig = async () => {
             try {
-                const response = await fetchLocal('config.json', { cache: 'no-cache' });
+                const response = await fetchLocal('config.json', { cache: 'no-store' });
 
                 if (!response.ok) {
                     throw new Error('network response was not ok');

--- a/src/scripts/settings/webSettings.js
+++ b/src/scripts/settings/webSettings.js
@@ -7,7 +7,7 @@ async function getConfig() {
     if (data) return Promise.resolve(data);
     try {
         const response = await fetchLocal('config.json', {
-            cache: 'no-cache'
+            cache: 'no-store'
         });
 
         if (!response.ok) {


### PR DESCRIPTION
**Changes**
Prevents the config.json file from being loaded from cache. In theory `no-cache` should only allow the file to be cached until it is changed, but we get a lot of reports of that not being the case. In my testing that it is also still loading old data when modified. This may only be an issue with reverse proxies or docker, but it comes up often enough that I think we should just avoid ever reading the config file from cache.

**Issues**
No specific issue, but it comes up often
