### PR TITLE
Fix library filter state not being saved on client

### DIFF
--- a/src/controllers/movies/movies.js
+++ b/src/controllers/movies/movies.js
@@ -297,6 +297,7 @@ export default function (view, params, tabContent, options) {
             });
             Events.on(filterDialog, 'filterchange', () => {
                 query.StartIndex = 0;
+                userSettings.saveQuerySettings(savedQueryKey, query);
                 itemsContainer.refreshItems();
             });
             filterDialog.show();

--- a/src/controllers/movies/movietrailers.js
+++ b/src/controllers/movies/movietrailers.js
@@ -190,6 +190,7 @@ export default function (view, params, tabContent) {
             });
             Events.on(filterDialog, 'filterchange', function () {
                 getQuery().StartIndex = 0;
+                libraryBrowser.saveQueryValues(getSavedQueryKey(), getQuery());
                 reloadItems();
             });
             filterDialog.show();

--- a/src/controllers/music/musicalbums.js
+++ b/src/controllers/music/musicalbums.js
@@ -197,6 +197,7 @@ export default function (view, params, tabContent) {
             });
             Events.on(filterDialog, 'filterchange', function () {
                 getQuery().StartIndex = 0;
+                libraryBrowser.saveQueryValues(getSavedQueryKey(), getQuery());
                 reloadItems();
             });
 

--- a/src/controllers/music/musicartists.js
+++ b/src/controllers/music/musicartists.js
@@ -178,6 +178,7 @@ export default function (view, params, tabContent) {
             });
             Events.on(filterDialog, 'filterchange', function () {
                 getQuery(tabContent).StartIndex = 0;
+                libraryBrowser.saveQueryValues(getSavedQueryKey(tabContent), getQuery(tabContent));
                 reloadItems(tabContent);
             });
             filterDialog.show();

--- a/src/controllers/music/songs.js
+++ b/src/controllers/music/songs.js
@@ -143,6 +143,7 @@ export default function (view, params, tabContent) {
             });
             Events.on(filterDialog, 'filterchange', function () {
                 getQuery(tabContent).StartIndex = 0;
+                libraryBrowser.saveQueryValues(getSavedQueryKey(tabContent), getQuery(tabContent));
                 reloadItems(tabContent);
             });
             filterDialog.show();

--- a/src/controllers/shows/episodes.js
+++ b/src/controllers/shows/episodes.js
@@ -178,6 +178,7 @@ export default function (view, params, tabContent) {
                 serverId: ApiClient.serverId()
             });
             Events.on(filterDialog, 'filterchange', function () {
+                libraryBrowser.saveQueryValues(getSavedQueryKey(tabContent), getQuery(tabContent));
                 reloadItems(tabContent);
             });
             filterDialog.show();

--- a/src/controllers/shows/tvshows.js
+++ b/src/controllers/shows/tvshows.js
@@ -207,6 +207,7 @@ export default function (view, params, tabContent) {
             });
             Events.on(filterDialog, 'filterchange', function () {
                 getQuery(tabContent).StartIndex = 0;
+                libraryBrowser.saveQueryValues(getSavedQueryKey(tabContent), getQuery(tabContent));
                 reloadItems(tabContent);
             });
             filterDialog.show();

--- a/src/scripts/libraryBrowser.js
+++ b/src/scripts/libraryBrowser.js
@@ -27,6 +27,10 @@ export function saveQueryValues(key, query) {
         values.SortOrder = query.SortOrder;
     }
 
+    if (query.Filters) {
+        values.Filters = query.Filters;
+    }
+
     userSettings.set(key, JSON.stringify(values));
 }
 

--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -530,6 +530,10 @@ export class UserSettings {
             values.SortOrder = query.SortOrder;
         }
 
+        if (query.Filters) {
+            values.Filters = query.Filters;
+        }
+
         return this.set(key, JSON.stringify(values));
     }
 


### PR DESCRIPTION
**Changes**
Added saveQuery function calls on several `filterchange` event callbacks to properly save the filter state on the client.

**Issues**
Fixes #40 
