### PR TITLE
Fix user menu shown when authenticated user is on select server page

### DIFF
--- a/src/components/toolbar/AppToolbar.tsx
+++ b/src/components/toolbar/AppToolbar.tsx
@@ -43,10 +43,7 @@ const AppToolbar: FC<AppToolbarProps> = ({
     const isBackButtonAvailable = appRouter.canGoBack();
 
     // Handles a specific case to hide the user menu on the select server page while authenticated
-    let isUserMenuAvailable = true;
-    if (currentLocation.pathname == '/selectserver.html') {
-        isUserMenuAvailable = false;
-    }
+    const isUserMenuAvailable = currentLocation.pathname !== '/selectserver.html';
 
     return (
         <Toolbar

--- a/src/components/toolbar/AppToolbar.tsx
+++ b/src/components/toolbar/AppToolbar.tsx
@@ -6,7 +6,7 @@ import Toolbar from '@mui/material/Toolbar';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import React, { FC, ReactNode } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 
 import appIcon from 'assets/img/icon-transparent.png';
 import { appRouter } from 'components/router/appRouter';
@@ -38,8 +38,15 @@ const AppToolbar: FC<AppToolbarProps> = ({
 }) => {
     const { user } = useApi();
     const isUserLoggedIn = Boolean(user);
+    const currentLocation = useLocation();
 
     const isBackButtonAvailable = appRouter.canGoBack();
+
+    // Handles a specific case to hide the user menu on the select server page while authenticated
+    let isUserMenuAvailable = true;
+    if (currentLocation.pathname == '/selectserver.html') {
+        isUserMenuAvailable = false;
+    }
 
     return (
         <Toolbar
@@ -111,7 +118,7 @@ const AppToolbar: FC<AppToolbarProps> = ({
 
             {children}
 
-            {isUserLoggedIn && (
+            {isUserLoggedIn && isUserMenuAvailable && (
                 <>
                     <Box sx={{ display: 'flex', flexGrow: 1, justifyContent: 'flex-end' }}>
                         {buttons}


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Added additional variable `isUserMenuAvailable` to allow conditional checking for not displaying the user menu when the current location is `selectserver.html`

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes (part of) #4815 
- Select server page should not show currently logged in user