### PR TITLE
bandaid fix for m4b on Safari

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "eslint.format.enable": true,
   "editor.formatOnSave": false

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -79,6 +79,7 @@
 - [Kevin Tan (Valius)](https://github.com/valius)
 - [Rasmus Krämer](https://github.com/rasmuslos)
 - [ntarelix](https://github.com/ntarelix)
+- [felix920506](https://github.com/felix920506)
 
 ## Emby Contributors
 

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -691,15 +691,17 @@ export default function (options) {
                 Type: 'Audio'
             });
 
-            // Safari won't play m4b, however Firefox and Edge seem to handle it fine
-            // Commenting out the following also causes aac in m4b to transcode regardless of support
-            // This should probably be addressed in the future one way or another
+            // For some reason m4b doesn't work in Safari, but works Firefox, Edge and Chrome.
+            // The segment below forces transcode for aac in m4b but in most cases a remux would be sufficient.
+            // Ideally there should be something done about it in the future to reduce unnecessary transcodes.
 
-            // profile.DirectPlayProfiles.push({
-            //     Container: 'm4b',
-            //     AudioCodec: audioFormat,
-            //     Type: 'Audio'
-            // });
+            if ((!browser.safari) && (!browser.iOS)) {
+                profile.DirectPlayProfiles.push({
+                    Container: 'm4b',
+                    AudioCodec: audioFormat,
+                    Type: 'Audio'
+                });
+            }
         }
     });
 

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -691,11 +691,15 @@ export default function (options) {
                 Type: 'Audio'
             });
 
-            profile.DirectPlayProfiles.push({
-                Container: 'm4b',
-                AudioCodec: audioFormat,
-                Type: 'Audio'
-            });
+            // Safari won't play m4b, however Firefox and Edge seem to handle it fine
+            // Commenting out the following also causes aac in m4b to transcode regardless of support
+            // This should probably be addressed in the future one way or another
+
+            // profile.DirectPlayProfiles.push({
+            //     Container: 'm4b',
+            //     AudioCodec: audioFormat,
+            //     Type: 'Audio'
+            // });
         }
     });
 


### PR DESCRIPTION
Enables m4b to play on iOS and Safari ~~at the cost of force transcoding aac in m4b for everyone (Yes transcoding, not remuxing)~~

The force transcoding for not safari has been addressed. However aac in m4b would still transcode for Safari or iOS browsers, which can be overkill in many cases. This would need to be addressed in the future.


**Changes**
Make web report m4b containers aren't supported

**Issues**
Bandaid fix for https://github.com/jellyfin/jellyfin/issues/6986 
