### PR TITLE
Add fMP4 playback support (HEVC, AV1) in HLS.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "flv.js": "1.6.2",
         "headroom.js": "0.12.0",
         "history": "5.3.0",
-        "hls.js": "1.4.4",
+        "hls.js": "github:nyanmisaka/hls.js#v1.5.0-fix-firefox-av1",
         "intersection-observer": "0.12.2",
         "jassub": "1.7.1",
         "jellyfin-apiclient": "1.10.0",
@@ -9460,9 +9460,8 @@
       }
     },
     "node_modules/hls.js": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.4.4.tgz",
-      "integrity": "sha512-Yix3i1klHtTWIj8Fa/yoN5mFreY3eLKGrmVldpkQ+2Bb1PmEok9Ah/VfAzlJnwtInCo4rs5l6/W2tUh76DaSNA=="
+      "resolved": "git+ssh://git@github.com/nyanmisaka/hls.js.git#2ca771e97a15d8078a3850c4c4cf225f497dcaa7",
+      "license": "Apache-2.0"
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
@@ -27345,9 +27344,8 @@
       }
     },
     "hls.js": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.4.4.tgz",
-      "integrity": "sha512-Yix3i1klHtTWIj8Fa/yoN5mFreY3eLKGrmVldpkQ+2Bb1PmEok9Ah/VfAzlJnwtInCo4rs5l6/W2tUh76DaSNA=="
+      "version": "git+ssh://git@github.com/nyanmisaka/hls.js.git#2ca771e97a15d8078a3850c4c4cf225f497dcaa7",
+      "from": "hls.js@github:nyanmisaka/hls.js#v1.5.0-fix-firefox-av1"
     },
     "hoist-non-react-statics": {
       "version": "3.3.2",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "flv.js": "1.6.2",
     "headroom.js": "0.12.0",
     "history": "5.3.0",
-    "hls.js": "1.4.4",
+    "hls.js": "github:nyanmisaka/hls.js#v1.5.0-fix-firefox-av1",
     "intersection-observer": "0.12.2",
     "jassub": "1.7.1",
     "jellyfin-apiclient": "1.10.0",

--- a/src/components/apphost.js
+++ b/src/components/apphost.js
@@ -16,10 +16,13 @@ function getBaseProfileOptions(item) {
         if (browser.edge) {
             disableHlsVideoAudioCodecs.push('mp3');
         }
-
-        disableHlsVideoAudioCodecs.push('ac3');
-        disableHlsVideoAudioCodecs.push('eac3');
-        disableHlsVideoAudioCodecs.push('opus');
+        if (!browser.edgeChromium) {
+            disableHlsVideoAudioCodecs.push('ac3');
+            disableHlsVideoAudioCodecs.push('eac3');
+        }
+        if (!(browser.chrome || browser.edgeChromium || browser.firefox)) {
+            disableHlsVideoAudioCodecs.push('opus');
+        }
     }
 
     return {

--- a/src/components/htmlMediaHelper.js
+++ b/src/components/htmlMediaHelper.js
@@ -43,8 +43,8 @@ export function enableHlsJsPlayer(runTimeTicks, mediaType) {
     }
 
     if (canPlayNativeHls()) {
-        // Having trouble with chrome's native support and transcoded music
-        if (browser.android && mediaType === 'Audio') {
+        // Android Webview's native HLS has performance and compatiblity issues
+        if (browser.android && (mediaType === 'Audio' || mediaType === 'Video')) {
             return true;
         }
 

--- a/src/controllers/dashboard/encodingsettings.html
+++ b/src/controllers/dashboard/encodingsettings.html
@@ -124,6 +124,12 @@
                             <span>${AllowHevcEncoding}</span>
                         </label>
                     </div>
+                    <div class="checkboxList">
+                        <label>
+                            <input type="checkbox" is="emby-checkbox" id="chkAllowAv1Encoding" />
+                            <span>${AllowAv1Encoding}</span>
+                        </label>
+                    </div>
                 </div>
 
                 <div class="vppTonemappingOptions hide">

--- a/src/controllers/dashboard/encodingsettings.js
+++ b/src/controllers/dashboard/encodingsettings.js
@@ -18,6 +18,7 @@ function loadPage(page, config, systemInfo) {
     page.querySelector('#chkIntelLpHevcHwEncoder').checked = config.EnableIntelLowPowerHevcHwEncoder;
     page.querySelector('#chkHardwareEncoding').checked = config.EnableHardwareEncoding;
     page.querySelector('#chkAllowHevcEncoding').checked = config.AllowHevcEncoding;
+    page.querySelector('#chkAllowAv1Encoding').checked = config.AllowAv1Encoding;
     $('#selectVideoDecoder', page).val(config.HardwareAccelerationType);
     $('#selectThreadCount', page).val(config.EncodingThreadCount);
     page.querySelector('#chkEnableAudioVbr').checked = config.EnableAudioVbr;
@@ -123,6 +124,7 @@ function onSubmit() {
             config.EnableIntelLowPowerHevcHwEncoder = form.querySelector('#chkIntelLpHevcHwEncoder').checked;
             config.EnableHardwareEncoding = form.querySelector('#chkHardwareEncoding').checked;
             config.AllowHevcEncoding = form.querySelector('#chkAllowHevcEncoding').checked;
+            config.AllowAv1Encoding = form.querySelector('#chkAllowAv1Encoding').checked;
             ApiClient.updateNamedConfiguration('encoding', config).then(function () {
                 updateEncoder(form);
             }, function () {

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1715,5 +1715,6 @@
     "Unreleased": "Not yet released",
     "LabelTonemappingMode": "Tone mapping mode",
     "TonemappingModeHelp": "Select the tone mapping mode. If you experience blown out highlights try switching to the RGB mode.",
-    "Unknown": "Unknown"
+    "Unknown": "Unknown",
+    "AllowAv1Encoding": "Allow encoding in AV1 format"
 }


### PR DESCRIPTION
The recent HLS.js update seems to have resolved the fMP4 seeking issue. Let's first enable fMP4 on HLS.js.

 Player/Feature | TS   | fMP4 seek  | H.264 | HEVC | AV1 | AAC | MP3 | AC3/EAC3 | FLAC | OPUS
--------------- | ---- | ---------- | ----- | ---- | --- | --- | --- | -------- | ---- | ----
Hls.js          | ✔️   | ✔️        | ✔️    | ✔️   | ✔️  | ✔️  | ✔️  | ✔️       | ✔️ (1.5.0)   | ✔️ (1.5.0)
Shaka           | ✔️   | ✔️        | ✔️    | ✔️   | ✔️  | ✔️  | ✔️  | ✔️       | ✔️   | ✔️

Tested codecs:
video: h264, hevc, av1 (av1 in firefox require 1.5.0)
audio: mp3, aac, ac3, eac3 (flac and opus require 1.5.0)

Tested browsers:
Chrome, Firefox, Edge Chromium, Safari and their mobile versions

**Changes**
- Add fMP4 playback support (HEVC, AV1) in HLS.js

**Issues**
- #3982