### PR TITLE
fix jittering in emby-checkbox

### DIFF
--- a/src/elements/emby-checkbox/emby-checkbox.scss
+++ b/src/elements/emby-checkbox/emby-checkbox.scss
@@ -120,10 +120,10 @@
 
 @keyframes repaintChrome {
     from {
-        padding: 0;
+        margin: 0;
     }
 
     to {
-        padding: 0;
+        margin: 0;
     }
 }


### PR DESCRIPTION
I've noticed that when you navigate through checkboxes or toggle them from the TV UI, there's this strange blinking animation. While looking for the culprit, I stumbled upon `forceRefresh`, and it looks like it's been around since the repo's creation.

I've been trying to figure out why it's there or look for any other references but came up with nothing. Removing it seems to solve the problem on my Tizen TV.

I initially recorded this issue in Chrome on my PC by spoofing the Tizen user agent, but I also did a test run on my TV using jellyfin-tizen. The TV didn't explode, so I thought it’d be a good idea to create this PR. :)

current behaviour
https://github.com/jellyfin/jellyfin-web/assets/28578847/21760c3f-4f94-4d24-826b-91a4c0892368

removing the hack
https://github.com/jellyfin/jellyfin-web/assets/28578847/9ff35bd6-bf4d-4677-ac6a-f92ef63c55c6