### PR TITLE
Fix iOS 12 crashing in scroller

### DIFF
--- a/src/libraries/scroller.js
+++ b/src/libraries/scroller.js
@@ -175,16 +175,7 @@ const scrollerFactory = function (frame, options) {
             requiresReflow = false;
 
             // Reset global variables
-            const frameStyle = window.getComputedStyle(frame);
-            if (o.horizontal) {
-                frameSize = frame.clientWidth;
-                frameSize -= parseFloat(frameStyle.paddingLeft) + parseFloat(frameStyle.paddingRight);
-            } else {
-                frameSize = frame.clientHeight;
-                frameSize -= parseFloat(frameStyle.paddingTop) + parseFloat(frameStyle.paddingBottom);
-            }
-            frameSize = Math.round(frameSize);
-
+            frameSize = slideeElement[o.horizontal ? 'clientWidth' : 'clientHeight'];
             slideeSize = o.scrollWidth || Math.max(slideeElement[o.horizontal ? 'offsetWidth' : 'offsetHeight'], slideeElement[o.horizontal ? 'scrollWidth' : 'scrollHeight']);
 
             // Set position limits & relatives

--- a/src/utils/string.test.ts
+++ b/src/utils/string.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { toBoolean, toFloat } from './string';
+
+describe('toBoolean', () => {
+    it('Should return the boolean represented by the string', () => {
+        let bool = toBoolean('true');
+        expect(bool).toBe(true);
+
+        bool = toBoolean('false', true);
+        expect(bool).toBe(false);
+    });
+
+    it('Should return default value for invalid values', () => {
+        let bool = toBoolean('test');
+        expect(bool).toBe(false);
+
+        bool = toBoolean(undefined);
+        expect(bool).toBe(false);
+
+        bool = toBoolean(null, true);
+        expect(bool).toBe(true);
+    });
+});
+
+describe('toFloat()', () => {
+    it('Should return a float', () => {
+        const number = toFloat('3.14159');
+        expect(number).toBe(3.14159);
+    });
+
+    it('Should return default value for NaN', () => {
+        let number = toFloat('test');
+        expect(number).toBe(0);
+
+        number = toFloat(undefined);
+        expect(number).toBe(0);
+
+        number = toFloat(null, -1);
+        expect(number).toBe(-1);
+    });
+});

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -19,9 +19,10 @@ export function toBoolean(value: string | undefined | null, defaultValue = false
  * @returns {number} The value.
  */
 export function toFloat(value: string | null | undefined, defaultValue = 0) {
-    if (!value || isNaN(value as never)) {
-        return defaultValue;
-    } else {
-        return parseFloat(value);
-    }
+    if (!value) return defaultValue;
+
+    const number = parseFloat(value);
+    if (isNaN(number)) return defaultValue;
+
+    return number;
 }


### PR DESCRIPTION
**Changes**
I still don't fully understand _why_ this was breaking on iOS 12, but this fixes a regression introduced by https://github.com/jellyfin/jellyfin-web/pull/4714.

The string utility changes ended up _not_ being used, but I don't really want to pull it out to a separate PR since it is mostly just adding tests... :sweat_smile: 

**Issues**
Issue reported in matrix