### PR TITLE
Keep exact sdk version in package.json

### DIFF
--- a/.github/workflows/update-sdk.yml
+++ b/.github/workflows/update-sdk.yml
@@ -33,7 +33,6 @@ jobs:
           npm i --save @jellyfin/sdk@unstable
           VERSION=$(jq -r '.dependencies["@jellyfin/sdk"]' package.json)
           echo "JF_SDK_VERSION=${VERSION}" >> $GITHUB_ENV
-          git checkout package.json
 
       - name: Open a pull request
         uses: peter-evans/create-pull-request@v6


### PR DESCRIPTION
**Changes**
Initially I thought that the exact version was being saved to `package.json` because of our save-exact preference in `.npmrc`, but it turns out npm just doesn't handle tags this way and will always resolve installing a tag to a specific version in the package file. Since we now have CI keeping the version up to date, there really isn't a reason to keep the unstable tag in the `package.json` file... especially since the lockfile ends up in an invalid state currently with the exact version referenced (see the change to `package-lock.json` in [this renovate commit](https://github.com/jellyfin/jellyfin-web/pull/5187/commits/f30deeaf8213340f1ff557b6032941ebd421c7b0)).

**Issues**
N/A