### PR TITLE
Remove unused Id prop from access schedule list

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -78,6 +78,7 @@
 - [DinuD](https://github.com/DinuD)
 - [Kevin Tan (Valius)](https://github.com/valius)
 - [Rasmus Krämer](https://github.com/rasmuslos)
+- [ntarelix](https://github.com/ntarelix)
 
 ## Emby Contributors
 

--- a/src/apps/dashboard/routes/users/parentalcontrol.tsx
+++ b/src/apps/dashboard/routes/users/parentalcontrol.tsx
@@ -414,7 +414,6 @@ const UserParentalControl: FunctionComponent = () => {
                                 return <AccessScheduleList
                                     key={accessSchedule.Id}
                                     index={index}
-                                    Id={accessSchedule.Id}
                                     DayOfWeek={accessSchedule.DayOfWeek}
                                     StartHour={accessSchedule.StartHour}
                                     EndHour={accessSchedule.EndHour}

--- a/src/components/dashboard/users/AccessScheduleList.tsx
+++ b/src/components/dashboard/users/AccessScheduleList.tsx
@@ -5,7 +5,6 @@ import IconButtonElement from '../../../elements/IconButtonElement';
 
 type AccessScheduleListProps = {
     index: number;
-    Id?: number;
     DayOfWeek?: string;
     StartHour?: number ;
     EndHour?: number;


### PR DESCRIPTION
Reported by sonarcloud: https://sonarcloud.io/project/issues?fileUuids=AX6fELCkjUUWs1HF_Tc8&resolved=false&types=CODE_SMELL&id=jellyfin_jellyfin-web&open=AYr_7x6Y4nroI6nze3Zu

**Changes**
[Recommendations for First Time Contributors](https://github.com/jellyfin/jellyfin-web/issues/3967) suggests fixing code smells listed on SonarCloud. The fixed smell is an unused React prop on the `AccessScheduleList` component. After confirming it was unused, I removed it from the interface and the sole reference to that prop from the `UserParentalControl` component. Building produced no errors, all vitest tests passed locally, and the parental control schedule seemed to have no regressions in my manual test in the browser.

The [Contributing docs](https://jellyfin.org/docs/general/contributing/development) also say to add your name to the contribution markdown file, so I included that in my commit.

**Issues**
No GitHub issues resolved, but the following SonarCloud code smell will be resolved: https://sonarcloud.io/project/issues?fileUuids=AX6fELCkjUUWs1HF_Tc8&resolved=false&types=CODE_SMELL&id=jellyfin_jellyfin-web&open=AYr_7x6Y4nroI6nze3Zu