### PR TITLE
Add addplugin.html to the list of plugin pages for the drawer

### DIFF
--- a/src/apps/experimental/components/drawers/dashboard/AdvancedDrawerSection.tsx
+++ b/src/apps/experimental/components/drawers/dashboard/AdvancedDrawerSection.tsx
@@ -16,6 +16,7 @@ const PLUGIN_PATHS = [
     '/installedplugins.html',
     '/availableplugins.html',
     '/repositories.html',
+    '/addplugin.html',
     '/configurationpage'
 ];
 


### PR DESCRIPTION
**Changes**
Adds addplugin.html to the list of plugin pages for the drawer. This keeps the plugin section expanded when on the add plugin pages.

![Screenshot 2023-05-20 at 00-53-18 Jellyfin](https://github.com/jellyfin/jellyfin-web/assets/3450688/ee5def2f-5f9e-41cb-87f6-05270b47cb02)

**Issues**
N/A