### PR TITLE
add keybinding to control subtitles offset

### DIFF
--- a/src/components/subtitlesync/subtitlesync.js
+++ b/src/components/subtitlesync/subtitlesync.js
@@ -151,6 +151,21 @@ class SubtitleSync {
             subtitleSyncContainer.classList.add('hide');
         }
     }
+
+    update(offset) {
+        this.toggle();
+
+        const value = parseFloat(subtitleSyncSlider.value) + offset;
+        subtitleSyncSlider.updateOffset(value);
+    }
+
+    incrementOffset() {
+        this.update(+subtitleSyncSlider.step);
+    }
+
+    decrementOffset() {
+        this.update(-subtitleSyncSlider.step);
+    }
 }
 
 export default SubtitleSync;

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1340,6 +1340,12 @@ export default function (view) {
             case 'PageDown':
                 playbackManager.previousChapter(currentPlayer);
                 break;
+            case 'g':
+                subtitleSyncOverlay?.decrementOffset();
+                break;
+            case 'h':
+                subtitleSyncOverlay?.incrementOffset();
+                break;
         }
     }
 

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1341,9 +1341,11 @@ export default function (view) {
                 playbackManager.previousChapter(currentPlayer);
                 break;
             case 'g':
+            case 'G':
                 subtitleSyncOverlay?.decrementOffset();
                 break;
             case 'h':
+            case 'H':
                 subtitleSyncOverlay?.incrementOffset();
                 break;
         }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
Bounding `g` and `h` to control subtitles offset in 0.1 steps, bindings are taken from VLC.
The subtitle offset overlay is shown while the offset is increased or decreased by pressing the keys. Pressing the keys while the offset is not shown still changes the offset.

<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
