### PR TITLE
Fix repeat and shuffle in SessionPlayer

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -2056,6 +2056,7 @@ class PlaybackManager {
                 state.PlayState.IsPaused = player.paused();
                 state.PlayState.RepeatMode = self.getRepeatMode(player);
                 state.PlayState.ShuffleMode = self.getQueueShuffleMode(player);
+                state.PlayState.OrderMode = self.getQueueShuffleMode(player);
                 state.PlayState.MaxStreamingBitrate = self.getMaxStreamingBitrate(player);
 
                 state.PlayState.PositionTicks = getCurrentTicks(player);
@@ -4033,6 +4034,9 @@ class PlaybackManager {
                 break;
             case 'SetShuffleQueue':
                 this.setQueueShuffleMode(cmd.Arguments.ShuffleMode, player);
+                break;
+            case 'SetOrderMode':
+                this.setQueueShuffleMode(cmd.Arguments.OrderMode, player);
                 break;
             case 'VolumeUp':
                 this.volumeUp(player);

--- a/src/plugins/sessionPlayer/plugin.js
+++ b/src/plugins/sessionPlayer/plugin.js
@@ -450,17 +450,17 @@ class SessionPlayer {
     }
 
     getRepeatMode() {
-        // not supported?
+        return this.lastPlayerData?.PlayState?.RepeatMode;
     }
 
     setQueueShuffleMode(mode) {
-        sendCommandByName(this, 'SetShuffleQueue', {
-            ShuffleMode: mode
+        sendCommandByName(this, 'SetOrderMode', {
+            OrderMode: mode
         });
     }
 
     getQueueShuffleMode() {
-        // not supported?
+        return this.lastPlayerData?.PlayState?.OrderMode;
     }
 
     displayContent(options) {

--- a/src/utils/dashboard.js
+++ b/src/utils/dashboard.js
@@ -175,7 +175,7 @@ export function alert(options) {
 export function capabilities(appHost) {
     return Object.assign({
         PlayableMediaTypes: ['Audio', 'Video'],
-        SupportedCommands: ['MoveUp', 'MoveDown', 'MoveLeft', 'MoveRight', 'PageUp', 'PageDown', 'PreviousLetter', 'NextLetter', 'ToggleOsd', 'ToggleContextMenu', 'Select', 'Back', 'SendKey', 'SendString', 'GoHome', 'GoToSettings', 'VolumeUp', 'VolumeDown', 'Mute', 'Unmute', 'ToggleMute', 'SetVolume', 'SetAudioStreamIndex', 'SetSubtitleStreamIndex', 'DisplayContent', 'GoToSearch', 'DisplayMessage', 'SetRepeatMode', 'SetShuffleQueue', 'ChannelUp', 'ChannelDown', 'PlayMediaSource', 'PlayTrailers'],
+        SupportedCommands: ['MoveUp', 'MoveDown', 'MoveLeft', 'MoveRight', 'PageUp', 'PageDown', 'PreviousLetter', 'NextLetter', 'ToggleOsd', 'ToggleContextMenu', 'Select', 'Back', 'SendKey', 'SendString', 'GoHome', 'GoToSettings', 'VolumeUp', 'VolumeDown', 'Mute', 'Unmute', 'ToggleMute', 'SetVolume', 'SetAudioStreamIndex', 'SetSubtitleStreamIndex', 'DisplayContent', 'GoToSearch', 'DisplayMessage', 'SetRepeatMode', 'SetOrderMode', 'ChannelUp', 'ChannelDown', 'PlayMediaSource', 'PlayTrailers'],
         SupportsPersistentIdentifier: window.appMode === 'cordova' || window.appMode === 'android',
         SupportsMediaControl: true
     }, appHost.getPushTokenInfo());


### PR DESCRIPTION
**Changes**
Fix repeat and shuffle in SessionPlayer. It was not possible to correctly send SetRepeatMode and SetShuffleQueue commands, because the values of RepeatMode and ShuffleMode couldn't be read.

**Issues**
https://github.com/jellyfin/jellyfin-web/issues/5012 - completely fixes the repeat button and partialy fixes the shuffle button (changes to server are required, currently ShuffleMode is always undefined, I have already created a PR https://github.com/jellyfin/jellyfin/pull/10934 )
