### PR TITLE
Bump jellyfin-apiclient to v1.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7839,9 +7839,9 @@
       }
     },
     "jellyfin-apiclient": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/jellyfin-apiclient/-/jellyfin-apiclient-1.10.0.tgz",
-      "integrity": "sha512-Y7Py/xuAznOhSuADihalrw4et3uTaDLbaClAoYzPMPQaPEjdP8dIST1kFEskOU30Iw28pi+S0byTEHDbQglIvQ=="
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/jellyfin-apiclient/-/jellyfin-apiclient-1.11.0.tgz",
+      "integrity": "sha512-XpYHdvoK8gT6CHSMquITz8Zk/z3Vo8Jwp5gIRX5p1FEVQQqDSoCxturhx45SXiCktcAaZesrq8f+Ay+xi/lrVQ=="
     },
     "jest-worker": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "headroom.js": "0.12.0",
     "hls.js": "0.14.17",
     "intersection-observer": "0.12.0",
-    "jellyfin-apiclient": "1.10.0",
+    "jellyfin-apiclient": "1.11.0",
     "jquery": "3.6.0",
     "jstree": "3.3.12",
     "libarchive.js": "1.3.0",


### PR DESCRIPTION
**Changes**
Backports the apiclient version update

**Issues**
N/A
