### PR TITLE
Remove H264 10bit support on Samsung TV (Tizen)

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -782,10 +782,9 @@ export function canPlaySecondaryAudio(videoTestElement) {
             maxH264Level = 52;
         }
 
-        if (browser.tizen ||
-            videoTestElement.canPlayType('video/mp4; codecs="avc1.6e0033"').replace(/no/, '')) {
+        if (videoTestElement.canPlayType('video/mp4; codecs="avc1.6e0033"').replace(/no/, '')) {
             // These tests are passing in safari, but playback is failing
-            if (!browser.safari && !browser.iOS && !browser.web0s && !browser.edge && !browser.mobile) {
+            if (!browser.safari && !browser.iOS && !browser.web0s && !browser.edge && !browser.mobile && !browser.tizen) {
                 h264Profiles += '|high 10';
             }
         }


### PR DESCRIPTION
So far as I can tell no Samsung TV's support H264 10bit. 

**Changes**
Remove high10 support for Tizen clients

**Issues**
Fixes #https://github.com/jellyfin/jellyfin-tizen/issues/206
