### PR TITLE
Handle json parse error when testing urls

### DIFF
--- a/src/components/ConnectionRequired.tsx
+++ b/src/components/ConnectionRequired.tsx
@@ -53,8 +53,12 @@ const ConnectionRequired: FunctionComponent<ConnectionRequiredProps> = ({
                 return;
             case ConnectionState.ServerSelection:
                 // Bounce to select server page
-                console.debug('[ConnectionRequired] redirecting to select server page');
-                navigate(BounceRoutes.SelectServer);
+                if (location.pathname === BounceRoutes.SelectServer) {
+                    setIsLoading(false);
+                } else {
+                    console.debug('[ConnectionRequired] redirecting to select server page');
+                    navigate(BounceRoutes.SelectServer);
+                }
                 return;
             case ConnectionState.ServerUpdateNeeded:
                 // Show update needed message and bounce to select server page

--- a/src/utils/dashboard.js
+++ b/src/utils/dashboard.js
@@ -56,9 +56,16 @@ export async function serverAddress() {
                     return;
                 }
 
+                let config;
+                try {
+                    config = await resp.json();
+                } catch (err) {
+                    return;
+                }
+
                 return {
                     url,
-                    config: await resp.json()
+                    config
                 };
             }).catch(error => {
                 console.error(error);


### PR DESCRIPTION
**Changes**
Fixes an issue where the app will crash if a tested url returns a successful response that is not valid json. This was particularly noticeable on the cloudflare pages deployments where `/System/Info/Public` is returning the `index.html` file by default.

**Issues**
N/A
