### PR TITLE
Fix duplicate year in the series details page

### DIFF
--- a/src/components/mediainfo/mediainfo.js
+++ b/src/components/mediainfo/mediainfo.js
@@ -183,7 +183,7 @@ export function getMediaInfoHtml(item, options = {}) {
             if (item.EndDate) {
                 try {
                     const endYear = datetime.toLocaleString(datetime.parseISO8601Date(item.EndDate).getFullYear(), { useGrouping: false });
-					/* At this point, text will contain only the start year */
+                    /* At this point, text will contain only the start year */
                     if (endYear !== text) {
                         text += ` - ${endYear}`;
                     }

--- a/src/components/mediainfo/mediainfo.js
+++ b/src/components/mediainfo/mediainfo.js
@@ -183,9 +183,9 @@ export function getMediaInfoHtml(item, options = {}) {
             if (item.EndDate) {
                 try {
                     const endYear = datetime.toLocaleString(datetime.parseISO8601Date(item.EndDate).getFullYear(), { useGrouping: false });
-
-                    if (endYear !== item.ProductionYear) {
-                        text += `-${endYear}`;
+					/* At this point, text will contain only the start year */
+                    if (endYear !== text) {
+                        text += ` - ${endYear}`;
                     }
                 } catch (e) {
                     console.error('error parsing date:', item.EndDate);


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Changed the comparision to use text instead of item.ProductionYear. Fixes the same year from appearing in the [year]-[year] format as seen below. Using Jellyfin 10.9.0.
![image](https://github.com/jellyfin/jellyfin-web/assets/81431263/4e566724-6c3f-4373-a012-b0c371de0194)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
