### PR TITLE
Remove the blinking caret in full screen playback.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -116,6 +116,7 @@
             z-index: 1;
             width: 0.8em;
             padding-left: env(safe-area-inset-left);
+            caret-color: transparent;
         }
 
         [dir="ltr"] .mainDrawerHandle {


### PR DESCRIPTION
Changed the caret color to transparet for the main drawer.

In full screen mode, during video playback, the caret would blink in the top left corner. The caret is not needed in the drawer. Unsure why I am the only one seeing it. 

Running chrome 115.0.5790.171.