### PR TITLE
Fix error on unmount in syncplay menu

### DIFF
--- a/src/apps/experimental/components/AppToolbar/menus/SyncPlayMenu.tsx
+++ b/src/apps/experimental/components/AppToolbar/menus/SyncPlayMenu.tsx
@@ -19,6 +19,7 @@ import React, { FC, useCallback, useEffect, useState } from 'react';
 
 import { pluginManager } from 'components/pluginManager';
 import { useApi } from 'hooks/useApi';
+import { useSyncPlayGroups } from 'hooks/useSyncPlayGroups';
 import globalize from 'scripts/globalize';
 import { PluginType } from 'types/plugin';
 import Events from 'utils/events';
@@ -47,7 +48,6 @@ const SyncPlayMenu: FC<SyncPlayMenuProps> = ({
 }) => {
     const [ syncPlay, setSyncPlay ] = useState<SyncPlayInstance>();
     const { __legacyApiClient__, api, user } = useApi();
-    const [ groups, setGroups ] = useState<GroupInfoDto[]>([]);
     const [ currentGroup, setCurrentGroup ] = useState<GroupInfoDto>();
     const isSyncPlayEnabled = Boolean(currentGroup);
 
@@ -55,25 +55,7 @@ const SyncPlayMenu: FC<SyncPlayMenuProps> = ({
         setSyncPlay(pluginManager.firstOfType(PluginType.SyncPlay)?.instance);
     }, []);
 
-    useEffect(() => {
-        let isMounted = true;
-
-        const fetchGroups = async () => {
-            if (api) {
-                const response = await getSyncPlayApi(api).syncPlayGetGroups();
-                if (isMounted) setGroups(response.data);
-            }
-        };
-
-        fetchGroups()
-            .catch(err => {
-                console.error('[SyncPlayMenu] unable to fetch SyncPlay groups', err);
-            });
-
-        return () => {
-            isMounted = false;
-        };
-    }, [ api ]);
+    const { data: groups } = useSyncPlayGroups();
 
     const onGroupAddClick = useCallback(() => {
         if (api && user) {
@@ -231,7 +213,7 @@ const SyncPlayMenu: FC<SyncPlayMenuProps> = ({
                 />
             </MenuItem>
         );
-    } else if (groups.length === 0 && user?.Policy?.SyncPlayAccess !== SyncPlayUserAccessType.CreateAndJoinGroups) {
+    } else if (!groups?.length && user?.Policy?.SyncPlayAccess !== SyncPlayUserAccessType.CreateAndJoinGroups) {
         menuItems.push(
             <MenuItem key='sync-play-unavailable' disabled>
                 <ListItemIcon>
@@ -241,7 +223,7 @@ const SyncPlayMenu: FC<SyncPlayMenuProps> = ({
             </MenuItem>
         );
     } else {
-        if (groups.length > 0) {
+        if (groups && groups.length > 0) {
             groups.forEach(group => {
                 menuItems.push(
                     <MenuItem

--- a/src/apps/experimental/components/AppToolbar/menus/SyncPlayMenu.tsx
+++ b/src/apps/experimental/components/AppToolbar/menus/SyncPlayMenu.tsx
@@ -56,9 +56,12 @@ const SyncPlayMenu: FC<SyncPlayMenuProps> = ({
     }, []);
 
     useEffect(() => {
+        let isMounted = true;
+
         const fetchGroups = async () => {
             if (api) {
-                setGroups((await getSyncPlayApi(api).syncPlayGetGroups()).data);
+                const response = await getSyncPlayApi(api).syncPlayGetGroups();
+                if (isMounted) setGroups(response.data);
             }
         };
 
@@ -66,6 +69,10 @@ const SyncPlayMenu: FC<SyncPlayMenuProps> = ({
             .catch(err => {
                 console.error('[SyncPlayMenu] unable to fetch SyncPlay groups', err);
             });
+
+        return () => {
+            isMounted = false;
+        };
     }, [ api ]);
 
     const onGroupAddClick = useCallback(() => {

--- a/src/hooks/useSyncPlayGroups.ts
+++ b/src/hooks/useSyncPlayGroups.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+import { JellyfinApiContext, useApi } from './useApi';
+import { getSyncPlayApi } from '@jellyfin/sdk/lib/utils/api/sync-play-api';
+import { AxiosRequestConfig } from 'axios';
+
+const fetchSyncPlayGroups = async (
+    currentApi: JellyfinApiContext,
+    options?: AxiosRequestConfig
+) => {
+    const { api } = currentApi;
+    if (!api) throw new Error('No API instance available');
+
+    const response = await getSyncPlayApi(api)
+        .syncPlayGetGroups(options);
+    return response.data;
+};
+
+export const useSyncPlayGroups = () => {
+    const currentApi = useApi();
+    return useQuery({
+        queryKey: [ 'SyncPlay', 'Groups' ],
+        queryFn: ({ signal }) => fetchSyncPlayGroups(currentApi, { signal })
+    });
+};


### PR DESCRIPTION
**Changes**
Fixes a React error when `setGroups` is called after the component is unmounted.

Using an `AbortController` might be technically better, but it looks like we would have to polyfill.

**Issues**
React error printed to console
