### PR TITLE
Fix emby-scroller not going to the screen edge on desktop

### DIFF
--- a/src/elements/emby-scroller/emby-scroller.scss
+++ b/src/elements/emby-scroller/emby-scroller.scss
@@ -3,10 +3,10 @@
 }
 
 .emby-scroller {
-    margin-left: 3.3%;
-    margin-left: max(env(safe-area-inset-left), 3.3%);
-    margin-right: 3.3%;
-    margin-right: max(env(safe-area-inset-right), 3.3%);
+    padding-left: 3.3%;
+    padding-left: max(env(safe-area-inset-left), 3.3%);
+    padding-right: 3.3%;
+    padding-right: max(env(safe-area-inset-right), 3.3%);
 }
 
 .servers > .card > .cardBox {
@@ -25,14 +25,4 @@
         margin-right: 0;
         margin-left: 1.2em;
     }
-}
-
-.layout-tv .emby-scroller,
-.layout-mobile .emby-scroller {
-    padding-left: 3.3%;
-    padding-left: max(env(safe-area-inset-left), 3.3%);
-    padding-right: 3.3%;
-    padding-right: max(env(safe-area-inset-right), 3.3%);
-    margin-left: 0;
-    margin-right: 0;
 }

--- a/src/libraries/scroller.js
+++ b/src/libraries/scroller.js
@@ -175,11 +175,19 @@ const scrollerFactory = function (frame, options) {
             requiresReflow = false;
 
             // Reset global variables
-            frameSize = o.horizontal ? (frame).offsetWidth : (frame).offsetHeight;
+            const frameStyle = window.getComputedStyle(frame);
+            if (o.horizontal) {
+                frameSize = frame.clientWidth;
+                frameSize -= parseFloat(frameStyle.paddingLeft) + parseFloat(frameStyle.paddingRight);
+            } else {
+                frameSize = frame.clientHeight;
+                frameSize -= parseFloat(frameStyle.paddingTop) + parseFloat(frameStyle.paddingBottom);
+            }
+            frameSize = Math.round(frameSize);
 
             slideeSize = o.scrollWidth || Math.max(slideeElement[o.horizontal ? 'offsetWidth' : 'offsetHeight'], slideeElement[o.horizontal ? 'scrollWidth' : 'scrollHeight']);
 
-            // Set position limits & relativess
+            // Set position limits & relatives
             self._pos.end = Math.max(slideeSize - frameSize, 0);
             if (globalize.getIsRTL())
                 self._pos.end *= -1;


### PR DESCRIPTION
**Changes**
Fixes emby-scroller components not going all the way to the edge of the screen on desktop

| Before | After |
|-|-|
| ![Screenshot 2023-07-10 at 16-31-12 Jellyfin](https://github.com/jellyfin/jellyfin-web/assets/3450688/29bc1da9-27e0-4c2c-89b5-429b4d51bff6) | ![Screenshot 2023-07-10 at 16-34-26 Jellyfin](https://github.com/jellyfin/jellyfin-web/assets/3450688/0b222c68-c54f-4c65-a927-9e1ffc3a55ca) |


**Issues**
N/A