### PR TITLE
Remove FLAC Audio in Video Support for Tizen (Backport #4938)

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -497,7 +497,8 @@ export function canPlaySecondaryAudio(videoTestElement) {
             }
         }
 
-        if (canPlayAudioFormat('flac')) {
+        // FLAC audio in video plays with a delay on Tizen
+        if (canPlayAudioFormat('flac') && !browser.tizen) {
             videoAudioCodecs.push('flac');
             hlsInFmp4VideoAudioCodecs.push('flac');
         }


### PR DESCRIPTION
**Changes**
Backport #4938
> Remove FLAC audio in video support for Tizen

**Issues**
Fixes https://github.com/jellyfin/jellyfin-web/pull/4938
