### PR TITLE
Disable the broken AV1 decoding on Edge 117+

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -200,7 +200,8 @@ function supportsHdr10(options) {
             || browser.web0s
             || browser.safari && ((browser.iOS && browser.iOSVersion >= 11) || browser.osx)
             // Chrome mobile and Firefox have no client side tone-mapping
-            // Edge Chromium on Nvidia is known to have color issues on 10-bit video
+            // Edge Chromium 117+ fixed the tone-mapping color issue on Nvidia
+            || browser.edgeChromium && browser.versionMajor >= 117
             || browser.chrome && !browser.mobile
     );
 }

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -28,6 +28,12 @@ function canPlayAv1(videoTestElement) {
         return true;
     }
 
+    // Edge Chromium broke the AV1 hardware decoding in 117+,
+    // and it can't decode AV1 in software as a fallback either.
+    if (browser.edgeChromium && browser.versionMajor >= 117) {
+        return false;
+    }
+
     // av1 main level 5.3
     return !!videoTestElement.canPlayType
         && (videoTestElement.canPlayType('video/mp4; codecs="av01.0.15M.08"').replace(/no/, '')

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -577,7 +577,7 @@ export default function (options) {
     }
 
     if (canPlayHevc(videoTestElement, options)
-        && (browser.edgeChromium || browser.safari || browser.tizen || browser.web0s || (browser.chrome && (!browser.android || browser.chrome.versionMajor >= 105)))) {
+        && (browser.edgeChromium || browser.safari || browser.tizen || browser.web0s || (browser.chrome && (!browser.android || browser.versionMajor >= 105)))) {
         // Chromium used to support HEVC on Android but not via MSE
         hlsInFmp4VideoCodecs.push('hevc');
     }

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1644,7 +1644,7 @@
     "LabelOriginalMediaInfo": "Original Media Info",
     "LabelSyncPlayInfo": "SyncPlay Info",
     "PreferFmp4HlsContainer": "Prefer fMP4-HLS Media Container",
-    "PreferFmp4HlsContainerHelp": "Prefer to use fMP4 as the default container for HLS, making it possible to direct stream HEVC content on supported devices.",
+    "PreferFmp4HlsContainerHelp": "Prefer to use fMP4 as the default container for HLS, making it possible to direct stream HEVC and AV1 content on supported devices.",
     "AllowHevcEncoding": "Allow encoding in HEVC format",
     "LabelAllowedAudioChannels": "Maximum Allowed Audio Channels",
     "LabelSelectAudioChannels": "Channels",


### PR DESCRIPTION
Edge Chromium broke the AV1 hardware decoding in 117+, and it can't decode AV1 in software as a fallback either.

**Changes**
- Disable the broken AV1 decoding on Edge 117+
- Re-enabled the HDR playback on Edge 117+
- Fix a typo in Chrome version check
- Update fMP4-HLS descriptions for AV1

**Issues**
https://www.reddit.com/r/AV1/comments/16mmm35/av1_and_edge/
https://techcommunity.microsoft.com/t5/discussions/av1-not-working-and-dropping-frames-on-yt-videos/m-p/3946087
