### PR TITLE
Add missing options for people metadata editor

### DIFF
--- a/src/components/metadataEditor/personEditor.template.html
+++ b/src/components/metadataEditor/personEditor.template.html
@@ -26,6 +26,8 @@
                 <option value="Engineer">${Engineer}</option>
                 <option value="Mixer">${Mixer}</option>
                 <option value="Remixer">${Remixer}</option>
+                <option value="AlbumArtist">${AlbumArtist}</option>
+                <option value="Artist">${Artist}</option>
             </select>
         </div>
 


### PR DESCRIPTION

**Changes**
Add missing options for people metadata editor mainly for music. Album Artist and Artist.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
