### PR TITLE
Add mks file support to subtitle uploader component and template

### DIFF
--- a/src/components/subtitleuploader/subtitleuploader.js
+++ b/src/components/subtitleuploader/subtitleuploader.js
@@ -32,7 +32,7 @@ function onFileReaderError(evt) {
 }
 
 function isValidSubtitleFile(file) {
-    return file && ['.sub', '.srt', '.vtt', '.ass', '.ssa']
+    return file && ['.sub', '.srt', '.vtt', '.ass', '.ssa', '.mks']
         .some(function(ext) {
             return file.name.endsWith(ext);
         });

--- a/src/components/subtitleuploader/subtitleuploader.template.html
+++ b/src/components/subtitleuploader/subtitleuploader.template.html
@@ -22,7 +22,7 @@
                 <div class="subtitleEditor-dropZone fieldDescription">
                     <div id="labelDropSubtitle">${LabelDropSubtitleHere}</div>
                     <output id="subtitleOutput" class="flex align-items-center justify-content-center" style="position: absolute;top:0;left:0;right:0;bottom:0;width:100%;"></output>
-                    <input type="file" accept=".sub,.srt,.vtt,.ass,.ssa" id="uploadSubtitle" name="uploadSubtitle" style="position: absolute;top:0;left:0;right:0;bottom:0;width:100%;opacity:0;"/>
+                    <input type="file" accept=".sub,.srt,.vtt,.ass,.ssa,.mks" id="uploadSubtitle" name="uploadSubtitle" style="position: absolute;top:0;left:0;right:0;bottom:0;width:100%;opacity:0;"/>
                 </div>
                 <div id="fldUpload" class="hide">
                     <br />


### PR DESCRIPTION
Changed subtitle uploader and appropriate template to support selecting mks files for uploading in the file select dialog.<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
Added mks file type to the validation function in the subtitle uploader component and in the template
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
resolves #4921 