### PR TITLE
Remove reset password option for admin users

### DIFF
--- a/src/components/dashboard/users/UserPasswordForm.tsx
+++ b/src/components/dashboard/users/UserPasswordForm.tsx
@@ -33,7 +33,9 @@ const UserPasswordForm: FunctionComponent<IProps> = ({ userId }: IProps) => {
         LibraryMenu.setTitle(user.Name);
 
         if (user.HasConfiguredPassword) {
-            (page.querySelector('#btnResetPassword') as HTMLDivElement).classList.remove('hide');
+            if (!user.Policy?.IsAdministrator) {
+                (page.querySelector('#btnResetPassword') as HTMLDivElement).classList.remove('hide');
+            }
             (page.querySelector('#fldCurrentPassword') as HTMLDivElement).classList.remove('hide');
         } else {
             (page.querySelector('#btnResetPassword') as HTMLDivElement).classList.add('hide');


### PR DESCRIPTION
Because admin users shouldn't be able to reset their own password without entering their password first, this commit removes the "reset password" option for admin users.

Currently, hitting the reset password option as an admin will result in a 400 Bad request saying "Admin user passwords must not be empty (Parameter 'newPassword')"

Related to issue [5199](https://github.com/jellyfin/jellyfin-web/issues/5199)