### PR TITLE
feat: add VideoToolbox Tone mapping support

### DIFF
--- a/src/controllers/dashboard/encodingsettings.html
+++ b/src/controllers/dashboard/encodingsettings.html
@@ -129,7 +129,7 @@
                             <span>${AllowHevcEncoding}</span>
                         </label>
                     </div>
-                    <div class="checkboxList">
+                    <div class="checkboxList allowAv1EncodingOption">
                         <label>
                             <input type="checkbox" is="emby-checkbox" id="chkAllowAv1Encoding" />
                             <span>${AllowAv1Encoding}</span>
@@ -152,6 +152,16 @@
                     <div class="inputContainer">
                         <input is="emby-input" type="number" id="txtVppTonemappingContrast" pattern="[0-9]*" min="1" max="2" step=".00001" label="${LabelVppTonemappingContrast}" />
                         <div class="fieldDescription">${LabelVppTonemappingContrastHelp}</div>
+                    </div>
+                </div>
+
+                <div class="videoToolboxTonemappingOptions hide">
+                    <div class="checkboxListContainer checkboxContainer-withDescription">
+                        <label>
+                            <input type="checkbox" is="emby-checkbox" id="chkVideoToolboxTonemapping" />
+                            <span>${EnableVideoToolboxTonemapping}</span>
+                        </label>
+                        <div class="fieldDescription checkboxFieldDescription">${AllowVideoToolboxTonemappingHelp}</div>
                     </div>
                 </div>
 

--- a/src/controllers/dashboard/encodingsettings.js
+++ b/src/controllers/dashboard/encodingsettings.js
@@ -222,12 +222,10 @@ $(document).on('pageinit', '#encodingSettingsPage', function () {
 
         if (this.value === 'videotoolbox') {
             page.querySelector('.videoToolboxTonemappingOptions').classList.remove('hide');
+            page.querySelector('.allowAv1EncodingOption').classList.add('hide');
         } else {
             page.querySelector('.videoToolboxTonemappingOptions').classList.add('hide');
-        }
-
-        if ((this.value == 'videotoolbox')) {
-            page.querySelector('.allowAv1EncodingOption').classList.add('hide');
+            page.querySelector('.allowAv1EncodingOption').classList.remove('hide');
         }
 
         if (systemInfo.OperatingSystem.toLowerCase() === 'linux' && (this.value == 'qsv' || this.value == 'vaapi')) {

--- a/src/controllers/dashboard/encodingsettings.js
+++ b/src/controllers/dashboard/encodingsettings.js
@@ -220,7 +220,7 @@ $(document).on('pageinit', '#encodingSettingsPage', function () {
             page.querySelector('.fldIntelLp').classList.add('hide');
         }
 
-        if ((this.value == 'videotoolbox')) {
+        if (this.value === 'videotoolbox') {
             page.querySelector('.videoToolboxTonemappingOptions').classList.remove('hide');
         } else {
             page.querySelector('.videoToolboxTonemappingOptions').classList.add('hide');

--- a/src/controllers/dashboard/encodingsettings.js
+++ b/src/controllers/dashboard/encodingsettings.js
@@ -32,6 +32,7 @@ function loadPage(page, config, systemInfo) {
     $('#txtVaapiDevice', page).val(config.VaapiDevice || '');
     page.querySelector('#chkTonemapping').checked = config.EnableTonemapping;
     page.querySelector('#chkVppTonemapping').checked = config.EnableVppTonemapping;
+    page.querySelector('#chkVideoToolboxTonemapping').checked = config.EnableVideoToolboxTonemapping;
     page.querySelector('#selectTonemappingAlgorithm').value = config.TonemappingAlgorithm;
     page.querySelector('#selectTonemappingMode').value = config.TonemappingMode;
     page.querySelector('#selectTonemappingRange').value = config.TonemappingRange;
@@ -93,6 +94,7 @@ function onSubmit() {
             config.VaapiDevice = $('#txtVaapiDevice', form).val();
             config.EnableTonemapping = form.querySelector('#chkTonemapping').checked;
             config.EnableVppTonemapping = form.querySelector('#chkVppTonemapping').checked;
+            config.EnableVideoToolboxTonemapping = form.querySelector('#chkVideoToolboxTonemapping').checked;
             config.TonemappingAlgorithm = form.querySelector('#selectTonemappingAlgorithm').value;
             config.TonemappingMode = form.querySelector('#selectTonemappingMode').value;
             config.TonemappingRange = form.querySelector('#selectTonemappingRange').value;
@@ -206,7 +208,7 @@ $(document).on('pageinit', '#encodingSettingsPage', function () {
             page.querySelector('.fld10bitHevcVp9HwDecoding').classList.add('hide');
         }
 
-        if (this.value == 'amf' || this.value == 'nvenc' || this.value == 'qsv' || this.value == 'vaapi' || this.value == 'rkmpp') {
+        if (this.value == 'amf' || this.value == 'nvenc' || this.value == 'qsv' || this.value == 'vaapi' || this.value == 'rkmpp' || this.value == 'videotoolbox') {
             page.querySelector('.tonemappingOptions').classList.remove('hide');
         } else {
             page.querySelector('.tonemappingOptions').classList.add('hide');
@@ -216,6 +218,16 @@ $(document).on('pageinit', '#encodingSettingsPage', function () {
             page.querySelector('.fldIntelLp').classList.remove('hide');
         } else {
             page.querySelector('.fldIntelLp').classList.add('hide');
+        }
+
+        if ((this.value == 'videotoolbox')) {
+            page.querySelector('.videoToolboxTonemappingOptions').classList.remove('hide');
+        } else {
+            page.querySelector('.videoToolboxTonemappingOptions').classList.add('hide');
+        }
+
+        if ((this.value == 'videotoolbox')) {
+            page.querySelector('.allowAv1EncodingOption').classList.add('hide');
         }
 
         if (systemInfo.OperatingSystem.toLowerCase() === 'linux' && (this.value == 'qsv' || this.value == 'vaapi')) {

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1660,6 +1660,8 @@
     "EnableEnhancedNvdecDecoder": "Enable enhanced NVDEC decoder",
     "EnableVppTonemapping": "Enable VPP Tone mapping",
     "AllowVppTonemappingHelp": "Full Intel driver based tone-mapping. Currently works only on certain hardware with HDR10 videos. This has a higher priority compared to another OpenCL implementation.",
+    "EnableVideoToolboxTonemapping": "Enable VideoToolbox Tone mapping",
+    "AllowVideoToolboxTonemappingHelp": "Hardware-accelerated tone-mapping provided by VideoToolbox. It works with most HDR formats, including HDR10, HDR10+, and HLG, but does not work with Dolby Vision Profile 5. This has a higher priority compared to another OpenCL implementation.",
     "Controls": "Controls",
     "LabelEnableGamepad": "Enable Gamepad",
     "EnableGamepadHelp": "Listen for input from any connected controllers. (Requires: 'TV' Display Mode)",


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
- Adds Tone mapping options to VideoToolbox
- Hides AV1 encoding from VideoToolbox option to not confuse our user


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Depends on jellyfin/jellyfin#11014