### PR TITLE
Use LTR for default subtitle direction

### DIFF
--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -143,7 +143,9 @@ function normalizeTrackEventText(text, useHtml) {
     const result = text
         .replace(/\\N/gi, '\n') // Correct newline characters
         .replace(/\r/gi, '') // Remove carriage return characters
-        .replace(/{\\.*?}/gi, ''); // Remove ass/ssa tags
+        .replace(/{\\.*?}/gi, '') // Remove ass/ssa tags
+        // Force LTR as the default direction
+        .split('\n').map(val => `\u200E${val}`).join('\n');
     return useHtml ? result.replace(/\n/gi, '<br>') : result;
 }
 


### PR DESCRIPTION
**Changes**
It seems that subtitle files have traditionally written RTL subs in LTR format to account for a lack of proper RTL support. Browser subtitle rendering will try to intelligently guess the proper text direction based on the first character in the text to prevent this behavior we need to prepend the LTR mark character to force the direction. I did find some precedence for this where Kodi have had to do something similar in the past. :man_shrugging: 

**Issues**
Fixes #4179 