### PR TITLE
Replace "Object.assing()" With an Object Spread

### DIFF
--- a/src/components/metadataEditor/metadataEditor.js
+++ b/src/components/metadataEditor/metadataEditor.js
@@ -167,7 +167,7 @@ function onSubmit(e) {
         })
     };
 
-    item.ProviderIds = Object.assign({}, currentItem.ProviderIds);
+    item.ProviderIds = { ...currentItem.ProviderIds };
 
     const idElements = form.querySelectorAll('.txtExternalId');
     Array.prototype.map.call(idElements, function (idElem) {


### PR DESCRIPTION
This is a change requested by [this issue](https://sonarcloud.io/project/issues?resolved=false&types=CODE_SMELL&id=jellyfin_jellyfin-web&open=AYnuoirDJnGD1tMStw4d&tab=code) on Sonar Cloud