### PR TITLE
Add device type for chromecast devices

### DIFF
--- a/src/plugins/chromecastPlayer/plugin.js
+++ b/src/plugins/chromecastPlayer/plugin.js
@@ -624,6 +624,7 @@ class ChromecastPlayer {
             isLocalPlayer: false,
             appName: PlayerName,
             deviceName: appName,
+            deviceType: 'cast',
             supportedCommands: [
                 'VolumeUp',
                 'VolumeDown',


### PR DESCRIPTION
**Changes**
This ensures the correct icon is displayed for chromecast devices instead of the generic fallback icon.

**Issues**
N/A