### PR TITLE
Handle pressing Enter to finish keyboard dragging of slider (Backport #4805)

### DIFF
--- a/src/elements/emby-slider/emby-slider.js
+++ b/src/elements/emby-slider/emby-slider.js
@@ -408,6 +408,13 @@ import '../emby-input/emby-input';
                 e.preventDefault();
                 e.stopPropagation();
                 break;
+            case 'Enter':
+                if (this.keyboardDragging) {
+                    finishKeyboardDragging(this);
+                    e.preventDefault();
+                    e.stopPropagation();
+                }
+                break;
         }
     }
 


### PR DESCRIPTION
I think it is pretty safe for release.

**Changes**
Backport #4805
> Handle pressing Enter to finish keyboard dragging of slider.
> This allows to skip the timeout (1s) before sending the change event.
