### PR TITLE
Make the server field ignore the trailing slash

### DIFF
--- a/src/controllers/session/addServer/index.js
+++ b/src/controllers/session/addServer/index.js
@@ -36,7 +36,7 @@ function handleConnectionResult(page, result) {
 
 function submitServer(page) {
     loading.show();
-    const host = page.querySelector('#txtServerHost').value;
+    const host = page.querySelector('#txtServerHost').value.replace(/\/+$/, '');
     ServerConnections.connectToAddress(host, {
         enableAutoLogin: appSettings.enableAutoLogin()
     }).then(function(result) {


### PR DESCRIPTION
**Changes**
Useful on the tizen build, if a trailing slash is added the error message is not helping.