### PR TITLE
Add option to enable replaygain scanning

### DIFF
--- a/src/components/libraryoptionseditor/libraryoptionseditor.js
+++ b/src/components/libraryoptionseditor/libraryoptionseditor.js
@@ -416,6 +416,8 @@ export function setContentType(parent, contentType) {
         }
     }
 
+    parent.querySelector('.chkUseReplayGainTagsContainer').classList.toggle('hide', contentType !== 'music');
+
     parent.querySelector('.chkEnableLUFSScanContainer').classList.toggle('hide', contentType !== 'music');
 
     if (contentType === 'tvshows') {
@@ -515,6 +517,7 @@ export function getLibraryOptions(parent) {
         EnablePhotos: parent.querySelector('.chkEnablePhotos').checked,
         EnableRealtimeMonitor: parent.querySelector('.chkEnableRealtimeMonitor').checked,
         EnableLUFSScan: parent.querySelector('.chkEnableLUFSScan').checked,
+        UseReplayGainTags: parent.querySelector('.chkUseReplayGainTags').checked,
         ExtractChapterImagesDuringLibraryScan: parent.querySelector('.chkExtractChaptersDuringLibraryScan').checked,
         EnableChapterImageExtraction: parent.querySelector('.chkExtractChapterImages').checked,
         EnableInternetProviders: true,
@@ -577,6 +580,7 @@ export function setLibraryOptions(parent, options) {
     parent.querySelector('.chkEnablePhotos').checked = options.EnablePhotos;
     parent.querySelector('.chkEnableRealtimeMonitor').checked = options.EnableRealtimeMonitor;
     parent.querySelector('.chkEnableLUFSScan').checked = options.EnableLUFSScan;
+    parent.querySelector('.chkUseReplayGainTags').checked = options.UseReplayGainTags;
     parent.querySelector('.chkExtractChaptersDuringLibraryScan').checked = options.ExtractChapterImagesDuringLibraryScan;
     parent.querySelector('.chkExtractChapterImages').checked = options.EnableChapterImageExtraction;
     parent.querySelector('#chkSaveLocal').checked = options.SaveLocalMetadata;

--- a/src/components/libraryoptionseditor/libraryoptionseditor.template.html
+++ b/src/components/libraryoptionseditor/libraryoptionseditor.template.html
@@ -55,6 +55,14 @@
     <div class="fieldDescription checkboxFieldDescription">${LabelEnableRealtimeMonitorHelp}</div>
 </div>
 
+<div class="checkboxContainer checkboxContainer-withDescription chkUseReplayGainTagsContainer advanced">
+    <label>
+        <input type="checkbox" is="emby-checkbox" class="chkUseReplayGainTags" checked />
+        <span>${LabelUseReplayGainTags}</span>
+    </label>
+    <div class="fieldDescription checkboxFieldDescription">${LabelUseReplayGainTagsHelp}</div>
+</div>
+
 <div class="checkboxContainer checkboxContainer-withDescription chkEnableLUFSScanContainer advanced">
     <label>
         <input type="checkbox" is="emby-checkbox" class="chkEnableLUFSScan" checked />

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -971,6 +971,8 @@
     "LabelTypeText": "Text",
     "LabelUnstable": "Unstable",
     "LabelUser": "User",
+    "LabelUseReplayGainTagsHelp": "Scan audio files for replaygain tags and use them instead of computing LUFS value. (Uses less computing power. Will override 'LUFS Scan' option)",
+    "LabelUseReplayGainTags": "Use ReplayGain Tags",
     "LabelUserAgent": "User agent",
     "LabelUserLibrary": "User library",
     "LabelUserLibraryHelp": "Select which user library to display to the device. Leave empty to inherit the default setting.",


### PR DESCRIPTION
Adds option to enable/disable scanning for replaygain tags. This is means that existing replaygain tags can be used instead of jellyfin scanning each track again.

Backend: https://github.com/jellyfin/jellyfin/pull/10566