### PR TITLE
Migrate preferences menu to react

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -91,6 +91,7 @@
 - [Chaitanya Shahare](https://github.com/Chaitanya-Shahare)
 - [Venkat Karasani](https://github.com/venkat-karasani)
 - [Connor Smith](https://github.com/ConnorS1110)
+- [Damian Kacperski](https://github.com/dkacperski97)
 
 ## Emby Contributors
 

--- a/src/apps/experimental/AppOverrides.scss
+++ b/src/apps/experimental/AppOverrides.scss
@@ -14,15 +14,6 @@ $drawer-width: 240px;
     }
 }
 
-// Hide some items from the user "settings" page that are in the drawer
-#myPreferencesMenuPage {
-    .lnkQuickConnectPreferences,
-    .adminSection,
-    .userSection {
-        display: none !important;
-    }
-}
-
 // Fix the padding of some pages
 .homePage.libraryPage.withTabs, // Home page
 // Library pages excluding the item details page and tabbed pages

--- a/src/apps/experimental/routes/asyncRoutes/user.ts
+++ b/src/apps/experimental/routes/asyncRoutes/user.ts
@@ -9,6 +9,7 @@ export const ASYNC_USER_ROUTES: AsyncRoute[] = [
     { path: 'tv.html', page: 'shows', type: AsyncRouteType.Experimental },
     { path: 'music.html', page: 'music', type: AsyncRouteType.Experimental },
     { path: 'livetv.html', page: 'livetv', type: AsyncRouteType.Experimental },
+    { path: 'mypreferencesmenu.html', page: 'user/menu', type: AsyncRouteType.Experimental },
     { path: 'mypreferencesdisplay.html', page: 'user/display', type: AsyncRouteType.Experimental },
 
     { path: 'homevideos.html', page: 'homevideos', type: AsyncRouteType.Experimental }

--- a/src/apps/experimental/routes/legacyRoutes/user.ts
+++ b/src/apps/experimental/routes/legacyRoutes/user.ts
@@ -20,12 +20,6 @@ export const LEGACY_USER_ROUTES: LegacyRoute[] = [
             view: 'lyrics.html'
         }
     }, {
-        path: 'mypreferencesmenu.html',
-        pageProps: {
-            controller: 'user/menu/index',
-            view: 'user/menu/index.html'
-        }
-    }, {
         path: 'mypreferencescontrols.html',
         pageProps: {
             controller: 'user/controls/index',

--- a/src/apps/experimental/routes/user/menu/hooks/usePreferencesMenuUser.tsx
+++ b/src/apps/experimental/routes/user/menu/hooks/usePreferencesMenuUser.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+import type { UserDto } from '@jellyfin/sdk/lib/generated-client';
+
+import { useApi } from 'hooks/useApi';
+import { getUserApi } from '@jellyfin/sdk/lib/utils/api/user-api';
+
+interface UsePreferencesMenuUserParams {
+    userId?: string | null;
+}
+
+export function usePreferencesMenuUser({ userId }: UsePreferencesMenuUserParams) {
+    const [user, setUser] = useState<UserDto>();
+    const { api, user: currentUser } = useApi();
+
+    useEffect(() => {
+        void (async () => {
+            const preferencesMenuUser =
+                !userId || userId === currentUser?.Id ?
+                    currentUser :
+                    api && (await getUserApi(api).getUserById({ userId })).data;
+            setUser(preferencesMenuUser);
+        })();
+    }, [api, currentUser, userId]);
+
+    return { user };
+}

--- a/src/apps/experimental/routes/user/menu/index.tsx
+++ b/src/apps/experimental/routes/user/menu/index.tsx
@@ -1,0 +1,141 @@
+import React, { type FunctionComponent, useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import List from '@mui/material/List';
+import ListItemMui from '@mui/material/ListItem';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import PersonIcon from '@mui/icons-material/Person';
+import TvIcon from '@mui/icons-material/Tv';
+import HomeIcon from '@mui/icons-material/Home';
+import PlayCircleFilledIcon from '@mui/icons-material/PlayCircleFilled';
+import ClosedCaptionIcon from '@mui/icons-material/ClosedCaption';
+import DevicesOtherIcon from '@mui/icons-material/DevicesOther';
+import KeyboardIcon from '@mui/icons-material/Keyboard';
+import Typography from '@mui/material/Typography';
+
+import { appHost } from 'components/apphost';
+import { useApi } from 'hooks/useApi';
+import globalize from 'scripts/globalize';
+import layoutManager from 'components/layoutManager';
+import Page from 'components/Page';
+import { usePreferencesMenuUser } from './hooks/usePreferencesMenuUser';
+
+const UserPreferencesMenu: FunctionComponent = () => {
+    // This page can also be used by admins to change user preferences from the user edit page
+    const [urlParams] = useSearchParams();
+    const { user: currentUser } = useApi();
+    const userId = urlParams.get('userId') || currentUser?.Id;
+    const { user } = usePreferencesMenuUser({ userId });
+
+    // Hide the actions if user preferences are being edited for a different user
+    const isForDifferentUser = urlParams.get('userId') && urlParams.get('userId') !== currentUser?.Id;
+
+    const onClientSettingsClick = useCallback(() => {
+        window.NativeShell?.openClientSettings();
+    }, []);
+
+    return (
+        <Page
+            id='myPreferencesMenuPage'
+            className='libraryPage userPreferencesPage noSecondaryNavPage'
+            title={globalize.translate('Settings')}
+        >
+            <div className='padded-left padded-right padded-bottom-page padded-top'>
+                <div className='readOnlyContent' style={{ margin: '0 auto' }}>
+                    <Typography variant='h2' sx={{ marginY: 2 }}>
+                        {user?.Name}
+                    </Typography>
+                    <List disablePadding>
+                        <ListItemMui disablePadding divider>
+                            <ListItemButton
+                                component='a'
+                                href={`#/userprofile.html?userId=${userId}`}
+                                disableRipple
+                            >
+                                <ListItemIcon>
+                                    <PersonIcon />
+                                </ListItemIcon>
+                                <ListItemText primary={globalize.translate('Profile')} />
+                            </ListItemButton>
+                        </ListItemMui>
+                        <ListItemMui disablePadding divider>
+                            <ListItemButton
+                                component='a'
+                                href={`#/mypreferencesdisplay.html?userId=${userId}`}
+                                disableRipple
+                            >
+                                <ListItemIcon>
+                                    <TvIcon />
+                                </ListItemIcon>
+                                <ListItemText primary={globalize.translate('Display')} />
+                            </ListItemButton>
+                        </ListItemMui>
+                        <ListItemMui disablePadding divider>
+                            <ListItemButton
+                                component='a'
+                                href={`#/mypreferenceshome.html?userId=${userId}`}
+                                disableRipple
+                            >
+                                <ListItemIcon>
+                                    <HomeIcon />
+                                </ListItemIcon>
+                                <ListItemText primary={globalize.translate('Home')} />
+                            </ListItemButton>
+                        </ListItemMui>
+                        <ListItemMui disablePadding divider>
+                            <ListItemButton
+                                component='a'
+                                href={`#/mypreferencesplayback.html?userId=${userId}`}
+                                disableRipple
+                            >
+                                <ListItemIcon>
+                                    <PlayCircleFilledIcon />
+                                </ListItemIcon>
+                                <ListItemText primary={globalize.translate('TitlePlayback')} />
+                            </ListItemButton>
+                        </ListItemMui>
+                        <ListItemMui disablePadding divider>
+                            <ListItemButton
+                                component='a'
+                                href={`#/mypreferencessubtitles.html?userId=${userId}`}
+                                disableRipple
+                            >
+                                <ListItemIcon>
+                                    <ClosedCaptionIcon />
+                                </ListItemIcon>
+                                <ListItemText primary={globalize.translate('Subtitles')} />
+                            </ListItemButton>
+                        </ListItemMui>
+                        {appHost.supports('clientsettings') && (
+                            <ListItemMui disablePadding divider>
+                                <ListItemButton onClick={onClientSettingsClick} disableRipple>
+                                    <ListItemIcon>
+                                        <DevicesOtherIcon />
+                                    </ListItemIcon>
+                                    <ListItemText primary={globalize.translate('ClientSettings')} />
+                                </ListItemButton>
+                            </ListItemMui>
+                        )}
+                        {!layoutManager.mobile && !isForDifferentUser && (
+                            <ListItemMui disablePadding divider>
+                                <ListItemButton
+                                    component='a'
+                                    href={`#/mypreferencescontrols.html?userId=${userId}`}
+                                    disableRipple
+                                >
+                                    <ListItemIcon>
+                                        <KeyboardIcon />
+                                    </ListItemIcon>
+                                    <ListItemText primary={globalize.translate('Controls')} />
+                                </ListItemButton>
+                            </ListItemMui>
+                        )}
+                    </List>
+                </div>
+            </div>
+        </Page>
+    );
+};
+
+export default UserPreferencesMenu;

--- a/src/styles/site.scss
+++ b/src/styles/site.scss
@@ -39,6 +39,7 @@ body {
     right: 0;
     bottom: 0;
     contain: strict;
+    z-index: -1;
 }
 
 .layout-mobile,


### PR DESCRIPTION
**Changes**
Updates the User Preferences menu to be React when using the experimental layout. I didn't migrate admin and user sections, because they weren't displayed on this page for the experimental layout anyway (they are now located in the AppUserMenu). I'm not sure if ripple should be disabled for buttons, but that how it is on the legacy page.

![image](https://github.com/jellyfin/jellyfin-web/assets/21142851/a52e1a6b-950a-4543-bdde-830f29fbd1d0)
