### PR TITLE
Update LabelCountry to ease the naming of controversial regions

### DIFF
--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -598,7 +598,7 @@
     "LabelCommunityRating": "Community rating",
     "LabelContentType": "Content type",
     "LabelCorruptedFrames": "Corrupted frames",
-    "LabelCountry": "Country",
+    "LabelCountry": "Country/Region",
     "LabelCreateHttpPortMap": "Enable automatic port mapping for HTTP traffic as well as HTTPS.",
     "LabelCreateHttpPortMapHelp": "Permit automatic port mapping to create a rule for HTTP traffic in addition to HTTPS traffic.",
     "LabelCriticRating": "Critics rating",


### PR DESCRIPTION
Use more neutral words `Country/Region` instead of only `Country` to describe `LabelCountry`.

It's a more sensible alternative of https://github.com/jellyfin/jellyfin/pull/10988 to end the controversies.

**Changes**
- Update LabelCountry to ease the naming of controversial regions