### PR TITLE
Enable AV1 remuxing via HLS fMP4 on Safari

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -573,8 +573,8 @@ export default function (options) {
     const hlsInFmp4VideoCodecs = [];
 
     if (canPlayAv1(videoTestElement)
-        && !browser.mobile && (browser.edgeChromium || browser.firefox || browser.chrome)) {
-        // disable av1 on mobile since it can be very slow software decoding
+        && (browser.safari || (!browser.mobile && (browser.edgeChromium || browser.firefox || browser.chrome)))) {
+        // disable av1 on non-safari mobile browsers since it can be very slow software decoding
         hlsInFmp4VideoCodecs.push('av1');
     }
 

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -619,12 +619,20 @@ export default function (options) {
 
     if (canPlayVp9) {
         mp4VideoCodecs.push('vp9');
-        webmVideoCodecs.push('vp9');
+        // webm support is unreliable on safari 17
+        if (!browser.safari
+             || (browser.safari && browser.versionMajor >= 15 && browser.versionMajor < 17)) {
+            webmVideoCodecs.push('vp9');
+        }
     }
 
     if (canPlayAv1(videoTestElement)) {
         mp4VideoCodecs.push('av1');
-        webmVideoCodecs.push('av1');
+        // webm support is unreliable on safari 17
+        if (!browser.safari
+             || (browser.safari && browser.versionMajor >= 15 && browser.versionMajor < 17)) {
+            webmVideoCodecs.push('av1');
+        }
     }
 
     if (canPlayVp8 || browser.tizen) {


### PR DESCRIPTION
**Changes**
- Enable AV1 remuxing via HLS fMP4 on Safari

    AV1 should be supported by Apple devices that support hardware
    acceleration. Software decoding is not yet supported on Safari.
    See also https://bitmovin.com/apple-av1-support


- Only enable `webm` for Safari 15 and 16 due to [an issue](https://www.reddit.com/r/ios/comments/16po1xx/my_iphone_xr_with_ios_17_does_not_play_webm_videos/) of Safari 17.