### PR TITLE
Disable ALAC on MacOS in non-Safari browsers

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -130,7 +130,7 @@ import browser from './browser';
 
             typeString = 'audio/ogg; codecs="opus"';
         } else if (format === 'alac') {
-            if (browser.iOS || browser.osx) {
+            if (browser.iOS || browser.osx && browser.safari) {
                 return true;
             }
         } else if (format === 'mp2') {


### PR DESCRIPTION
**Changes**
Disable ALAC on MacOS in non-Safari browsers.

**Issues**
Fixes #4686
Fixes https://github.com/jellyfin/jellyfin/issues/9855
Fixes https://github.com/jellyfin/jellyfin/issues/9850
