### PR TITLE
Exclude resumable in next up home screen section

### DIFF
--- a/src/components/homesections/sections/nextUp.ts
+++ b/src/components/homesections/sections/nextUp.ts
@@ -29,6 +29,7 @@ function getNextUpFetchFn(
             EnableTotalRecordCount: false,
             DisableFirstEpisode: false,
             NextUpDateCutoff: oldestDateForNextUp.toISOString(),
+            EnableResumable: false,
             EnableRewatching: userSettings.enableRewatchingInNextUp()
         });
     };


### PR DESCRIPTION
**Changes**
Follow up to https://github.com/jellyfin/jellyfin/pull/10200 to exclude resumable content from the next up home screen section since it would be duplicated in continue watching.

**Issues**
N/A