### PR TITLE
Randomize backdrop images in screensaver

### DIFF
--- a/src/components/slideshow/slideshow.js
+++ b/src/components/slideshow/slideshow.js
@@ -14,6 +14,7 @@ import 'material-design-icons-iconfont';
 import '../../elements/emby-button/paper-icon-button-light';
 import ServerConnections from '../ServerConnections';
 import screenfull from 'screenfull';
+import { randomInt } from '../../utils/number.ts';
 
 /**
  * Name of transition event.
@@ -71,7 +72,8 @@ function getBackdropImageUrl(item, options, apiClient) {
     }
 
     if (item.BackdropImageTags?.length) {
-        options.tag = item.BackdropImageTags[0];
+        options.index = randomInt(0, item.BackdropImageTags.length - 1);
+        options.tag = item.BackdropImageTags[options.index];
         return apiClient.getScaledImageUrl(item.Id, options);
     }
 

--- a/src/plugins/backdropScreensaver/plugin.js
+++ b/src/plugins/backdropScreensaver/plugin.js
@@ -18,7 +18,7 @@ class BackdropScreensaver {
             SortBy: 'Random',
             Recursive: true,
             Fields: 'Taglines',
-            ImageTypeLimit: 1,
+            ImageTypeLimit: 10,
             StartIndex: 0,
             Limit: 200
         };


### PR DESCRIPTION
~~Added 'Backdrop,Backdrop1,Backdrop2,Backdrop3,Backdrop4,Backdrop5' to imagetypes and Enableimagetypes.~~

~~Added "Season" to Includeitemtypes.~~

~~Increased `Limit` to 400.~~

Changed Slideshow.js to include `RandomInt` to pull random image instead of first. 

Increased `ImageTypeLimit` to 10.

This provides a more varied experience viewing the backdrop screensaver.


