### PR TITLE
Add check for quick connect enabled in menu

### DIFF
--- a/src/components/toolbar/AppUserMenu.tsx
+++ b/src/components/toolbar/AppUserMenu.tsx
@@ -19,6 +19,7 @@ import { appHost } from 'components/apphost';
 import { useApi } from 'hooks/useApi';
 import globalize from 'scripts/globalize';
 import Dashboard from 'utils/dashboard';
+import { useQuickConnectEnabled } from 'hooks/useQuickConnect';
 
 export const ID = 'app-user-menu';
 
@@ -32,6 +33,7 @@ const AppUserMenu: FC<AppUserMenuProps> = ({
     onMenuClose
 }) => {
     const { user } = useApi();
+    const { data: isQuickConnectEnabled } = useQuickConnectEnabled();
 
     const onClientSettingsClick = useCallback(() => {
         window.NativeShell?.openClientSettings();
@@ -138,18 +140,20 @@ const AppUserMenu: FC<AppUserMenuProps> = ({
             ])}
 
             <Divider />
-            <MenuItem
-                component={Link}
-                to='/quickconnect'
-                onClick={onMenuClose}
-            >
-                <ListItemIcon>
-                    <PhonelinkLock />
-                </ListItemIcon>
-                <ListItemText>
-                    {globalize.translate('QuickConnect')}
-                </ListItemText>
-            </MenuItem>
+            {isQuickConnectEnabled && (
+                <MenuItem
+                    component={Link}
+                    to='/quickconnect'
+                    onClick={onMenuClose}
+                >
+                    <ListItemIcon>
+                        <PhonelinkLock />
+                    </ListItemIcon>
+                    <ListItemText>
+                        {globalize.translate('QuickConnect')}
+                    </ListItemText>
+                </MenuItem>
+            )}
 
             {appHost.supports('multiserver') && (
                 <MenuItem

--- a/src/hooks/useQuickConnect.ts
+++ b/src/hooks/useQuickConnect.ts
@@ -1,0 +1,25 @@
+import { getQuickConnectApi } from '@jellyfin/sdk/lib/utils/api/quick-connect-api';
+import { useQuery } from '@tanstack/react-query';
+import { AxiosRequestConfig } from 'axios';
+
+import { JellyfinApiContext, useApi } from './useApi';
+
+const fetchQuickConnectEnabled = async (
+    apiContext: JellyfinApiContext,
+    options?: AxiosRequestConfig
+) => {
+    const { api } = apiContext;
+    if (!api) throw new Error('No API instance available');
+
+    const response = await getQuickConnectApi(api)
+        .getQuickConnectEnabled(options);
+    return response.data;
+};
+
+export const useQuickConnectEnabled = () => {
+    const currentApi = useApi();
+    return useQuery({
+        queryKey: [ 'QuickConnect', 'Enabled' ],
+        queryFn: ({ signal }) => fetchQuickConnectEnabled(currentApi, { signal })
+    });
+};


### PR DESCRIPTION
**Changes**
The user menu in the experimental layout was not checking if quick connect was enabled when rendering the link. This can be tested using the demo server where quick connect is disabled.

**Issues**
N/A
