### PR TITLE
Change search page to support query param

### DIFF
--- a/src/apps/stable/routes/search.tsx
+++ b/src/apps/stable/routes/search.tsx
@@ -19,11 +19,12 @@ function usePrevious(value: string) {
 
 const Search: FunctionComponent = () => {
     const [ searchParams ] = useSearchParams();
-    const [ query, setQuery ] = useState<string>(searchParams.get('query') || '');
+    const urlQuery = searchParams.get('query') || '';
+    const [ query, setQuery ] = useState<string>(urlQuery);
     const prevQuery = usePrevious(query);
 
-    if (query == prevQuery && searchParams.get('query') != query) {
-        setQuery(searchParams.get('query') || '');
+    if (query == prevQuery && urlQuery != query) {
+        setQuery(urlQuery);
     }
 
     useEffect(() => {

--- a/src/apps/stable/routes/search.tsx
+++ b/src/apps/stable/routes/search.tsx
@@ -11,6 +11,7 @@ import globalize from '../../../scripts/globalize';
 const Search: FunctionComponent = () => {
     const [ query, setQuery ] = useState<string>();
     const [ searchParams ] = useSearchParams();
+    if (!query && searchParams.get('q')) setQuery(searchParams.get('q') || '');
 
     return (
         <Page

--- a/src/apps/stable/routes/search.tsx
+++ b/src/apps/stable/routes/search.tsx
@@ -11,7 +11,7 @@ import globalize from '../../../scripts/globalize';
 const Search: FunctionComponent = () => {
     const [ query, setQuery ] = useState<string>();
     const [ searchParams ] = useSearchParams();
-    if (!query && searchParams.get('q')) setQuery(searchParams.get('q') || '');
+    if (!query && searchParams.get('query')) setQuery(searchParams.get('query') || '');
 
     return (
         <Page

--- a/src/apps/stable/routes/search.tsx
+++ b/src/apps/stable/routes/search.tsx
@@ -22,9 +22,7 @@ const Search: FunctionComponent = () => {
     const [ query, setQuery ] = useState<string>(searchParams.get('query') || '');
     const prevQuery = usePrevious(query);
 
-    console.error('Search component initialized', { 'urlParam': searchParams.get('query'), 'obj.query': query, 'prevQuery': prevQuery });
     if (query == prevQuery && searchParams.get('query') != query) {
-        console.error('SET QUERY VIA URL', searchParams.get('query'));
         setQuery(searchParams.get('query') || '');
     }
 
@@ -34,7 +32,6 @@ const Search: FunctionComponent = () => {
             /* Explicitly using `window.history.pushState` instead of `history.replace` as the use of the latter
             triggers a re-rendering of this component, resulting in double-execution searches. If there's a
             way to use `history` without this side effect, it would likely be preferable. */
-            console.error('PUSH STATE VIA QUERY', query);
             window.history.pushState({}, '', `/#${history.location.pathname}${newSearch}`);
         }
     }, [query, prevQuery]);

--- a/src/components/search/SearchFields.tsx
+++ b/src/components/search/SearchFields.tsx
@@ -31,16 +31,22 @@ const createInputElement = () => ({
 const normalizeInput = (value = '') => value.trim();
 
 type SearchFieldsProps = {
+    query: string,
     onSearch?: (query: string) => void
 };
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
-const SearchFields: FunctionComponent<SearchFieldsProps> = ({ onSearch = () => {} }: SearchFieldsProps) => {
+const SearchFields: FunctionComponent<SearchFieldsProps> = ({ onSearch = () => {}, query }: SearchFieldsProps) => {
     const element = useRef<HTMLDivElement>(null);
 
     const getSearchInput = () => element?.current?.querySelector<HTMLInputElement>('.searchfields-txtSearch');
 
     const debouncedOnSearch = useMemo(() => debounce(onSearch, 400), [onSearch]);
+
+    const initSearchInput = getSearchInput();
+    if (initSearchInput) {
+        initSearchInput.value = query;
+    }
 
     useEffect(() => {
         getSearchInput()?.addEventListener('input', e => {

--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -1258,11 +1258,11 @@ function renderTags(page, item) {
     }
 
     for (let i = 0, length = tags.length; i < length; i++) {
-        tagElements.push(tags[i]);
+        tagElements.push('<a href="#/search.html?query=' + encodeURIComponent(tags[i]) + '" class="button-link emby-button" is="emby-linkbutton">' + tags[i] + '</a>');
     }
 
     if (tagElements.length) {
-        itemTags.innerText = globalize.translate('TagsValue', tagElements.join(', '));
+        itemTags.innerHTML = globalize.translate('TagsValue', tagElements.join(', '));
         itemTags.classList.remove('hide');
     } else {
         itemTags.innerHTML = '';


### PR DESCRIPTION
**Changes**

* Augmenting `search.tsx` to support a linked search (e.g. `/#/search.html?q=foobar`).
  *  Changes to the search input are dynamically represented in the URL
  *  Changes to the URL are dynamically represented in the search input
* Demonstrating functionality of this by additionally altering `itemTags` to link to predefined searches.

**Issues**

https://features.jellyfin.org/?query=Search%20parameters%20in%20URL (ironically, features.jellyfin.org supports linked searches!)