### PR TITLE
fix: update JASSUB

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "history": "5.3.0",
         "hls.js": "1.4.3",
         "intersection-observer": "0.12.2",
-        "jassub": "1.7.0",
+        "jassub": "1.7.1",
         "jellyfin-apiclient": "1.10.0",
         "jquery": "3.7.0",
         "jstree": "3.3.15",
@@ -10431,9 +10431,9 @@
       }
     },
     "node_modules/jassub": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/jassub/-/jassub-1.7.0.tgz",
-      "integrity": "sha512-ILno/cvF36lEbBIqdO2rbX8RC0H249nr0FyS1VPOhm6jfeJZODXdH0tOJSgKnKB50sxtLl44IeA0ge72LdZVPw==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/jassub/-/jassub-1.7.1.tgz",
+      "integrity": "sha512-xvrF/4/4ifJCxyF9wgmNW/fzvKuqrvU3OKl1B4373STaCPhblMHkRCHDN6DnRdeI9jUyriWDPcKT97cg38YbNw==",
       "dependencies": {
         "rvfc-polyfill": "^1.0.4"
       }
@@ -27838,9 +27838,9 @@
       "dev": true
     },
     "jassub": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/jassub/-/jassub-1.7.0.tgz",
-      "integrity": "sha512-ILno/cvF36lEbBIqdO2rbX8RC0H249nr0FyS1VPOhm6jfeJZODXdH0tOJSgKnKB50sxtLl44IeA0ge72LdZVPw==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/jassub/-/jassub-1.7.1.tgz",
+      "integrity": "sha512-xvrF/4/4ifJCxyF9wgmNW/fzvKuqrvU3OKl1B4373STaCPhblMHkRCHDN6DnRdeI9jUyriWDPcKT97cg38YbNw==",
       "requires": {
         "rvfc-polyfill": "^1.0.4"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "history": "5.3.0",
         "hls.js": "1.4.3",
         "intersection-observer": "0.12.2",
-        "jassub": "1.5.13",
+        "jassub": "1.7.0",
         "jellyfin-apiclient": "1.10.0",
         "jquery": "3.7.0",
         "jstree": "3.3.15",
@@ -10431,9 +10431,9 @@
       }
     },
     "node_modules/jassub": {
-      "version": "1.5.13",
-      "resolved": "https://registry.npmjs.org/jassub/-/jassub-1.5.13.tgz",
-      "integrity": "sha512-mQM88BcYgppvpPG6VE+DPQm7r6QS65EBedbm13RE4lRIhdrnQ+ihWhBOZXYZe3SlGhg+ROIDRK8uY4dm9ER2XQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/jassub/-/jassub-1.7.0.tgz",
+      "integrity": "sha512-ILno/cvF36lEbBIqdO2rbX8RC0H249nr0FyS1VPOhm6jfeJZODXdH0tOJSgKnKB50sxtLl44IeA0ge72LdZVPw==",
       "dependencies": {
         "rvfc-polyfill": "^1.0.4"
       }
@@ -27838,9 +27838,9 @@
       "dev": true
     },
     "jassub": {
-      "version": "1.5.13",
-      "resolved": "https://registry.npmjs.org/jassub/-/jassub-1.5.13.tgz",
-      "integrity": "sha512-mQM88BcYgppvpPG6VE+DPQm7r6QS65EBedbm13RE4lRIhdrnQ+ihWhBOZXYZe3SlGhg+ROIDRK8uY4dm9ER2XQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/jassub/-/jassub-1.7.0.tgz",
+      "integrity": "sha512-ILno/cvF36lEbBIqdO2rbX8RC0H249nr0FyS1VPOhm6jfeJZODXdH0tOJSgKnKB50sxtLl44IeA0ge72LdZVPw==",
       "requires": {
         "rvfc-polyfill": "^1.0.4"
       }

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "history": "5.3.0",
     "hls.js": "1.4.3",
     "intersection-observer": "0.12.2",
-    "jassub": "1.7.0",
+    "jassub": "1.7.1",
     "jellyfin-apiclient": "1.10.0",
     "jquery": "3.7.0",
     "jstree": "3.3.15",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "history": "5.3.0",
     "hls.js": "1.4.3",
     "intersection-observer": "0.12.2",
-    "jassub": "1.5.13",
+    "jassub": "1.7.0",
     "jellyfin-apiclient": "1.10.0",
     "jquery": "3.7.0",
     "jstree": "3.3.15",

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1252,37 +1252,45 @@ export class HtmlVideoPlayer {
         const fallbackFontList = apiClient.getUrl('/FallbackFont/Fonts', {
             api_key: apiClient.accessToken()
         });
-        const options = {
-            video: videoElement,
-            subUrl: getTextTrackUrl(track, item),
-            fonts: avaliableFonts,
-            fallbackFont: 'liberation sans',
-            availableFonts: { 'liberation sans': `${appRouter.baseUrl()}/default.woff2` },
-            // Disabled eslint compat, but is safe as corejs3 polyfills URL
-            // eslint-disable-next-line compat/compat
-            workerUrl: new URL('jassub/dist/jassub-worker.js', import.meta.url),
-            // eslint-disable-next-line compat/compat
-            legacyWorkerUrl: new URL('jassub/dist/jassub-worker-legacy.js', import.meta.url),
-            timeOffset: (this._currentPlayOptions.transcodingOffsetTicks || 0) / 10000000,
-            // new jassub options; override all, even defaults
-            blendMode: 'js',
-            asyncRender: true,
-            // firefox implements offscreen canvas, but not according to spec which causes errors
-            offscreenRender: !browser.firefox,
-            // RVFC is polyfilled everywhere, but webOS 2 reports polyfill API's as functional even tho they aren't
-            onDemandRender: browser.web0sVersion !== 2,
-            useLocalFonts: true,
-            dropAllAnimations: false,
-            libassMemoryLimit: 40,
-            libassGlyphLimit: 40,
-            targetFps: 24,
-            prescaleFactor: 0.8,
-            prescaleHeightLimit: 1080,
-            maxRenderHeight: 2160
-        };
             // TODO: replace with `event-target-polyfill` once https://github.com/benlesh/event-target-polyfill/pull/12 or 11 is merged
         import('event-target-polyfill').then(() => {
             import('jassub').then(({ default: JASSUB }) => {
+                // test SIMD support
+                JASSUB._test();
+
+                const options = {
+                    video: videoElement,
+                    subUrl: getTextTrackUrl(track, item),
+                    fonts: avaliableFonts,
+                    fallbackFont: 'liberation sans',
+                    availableFonts: { 'liberation sans': `${appRouter.baseUrl()}/default.woff2` },
+                    // Disabled eslint compat, but is safe as corejs3 polyfills URL
+                    // eslint-disable-next-line compat/compat
+                    workerUrl: new URL('jassub/dist/jassub-worker.js', import.meta.url),
+                    // eslint-disable-next-line compat/compat
+                    wasmUrl: new URL('jassub/dist/jassub-worker.wasm', import.meta.url),
+                    // eslint-disable-next-line compat/compat
+                    legacyWasmUrl: new URL('jassub/dist/jassub-worker.wasm.js', import.meta.url),
+                    // eslint-disable-next-line compat/compat
+                    modernWasmUrl : new URL('jassub/dist/jassub-worker-modern.wasm', import.meta.url),
+                    timeOffset: (this._currentPlayOptions.transcodingOffsetTicks || 0) / 10000000,
+                    // new jassub options; override all, even defaults
+                    blendMode: 'js',
+                    asyncRender: true,
+                    offscreenRender: true,
+                    // RVFC is polyfilled everywhere, but webOS 2 reports polyfill API's as functional even tho they aren't
+                    onDemandRender: browser.web0sVersion !== 2,
+                    useLocalFonts: true,
+                    dropAllAnimations: false,
+                    dropAllBlur: !JASSUB._supportsSIMD,
+                    libassMemoryLimit: 40,
+                    libassGlyphLimit: 40,
+                    targetFps: 24,
+                    prescaleFactor: 0.8,
+                    prescaleHeightLimit: 1080,
+                    maxRenderHeight: 2160
+                };
+
                 Promise.all([
                     apiClient.getNamedConfiguration('encoding'),
                     // Worker in Tizen 5 doesn't resolve relative path with async request

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -12,7 +12,6 @@ const Assets = [
 ];
 
 const JassubWasm = [
-    'jassub/dist/jassub-worker.wasm',
     'jassub/dist/default.woff2'
 ];
 


### PR DESCRIPTION
**Changes**
This PR updates JASSUB to latest.

This adds a new [optional] modern WASM module, which adds 2.1MB to the bundle size. This module adds SIMD support [TLDR fast math operations] which libass utilizes to calculate blur quicker, this makes blur calculations almost 40% faster, and on blur heavy TS the render times can be sped up by anywhere from 15% to 35%.

If the user's browser doesn't support SIMD it will disable blur, on typesetting, this is a little bit aggressive, but it brings heavy TS rendering performance well over what the SIMD WASM can do. [Should this be removed?]

Fixes offscreen rendering for firefox.

Adds support for colorspace mangling. If the subtitle's colorspace didn't match that of the current video's the subtitles would often be incorrectly colored, leading to poor masking, this is now supported and handled correctly:
![image](https://cdn.discordapp.com/attachments/856406641872207903/1102778758081028116/image.png)
![image](https://cdn.discordapp.com/attachments/856406641872207903/1102778676455690310/image.png)


**Issues**
https://github.com/jellyfin/jellyfin-web/pull/4585
