### PR TITLE
Remove unnecessary renaming

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -66,6 +66,7 @@ module.exports = {
         'no-unused-expressions': ['off'],
         '@typescript-eslint/no-unused-expressions': ['error', { 'allowShortCircuit': true, 'allowTernary': true, 'allowTaggedTemplates': true }],
         'no-unused-private-class-members': ['error'],
+        'no-useless-rename': ['error'],
         'no-useless-constructor': ['off'],
         '@typescript-eslint/no-useless-constructor': ['error'],
         'no-var': ['error'],

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -66,6 +66,7 @@
  - [Fishbigger](https://github.com/fishbigger)
  - [sleepycatcoding](https://github.com/sleepycatcoding)
  - [TheMelmacian](https://github.com/TheMelmacian)
+ - [tehciolo](https://github.com/tehciolo)
 
 # Emby Contributors
 

--- a/src/components/itemContextMenu.js
+++ b/src/components/itemContextMenu.js
@@ -444,7 +444,7 @@ function executeCommand(item, id, options) {
                 });
                 break;
             case 'multiSelect':
-                import('./multiSelect/multiSelect').then(({ startMultiSelect: startMultiSelect }) => {
+                import('./multiSelect/multiSelect').then(({ startMultiSelect }) => {
                     const card = dom.parentWithClass(options.positionTo, 'card');
                     startMultiSelect(card);
                 });


### PR DESCRIPTION
**Changes**
- remove `startMultiSelect` renaming to address code smell below

**Issues**
Fixes [this code smell](https://sonarcloud.io/project/issues?cleanCodeAttributeCategories=INTENTIONAL&resolved=false&rules=javascript%3AS6650&id=jellyfin_jellyfin-web&open=AYljc2a2J8YZ6p3GEUmv)

----

I do not know how to manually test this in the UI, but I will happily do so if given minor pointers.

That being said, the change should be SAFE.
