### PR TITLE
Prefer unplayed items when shuffling a folder

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -1884,7 +1884,7 @@ class PlaybackManager {
             } else if (firstItem.IsFolder) {
                 let sortBy = null;
                 if (options.shuffle) {
-                    sortBy = 'Random';
+                    sortBy = 'IsPlayed,Random';
                 } else if (firstItem.Type !== 'BoxSet') {
                     sortBy = 'SortName';
                 }


### PR DESCRIPTION
**Changes**
When shuffling a folder, sort by `"IsPlayed,Random"` instead of just `"Random"`, causing unplayed items to always be ahead of played items.

The idea here is that when a user hits the "Shuffle" button in a video context (e.g. a show, a library, a collection), they are probably not interested in seeing items that they have recently already played via shuffle. Tying the priority to the "Played" flag gives the user some control over this behavior, e.g. if they want to "reset" their shuffle exclusion, they can mark a folder as unplayed.

Tested this behavior against my home Jellyfin server (v10.9.0), verified that it shoves items with `Played: true` to the bottom of the response (or after the end of the response, if there's more than the default limit of 300 items).

**Issues**
[Feature Request 717](https://features.jellyfin.org/posts/717/shuffle-weight-recently-played-media-should-be-less-likely-to-be-next)

**Errata**
I originally tried to do this on the backend in https://github.com/jellyfin/jellyfin/pull/10011, but it was pointed out that prioritizing unplayed items was not _always_ the best move (e.g. when playing music it's not helpful). I then realized that it would be easier to just request this behavior on the frontend, when appropriate, using the existing multi-column sort feature.