### PR TITLE
Improve keyboard control

### DIFF
--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1056,6 +1056,21 @@ import { appRouter } from '../../../components/appRouter';
                 return;
             }
 
+            if (layoutManager.tv && !currentVisibleMenu) {
+                // Change the behavior of some keys when the OSD is hidden
+                switch (key) {
+                    case 'ArrowLeft':
+                    case 'ArrowRight':
+                        showOsd(nowPlayingPositionSlider);
+                        nowPlayingPositionSlider.dispatchEvent(new KeyboardEvent(e.type, e));
+                        return;
+                    case 'Enter':
+                        playbackManager.playPause(currentPlayer);
+                        showOsd(btnPlayPause);
+                        return;
+                }
+            }
+
             if (layoutManager.tv && keyboardnavigation.isNavigationKey(key)) {
                 showOsd();
                 return;

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1091,12 +1091,10 @@ import { appRouter } from '../../../components/appRouter';
                 case 'f':
                     if (!e.ctrlKey && !e.metaKey) {
                         playbackManager.toggleFullscreen(currentPlayer);
-                        showOsd();
                     }
                     break;
                 case 'm':
                     playbackManager.toggleMute(currentPlayer);
-                    showOsd();
                     break;
                 case 'p':
                 case 'P':

--- a/src/legacy/keyboardEvent.js
+++ b/src/legacy/keyboardEvent.js
@@ -1,0 +1,48 @@
+/**
+ * Polyfill for KeyboardEvent
+ * - Constructor.
+ */
+
+(function (window) {
+    'use strict';
+
+    try {
+        new window.KeyboardEvent('event', { bubbles: true, cancelable: true });
+    } catch (e) {
+        // We can't use `KeyboardEvent` in old WebKit because `initKeyboardEvent`
+        // doesn't seem to populate some properties (`keyCode`, `which`) that
+        // are read-only.
+        const KeyboardEventOriginal = window.Event;
+
+        const KeyboardEvent = function (eventName, options) {
+            options = options || {};
+
+            const event = document.createEvent('Event');
+
+            event.initEvent(eventName, !!options.bubbles, !!options.cancelable);
+
+            event.view = options.view || document.defaultView;
+
+            event.key = options.key || options.keyIdentifier || '';
+            event.keyCode = options.keyCode || 0;
+            event.code = options.code || '';
+            event.charCode = options.charCode || 0;
+            event.char = options.char || '';
+            event.which = options.which || 0;
+
+            event.location = options.location || options.keyLocation || 0;
+
+            event.ctrlKey = !!options.ctrlKey;
+            event.altKey = !!options.altKey;
+            event.shiftKey = !!options.shiftKey;
+            event.metaKey = !!options.metaKey;
+
+            event.repeat = !!options.repeat;
+
+            return event;
+        };
+
+        KeyboardEvent.prototype = KeyboardEventOriginal.prototype;
+        window.KeyboardEvent = KeyboardEvent;
+    }
+}(window));

--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -32,6 +32,7 @@ import '../components/playback/playerSelectionMenu';
 import '../legacy/domParserTextHtml';
 import '../legacy/focusPreventScroll';
 import '../legacy/htmlMediaElement';
+import '../legacy/keyboardEvent';
 import '../legacy/vendorStyles';
 import SyncPlay from '../components/syncPlay/core';
 import { playbackManager } from '../components/playback/playbackmanager';


### PR DESCRIPTION
https://github.com/jellyfin/jellyfin-webos/issues/125#issuecomment-1411588082

**Changes**
- Don't show OSD for `Fullscreen` and `Mute`.
- Focus on corresponding button.
_Samsung checklist requires this, iirc._
- Make keys multi-purpose:
  - `Left/Right` activates dragging the position slider when OSD is hidden.
  - `Enter` pauses the playback when OSD is hidden.
- Add `KeyboardEvent` constructor polyfill.
`KeyboardEvent` is not constructible in WebKit (webOS 1.2/2.0, Tizen 2.3/2.4) - `KeyboardEventConstructor` is an object (not a function).
I have tested a few existing polyfills, but they rely on `initKeyboardEvent` method, which is broken in WebKit - it doesn't populate some properties (`keyCode`, `which`) that are read-only.

**Issues**
Fixes https://github.com/jellyfin/jellyfin-webos/issues/125

_Feature_ or _Bugfix_? :thinking: 