### PR TITLE
Update editorconfig for yaml indentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,5 +8,5 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 end_of_line = lf
 
-[*.json]
+[*.{json,yaml,yml}]
 indent_size = 2


### PR DESCRIPTION
**Changes**
We tend to use 2 spaces for indentation in yaml files so this updates the editorconfig to reflect that.

**Issues**
N/A