### PR TITLE
Add speeds for 2.5x 3x 3.5x 4x

### DIFF
--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1978,6 +1978,18 @@ export class HtmlVideoPlayer {
         }, {
             name: '2x',
             id: 2.0
+        }, {
+            name: '2.5x',
+            id: 2.5
+        }, {
+            name: '3x',
+            id: 3.0
+        }, {
+            name: '3.5x',
+            id: 3.5
+        }, {
+            name: '4.0x',
+            id: 4.0
         }];
     }
 


### PR DESCRIPTION
Changes: Increase max playback speeds. Adds speeds between 2x-4x in 0.5x increments

Feature request: 1916

https://features.jellyfin.org/posts/1916/allow-playback-speed-increase-in-web-client-beyond-2x