### PR TITLE
Change child item sort for Movies to PremiereDate

### DIFF
--- a/src/scripts/itemsByName.js
+++ b/src/scripts/itemsByName.js
@@ -195,7 +195,7 @@ function renderSection(item, element, type) {
                 PersonTypes: '',
                 ArtistIds: '',
                 AlbumArtistIds: '',
-                SortOrder: 'Descending',
+                SortOrder: 'Descending,Desending,Ascending',
                 SortBy: 'PremiereDate,ProductionYear,Sortname'
             }, {
                 shape: 'overflowSquare',

--- a/src/scripts/itemsByName.js
+++ b/src/scripts/itemsByName.js
@@ -125,8 +125,8 @@ function renderSection(item, element, type) {
                 ArtistIds: '',
                 AlbumArtistIds: '',
                 Limit: 10,
-                SortOrder: 'Descending',
-                SortBy: 'PremiereDate,ProductionYear,Sortname'
+                SortOrder: 'Descending,Desending,Ascending',
+                SortBy: 'PremiereDate,ProductionYear,SortName'
             }, {
                 shape: 'overflowPortrait',
                 showTitle: true,

--- a/src/scripts/itemsByName.js
+++ b/src/scripts/itemsByName.js
@@ -125,7 +125,8 @@ function renderSection(item, element, type) {
                 ArtistIds: '',
                 AlbumArtistIds: '',
                 Limit: 10,
-                SortBy: 'SortName'
+                SortOrder: 'Descending',
+                SortBy: 'PremiereDate,ProductionYear,Sortname'
             }, {
                 shape: 'overflowPortrait',
                 showTitle: true,


### PR DESCRIPTION
**Changes**

This change alters the `/detail` page of actors/directors/etc such that the `childrenContent` section for Movies now displays in reverse chronological order. Not without precedent, [itemsByName.js for MusicAlbum](https://github.com/jellyfin/jellyfin-web/blob/5bc595dc877cef5b3e1e9c86d24d5c9fd7b61271/src/scripts/itemsByName.js#L198) already sorts in this way.

**Issues**

No issues were created related to this change.