### PR TITLE
Handle pressing Enter to finish keyboard dragging of slider

### DIFF
--- a/src/elements/emby-slider/emby-slider.js
+++ b/src/elements/emby-slider/emby-slider.js
@@ -501,6 +501,13 @@ function onKeyDown(e) {
             e.preventDefault();
             e.stopPropagation();
             break;
+        case 'Enter':
+            if (this.keyboardDragging) {
+                finishKeyboardDragging(this);
+                e.preventDefault();
+                e.stopPropagation();
+            }
+            break;
     }
 }
 


### PR DESCRIPTION
This allows to skip the timeout (1s) before sending the `change` event.

**Changes**
Handle pressing Enter to finish keyboard dragging of slider.
