### PR TITLE
Update node version in docker build

### DIFF
--- a/deployment/Dockerfile.docker
+++ b/deployment/Dockerfile.docker
@@ -1,4 +1,4 @@
-FROM node:lts-alpine
+FROM node:20-alpine
 
 ARG SOURCE_DIR=/src
 ARG ARTIFACT_DIR=/jellyfin-web


### PR DESCRIPTION
**Changes**
Update node version in docker build to v20

**Issues**
Fixes the build on develop failing since 20 is not tagged as the lts yet
