### PR TITLE
Fix playing empty item set

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -1734,6 +1734,8 @@ class PlaybackManager {
         }
 
         function translateItemsForPlayback(items, options) {
+            if (!items.length) return Promise.resolve([]);
+
             if (items.length > 1 && options && options.ids) {
                 // Use the original request id array for sorting the result in the proper order
                 items.sort(function (a, b) {


### PR DESCRIPTION
**Changes**
Return from the function if no items are provided.

It shows `This client isn't compatible with the media and the server isn't sending a compatible media format.` and the loading remains unhidden. So we need appropriate error handling.

**Issues**
Runtime error: accessing `items[0]` from an empty array.
