### PR TITLE
Remove caching of main animated pages element

### DIFF
--- a/src/components/viewContainer.js
+++ b/src/components/viewContainer.js
@@ -3,11 +3,7 @@ import './viewManager/viewContainer.scss';
 import Dashboard from '../utils/dashboard';
 
 const getMainAnimatedPages = () => {
-    if (!mainAnimatedPages) {
-        mainAnimatedPages = document.querySelector('.mainAnimatedPages');
-    }
-
-    return mainAnimatedPages;
+    return document.querySelector('.mainAnimatedPages');
 };
 
 function setControllerClass(view, options) {
@@ -61,7 +57,9 @@ export function loadView(options) {
 
         view.classList.add('mainAnimatedPage');
 
-        if (!getMainAnimatedPages()) {
+        const mainAnimatedPages = getMainAnimatedPages();
+
+        if (!mainAnimatedPages) {
             console.warn('[viewContainer] main animated pages element is not present');
             return;
         }
@@ -187,6 +185,7 @@ export function setOnBeforeChange(fn) {
 }
 
 export function tryRestoreView(options) {
+    console.debug('[viewContainer] tryRestoreView', options);
     const url = options.url;
     const index = currentUrls.indexOf(url);
 
@@ -232,14 +231,15 @@ function triggerDestroy(view) {
 }
 
 export function reset() {
+    console.debug('[viewContainer] resetting view cache');
     allPages = [];
     currentUrls = [];
+    const mainAnimatedPages = getMainAnimatedPages();
     if (mainAnimatedPages) mainAnimatedPages.innerHTML = '';
     selectedPageIndex = -1;
 }
 
 let onBeforeChange;
-let mainAnimatedPages;
 let allPages = [];
 let currentUrls = [];
 const pageContainerCount = 3;
@@ -248,8 +248,8 @@ reset();
 getMainAnimatedPages()?.classList.remove('hide');
 
 export default {
-    loadView: loadView,
-    tryRestoreView: tryRestoreView,
-    reset: reset,
-    setOnBeforeChange: setOnBeforeChange
+    loadView,
+    tryRestoreView,
+    reset,
+    setOnBeforeChange
 };


### PR DESCRIPTION
**Changes**
Remove caching of the main animated pages element to fix breakages caused by the element being removed and restored to the dom.

Required for the dashboard app separation.

**Issues**
N/A
