### PR TITLE
feat(livetv): add filter for channel groups

### DIFF
--- a/src/components/filterdialog/filterdialog.template.html
+++ b/src/components/filterdialog/filterdialog.template.html
@@ -140,4 +140,9 @@
         <div class="collapseContent filterOptions">
         </div>
     </div>
+
+    <div is="emby-collapse" title="${HeaderChannelGroups}" class="channelGroupFilters hide">
+        <div class="collapseContent filterOptions">
+        </div>
+    </div>
 </div>

--- a/src/controllers/livetv/livetvchannels.js
+++ b/src/controllers/livetv/livetvchannels.js
@@ -12,6 +12,7 @@ export default function (view, params, tabContent) {
         if (!pageData) {
             pageData = {
                 query: {
+                    IncludeItemTypes: 'LiveTvChannel',
                     StartIndex: 0,
                     Fields: 'PrimaryImageAspectRatio'
                 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
This PR adds a filter to the LiveTV channels allowing users to filter by channel groups.
Linked to this [PR](https://github.com/jellyfin/jellyfin/pull/10526).

I did some refactor because there were a lot of duplicates in the code.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Addresses [#1227](https://github.com/jellyfin/jellyfin/issues/1227) (moved [here](https://features.jellyfin.org/posts/186/iptv-channel-groupings))