### PR TITLE
Re-order Cast & Crew to appear beneath features of the main item

### DIFF
--- a/src/controllers/itemDetails/index.html
+++ b/src/controllers/itemDetails/index.html
@@ -194,13 +194,6 @@
                     </div>
                 </div>
 
-                <div id="castCollapsible" class="verticalSection detailVerticalSection hide">
-                    <h2 id="peopleHeader" class="sectionTitle sectionTitle-cards padded-right">${HeaderCastAndCrew}</h2>
-                    <div is="emby-scroller" class="padded-top-focusscale padded-bottom-focusscale" data-centerfocus="true">
-                        <div id="castContent" is="emby-itemscontainer" class="scrollSlider focuscontainer-x itemsContainer"></div>
-                    </div>
-                </div>
-
                 <div id="guestCastCollapsible" class="verticalSection detailVerticalSection hide">
                     <h2 id="guestCastHeader" class="sectionTitle sectionTitle-cards padded-right">${HeaderGuestCast}</h2>
                     <div is="emby-scroller" class="padded-top-focusscale padded-bottom-focusscale" data-centerfocus="true">
@@ -231,6 +224,13 @@
                     <h2 class="sectionTitle sectionTitle-cards padded-right">${HeaderScenes}</h2>
                     <div is="emby-scroller" class="padded-top-focusscale padded-bottom-focusscale" data-centerfocus="true">
                         <div id="scenesContent" is="emby-itemscontainer" class="scrollSlider focuscontainer-x itemsContainer"></div>
+                    </div>
+                </div>
+
+                <div id="castCollapsible" class="verticalSection detailVerticalSection hide">
+                    <h2 id="peopleHeader" class="sectionTitle sectionTitle-cards padded-right">${HeaderCastAndCrew}</h2>
+                    <div is="emby-scroller" class="padded-top-focusscale padded-bottom-focusscale" data-centerfocus="true">
+                        <div id="castContent" is="emby-itemscontainer" class="scrollSlider focuscontainer-x itemsContainer"></div>
                     </div>
                 </div>
 

--- a/src/controllers/itemDetails/index.html
+++ b/src/controllers/itemDetails/index.html
@@ -194,13 +194,6 @@
                     </div>
                 </div>
 
-                <div id="guestCastCollapsible" class="verticalSection detailVerticalSection hide">
-                    <h2 id="guestCastHeader" class="sectionTitle sectionTitle-cards padded-right">${HeaderGuestCast}</h2>
-                    <div is="emby-scroller" class="padded-top-focusscale padded-bottom-focusscale" data-centerfocus="true">
-                        <div id="guestCastContent" is="emby-itemscontainer" class="scrollSlider focuscontainer-x itemsContainer"></div>
-                    </div>
-                </div>
-
                 <div id="seriesScheduleSection" class="verticalSection detailVerticalSection hide">
                     <h2 class="sectionTitle padded-right">${HeaderUpcomingOnTV}</h2>
                     <div id="seriesScheduleList" is="emby-itemscontainer" class="itemsContainer vertical-list padded-right"></div>
@@ -224,6 +217,13 @@
                     <h2 class="sectionTitle sectionTitle-cards padded-right">${HeaderScenes}</h2>
                     <div is="emby-scroller" class="padded-top-focusscale padded-bottom-focusscale" data-centerfocus="true">
                         <div id="scenesContent" is="emby-itemscontainer" class="scrollSlider focuscontainer-x itemsContainer"></div>
+                    </div>
+                </div>
+
+                <div id="guestCastCollapsible" class="verticalSection detailVerticalSection hide">
+                    <h2 id="guestCastHeader" class="sectionTitle sectionTitle-cards padded-right">${HeaderGuestCast}</h2>
+                    <div is="emby-scroller" class="padded-top-focusscale padded-bottom-focusscale" data-centerfocus="true">
+                        <div id="guestCastContent" is="emby-itemscontainer" class="scrollSlider focuscontainer-x itemsContainer"></div>
                     </div>
                 </div>
 


### PR DESCRIPTION
**Changes**
When viewing an item in Jellyfin, the Cast & Crew details (including Guest Cast) are less important than the featurettes / extras. This PR simply moves the cast & crew section to the bottom of the details page. This ensures that if users are looking for extras and they can't find it in seasons, there is an affordance given to users scanning the page that they will find the extras next.