### PR TITLE
Fix sending URLs instead of strings to jassub, leading to DataCloneErrors

### DIFF
--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1271,13 +1271,13 @@ export class HtmlVideoPlayer {
                     availableFonts: { 'liberation sans': `${appRouter.baseUrl()}/default.woff2` },
                     // Disabled eslint compat, but is safe as corejs3 polyfills URL
                     // eslint-disable-next-line compat/compat
-                    workerUrl: new URL('jassub/dist/jassub-worker.js', import.meta.url),
+                    workerUrl: new URL('jassub/dist/jassub-worker.js', import.meta.url).href,
                     // eslint-disable-next-line compat/compat
-                    wasmUrl: new URL('jassub/dist/jassub-worker.wasm', import.meta.url),
+                    wasmUrl: new URL('jassub/dist/jassub-worker.wasm', import.meta.url).href,
                     // eslint-disable-next-line compat/compat
-                    legacyWasmUrl: new URL('jassub/dist/jassub-worker.wasm.js', import.meta.url),
+                    legacyWasmUrl: new URL('jassub/dist/jassub-worker.wasm.js', import.meta.url).href,
                     // eslint-disable-next-line compat/compat
-                    modernWasmUrl : new URL('jassub/dist/jassub-worker-modern.wasm', import.meta.url),
+                    modernWasmUrl : new URL('jassub/dist/jassub-worker-modern.wasm', import.meta.url).href,
                     timeOffset: (this._currentPlayOptions.transcodingOffsetTicks || 0) / 10000000,
                     // new jassub options; override all, even defaults
                     blendMode: 'js',


### PR DESCRIPTION
**Issues**
- Closes #4701: Fix sending URLs instead of [strings to jassub](https://github.com/ThaUnknown/jassub/blob/ec53846e685e64f5d47afa9d0573494d98ee4f2e/index.d.ts#L65-L68), [leading to DataCloneErrors](https://github.com/ThaUnknown/jassub/blob/ec53846e685e64f5d47afa9d0573494d98ee4f2e/src/jassub.js#L129-L130) as URLs may not be structurally copied