### PR TITLE
Allow any application id for cast receiver

### DIFF
--- a/src/plugins/chromecastPlayer/plugin.js
+++ b/src/plugins/chromecastPlayer/plugin.js
@@ -106,10 +106,9 @@ class CastPlayer {
             return;
         }
 
-        let applicationID = applicationStable;
-        if (userSettings.chromecastVersion() === 'unstable') {
-            applicationID = applicationUnstable;
-        }
+        let applicationID = userSettings.chromecastVersion();
+        if (applicationID === 'stable') applicationID = applicationStable;
+        if (applicationID === 'unstable') applicationID = applicationUnstable;
 
         // request session
         const sessionRequest = new chrome.cast.SessionRequest(applicationID);
@@ -117,7 +116,7 @@ class CastPlayer {
             this.sessionListener.bind(this),
             this.receiverListener.bind(this));
 
-        console.debug('chromecast.initialize');
+        console.debug(`chromecast.initialize (applicationId=${applicationID})`);
         chrome.cast.initialize(apiConfig, this.onInitSuccess.bind(this), this.errorHandler);
     }
 


### PR DESCRIPTION
Making the cast developer life a bit easier.

**Changes**
- Allow any string to be saved as chromecast version
  - Special values "stable" and "unstable" are mapped to the known ids
  - Other values are passed to the SessionRequest as-is

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
