### PR TITLE
Change webOS version needed for audioTracks to 4.0

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -79,6 +79,7 @@
 - [Kevin Tan (Valius)](https://github.com/valius)
 - [Rasmus Krämer](https://github.com/rasmuslos)
 - [ntarelix](https://github.com/ntarelix)
+- [András Maróy](https://github.com/andrasmaroy)
 
 ## Emby Contributors
 

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -394,8 +394,7 @@ export function canPlaySecondaryAudio(videoTestElement) {
         && !browser.firefox
         // It seems to work on Tizen 5.5+ (2020, Chrome 69+). See https://developer.tizen.org/forums/web-application-development/video-tag-not-work-audiotracks
         && (browser.tizenVersion >= 5.5 || !browser.tizen)
-        // Assume webOS 5+ (2020, Chrome 68+) supports secondary audio like Tizen 5.5+
-        && (browser.web0sVersion >= 5.0 || !browser.web0sVersion);
+        && (browser.web0sVersion >= 4.0 || !browser.web0sVersion);
 }
 
 export default function (options) {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Implementation of the proposed solution in #4729. Tested on an LG 55OLEDB9 (WebOS4.5, 05.40.10 FW), running Jellyfin 10.8.11 patched with this change. Tested with an mp4 file with an aac and an eac3 audio track and with an mkv with 2 eac3 tracks. Both files direct played with both audio tracks.

This also solved the issue described in jellyfin/jellyfin-webos#198 where Dolby Vision content failed to trigger DoVi on the second audio track because it was remuxed server-side because of this issue.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #4729 
Fixes #4661 
Fixes jellyfin/jellyfin-webos#198