### PR TITLE
Fix subtitle offset textfield being clamped to 30s

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -77,6 +77,7 @@
 - [Grady Hallenbeck](https://github.com/grhallenbeck)
 - [DinuD](https://github.com/DinuD)
 - [Kevin Tan (Valius)](https://github.com/valius)
+- [MP430](https://github.com/MP430)
 
 ## Emby Contributors
 

--- a/src/components/subtitlesync/subtitlesync.js
+++ b/src/components/subtitlesync/subtitlesync.js
@@ -47,7 +47,11 @@ function init(instance) {
                 inputOffset = inputOffset[0];
                 inputOffset = parseFloat(inputOffset);
 
+                // synchronize with slider value
                 subtitleSyncSlider.updateOffset(inputOffset);
+
+                subtitleSyncTextField.updateOffset(inputOffset);
+                updateSubtitleOffset(inputOffset);
             } else {
                 this.textContent = (playbackManager.getPlayerSubtitleOffset(player) || 0) + 's';
             }
@@ -72,22 +76,23 @@ function init(instance) {
         }
     };
 
-    function updateSubtitleOffset() {
-        const value = parseFloat(subtitleSyncSlider.value);
+    function updateSubtitleOffset(value) {
         // set new offset
         playbackManager.setSubtitleOffset(value, player);
-        // synchronize with textField value
-        subtitleSyncTextField.updateOffset(value);
     }
 
     subtitleSyncSlider.updateOffset = function (sliderValue) {
         // default value is 0s = 0ms
         this.value = sliderValue === undefined ? 0 : sliderValue;
-
-        updateSubtitleOffset();
     };
 
-    subtitleSyncSlider.addEventListener('change', () => updateSubtitleOffset());
+    subtitleSyncSlider.addEventListener('change', function () {
+        const sliderValue = parseFloat(subtitleSyncSlider.value);
+
+        // synchronize with textField value
+        subtitleSyncTextField.updateOffset(sliderValue);
+        updateSubtitleOffset(sliderValue);
+    });
 
     subtitleSyncSlider.getBubbleHtml = function (_, value) {
         return '<h1 class="sliderBubbleText">'


### PR DESCRIPTION
Fix for #3783.
Subtitle offset textfield now allows values outside -+30s range.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
