### PR TITLE
Add conditional build USE_SYSTEM_FONTS

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -92,9 +92,13 @@ function onGlobalizeInit() {
     if (browser.tv && !browser.android) {
         console.debug('using system fonts with explicit sizes');
         import('./styles/fonts.sized.scss');
+    } else if (__USE_SYSTEM_FONTS__) { // eslint-disable-line no-undef
+        console.debug('using system fonts');
+        import('./styles/fonts.scss');
     } else {
         console.debug('using default fonts');
         import('./styles/fonts.scss');
+        import('./styles/fonts.noto.scss');
     }
 
     import('./styles/librarybrowser.scss');

--- a/src/styles/fonts.noto.scss
+++ b/src/styles/fonts.noto.scss
@@ -1,0 +1,25 @@
+@import "../styles/noto-sans/index.scss";
+
+html {
+    font-family: "Noto Sans", "Noto Sans HK", "Noto Sans JP", "Noto Sans KR", "Noto Sans SC", "Noto Sans TC", sans-serif;
+}
+
+html[lang|="ja"] {
+    font-family: "Noto Sans", "Noto Sans JP", "Noto Sans HK", "Noto Sans KR", "Noto Sans SC", "Noto Sans TC", sans-serif;
+}
+
+html[lang|="ko"] {
+    font-family: "Noto Sans", "Noto Sans KR", "Noto Sans HK", "Noto Sans JP", "Noto Sans SC", "Noto Sans TC", sans-serif;
+}
+
+html[lang|="zh-CN"] {
+    font-family: "Noto Sans", "Noto Sans SC", "Noto Sans HK", "Noto Sans JP", "Noto Sans KR", "Noto Sans TC", sans-serif;
+}
+
+html[lang|="zh-TW"] {
+    font-family: "Noto Sans", "Noto Sans TC", "Noto Sans HK", "Noto Sans JP", "Noto Sans KR", "Noto Sans SC", sans-serif;
+}
+
+html[lang|="zh-HK"] {
+    font-family: "Noto Sans", "Noto Sans HK", "Noto Sans JP", "Noto Sans KR", "Noto Sans SC", "Noto Sans TC", sans-serif;
+}

--- a/src/styles/fonts.scss
+++ b/src/styles/fonts.scss
@@ -1,5 +1,3 @@
-@import "../styles/noto-sans/index.scss";
-
 @mixin font($weight: null, $size: null) {
     font-weight: $weight;
     font-size: $size;
@@ -7,30 +5,9 @@
 
 html {
     @include font($size: 93%);
-    font-family: "Noto Sans", "Noto Sans HK", "Noto Sans JP", "Noto Sans KR", "Noto Sans SC", "Noto Sans TC", sans-serif;
     text-size-adjust: 100%;
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
-}
-
-html[lang|="ja"] {
-    font-family: "Noto Sans", "Noto Sans JP", "Noto Sans HK", "Noto Sans KR", "Noto Sans SC", "Noto Sans TC", sans-serif;
-}
-
-html[lang|="ko"] {
-    font-family: "Noto Sans", "Noto Sans KR", "Noto Sans HK", "Noto Sans JP", "Noto Sans SC", "Noto Sans TC", sans-serif;
-}
-
-html[lang|="zh-CN"] {
-    font-family: "Noto Sans", "Noto Sans SC", "Noto Sans HK", "Noto Sans JP", "Noto Sans KR", "Noto Sans TC", sans-serif;
-}
-
-html[lang|="zh-TW"] {
-    font-family: "Noto Sans", "Noto Sans TC", "Noto Sans HK", "Noto Sans JP", "Noto Sans KR", "Noto Sans SC", sans-serif;
-}
-
-html[lang|="zh-HK"] {
-    font-family: "Noto Sans", "Noto Sans HK", "Noto Sans JP", "Noto Sans KR", "Noto Sans SC", "Noto Sans TC", sans-serif;
 }
 
 h1 {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -47,6 +47,7 @@ const config = {
     },
     plugins: [
         new DefinePlugin({
+            __USE_SYSTEM_FONTS__: JSON.stringify(!!process.env.USE_SYSTEM_FONTS),
             __WEBPACK_SERVE__: JSON.stringify(!!process.env.WEBPACK_SERVE)
         }),
         new CleanWebpackPlugin(),


### PR DESCRIPTION
To be able to discard unused fonts for embedding in a Tizen app.
```sh
USE_SYSTEM_FONTS=1 npm run build:production
```

I am currently filtering them using [an unreliable method](https://github.com/jellyfin/jellyfin-tizen/blob/3ce22e1a33ff8d3b1da1f2ae87a5fb521bd24467/gulpfile.js#L39-L49). And some of them (default font for JASSUB, Material Design Icons font) become missing.

**Changes**
Add conditional build `USE_SYSTEM_FONTS`.

**Issues**
There is no normal way to discard unused fonts.
