### PR TITLE
Use cast receiver application from user configuration

### DIFF
--- a/src/components/playbackSettings/playbackSettings.template.html
+++ b/src/components/playbackSettings/playbackSettings.template.html
@@ -138,10 +138,7 @@
         </div>
 
         <div class="selectContainer">
-            <select is="emby-select" class="selectChromecastVersion" label="${LabelChromecastVersion}">
-                <option value="stable">${LabelStable}</option>
-                <option value="unstable">${LabelUnstable}</option>
-            </select>
+            <select is="emby-select" class="selectChromecastVersion" label="${LabelChromecastVersion}"></select>
         </div>
 
         <div class="selectContainer">

--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -339,19 +339,6 @@ export class UserSettings {
     }
 
     /**
-     * Get or set Chromecast version.
-     * @param {string|undefined} val - Chromecast version.
-     * @return {string} Chromecast version.
-     */
-    chromecastVersion(val) {
-        if (val !== undefined) {
-            return this.set('chromecastVersion', val.toString());
-        }
-
-        return this.get('chromecastVersion') || 'stable';
-    }
-
-    /**
      * Get or set amount of rewind.
      * @param {number|undefined} val - Amount of rewind.
      * @return {number} Amount of rewind.
@@ -648,7 +635,6 @@ export const detailsBanner = currentSettings.detailsBanner.bind(currentSettings)
 export const useEpisodeImagesInNextUpAndResume = currentSettings.useEpisodeImagesInNextUpAndResume.bind(currentSettings);
 export const language = currentSettings.language.bind(currentSettings);
 export const dateTimeLocale = currentSettings.dateTimeLocale.bind(currentSettings);
-export const chromecastVersion = currentSettings.chromecastVersion.bind(currentSettings);
 export const skipBackLength = currentSettings.skipBackLength.bind(currentSettings);
 export const skipForwardLength = currentSettings.skipForwardLength.bind(currentSettings);
 export const dashboardTheme = currentSettings.dashboardTheme.bind(currentSettings);


### PR DESCRIPTION
Touching this code made me cry.

**Changes**
- Delay cast plugin initialization until user is signed in
- Use the cast receiver id from the user configuration
- Update playback settings page to use new cast receiver magic

~~The user configuration page will be in a separate PR because touching this code is dirty and I can't look at it for too long.~~

**Issues**

META jellyfin/jellyfin-meta#45
SERVER jellyfin/jellyfin#10270