### PR TITLE
Enable DTS on webOS 23

### DIFF
--- a/src/scripts/browser.js
+++ b/src/scripts/browser.js
@@ -116,7 +116,11 @@ function web0sVersion(browser) {
 
         // The next is only valid for the app
 
-        if (browser.versionMajor >= 79) {
+        if (browser.versionMajor >= 94) {
+            return 23;
+        } else if (browser.versionMajor >= 87) {
+            return 22;
+        } else if (browser.versionMajor >= 79) {
             return 6;
         } else if (browser.versionMajor >= 68) {
             return 5;

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -501,8 +501,8 @@ export default function (options) {
     if (supportsDts == null) {
         supportsDts = browser.tizen || browser.web0sVersion || videoTestElement.canPlayType('video/mp4; codecs="dts-"').replace(/no/, '') || videoTestElement.canPlayType('video/mp4; codecs="dts+"').replace(/no/, '');
 
-        // DTS audio is not supported by Samsung TV 2018+ (Tizen 4.0+) and LG TV 2020+ (webOS 5.0+) models
-        if (browser.tizenVersion >= 4 || browser.web0sVersion >= 5) {
+        // DTS audio is not supported by Samsung TV 2018+ (Tizen 4.0+) and LG TV 2020-2022 (webOS 5.0, 6.0 and 22) models
+        if (browser.tizenVersion >= 4 || (browser.web0sVersion >= 5 && browser.web0sVersion < 23)) {
             supportsDts = false;
         }
     }


### PR DESCRIPTION
**Changes**
Enables DTS playback on 2023 LG TVs (webOS 23).

**Issues**
Fixes https://github.com/jellyfin/jellyfin-webos/issues/172