### PR TITLE
Clean backdrops when tab is not selected

### DIFF
--- a/src/components/backdrop/backdrop.js
+++ b/src/components/backdrop/backdrop.js
@@ -37,8 +37,11 @@ class Backdrop {
             parent.appendChild(backdropImage);
 
             if (!enableAnimation()) {
-                if (existingBackdropImage?.parentNode) {
-                    existingBackdropImage.parentNode.removeChild(existingBackdropImage);
+                if (existingBackdropImage) {
+                    const backdropContainer = getBackdropContainer();
+                    while (backdropContainer.childNodes.length > 1) {
+                        backdropContainer.removeChild(backdropContainer.firstChild);
+                    }
                 }
                 internalBackdrop(true);
                 return;
@@ -51,8 +54,11 @@ class Backdrop {
                 if (backdropImage === self.currentAnimatingElement) {
                     self.currentAnimatingElement = null;
                 }
-                if (existingBackdropImage?.parentNode) {
-                    existingBackdropImage.parentNode.removeChild(existingBackdropImage);
+                if (existingBackdropImage) {
+                    const backdropContainer = getBackdropContainer();
+                    while (backdropContainer.childNodes.length > 1) {
+                        backdropContainer.removeChild(backdropContainer.firstChild);
+                    }
                 }
             };
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**

When the tab is unselected, the function `existingBackdropImage.parentNode.remove(existingBackdropImage)` failed silently. Instead, now the parent `backdropContainer` is located and all the divs except the first one are removed. 

<!-- Describe your changes here in 1-5 sentences. -->

**Issues**

Fixes #3916 

<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
