### PR TITLE
(Tizen) Add logout to exit menu

### DIFF
--- a/src/components/apphost.js
+++ b/src/components/apphost.js
@@ -304,7 +304,7 @@ function askForExit() {
         return;
     }
 
-    import('../scripts/clientUtils').then(() => {
+    import('../utils/dashboard').then(() => {
         import('../components/actionSheet/actionSheet').then((actionsheet) => {
             const userId = Dashboard.getCurrentUserId();
             const logoutEntry = userId ? [{ id: 'logout', name: globalize.translate('ButtonSignOut') }] : [];

--- a/src/components/apphost.js
+++ b/src/components/apphost.js
@@ -304,24 +304,26 @@ function askForExit() {
         return;
     }
 
-    import('../components/actionSheet/actionSheet').then((actionsheet) => {
-        exitPromise = actionsheet.show({
-            title: globalize.translate('MessageConfirmAppExit'),
-            items: [
-                { id: 'logout', name: globalize.translate('ButtonSignOut') },
-                { id: 'yes', name: globalize.translate('Yes') },
-                { id: 'no', name: globalize.translate('No') }
-            ]
-        }).then(function (value) {
-            if (value === 'yes') {
-                doExit();
-            } else if (value === 'logout') {
-                import('../scripts/clientUtils').then((clientUtils) => {
+    import('../scripts/clientUtils').then(() => {
+        import('../components/actionSheet/actionSheet').then((actionsheet) => {
+            const userId = Dashboard.getCurrentUserId();
+            const logoutEntry = userId ? [{ id: 'logout', name: globalize.translate('ButtonSignOut') }] : [];
+            exitPromise = actionsheet.show({
+                title: globalize.translate('MessageConfirmAppExit'),
+                items: [
+                    ...logoutEntry,
+                    { id: 'yes', name: globalize.translate('Yes') },
+                    { id: 'no', name: globalize.translate('No') }
+                ]
+            }).then(function (value) {
+                if (value === 'yes') {
+                    doExit();
+                } else if (value === 'logout') {
                     Dashboard.logout();
-                });
-            }
-        }).finally(function () {
-            exitPromise = null;
+                }
+            }).finally(function () {
+                exitPromise = null;
+            });
         });
     });
 }

--- a/src/components/apphost.js
+++ b/src/components/apphost.js
@@ -308,12 +308,17 @@ function askForExit() {
         exitPromise = actionsheet.show({
             title: globalize.translate('MessageConfirmAppExit'),
             items: [
+                { id: 'logout', name: globalize.translate('ButtonSignOut') },
                 { id: 'yes', name: globalize.translate('Yes') },
                 { id: 'no', name: globalize.translate('No') }
             ]
         }).then(function (value) {
             if (value === 'yes') {
                 doExit();
+            } else if (value === 'logout') {
+                import('../scripts/clientUtils').then((clientUtils) => {
+                    Dashboard.logout();
+                });
             }
         }).finally(function () {
             exitPromise = null;


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
Adds `Sign Out` option to Tizen TV exit menu to mitigate the hassle of switching users that would otherwise require much more interaction. 

Users would either have to:

1. Fully close the app and start it back up again
    - This has wait time, especially on older TVs (like mine)
    - Only really works nicely when users are configured to **Not** be remembered and have no password configured
 2. Logout through the menu
    - This requires at least 16 remote interactions. Which is just too much of a hassle.
      - From the top of the Home Screen; Up (1), Right(4), Ok(1), Down(9), Ok(1)