### PR TITLE
Refactor edit user string

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "eslint.format.enable": true,
   "editor.formatOnSave": false

--- a/src/apps/dashboard/routes/users/index.tsx
+++ b/src/apps/dashboard/routes/users/index.tsx
@@ -58,7 +58,7 @@ const UserProfiles: FunctionComponent = () => {
             const menuItems: MenuEntry[] = [];
 
             menuItems.push({
-                name: globalize.translate('ButtonOpen'),
+                name: globalize.translate('ButtonEditUser'),
                 id: 'open',
                 icon: 'mode_edit'
             });

--- a/src/strings/af.json
+++ b/src/strings/af.json
@@ -166,7 +166,7 @@
     "ButtonPreviousTrack": "Vorige Snit",
     "ButtonPause": "Staak",
     "ButtonParentalControl": "Ouerbeheer",
-    "ButtonOpen": "Maak Oop",
+    "ButtonEditUser": "Maak Oop",
     "ButtonOk": "Regso",
     "ButtonNextTrack": "Volgende Snit",
     "ButtonNetwork": "Netwerk",

--- a/src/strings/ar.json
+++ b/src/strings/ar.json
@@ -31,7 +31,7 @@
     "ButtonNetwork": "الشبكة",
     "ButtonNextTrack": "المقطع التالي",
     "ButtonOk": "موافق",
-    "ButtonOpen": "إفتح",
+    "ButtonEditUser": "إفتح",
     "ButtonParentalControl": "التحكم الأبوي",
     "ButtonPause": "التوقف المؤقت",
     "ButtonPreviousTrack": "المقطع السابق",

--- a/src/strings/be-by.json
+++ b/src/strings/be-by.json
@@ -136,7 +136,7 @@
     "Box": "Скрынка",
     "ButtonAddServer": "Дадаць сервер",
     "ButtonBack": "Назад",
-    "ButtonOpen": "Адчыніць",
+    "ButtonEditUser": "Адчыніць",
     "ButtonRevoke": "Адклікаць",
     "ButtonPreviousTrack": "Папярэдні трэк",
     "ButtonSend": "Адправіць",

--- a/src/strings/bg-bg.json
+++ b/src/strings/bg-bg.json
@@ -36,7 +36,7 @@
     "ButtonMore": "Още",
     "ButtonNextTrack": "Следваща пътека",
     "ButtonOk": "Добре",
-    "ButtonOpen": "Отваряне",
+    "ButtonEditUser": "Отваряне",
     "ButtonParentalControl": "Родителски контрол",
     "ButtonPause": "Пауза",
     "ButtonPreviousTrack": "Предишна пътека",

--- a/src/strings/bn_BD.json
+++ b/src/strings/bn_BD.json
@@ -19,7 +19,7 @@
     "AddToCollection": "কালেকশন এ অ্যাড করুন",
     "ButtonPause": "বিরতি",
     "ButtonParentalControl": "অভিভাবকীয় নিয়ন্ত্রণ",
-    "ButtonOpen": "খুলুন",
+    "ButtonEditUser": "খুলুন",
     "ButtonOk": "আচ্ছা",
     "ButtonNextTrack": "পরবর্তী ট্র্যাক",
     "ButtonNetwork": "নেটওয়ার্ক",

--- a/src/strings/ca.json
+++ b/src/strings/ca.json
@@ -31,7 +31,7 @@
     "ButtonMore": "Més",
     "ButtonNextTrack": "Pista següent",
     "ButtonOk": "D'acord",
-    "ButtonOpen": "Obre",
+    "ButtonEditUser": "Obre",
     "ButtonParentalControl": "Control parental",
     "ButtonPause": "Pausa",
     "ButtonPreviousTrack": "Pista anterior",

--- a/src/strings/cs.json
+++ b/src/strings/cs.json
@@ -52,7 +52,7 @@
     "ButtonMore": "Více",
     "ButtonNetwork": "Síť",
     "ButtonNextTrack": "Následující stopa",
-    "ButtonOpen": "Otevřít",
+    "ButtonEditUser": "Otevřít",
     "ButtonParentalControl": "Rodičovská kontrola",
     "ButtonPause": "Pozastavit",
     "ButtonPreviousTrack": "Předchozí stopa",

--- a/src/strings/cy.json
+++ b/src/strings/cy.json
@@ -78,7 +78,7 @@
     "ButtonRemove": "Gwaredu",
     "ButtonPlayer": "Chwaraewr",
     "ButtonPause": "Saib",
-    "ButtonOpen": "Agor",
+    "ButtonEditUser": "Agor",
     "ButtonOk": "Iawn",
     "ButtonNetwork": "Rhwydwaith",
     "ButtonMore": "Mwy",

--- a/src/strings/da.json
+++ b/src/strings/da.json
@@ -49,7 +49,7 @@
     "ButtonMore": "Mere",
     "ButtonNetwork": "Netværk",
     "ButtonNextTrack": "Næste spor",
-    "ButtonOpen": "Åben",
+    "ButtonEditUser": "Åben",
     "ButtonParentalControl": "Forældrekontrol",
     "ButtonPreviousTrack": "Forrige spor",
     "ButtonQuickStartGuide": "Hurtig-start guide",

--- a/src/strings/de.json
+++ b/src/strings/de.json
@@ -64,7 +64,7 @@
     "ButtonMore": "Mehr",
     "ButtonNetwork": "Netzwerk",
     "ButtonNextTrack": "Nächstes Lied",
-    "ButtonOpen": "Öffnen",
+    "ButtonEditUser": "Öffnen",
     "ButtonParentalControl": "Kindersicherung",
     "ButtonPreviousTrack": "Vorheriges Lied",
     "ButtonQuickStartGuide": "Schnellstartanleitung",

--- a/src/strings/el.json
+++ b/src/strings/el.json
@@ -62,7 +62,7 @@
     "ButtonManualLogin": "Χειροκίνητη Είσοδος",
     "ButtonMore": "Περισσότερα",
     "ButtonNextTrack": "Επόμενο",
-    "ButtonOpen": "Άνοιγμα",
+    "ButtonEditUser": "Άνοιγμα",
     "ButtonParentalControl": "Γονικός έλεγχος",
     "ButtonPause": "Παύση",
     "ButtonPreviousTrack": "Προηγούμενο",

--- a/src/strings/en-gb.json
+++ b/src/strings/en-gb.json
@@ -116,7 +116,7 @@
     "ButtonNetwork": "Network",
     "ButtonNextTrack": "Next track",
     "ButtonOk": "OK",
-    "ButtonOpen": "Open",
+    "ButtonEditUser": "Open",
     "ButtonParentalControl": "Parental control",
     "ButtonPause": "Pause",
     "ButtonPreviousTrack": "Previous track",

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -97,7 +97,7 @@
     "ButtonMore": "More",
     "ButtonNextTrack": "Next track",
     "ButtonOk": "Ok",
-    "ButtonOpen": "Open",
+    "ButtonEditUser": "Edit User Settings",
     "ButtonParentalControl": "Parental control",
     "ButtonPause": "Pause",
     "ButtonPlayer": "Player",

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -97,7 +97,7 @@
     "ButtonMore": "More",
     "ButtonNextTrack": "Next track",
     "ButtonOk": "Ok",
-    "ButtonEditUser": "Edit User Settings",
+    "ButtonEditUser": "Edit User Permissions",
     "ButtonParentalControl": "Parental control",
     "ButtonPause": "Pause",
     "ButtonPlayer": "Player",

--- a/src/strings/eo.json
+++ b/src/strings/eo.json
@@ -1139,7 +1139,7 @@
     "OptionTrackName": "Traka Nomo",
     "LabelTrackNumber": "Traka numero",
     "HeaderTracks": "Trakoj",
-    "ButtonOpen": "Malfermi",
+    "ButtonEditUser": "Malfermi",
     "ButtonOk": "Ek",
     "ButtonMore": "Pli",
     "ButtonFullscreen": "Plenekranen",

--- a/src/strings/es-ar.json
+++ b/src/strings/es-ar.json
@@ -106,7 +106,7 @@
     "ButtonNetwork": "Red",
     "ButtonNextTrack": "Pista siguiente",
     "ButtonOk": "Aceptar",
-    "ButtonOpen": "Abrir",
+    "ButtonEditUser": "Abrir",
     "ButtonParentalControl": "Control parental",
     "ButtonPause": "Pausar",
     "ButtonPreviousTrack": "Pista anterior",

--- a/src/strings/es-mx.json
+++ b/src/strings/es-mx.json
@@ -68,7 +68,7 @@
     "ButtonMore": "Más",
     "ButtonNetwork": "Red",
     "ButtonNextTrack": "Pista siguiente",
-    "ButtonOpen": "Abrir",
+    "ButtonEditUser": "Abrir",
     "ButtonParentalControl": "Control parental",
     "ButtonPause": "Pausar",
     "ButtonPreviousTrack": "Pista anterior",

--- a/src/strings/es.json
+++ b/src/strings/es.json
@@ -59,7 +59,7 @@
     "ButtonNetwork": "Red",
     "ButtonNextTrack": "Pista siguiente",
     "ButtonOk": "OK",
-    "ButtonOpen": "Abrir",
+    "ButtonEditUser": "Abrir",
     "ButtonParentalControl": "Control parental",
     "ButtonPause": "Pausa",
     "ButtonPreviousTrack": "Pista anterior",

--- a/src/strings/es_419.json
+++ b/src/strings/es_419.json
@@ -1253,7 +1253,7 @@
     "ButtonPreviousTrack": "Pista anterior",
     "ButtonPause": "Pausar",
     "ButtonParentalControl": "Control parental",
-    "ButtonOpen": "Abrir",
+    "ButtonEditUser": "Abrir",
     "ButtonOk": "OK",
     "ButtonNextTrack": "Pista siguiente",
     "ButtonNetwork": "Red",

--- a/src/strings/et.json
+++ b/src/strings/et.json
@@ -568,7 +568,7 @@
     "ButtonPlayer": "Pleier",
     "ButtonPause": "Paus",
     "ButtonParentalControl": "Lapselukk",
-    "ButtonOpen": "Ava",
+    "ButtonEditUser": "Ava",
     "ButtonOk": "Ok",
     "ButtonNextTrack": "Järgmine rada",
     "ButtonNetwork": "Võrk",

--- a/src/strings/eu.json
+++ b/src/strings/eu.json
@@ -1496,7 +1496,7 @@
     "ButtonPlayer": "Ugaltzailea",
     "ButtonPause": "Etenaldia",
     "ButtonParentalControl": "Gurasoen kontrola",
-    "ButtonOpen": "Ireki",
+    "ButtonEditUser": "Ireki",
     "ButtonOk": "OK",
     "ButtonNextTrack": "Hurrengo pista",
     "ButtonMore": "Gehiago",

--- a/src/strings/fa.json
+++ b/src/strings/fa.json
@@ -109,7 +109,7 @@
     "ButtonPreviousTrack": "ترانه پیشین",
     "ButtonPause": "مکث",
     "ButtonParentalControl": "رتبه بندی والدین",
-    "ButtonOpen": "باز",
+    "ButtonEditUser": "باز",
     "ButtonNetwork": "شبکه",
     "ButtonMore": "بیشتر",
     "ButtonManualLogin": "ورود دستی",

--- a/src/strings/fi.json
+++ b/src/strings/fi.json
@@ -108,7 +108,7 @@
     "ButtonNetwork": "Verkko",
     "ButtonNextTrack": "Seuraava raita",
     "ButtonOk": "Ok",
-    "ButtonOpen": "Avaa",
+    "ButtonEditUser": "Avaa",
     "BurnSubtitlesHelp": "Määritä polttaako palvelin tekstitykset transkoodauksen aikana suoraan videoon. Tämä kasvattaa palvelimen kuormitusta merkittävästi. 'Automaattinen' polttaa kuva- (mm. VobSub, PGS ja SUB/IDX) ja tietyt tekstipohjaiset (ASS/SSA) tekstitykset.",
     "ButtonParentalControl": "Lapsilukko",
     "ButtonPause": "Tauko",

--- a/src/strings/fil.json
+++ b/src/strings/fil.json
@@ -1542,7 +1542,7 @@
     "ButtonQuickStartGuide": "Gabay sa Mabilis na Pagsisimula",
     "ButtonPlayer": "Pampatugtug",
     "ButtonPause": "I-pause",
-    "ButtonOpen": "Buksan",
+    "ButtonEditUser": "Buksan",
     "ButtonOk": "Ok",
     "ButtonNextTrack": "Susunod na track",
     "ButtonNetwork": "Network",

--- a/src/strings/fr-ca.json
+++ b/src/strings/fr-ca.json
@@ -196,7 +196,7 @@
     "ButtonPreviousTrack": "Piste précédente",
     "ButtonPause": "Pause",
     "ButtonParentalControl": "Contrôle parentale",
-    "ButtonOpen": "Ouvrir",
+    "ButtonEditUser": "Ouvrir",
     "ButtonOk": "OK",
     "ButtonNextTrack": "Prochaine piste",
     "ButtonAddImage": "Ajouter l'image",

--- a/src/strings/fr.json
+++ b/src/strings/fr.json
@@ -69,7 +69,7 @@
     "ButtonNetwork": "Réseau",
     "ButtonNextTrack": "Piste suivante",
     "ButtonOk": "OK",
-    "ButtonOpen": "Ouvrir",
+    "ButtonEditUser": "Ouvrir",
     "ButtonParentalControl": "Contrôle parental",
     "ButtonPreviousTrack": "Piste précédente",
     "ButtonQuickStartGuide": "Guide de démarrage rapide",

--- a/src/strings/gl.json
+++ b/src/strings/gl.json
@@ -178,7 +178,7 @@
     "CancelRecording": "Cancelar gravación",
     "ButtonAddMediaLibrary": "Engadir biblioteca multimedia",
     "ButtonBack": "Atrás",
-    "ButtonOpen": "Abrir",
+    "ButtonEditUser": "Abrir",
     "ButtonMore": "Máis",
     "ButtonOk": "Ok",
     "ButtonResume": "Retomar",

--- a/src/strings/he.json
+++ b/src/strings/he.json
@@ -567,7 +567,7 @@
     "ButtonRevoke": "בטל",
     "TabScheduledTasks": "משימות מתוזמנות",
     "ButtonResume": "המשך",
-    "ButtonOpen": "פתח",
+    "ButtonEditUser": "פתח",
     "HeaderTracks": "רצועות",
     "ButtonPreviousTrack": "הרצועה הקודמת",
     "ButtonNextTrack": "הרצועה הבאה",

--- a/src/strings/hi-in.json
+++ b/src/strings/hi-in.json
@@ -95,7 +95,7 @@
     "BoxSet": "बॉक्स सेट",
     "BurnSubtitlesHelp": "निर्धारित करता है कि वीडियो ट्रांसकोडिंग करते समय सर्वर को उपशीर्षक बर्न-इन करना चाहिए। इससे बचने से प्रदर्शन में बहुत सुधार होगा। छवि आधारित उपशीर्षक (VOBSUB, PGS, SUB, IDX, …) एवं ASS अथवा SSA जैसे उपशीर्षक बर्न-इन करने के लिए ऑटो का चयन करें।",
     "ButtonRemove": "हटाना",
-    "ButtonOpen": "खोलो",
+    "ButtonEditUser": "खोलो",
     "HeaderContinueWatching": "देखते रहिए",
     "HeaderAlbumArtists": "एल्बम कलाकार",
     "Genres": "शैली",

--- a/src/strings/hr.json
+++ b/src/strings/hr.json
@@ -35,7 +35,7 @@
     "ButtonNetwork": "Mreža",
     "ButtonNextTrack": "Sljedeća pjesma",
     "ButtonOk": "U redu",
-    "ButtonOpen": "Otvori",
+    "ButtonEditUser": "Otvori",
     "ButtonParentalControl": "Roditeljska kontrola",
     "ButtonPause": "Pauza",
     "ButtonPreviousTrack": "Prethodna pjesma",

--- a/src/strings/hu.json
+++ b/src/strings/hu.json
@@ -27,7 +27,7 @@
     "ButtonManualLogin": "Kézi belépés",
     "ButtonMore": "Tovább",
     "ButtonNextTrack": "Következő sáv",
-    "ButtonOpen": "Megnyitás",
+    "ButtonEditUser": "Megnyitás",
     "ButtonParentalControl": "Szülői felügyelet",
     "ButtonPause": "Szünet",
     "ButtonPreviousTrack": "Előző sáv",

--- a/src/strings/hy.json
+++ b/src/strings/hy.json
@@ -29,7 +29,7 @@
     "ButtonArrowLeft": "Ձախ",
     "ButtonArrowRight": "Աջ",
     "ButtonBack": "Հետ",
-    "ButtonOpen": "Բացել",
+    "ButtonEditUser": "Բացել",
     "ButtonParentalControl": "Ծնողական հսկողություն",
     "Continuing": "Շարունակում",
     "AddToFavorites": "Ավելացնել սիրվածներին",

--- a/src/strings/id.json
+++ b/src/strings/id.json
@@ -83,7 +83,7 @@
     "ButtonRefreshGuideData": "Muat ulang Data Panduan",
     "ButtonPause": "Jeda",
     "ButtonParentalControl": "Kendali orang tua",
-    "ButtonOpen": "Buka",
+    "ButtonEditUser": "Buka",
     "ButtonOk": "OK",
     "ButtonNetwork": "Jaringan",
     "ButtonMore": "Lebih banyak",

--- a/src/strings/is-is.json
+++ b/src/strings/is-is.json
@@ -170,7 +170,7 @@
     "ButtonSignIn": "Innskráning",
     "ButtonSend": "Senda",
     "ButtonSelectDirectory": "Velja möppu",
-    "ButtonOpen": "Opna",
+    "ButtonEditUser": "Opna",
     "Songs": "Lög",
     "ButtonPreviousTrack": "Fyrra lag",
     "ButtonPause": "Pása",

--- a/src/strings/it.json
+++ b/src/strings/it.json
@@ -62,7 +62,7 @@
     "ButtonMore": "Altro",
     "ButtonNetwork": "Rete",
     "ButtonNextTrack": "Traccia Successiva",
-    "ButtonOpen": "Apri",
+    "ButtonEditUser": "Apri",
     "ButtonParentalControl": "Controllo parentale",
     "ButtonPause": "Pausa",
     "ButtonPreviousTrack": "Traccia Precedente",

--- a/src/strings/ja.json
+++ b/src/strings/ja.json
@@ -74,7 +74,7 @@
     "ButtonNetwork": "ネットワーク",
     "ButtonNextTrack": "次のトラック",
     "ButtonOk": "OK",
-    "ButtonOpen": "開く",
+    "ButtonEditUser": "開く",
     "ButtonParentalControl": "ペアレンタルコントロール",
     "ButtonPause": "一時停止",
     "ButtonPreviousTrack": "前のトラック",

--- a/src/strings/kk.json
+++ b/src/strings/kk.json
@@ -73,7 +73,7 @@
     "ButtonNetwork": "Jelı",
     "ButtonNextTrack": "Kelesı jolşyq",
     "ButtonOk": "Jaraidy",
-    "ButtonOpen": "Aşu",
+    "ButtonEditUser": "Aşu",
     "ButtonParentalControl": "Mazmūndy basqaru",
     "ButtonPause": "Üzu",
     "ButtonPreviousTrack": "Aldyñğy jolşyq",

--- a/src/strings/ko.json
+++ b/src/strings/ko.json
@@ -30,7 +30,7 @@
     "ButtonNetwork": "네트워크",
     "ButtonNextTrack": "다음 트랙",
     "ButtonOk": "확인",
-    "ButtonOpen": "열기",
+    "ButtonEditUser": "열기",
     "ButtonPause": "일시 중지",
     "ButtonPreviousTrack": "이전 트랙",
     "ButtonQuickStartGuide": "빠른 시작 가이드",

--- a/src/strings/lt-lt.json
+++ b/src/strings/lt-lt.json
@@ -459,7 +459,7 @@
     "ButtonLibraryAccess": "Mediatekos prieiga",
     "ButtonMore": "Daugiau",
     "ButtonNetwork": "Tinklas",
-    "ButtonOpen": "Atidaryti",
+    "ButtonEditUser": "Atidaryti",
     "ButtonParentalControl": "Tėvų kontrolė",
     "ButtonRename": "Pervadinti",
     "ButtonResume": "Tęsti",

--- a/src/strings/lv.json
+++ b/src/strings/lv.json
@@ -445,7 +445,7 @@
     "ButtonPreviousTrack": "Iepriekšējais celiņš",
     "ButtonPause": "Pauzēt",
     "ButtonParentalControl": "Vecāku pārvaldība",
-    "ButtonOpen": "Atvērt",
+    "ButtonEditUser": "Atvērt",
     "ButtonOk": "Labi",
     "ButtonNextTrack": "Nākamais celiņš",
     "ButtonNetwork": "Tīkls",

--- a/src/strings/mk.json
+++ b/src/strings/mk.json
@@ -47,7 +47,7 @@
     "ButtonPreviousTrack": "Претходна нумера",
     "ButtonPause": "Паузирај",
     "ButtonParentalControl": "Родителска контрола",
-    "ButtonOpen": "Отвори",
+    "ButtonEditUser": "Отвори",
     "ButtonOk": "Во ред",
     "ButtonNextTrack": "Следна нумера",
     "ButtonMore": "Повеќе",

--- a/src/strings/ml.json
+++ b/src/strings/ml.json
@@ -21,7 +21,7 @@
     "ButtonPlayer": "കളിക്കാരൻ",
     "ButtonPause": "താൽക്കാലികമായി നിർത്തുക",
     "ButtonParentalControl": "രക്ഷിതാക്കളുടെ നിയത്രണം",
-    "ButtonOpen": "തുറക്കുക",
+    "ButtonEditUser": "തുറക്കുക",
     "ButtonOk": "ശരി",
     "ButtonNextTrack": "അടുത്ത ട്രാക്ക്",
     "ButtonNetwork": "നെറ്റ്‌വർക്ക്",

--- a/src/strings/mr.json
+++ b/src/strings/mr.json
@@ -1,5 +1,5 @@
 {
-    "ButtonOpen": "उघडा",
+    "ButtonEditUser": "उघडा",
     "ButtonOk": "ऑन",
     "ButtonNextTrack": "पुढचा ट्रॅक",
     "ButtonNetwork": "नेटवर्क",

--- a/src/strings/ms.json
+++ b/src/strings/ms.json
@@ -107,7 +107,7 @@
     "Playlists": "Senarai ulangmain",
     "Photos": "Gambar-gambar",
     "ButtonParentalControl": "Kawalan penjaga",
-    "ButtonOpen": "Buka",
+    "ButtonEditUser": "Buka",
     "ButtonOk": "Ok",
     "ButtonPreviousTrack": "Trek sebelumnya",
     "ButtonPause": "Henti Sejenak",

--- a/src/strings/my.json
+++ b/src/strings/my.json
@@ -32,7 +32,7 @@
     "ButtonPlayer": "ပလေယာ",
     "ButtonPause": "ရပ်ထားမည်",
     "ButtonParentalControl": "အုပ်ထိန်းသူ လုပ်ပိုင်ခွင့်",
-    "ButtonOpen": "ဖွင့်မည်",
+    "ButtonEditUser": "ဖွင့်မည်",
     "ButtonOk": "အိုကေ",
     "ButtonNextTrack": "နောက်တစ်ပုဒ်",
     "ButtonMore": "ပိုမို၍",

--- a/src/strings/nb.json
+++ b/src/strings/nb.json
@@ -52,7 +52,7 @@
     "ButtonNetwork": "Nettverk",
     "ButtonNextTrack": "Neste spor",
     "ButtonOk": "OK",
-    "ButtonOpen": "Åpne",
+    "ButtonEditUser": "Åpne",
     "ButtonParentalControl": "Foreldrekontroll",
     "ButtonPreviousTrack": "Forrige spor",
     "ButtonQuickStartGuide": "Hurtigveiledning",

--- a/src/strings/ne.json
+++ b/src/strings/ne.json
@@ -44,7 +44,7 @@
     "LabelTitle": "शीर्षक",
     "LogLevel.Warning": "चेतावनी",
     "ButtonOk": "हुन्छ",
-    "ButtonOpen": "खोल्नुहोस",
+    "ButtonEditUser": "खोल्नुहोस",
     "ButtonPause": "रोक्नुहोस्",
     "ButtonRename": "पुन: नामकरण",
     "ButtonRemove": "हटाउनुहोस्",

--- a/src/strings/nl.json
+++ b/src/strings/nl.json
@@ -66,7 +66,7 @@
     "ButtonMore": "Meer",
     "ButtonNetwork": "Netwerk",
     "ButtonNextTrack": "Volgende nummer",
-    "ButtonOpen": "Openen",
+    "ButtonEditUser": "Openen",
     "ButtonParentalControl": "Ouderlijk toezicht",
     "ButtonPause": "Pauzeren",
     "ButtonPreviousTrack": "Vorige nummer",

--- a/src/strings/nn.json
+++ b/src/strings/nn.json
@@ -503,7 +503,7 @@
     "ButtonPlayer": "Spelar",
     "ButtonPause": "Pause",
     "ButtonParentalControl": "Foreldrekontroll",
-    "ButtonOpen": "Opne",
+    "ButtonEditUser": "Opne",
     "ButtonOk": "OK",
     "ButtonNextTrack": "Neste spor",
     "ButtonNetwork": "Nettverk",

--- a/src/strings/pa.json
+++ b/src/strings/pa.json
@@ -61,7 +61,7 @@
     "ButtonRemove": "ਹਟਾਓ",
     "ButtonPlayer": "ਪਲੇਅਰ",
     "ButtonPause": "ਰੋਕੋ",
-    "ButtonOpen": "ਖੋਲ੍ਹੋ",
+    "ButtonEditUser": "ਖੋਲ੍ਹੋ",
     "ButtonOk": "ਠੀਕ ਹੈ",
     "ButtonNetwork": "ਨੈਟਵਰਕ",
     "ButtonMore": "ਹੋਰ",

--- a/src/strings/pl.json
+++ b/src/strings/pl.json
@@ -72,7 +72,7 @@
     "ButtonMore": "Więcej",
     "ButtonNetwork": "Sieć",
     "ButtonNextTrack": "Następny utwór",
-    "ButtonOpen": "Otwórz",
+    "ButtonEditUser": "Otwórz",
     "ButtonParentalControl": "Kontrola rodzicielska",
     "ButtonPause": "Pauza",
     "ButtonPreviousTrack": "Poprzedni utwór",

--- a/src/strings/pt-br.json
+++ b/src/strings/pt-br.json
@@ -68,7 +68,7 @@
     "ButtonNetwork": "Rede",
     "ButtonNextTrack": "Próxima faixa",
     "ButtonOk": "OK",
-    "ButtonOpen": "Abrir",
+    "ButtonEditUser": "Abrir",
     "ButtonParentalControl": "Controle dos pais",
     "ButtonPause": "Pausar",
     "ButtonPreviousTrack": "Faixa anterior",

--- a/src/strings/pt-pt.json
+++ b/src/strings/pt-pt.json
@@ -24,7 +24,7 @@
     "ButtonMore": "Mais",
     "ButtonNetwork": "Rede",
     "ButtonNextTrack": "Faixa seguinte",
-    "ButtonOpen": "Abrir",
+    "ButtonEditUser": "Abrir",
     "ButtonPause": "Pausar",
     "ButtonPreviousTrack": "Faixa anterior",
     "ButtonQuickStartGuide": "Guia de Início Rápido",

--- a/src/strings/pt.json
+++ b/src/strings/pt.json
@@ -847,7 +847,7 @@
     "ButtonPreviousTrack": "Faixa anterior",
     "ButtonPause": "Pausar",
     "ButtonParentalControl": "Controlo parental",
-    "ButtonOpen": "Abrir",
+    "ButtonEditUser": "Abrir",
     "ButtonOk": "OK",
     "ButtonNextTrack": "Faixa seguinte",
     "ButtonNetwork": "Rede",

--- a/src/strings/ro.json
+++ b/src/strings/ro.json
@@ -241,7 +241,7 @@
     "ButtonNetwork": "Rețea",
     "ButtonNextTrack": "Următoarea cale",
     "ButtonOk": "Ok",
-    "ButtonOpen": "Deschide",
+    "ButtonEditUser": "Deschide",
     "ButtonParentalControl": "Control parental",
     "ButtonPause": "Pauză",
     "ConfirmEndPlayerSession": "Dorești să oprești serverul Jellyfin pe {0}?",

--- a/src/strings/ru.json
+++ b/src/strings/ru.json
@@ -73,7 +73,7 @@
     "ButtonNetwork": "Сеть",
     "ButtonNextTrack": "Следующая дорожка",
     "ButtonOk": "Ок",
-    "ButtonOpen": "Открыть",
+    "ButtonEditUser": "Открыть",
     "ButtonParentalControl": "Родительский контроль",
     "ButtonPause": "Пауза",
     "ButtonPreviousTrack": "Предыдущая дорожка",

--- a/src/strings/sk.json
+++ b/src/strings/sk.json
@@ -43,7 +43,7 @@
     "ButtonMore": "Viac",
     "ButtonNetwork": "Sieť",
     "ButtonNextTrack": "Nasledujúca stopa",
-    "ButtonOpen": "Otvoriť",
+    "ButtonEditUser": "Otvoriť",
     "ButtonParentalControl": "Rodičovská kontrola",
     "ButtonPause": "Pozastaviť",
     "ButtonPreviousTrack": "Predchádzajúca stopa",

--- a/src/strings/sl-si.json
+++ b/src/strings/sl-si.json
@@ -126,7 +126,7 @@
     "ButtonNetwork": "Omrežje",
     "ButtonNextTrack": "Naslednja skladba",
     "ButtonOk": "Ok",
-    "ButtonOpen": "Odpri",
+    "ButtonEditUser": "Odpri",
     "ButtonParentalControl": "Starševski nadzor",
     "ButtonPause": "Premor",
     "ButtonPreviousTrack": "Prejšnja skladba",

--- a/src/strings/sq.json
+++ b/src/strings/sq.json
@@ -108,7 +108,7 @@
     "ButtonPlayer": "Luajtësi",
     "ButtonPause": "Ndal",
     "ButtonParentalControl": "Kontrollimet Prindërore",
-    "ButtonOpen": "Hap",
+    "ButtonEditUser": "Hap",
     "ButtonOk": "Ok",
     "ButtonNextTrack": "Kënga tjetër",
     "ButtonNetwork": "Rrjeti",

--- a/src/strings/sr.json
+++ b/src/strings/sr.json
@@ -25,7 +25,7 @@
     "AccessRestrictedTryAgainLater": "Приступ је тренутно ограничен. Покушајте поново касније.",
     "ButtonPause": "Пауза",
     "ButtonParentalControl": "Родитељска контрола",
-    "ButtonOpen": "Отвори",
+    "ButtonEditUser": "Отвори",
     "ButtonOk": "У реду",
     "ButtonNextTrack": "Следећа нумера",
     "ButtonNetwork": "Мрежа",

--- a/src/strings/sv.json
+++ b/src/strings/sv.json
@@ -64,7 +64,7 @@
     "ButtonNetwork": "Nätverk",
     "ButtonNextTrack": "Nästa spår",
     "ButtonOk": "OK",
-    "ButtonOpen": "Öppna",
+    "ButtonEditUser": "Öppna",
     "ButtonParentalControl": "Föräldralås",
     "ButtonPause": "Paus",
     "ButtonPreviousTrack": "Föregående spår",

--- a/src/strings/ta.json
+++ b/src/strings/ta.json
@@ -127,7 +127,7 @@
     "ButtonPreviousTrack": "முந்தைய பாடல்",
     "ButtonPause": "இடைநிறுத்தம்",
     "ButtonParentalControl": "பெற்றோர் கட்டுப்பாடு",
-    "ButtonOpen": "திற",
+    "ButtonEditUser": "திற",
     "ButtonOk": "சரி",
     "ButtonNextTrack": "அடுத்த பாடல்",
     "ButtonNew": "புதியது",

--- a/src/strings/te.json
+++ b/src/strings/te.json
@@ -1353,7 +1353,7 @@
     "ButtonPlayer": "ప్లేయర్",
     "ButtonPause": "పాజ్ చేయండి",
     "ButtonParentalControl": "తల్లి దండ్రుల నియంత్రణ",
-    "ButtonOpen": "తెరవండి",
+    "ButtonEditUser": "తెరవండి",
     "ButtonOk": "అలాగే",
     "ButtonNextTrack": "తదుపరి ట్రాక్",
     "ButtonNetwork": "నెట్‌వర్క్",

--- a/src/strings/th.json
+++ b/src/strings/th.json
@@ -128,7 +128,7 @@
     "ButtonPlayer": "ตัวเล่น",
     "ButtonPause": "หยุดชั่วคราว",
     "ButtonParentalControl": "การควบคุมโดยผู้ปกครอง",
-    "ButtonOpen": "เปิด",
+    "ButtonEditUser": "เปิด",
     "ButtonInfo": "ข้อมูล",
     "ButtonCast": "แคสต์ไปยังอุปกรณ์",
     "ButtonBack": "กลับ",

--- a/src/strings/tr.json
+++ b/src/strings/tr.json
@@ -236,7 +236,7 @@
     "ButtonChangeServer": "Sunucu Değiştir",
     "ButtonGotIt": "Anlaşıldı",
     "ButtonMore": "Diğer",
-    "ButtonOpen": "Aç",
+    "ButtonEditUser": "Aç",
     "ButtonNetwork": "Ağ",
     "ButtonNextTrack": "Sonraki parça",
     "ButtonParentalControl": "Ebeveyn kontrolü",

--- a/src/strings/uk.json
+++ b/src/strings/uk.json
@@ -174,7 +174,7 @@
     "ButtonPreviousTrack": "Попередня доріжка",
     "ButtonPause": "Пауза",
     "ButtonParentalControl": "Батьківський контроль",
-    "ButtonOpen": "Відкрити",
+    "ButtonEditUser": "Відкрити",
     "ButtonOk": "Ок",
     "ButtonNextTrack": "Наступна доріжка",
     "ButtonNetwork": "Мережа",

--- a/src/strings/ur_PK.json
+++ b/src/strings/ur_PK.json
@@ -915,7 +915,7 @@
     "Saturday": "ہفتہ",
     "HeaderUninstallPlugin": "پلگ ان ان انسٹال کریں",
     "HeaderRevisionHistory": "نظرثانی کی تاریخ",
-    "ButtonOpen": "کھولیں۔",
+    "ButtonEditUser": "کھولیں۔",
     "PasswordSaved": "پاس ورڈ محفوظ ہو گیا۔",
     "NoSubtitleSearchResultsFound": "کوئی نتیجہ نہیں.",
     "LabelManufacturerUrl": "مینوفیکچرر URL",

--- a/src/strings/uz.json
+++ b/src/strings/uz.json
@@ -120,7 +120,7 @@
     "ButtonPlayer": "O'yinchi",
     "ButtonPause": "Pauza",
     "ButtonParentalControl": "Ota-ona nazorati",
-    "ButtonOpen": "Ochish",
+    "ButtonEditUser": "Ochish",
     "ButtonOk": "OK",
     "ButtonNextTrack": "Keyingi trek",
     "ButtonMore": "Yana",

--- a/src/strings/vi.json
+++ b/src/strings/vi.json
@@ -89,7 +89,7 @@
     "ButtonPreviousTrack": "Bản ghi trước",
     "ButtonPause": "Tạm dừng",
     "ButtonParentalControl": "Kiểm soát của cha mẹ",
-    "ButtonOpen": "Mở",
+    "ButtonEditUser": "Mở",
     "ButtonNextTrack": "Bản ghi tiếp theo",
     "ButtonNetwork": "Mạng",
     "ButtonMore": "Thêm",

--- a/src/strings/zh-cn.json
+++ b/src/strings/zh-cn.json
@@ -67,7 +67,7 @@
     "ButtonNetwork": "网络",
     "ButtonNextTrack": "下一音轨",
     "ButtonOk": "确定",
-    "ButtonOpen": "打开",
+    "ButtonEditUser": "打开",
     "ButtonParentalControl": "家长控制",
     "ButtonPause": "暂停",
     "ButtonPreviousTrack": "上一音轨",

--- a/src/strings/zh-hk.json
+++ b/src/strings/zh-hk.json
@@ -336,7 +336,7 @@
     "ButtonResetEasyPassword": "重設簡易 PIN 碼",
     "ButtonPause": "暫停",
     "ButtonParentalControl": "家長監控",
-    "ButtonOpen": "開啟",
+    "ButtonEditUser": "開啟",
     "ButtonNetwork": "網絡",
     "ButtonMore": "更多",
     "ButtonInfo": "資訊",

--- a/src/strings/zh-tw.json
+++ b/src/strings/zh-tw.json
@@ -264,7 +264,7 @@
     "ButtonMore": "更多",
     "ButtonNetwork": "網路",
     "ButtonNextTrack": "下一首",
-    "ButtonOpen": "開啟",
+    "ButtonEditUser": "開啟",
     "ButtonParentalControl": "家長控制",
     "ButtonPause": "暫停",
     "ButtonPreviousTrack": "上一首",

--- a/src/strings/zu.json
+++ b/src/strings/zu.json
@@ -80,7 +80,7 @@
     "ButtonRemove": "Khipha",
     "ButtonPlayer": "Isidlali",
     "ButtonPause": "Phumuza isikhashana",
-    "ButtonOpen": "Vula",
+    "ButtonEditUser": "Vula",
     "ButtonOk": "Kulungile",
     "ButtonNetwork": "Inethiwekhi",
     "ButtonMore": "Okwengeziwe",


### PR DESCRIPTION
Refactor the name of the string to make it make more sense when looking at it in Weblate.
Also changes the en-US source string so it isn't confusing

This key is for the "Open" button of users in the users view in the dashboard and I think it makes more sense labeling it "Edit User Permissions" than "Open" and removes any confusion there might be when trying to translate it in Weblate

<img width="907" alt="截圖 2024-02-21 上午1 17 09" src="https://github.com/jellyfin/jellyfin-web/assets/25688628/353a31c7-c844-4d81-8698-0221a9c3bc7a">

**Changes**

Refactor key "ButtonOpen" to "ButtonEditUser"
Change en-US string from "Open" to "Edit User Permissions"

**Issues**
None
