### PR TITLE
Add custom icon support for custom links

### DIFF
--- a/src/apps/experimental/components/drawers/MainDrawerContent.tsx
+++ b/src/apps/experimental/components/drawers/MainDrawerContent.tsx
@@ -6,8 +6,8 @@ import Dashboard from '@mui/icons-material/Dashboard';
 import Edit from '@mui/icons-material/Edit';
 import Favorite from '@mui/icons-material/Favorite';
 import Home from '@mui/icons-material/Home';
-import Link from '@mui/icons-material/Link';
 import Divider from '@mui/material/Divider';
+import Icon from '@mui/material/Icon';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemButton from '@mui/material/ListItemButton';
@@ -98,8 +98,7 @@ const MainDrawerContent = () => {
                                     rel='noopener noreferrer'
                                 >
                                     <ListItemIcon>
-                                        {/* TODO: Support custom icons */}
-                                        <Link />
+                                        <Icon>{menuLink.icon ?? 'link'}</Icon>
                                     </ListItemIcon>
                                     <ListItemText primary={menuLink.name} />
                                 </ListItemButton>


### PR DESCRIPTION
**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

Updates experimental app custom links in the app drawer to support custom icon definitions. MUI Icons supports dynamically defining the icon by icon ID with the `<Icon>icon_name</Icon>` syntax.

![Screenshot 2023-12-21 143340](https://github.com/jellyfin/jellyfin-web/assets/6994499/01aebaa4-23e0-4b27-bed6-dca0d2e40943)

