### PR TITLE
Fix overlap of slider bubble

### DIFF
--- a/src/elements/emby-slider/emby-slider.scss
+++ b/src/elements/emby-slider/emby-slider.scss
@@ -224,6 +224,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    z-index: 1;
 }
 
 .sliderBubbleText {


### PR DESCRIPTION
**Changes**
Set `z-index: 1` for the bubble, like the slider.
_Because of the method by which the slider is constructed, `z-index: 1` is applied to it, so that its progress lines are below it._

**Issues**
Fixes #4622 
