### PR TITLE
Remove FLAC Audio in Video Support for Tizen

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -536,7 +536,7 @@ export default function (options) {
         }
     }
 
-    if (canPlayAudioFormat('flac')) {
+    if (canPlayAudioFormat('flac') && !browser.tizen) {
         videoAudioCodecs.push('flac');
         hlsInFmp4VideoAudioCodecs.push('flac');
     }

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -536,6 +536,7 @@ export default function (options) {
         }
     }
 
+    // FLAC audio in video plays with a delay on Tizen
     if (canPlayAudioFormat('flac') && !browser.tizen) {
         videoAudioCodecs.push('flac');
         hlsInFmp4VideoAudioCodecs.push('flac');


### PR DESCRIPTION
I opened this issue here https://github.com/jellyfin/jellyfin/issues/10504 where I explain it better (wrong repo).

Basically, FLAC support on Samsung is weird. In their documentation, they don't claim to support it, but you can play it. However, you will probably get audio and video that are not synced most of the time. I also tested and found that Plex transcodes FLAC audio in videos for Samsung, and I found a post in the Emby forums (linked in the issue I opened) where they update it to do the same.

**Changes**
Remove FLAC audio in video support for Tizen