### PR TITLE
Feature: Delete items from containers on user delete

### DIFF
--- a/src/components/itemContextMenu.js
+++ b/src/components/itemContextMenu.js
@@ -9,6 +9,8 @@ import itemHelper from './itemHelper';
 import { playbackManager } from './playback/playbackmanager';
 import ServerConnections from './ServerConnections';
 import toast from './toast/toast';
+import events from 'utils/events';
+import clientNotifications from '../scripts/clientNotifications';
 
 export function getCommands(options) {
     const item = options.item;
@@ -623,6 +625,7 @@ function deleteItem(apiClient, item) {
                 item: item,
                 navigate: false
             }).then(function () {
+                events.trigger(clientNotifications, clientNotifications.ItemDeleted, [item]);
                 resolve(true);
             }, reject);
         });

--- a/src/elements/emby-itemscontainer/emby-itemscontainer.js
+++ b/src/elements/emby-itemscontainer/emby-itemscontainer.js
@@ -8,6 +8,7 @@ import dom from '../../scripts/dom';
 import loading from '../../components/loading/loading';
 import focusManager from '../../components/focusManager';
 import serverNotifications from '../../scripts/serverNotifications';
+import clientNotifications from '../../scripts/clientNotifications';
 import Events from '../../utils/events.ts';
 import 'webcomponents.js/webcomponents-lite';
 import ServerConnections from '../../components/ServerConnections';
@@ -307,10 +308,19 @@ ItemsContainerPrototype.attachedCallback = function () {
     addNotificationEvent(this, 'LibraryChanged', onLibraryChanged);
     addNotificationEvent(this, 'playbackstop', onPlaybackStopped, playbackManager);
 
+    addNotificationEvent(this, clientNotifications.ItemDeleted, onItemDeleted, clientNotifications);
+
     if (this.getAttribute('data-dragreorder') === 'true') {
         this.enableDragReordering(true);
     }
 };
+
+function onItemDeleted(e, item) {
+    const itemToRemove = this.querySelector('[data-id="' + item.Id + '"]');
+    if(itemToRemove) {
+        itemToRemove.remove();
+    }
+}
 
 ItemsContainerPrototype.detachedCallback = function () {
     clearRefreshInterval(this);
@@ -330,6 +340,8 @@ ItemsContainerPrototype.detachedCallback = function () {
     removeNotificationEvent(this, 'SeriesTimerCancelled');
     removeNotificationEvent(this, 'LibraryChanged');
     removeNotificationEvent(this, 'playbackstop', playbackManager);
+
+    removeNotificationEvent(this, clientNotifications.ItemDeleted, clientNotifications);
 
     this.fetchData = null;
     this.getItemsHtml = null;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -28,6 +28,7 @@ import './components/themeMediaPlayer';
 import { pageClassOn, serverAddress } from './utils/dashboard';
 import './scripts/screensavermanager';
 import './scripts/serverNotifications';
+import './scripts/clientNotifications';
 import './components/playback/playerSelectionMenu';
 import './legacy/domParserTextHtml';
 import './legacy/focusPreventScroll';

--- a/src/scripts/clientNotifications.js
+++ b/src/scripts/clientNotifications.js
@@ -1,0 +1,8 @@
+
+const clientNotifications = {
+    ItemDeleted: 'ItemDeleted',
+};
+
+window.ClientNotifications = clientNotifications;
+
+export default clientNotifications;


### PR DESCRIPTION
Creating this PR as draft to discuss implementation and UX of this feature.

This PR updates the emby ItemContainer element to listen for new clientNotifications.itemDeleted events and remove any matching children from the container that have a matching id. The item is completely removed from the dom so this would trigger a redraw which may not be desirable.

Additionally, when deleting an item from some sections, such as "NextUp", the next up data is not refreshed. A refresh of data could be implemented specifically for these sections where it makes sense to refetch the contents.

**Changes**
- Add clientNotifications for eventing
- Listen for clientNotifications.ItemDeleted events in itemContainer
- Trigger clientNotifications.ItemDeleted event from itemContextMenu upon delete

**Issues**
https://github.com/jellyfin/jellyfin/issues/905 
