### PR TITLE
Update HLS.js to use upstream version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "flv.js": "1.6.2",
         "headroom.js": "0.12.0",
         "history": "5.3.0",
-        "hls.js": "github:nyanmisaka/hls.js#v1.5.0-fix-firefox-av1",
+        "hls.js": "1.5.0-beta.3",
         "intersection-observer": "0.12.2",
         "jassub": "1.7.13",
         "jellyfin-apiclient": "1.11.0",
@@ -10785,8 +10785,9 @@
       }
     },
     "node_modules/hls.js": {
-      "resolved": "git+ssh://git@github.com/nyanmisaka/hls.js.git#2ca771e97a15d8078a3850c4c4cf225f497dcaa7",
-      "license": "Apache-2.0"
+      "version": "1.5.0-beta.3",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.5.0-beta.3.tgz",
+      "integrity": "sha512-QEXsMllxmmzADmszSeG7yQRFhX4WLz+/Tm0clG7hyWJvpblSLkQMULpFXSk9UbSwl20iped4VYVQfLcObd4aVw=="
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
@@ -30195,8 +30196,9 @@
       }
     },
     "hls.js": {
-      "version": "git+ssh://git@github.com/nyanmisaka/hls.js.git#2ca771e97a15d8078a3850c4c4cf225f497dcaa7",
-      "from": "hls.js@github:nyanmisaka/hls.js#v1.5.0-fix-firefox-av1"
+      "version": "1.5.0-beta.3",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.5.0-beta.3.tgz",
+      "integrity": "sha512-QEXsMllxmmzADmszSeG7yQRFhX4WLz+/Tm0clG7hyWJvpblSLkQMULpFXSk9UbSwl20iped4VYVQfLcObd4aVw=="
     },
     "hoist-non-react-statics": {
       "version": "3.3.2",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "flv.js": "1.6.2",
     "headroom.js": "0.12.0",
     "history": "5.3.0",
-    "hls.js": "github:nyanmisaka/hls.js#v1.5.0-fix-firefox-av1",
+    "hls.js": "1.5.0-beta.3",
     "intersection-observer": "0.12.2",
     "jassub": "1.7.13",
     "jellyfin-apiclient": "1.11.0",


### PR DESCRIPTION
My fix was already included in the upstream HLS.js 1.5.x, so there's no need to reference my repo anymore.

**Changes**
- Update HLS.js to use upstream version