### PR TITLE
Hide currently selected episode in 'More From Season' section

### DIFF
--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -1095,7 +1095,7 @@ function renderMoreFromSeason(view, item, apiClient) {
             section.classList.remove('hide');
             section.querySelector('h2').innerText = globalize.translate('MoreFromValue', item.SeasonName);
             const itemsContainer = section.querySelector('.itemsContainer');
-            cardBuilder.buildCards(result.Items, {
+            cardBuilder.buildCards(result.Items.filter((i) => i.Id !== item.Id), {
                 parentContainer: section,
                 itemsContainer: itemsContainer,
                 shape: 'autooverflow',


### PR DESCRIPTION
**Changes**
Filter out currently selected episode in 'More From Season' section that's visible in an episode's detailed view.

Before
![image](https://github.com/jellyfin/jellyfin-web/assets/68612932/c6738957-c08c-4db9-b4d0-d987f48b77e0)

After
![image](https://github.com/jellyfin/jellyfin-web/assets/68612932/3990f020-3195-4bd8-a7fb-5d32ccfa204b)