### PR TITLE
Remove Dolby Vision support on Samsung TV (Tizen)

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -833,7 +833,8 @@ export function canPlaySecondaryAudio(videoTestElement) {
         }
 
         if (browser.tizen || browser.web0s) {
-            hevcVideoRangeTypes += '|HDR10|HLG|DOVI';
+            hevcVideoRangeTypes += '|HDR10|HLG';
+            if (browser.web0s) hevcVideoRangeTypes += '|DOVI';
             vp9VideoRangeTypes += '|HDR10|HLG';
             av1VideoRangeTypes += '|HDR10|HLG';
         }


### PR DESCRIPTION
It appears that none of Samsung TVs support Dolby Vision.

**Changes**
Remove Dolby Vision support on Samsung TV (Tizen).

**Issues**
Fixes https://github.com/jellyfin/jellyfin-tizen/issues/218
