### PR TITLE
Add current branch to CF Pages publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,7 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           projectName: jellyfin-web
+          branch: ${{ github.event.workflow_run.head_branch }}
           directory: dist
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
**Changes**
Adds the name of the branch triggering the workflow to the action. This ensures that publishes are correctly tagged as prodution/preview. refs: https://github.com/cloudflare/pages-action/tree/1/#specifying-a-branch

**Issues**
N/A
