### PR TITLE
Wait for login before ask for notification permission

### DIFF
--- a/src/components/notifications/notifications.js
+++ b/src/components/notifications/notifications.js
@@ -28,7 +28,7 @@ function initPermissionRequest() {
     const apiClient = ServerConnections.currentApiClient();
     if (apiClient) {
         apiClient.getCurrentUser()
-            .then(user => user && registerOneDocumentClickHandler())
+            .then(user => registerOneDocumentClickHandler())
             .catch(() => {
                 Events.on(ServerConnections, 'localusersignedin', registerOneDocumentClickHandler);
             });

--- a/src/components/notifications/notifications.js
+++ b/src/components/notifications/notifications.js
@@ -17,6 +17,7 @@ function onOneDocumentClick() {
         Notification.requestPermission();
     }
 }
+
 function registerOneDocumentClickHandler() {
     Events.off(ServerConnections, 'localusersignedin', registerOneDocumentClickHandler);
 
@@ -28,7 +29,7 @@ function initPermissionRequest() {
     const apiClient = ServerConnections.currentApiClient();
     if (apiClient) {
         apiClient.getCurrentUser()
-            .then(user => registerOneDocumentClickHandler())
+            .then(() => registerOneDocumentClickHandler())
             .catch(() => {
                 Events.on(ServerConnections, 'localusersignedin', registerOneDocumentClickHandler);
             });

--- a/src/components/notifications/notifications.js
+++ b/src/components/notifications/notifications.js
@@ -3,6 +3,7 @@ import { playbackManager } from '../playback/playbackmanager';
 import Events from '../../utils/events.ts';
 import globalize from '../../scripts/globalize';
 import { getItems } from '../../utils/jellyfin-apiclient/getItems.ts';
+import ServerConnections from '../../components/ServerConnections';
 
 import NotificationIcon from './notificationicon.png';
 
@@ -16,9 +17,27 @@ function onOneDocumentClick() {
         Notification.requestPermission();
     }
 }
+function registerOneDocumentClickHandler() {
+    Events.off(ServerConnections, 'localusersignedin', registerOneDocumentClickHandler);
 
-document.addEventListener('click', onOneDocumentClick);
-document.addEventListener('keydown', onOneDocumentClick);
+    document.addEventListener('click', onOneDocumentClick);
+    document.addEventListener('keydown', onOneDocumentClick);
+}
+
+function initPermissionRequest() {
+    const apiClient = ServerConnections.currentApiClient();
+    if (apiClient) {
+        apiClient.getCurrentUser()
+            .then(user => user && registerOneDocumentClickHandler())
+            .catch(() => {
+                Events.on(ServerConnections, 'localusersignedin', registerOneDocumentClickHandler);
+            });
+    } else {
+        registerOneDocumentClickHandler();
+    }
+}
+
+initPermissionRequest();
 
 let serviceWorkerRegistration;
 


### PR DESCRIPTION
**Changes**
Previously the user was interrupted on first login with a popup to allow notifications.

Now the popup component checks if there is a current user and if not it will listen to the login event, to register the eventlisteners wich trigger the permission request


**Issues**
Fixes: #3243
