### PR TITLE
Add abortable fetch polyfill

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,11 +1,11 @@
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 import 'jquery';
-import 'abortcontroller-polyfill/dist/abortcontroller-polyfill-only';
 import 'fast-text-encoding';
 import 'intersection-observer';
 import 'classlist.js';
 import 'whatwg-fetch';
+import 'abortcontroller-polyfill'; // requires fetch
 import 'resize-observer-polyfill';
 import './styles/site.scss';
 import React, { StrictMode } from 'react';


### PR DESCRIPTION
`AbortController` is not enough (https://github.com/jellyfin/jellyfin-web/pull/4958).

**Changes**
Add abortable fetch polyfill.

**Issues**
Fixes https://github.com/jellyfin/jellyfin-web/issues/4940
