### PR TITLE
Fix handling of single click on the previous track button

### DIFF
--- a/src/components/nowPlayingBar/nowPlayingBar.js
+++ b/src/components/nowPlayingBar/nowPlayingBar.js
@@ -180,7 +180,7 @@ function bindEvents(elem) {
                 // to the previous track, unless we are at the first track so no previous track exists.
                 // currentTime is in msec.
 
-                if (playbackManager.currentTime(currentPlayer) >= 5 || playbackManager.getCurrentPlaylistIndex(currentPlayer) <= 1) {
+                if (playbackManager.currentTime(currentPlayer) >= 5 * 1000 || playbackManager.getCurrentPlaylistIndex(currentPlayer) <= 0) {
                     playbackManager.seekPercent(0, currentPlayer);
                     // This is done automatically by playbackManager, however, setting this here gives instant visual feedback.
                     // TODO: Check why seekPercent doesn't reflect the changes inmmediately, so we can remove this workaround.

--- a/src/components/remotecontrol/remotecontrol.js
+++ b/src/components/remotecontrol/remotecontrol.js
@@ -784,7 +784,7 @@ export default function () {
                     // to the previous track, unless we are at the first track so no previous track exists.
                     // currentTime is in msec.
 
-                    if (playbackManager.currentTime(currentPlayer) >= 5 || playbackManager.getCurrentPlaylistIndex(currentPlayer) <= 1) {
+                    if (playbackManager.currentTime(currentPlayer) >= 5 * 1000 || playbackManager.getCurrentPlaylistIndex(currentPlayer) <= 0) {
                         playbackManager.seekPercent(0, currentPlayer);
                         // This is done automatically by playbackManager, however, setting this here gives instant visual feedback.
                         // TODO: Check why seekPercent doesn't reflect the changes inmmediately, so we can remove this workaround.


### PR DESCRIPTION
**Changes**
Fix handling of single click on the previous track button. 

Currently the player starts playing previous song after the button has been click once only if 5ms (or less 🙃) of the song has passed. `currentPlayer._currentTime` (which returns the time in seconds) has been replaced in https://github.com/jellyfin/jellyfin-web/pull/4891 by `playbackManager.currentTime(currentPlayer)` (which returns the time in milliseconds), but the value to which it is compered has not changed.

Also, currently the previous song only starts playing if we are playing the third or later song in the queue (indexes returned by `getCurrentPlaylistIndex` starts from 0, not 1). This check has been changed in https://github.com/jellyfin/jellyfin-web/pull/4463