### PR TITLE
Fix FilterMenu not saving simple filters

### DIFF
--- a/src/components/filtermenu/filtermenu.js
+++ b/src/components/filtermenu/filtermenu.js
@@ -103,7 +103,7 @@ function onInputCommand(e) {
     }
 }
 function saveValues(context, settings, settingsKey, setfilters) {
-    let elems = context.querySelectorAll('.simpleFilter');
+    let elems;
 
     // Video type
     const videoTypes = [];
@@ -157,6 +157,8 @@ function saveValues(context, settings, settingsKey, setfilters) {
             GenreIds: genres.join(',')
         }));
     } else {
+        elems = context.querySelectorAll('.simpleFilter');
+
         for (let i = 0, length = elems.length; i < length; i++) {
             if (elems[i].tagName === 'INPUT') {
                 setBasicFilter(context, settingsKey + '-filter-' + elems[i].getAttribute('data-settingname'), elems[i]);

--- a/src/components/filtermenu/filtermenu.js
+++ b/src/components/filtermenu/filtermenu.js
@@ -105,27 +105,27 @@ function onInputCommand(e) {
 function saveValues(context, settings, settingsKey, setfilters) {
     // Video type
     const videoTypes = [];
-    for (const elem of context.querySelectorAll('.chkVideoTypeFilter')) {
+    context.querySelectorAll('.chkVideoTypeFilter').forEach(elem => {
         if (elem.checked) {
             videoTypes.push(elem.getAttribute('data-filter'));
         }
-    }
+    });
 
     // Series status
     const seriesStatuses = [];
-    for (const elem of context.querySelectorAll('.chkSeriesStatus')) {
+    context.querySelectorAll('.chkSeriesStatus').forEach(elem => {
         if (elem.checked) {
             seriesStatuses.push(elem.getAttribute('data-filter'));
         }
-    }
+    });
 
     // Genres
     const genres = [];
-    for (const elem of context.querySelectorAll('.chkGenreFilter')) {
+    context.querySelectorAll('.chkGenreFilter').forEach(elem => {
         if (elem.checked) {
             genres.push(elem.getAttribute('data-filter'));
         }
-    }
+    });
 
     if (setfilters) {
         setfilters((prevState) => ({
@@ -149,13 +149,13 @@ function saveValues(context, settings, settingsKey, setfilters) {
             GenreIds: genres.join(',')
         }));
     } else {
-        for (const elem of context.querySelectorAll('.simpleFilter')) {
+        context.querySelectorAll('.simpleFilter').forEach(elem => {
             if (elem.tagName === 'INPUT') {
                 setBasicFilter(context, settingsKey + '-filter-' + elem.getAttribute('data-settingname'), elem);
             } else {
                 setBasicFilter(context, settingsKey + '-filter-' + elem.getAttribute('data-settingname'), elem.querySelector('input'));
             }
-        }
+        });
 
         userSettings.setFilter(settingsKey + '-filter-GenreIds', genres.join(','));
     }

--- a/src/components/filtermenu/filtermenu.js
+++ b/src/components/filtermenu/filtermenu.js
@@ -103,35 +103,27 @@ function onInputCommand(e) {
     }
 }
 function saveValues(context, settings, settingsKey, setfilters) {
-    let elems;
-
     // Video type
     const videoTypes = [];
-    elems = context.querySelectorAll('.chkVideoTypeFilter');
-
-    for (let i = 0, length = elems.length; i < length; i++) {
-        if (elems[i].checked) {
-            videoTypes.push(elems[i].getAttribute('data-filter'));
+    for (const elem of context.querySelectorAll('.chkVideoTypeFilter')) {
+        if (elem.checked) {
+            videoTypes.push(elem.getAttribute('data-filter'));
         }
     }
 
     // Series status
     const seriesStatuses = [];
-    elems = context.querySelectorAll('.chkSeriesStatus');
-
-    for (let i = 0, length = elems.length; i < length; i++) {
-        if (elems[i].checked) {
-            seriesStatuses.push(elems[i].getAttribute('data-filter'));
+    for (const elem of context.querySelectorAll('.chkSeriesStatus')) {
+        if (elem.checked) {
+            seriesStatuses.push(elem.getAttribute('data-filter'));
         }
     }
 
     // Genres
     const genres = [];
-    elems = context.querySelectorAll('.chkGenreFilter');
-
-    for (let i = 0, length = elems.length; i < length; i++) {
-        if (elems[i].checked) {
-            genres.push(elems[i].getAttribute('data-filter'));
+    for (const elem of context.querySelectorAll('.chkGenreFilter')) {
+        if (elem.checked) {
+            genres.push(elem.getAttribute('data-filter'));
         }
     }
 
@@ -157,13 +149,11 @@ function saveValues(context, settings, settingsKey, setfilters) {
             GenreIds: genres.join(',')
         }));
     } else {
-        elems = context.querySelectorAll('.simpleFilter');
-
-        for (let i = 0, length = elems.length; i < length; i++) {
-            if (elems[i].tagName === 'INPUT') {
-                setBasicFilter(context, settingsKey + '-filter-' + elems[i].getAttribute('data-settingname'), elems[i]);
+        for (const elem of context.querySelectorAll('.simpleFilter')) {
+            if (elem.tagName === 'INPUT') {
+                setBasicFilter(context, settingsKey + '-filter-' + elem.getAttribute('data-settingname'), elem);
             } else {
-                setBasicFilter(context, settingsKey + '-filter-' + elems[i].getAttribute('data-settingname'), elems[i].querySelector('input'));
+                setBasicFilter(context, settingsKey + '-filter-' + elem.getAttribute('data-settingname'), elem.querySelector('input'));
             }
         }
 


### PR DESCRIPTION
Regression 6341a71fec882726bdffa4ed3460a6cbcf252d6e

**Changes**
- Move "simpleFilter" query to where it is used.
- Move queries into loops.

**Issues**
FilterMenu doesn't save simple filters because of `elems` override.
