### PR TITLE
Fix PR publish in GH actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,3 +39,27 @@ jobs:
           name: jellyfin-web__prod
           path: |
             dist
+
+  pr_context:
+    name: Save PR context as artifact
+    if: ${{ always() && !cancelled() && github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    needs:
+      - run-build-prod
+
+    steps:
+      - name: Save PR context
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+          PR_SHA: ${{ github.sha }}
+        run: |
+          echo $PR_NUMBER > PR_number
+          echo $PR_SHA > PR_sha
+
+      - name: Upload PR number as artifact
+        uses: actions/upload-artifact@v3.1.3
+        with:
+          name: PR_context
+          path: |
+            PR_number
+            PR_sha

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,3 +1,5 @@
+name: Publish
+
 on:
   workflow_run:
     workflows:


### PR DESCRIPTION
**Changes**
Fixes (hopefully) the errors when GH actions attempts to publish a PR to CF pages by adding the missing context upload job

**Issues**
https://github.com/jellyfin/jellyfin-web/actions/runs/6464611630
