### PR TITLE
Remove H264 10bit support on Samsung TV (Tizen) (Backport #4797)

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -848,10 +848,9 @@ export default function (options) {
         maxH264Level = 52;
     }
 
-    if ((browser.tizen
-            || videoTestElement.canPlayType('video/mp4; codecs="avc1.6e0033"').replace(/no/, ''))
+    if (videoTestElement.canPlayType('video/mp4; codecs="avc1.6e0033"').replace(/no/, '')
             // These tests are passing in safari, but playback is failing
-            && !browser.safari && !browser.iOS && !browser.web0s && !browser.edge && !browser.mobile
+            && !browser.safari && !browser.iOS && !browser.web0s && !browser.edge && !browser.mobile && !browser.tizen
     ) {
         h264Profiles += '|high 10';
     }


### PR DESCRIPTION
**Changes**
Backport #4797
> Remove high10 support for Tizen clients

**Issues**
Fixes https://github.com/jellyfin/jellyfin-tizen/issues/206
