### PR TITLE
Fix en-us string

### DIFF
--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -38,7 +38,7 @@
     "AllowOnTheFlySubtitleExtractionHelp": "Embedded subtitles can be extracted from videos and delivered to clients in plain text, in order to help prevent video transcoding. On some systems this can take a long time and cause video playback to stall during the extraction process. Disable this to have embedded subtitles burned in with video transcoding when they are not natively supported by the client device.",
     "AllowRemoteAccess": "Allow remote connections to this server",
     "AllowRemoteAccessHelp": "If unchecked, all remote connections will be blocked.",
-    "AllowTonemappingHelp": "Tone-mapping can transform the dynamic range of a video from HDR to SDR while maintaining image details and colors, which are very important information for representing the original scene. Currently works only with 10bit HDR10,HLG and DoVi videos. This requires the corresponding OpenCL or CUDA runtime.",
+    "AllowTonemappingHelp": "Tone-mapping can transform the dynamic range of a video from HDR to SDR while maintaining image details and colors, which are very important information for representing the original scene. Currently works only with 10bit HDR10, HLG and DoVi videos. This requires the corresponding OpenCL or CUDA runtime.",
     "AlwaysPlaySubtitles": "Always Play",
     "AlwaysPlaySubtitlesHelp": "Subtitles matching the language preference will be loaded regardless of the audio language.",
     "AnyLanguage": "Any Language",

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -38,7 +38,7 @@
     "AllowOnTheFlySubtitleExtractionHelp": "Embedded subtitles can be extracted from videos and delivered to clients in plain text, in order to help prevent video transcoding. On some systems this can take a long time and cause video playback to stall during the extraction process. Disable this to have embedded subtitles burned in with video transcoding when they are not natively supported by the client device.",
     "AllowRemoteAccess": "Allow remote connections to this server",
     "AllowRemoteAccessHelp": "If unchecked, all remote connections will be blocked.",
-    "AllowTonemappingHelp": "Tone-mapping can transform the dynamic range of a video from HDR to SDR while maintaining image details and colors, which are very important information for representing the original scene. Currently works only with 10bit HDR10，HLG and DoVi videos. This requires the corresponding OpenCL or CUDA runtime.",
+    "AllowTonemappingHelp": "Tone-mapping can transform the dynamic range of a video from HDR to SDR while maintaining image details and colors, which are very important information for representing the original scene. Currently works only with 10bit HDR10,HLG and DoVi videos. This requires the corresponding OpenCL or CUDA runtime.",
     "AlwaysPlaySubtitles": "Always Play",
     "AlwaysPlaySubtitlesHelp": "Subtitles matching the language preference will be loaded regardless of the audio language.",
     "AnyLanguage": "Any Language",


### PR DESCRIPTION
Changes in en-us translation:
Remove comma from foreign language (likely Chinese or Japanese) and change it back to a normal comma
