### PR TITLE
Fix admin check in dashboard routes

### DIFF
--- a/src/apps/dashboard/App.tsx
+++ b/src/apps/dashboard/App.tsx
@@ -53,10 +53,10 @@ const DashboardApp = () => (
                     <ServerContentPage view='/web/configurationpage' />
                 } />
             </Route>
-
-            {/* Suppress warnings for unhandled routes */}
-            <Route path='*' element={null} />
         </Route>
+
+        {/* Suppress warnings for unhandled routes */}
+        <Route path='*' element={null} />
 
         {/* Redirects for old paths */}
         {REDIRECTS.map(toRedirectRoute)}


### PR DESCRIPTION
**Changes**
Fixes a regression introduced in https://github.com/jellyfin/jellyfin-web/pull/4816

The admin check was inadvertently applied to all routes causing non-admin users to constantly be redirected to the home screen.

**Issues**
None, but it has been reported a couple times in matrix.
