### PR TITLE
Fixed issue with displaying very long artist names

### DIFF
--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -440,12 +440,12 @@ function renderName(item, container, context) {
         if (parentNameLast) {
             // Music
             if (layoutManager.mobile) {
-                html = '<h3 class="parentName musicParentName">' + parentNameHtml.join('</br>') + '</h3>';
+                html = '<h3 class="parentName infoText musicParentName">' + parentNameHtml.join('</br>') + '</h3>';
             } else {
-                html = '<h3 class="parentName musicParentName focuscontainer-x">' + parentNameHtml.join(' - ') + '</h3>';
+                html = '<h3 class="parentName infoText musicParentName focuscontainer-x">' + parentNameHtml.join(' - ') + '</h3>';
             }
         } else {
-            html = '<h1 class="parentName focuscontainer-x"><bdi>' + tvShowHtml + '</bdi></h1>';
+            html = '<h1 class="parentName infoText focuscontainer-x"><bdi>' + tvShowHtml + '</bdi></h1>';
         }
     }
 

--- a/src/styles/librarybrowser.scss
+++ b/src/styles/librarybrowser.scss
@@ -672,14 +672,6 @@
 .itemName {
     margin: 0.5em 0;
     font-weight: 600;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    overflow: hidden;
-
-    .layout-mobile & {
-        white-space: normal;
-        overflow: visible;
-    }
 }
 
 .itemName.originalTitle {
@@ -709,6 +701,13 @@
 
 .layout-mobile .itemName.originalTitle {
     margin: 0.5em 0 0.5em;
+}
+
+.layout-desktop .itemName,
+.layout-desktop .parentName {
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
 }
 
 .nameContainer {


### PR DESCRIPTION
The artist name field gets messy when I add a music album with a really long artist name. I tweaked the desktop layout's CSS to show the artist's name as the item name, cutting off the lengthy text with an ellipsis.

Before:

![before](https://github.com/jellyfin/jellyfin-web/assets/488066/efb80c0a-df3d-43da-9ad0-c69f89ea26be)

After:

![after](https://github.com/jellyfin/jellyfin-web/assets/488066/e093954c-ae2a-4f71-84bf-911fba5b2ac0)