### PR TITLE
Fix Movies/Favorites crash when accessing the missing Shuffle button

### DIFF
--- a/src/controllers/movies/movies.js
+++ b/src/controllers/movies/movies.js
@@ -86,7 +86,7 @@ export default function (view, params, tabContent, options) {
             elem.addEventListener('click', onPreviousPageClick);
         }
 
-        tabContent.querySelector('.btnShuffle').classList.toggle('hide', result.TotalRecordCount < 1);
+        tabContent.querySelector('.btnShuffle')?.classList.toggle('hide', result.TotalRecordCount < 1);
 
         isLoading = false;
         loading.hide();
@@ -258,7 +258,7 @@ export default function (view, params, tabContent, options) {
             itemsContainer.refreshItems();
         });
 
-        tabElement.querySelector('.btnShuffle').addEventListener('click', shuffle);
+        tabElement.querySelector('.btnShuffle')?.addEventListener('click', shuffle);
     };
 
     let itemsContainer = tabContent.querySelector('.itemsContainer');


### PR DESCRIPTION
**Changes**
Fix access to the missing `Shuffle` button.

**Issues**
`Movies/Favorites` crashes when accessing the missing `Shuffle` button.

Oversight #3627