### PR TITLE
Fix quality check workflows

### DIFF
--- a/.github/workflows/pr-suggestions.yml
+++ b/.github/workflows/pr-suggestions.yml
@@ -1,0 +1,38 @@
+name: PR suggestions
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.id || github.run_id }}
+  cancel-in-progress: true
+
+on:
+  pull_request_target:
+    branches: [ master, release* ]
+    types:
+      - synchronize
+
+jobs:
+  run-eslint:
+    name: Run eslint suggestions
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup node environment
+        uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8 # v3.7.0
+        with:
+          node-version: 20
+          check-latest: true
+          cache: npm
+
+      - name: Install Node.js dependencies
+        run: npm ci --no-audit
+
+      - name: Run eslint
+        if: ${{ github.repository == 'jellyfin/jellyfin-web' }}
+        uses: CatChen/eslint-suggestion-action@d43938d6a379bc9a53c9c6d307e2d43bff0536be # v3.0.2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -7,10 +7,8 @@ concurrency:
 on:
   push:
     branches: [ master, release* ]
-  pull_request_target:
+  pull_request:
     branches: [ master, release* ]
-    types:
-      - synchronize
 
 jobs:
   run-escheck:
@@ -55,15 +53,7 @@ jobs:
       - name: Install Node.js dependencies
         run: npm ci --no-audit
 
-
-      - name: Run eslint (changed)
-        if: ${{ github.repository == 'jellyfin/jellyfin-web' }}
-        uses: CatChen/eslint-suggestion-action@d43938d6a379bc9a53c9c6d307e2d43bff0536be # v3.0.2
-        with:
-          github-token: ${{ secrets.JF_BOT_TOKEN }}
-
-      - name: Run eslint (all)
-        if: always()
+      - name: Run eslint
         run: npx eslint --quiet "."
 
   run-stylelint-css:


### PR DESCRIPTION
**Changes**
Reverts the quality workflow trigger to use `pull_request` and moves the eslint suggestions to a separate workflow that explicitly checks out the PR SHA

**Issues**
None but the quality workflow is currently checking out master instead of the PR content :grimacing: :sweat_smile: 