### PR TITLE
Remove ssa/ass tags from text subtitles

### DIFF
--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -137,7 +137,10 @@ function zoomIn(elem) {
 }
 
 function normalizeTrackEventText(text, useHtml) {
-    const result = text.replace(/\\N/gi, '\n').replace(/\r/gi, '');
+    const result = text
+        .replace(/\\N/gi, '\n') // Correct newline characters
+        .replace(/\r/gi, '') // Remove carriage return characters
+        .replace(/{\\.*?}/gi, ''); // Remove ass/ssa tags
     return useHtml ? result.replace(/\n/gi, '<br>') : result;
 }
 


### PR DESCRIPTION
**Changes**
Removes ssa/ass tags from text subtitles when normalizing the text. Similar approach has been taken in the Android TV app (https://github.com/jellyfin/jellyfin-androidtv/pull/2741).

**Issues**
Fixes #3727 
