### PR TITLE
Fix movies Shuffle button

### DIFF
--- a/src/controllers/movies/movies.js
+++ b/src/controllers/movies/movies.js
@@ -30,11 +30,11 @@ export default function (view, params, tabContent, options) {
     }
 
     function shuffle() {
-        ApiClient.getItem(
-            ApiClient.getCurrentUserId(),
-            params.topParentId
-        ).then((item) => {
-            playbackManager.shuffle(item);
+        isLoading = true;
+        loading.show();
+        const newQuery = { ...query, SortBy: 'Random' };
+        return ApiClient.getItems(ApiClient.getCurrentUserId(), newQuery).then(({ Items }) => {
+            playbackManager.shuffle(Items[0]);
         });
     }
 


### PR DESCRIPTION
The Movies `Shuffle` button doesn't do anything anymore, as `topParentId` is `undefined`, which isn't permitted by `ApiClient.getItem`. I've fixed it by using the `SortBy: Random` query option and now pick the first item from the list that it returns.