### PR TITLE
Remove unneeded comma from translation string

### DIFF
--- a/src/strings/en-gb.json
+++ b/src/strings/en-gb.json
@@ -1517,7 +1517,7 @@
     "MessagePlaybackError": "There was an error playing this file on your Google Cast receiver.",
     "MessageChromecastConnectionError": "Your Google Cast receiver is unable to contact the Jellyfin server. Please check the connection and try again.",
     "Framerate": "Framerate",
-    "DirectPlayHelp": "The source file is entirely compatible with this client, and the session is receiving the file without modifications.",
+    "DirectPlayHelp": "The source file is entirely compatible with this client and the session is receiving the file without modifications.",
     "EnableGamepadHelp": "Listen for input from any connected controllers. (Requires: 'TV' Display Mode)",
     "LabelEnableGamepad": "Enable Gamepad",
     "Controls": "Controls",

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -189,7 +189,7 @@
     "Director": "Director",
     "Directors": "Directors",
     "DirectPlaying": "Direct playing",
-    "DirectPlayHelp": "The source file is entirely compatible with this client, and the session is receiving the file without modifications.",
+    "DirectPlayHelp": "The source file is entirely compatible with this client and the session is receiving the file without modifications.",
     "DirectStreamHelp1": "The video stream is compatible with the device, but has an incompatible audio format (DTS, Dolby TrueHD, etc.) or number of audio channels. The video stream will be repackaged losslessly on the fly before being sent to the device. Only the audio stream will be transcoded.",
     "DirectStreamHelp2": "Power consumed by direct streaming usually depends on the audio profile. Only the video stream is lossless.",
     "DirectStreaming": "Direct streaming",


### PR DESCRIPTION
We copied this text for the roku client and noticed the unneeded comma. Figured I should update the web client as well.


