### PR TITLE
Change default AutoLogin

### DIFF
--- a/src/controllers/session/login/index.js
+++ b/src/controllers/session/login/index.js
@@ -229,6 +229,12 @@ export default function (view, params) {
                 showManualForm(context, true);
             } else if (haspw == 'false') {
                 authenticateUserByName(context, getApiClient(), getTargetUrl(), name, '');
+                getApiClient().getPublicUsers().then((users) => {
+                    if (users.length >= 2) {
+                        // Disable RememberMe if multiple users exist and no password is used
+                        appSettings.enableAutoLogin(false);
+                    } 
+                });
             } else {
                 context.querySelector('#txtManualName').value = name;
                 context.querySelector('#txtManualPassword').value = '';

--- a/src/scripts/settings/appSettings.js
+++ b/src/scripts/settings/appSettings.js
@@ -15,7 +15,7 @@ class AppSettings {
             this.set('enableAutoLogin', val.toString());
         }
 
-        return toBoolean(this.get('enableAutoLogin'), true);
+        return toBoolean(this.get('enableAutoLogin'), false);
     }
 
     /**


### PR DESCRIPTION
**Changes**
Changes the default for `enableAutoLogin` to False when login without password is used and multiple users exist.

Based on these suggestions in https://github.com/jellyfin/jellyfin-web/pull/5271#pullrequestreview-1926196757:

> 1. Use sessionStore (or session cookies) to store the credentials.
> 2. Make Remember Me unchecked by default. This requires 1. Otherwise, opening links in the new tab doesn't sign in.
> 3. Uncheck Remember Me when password-less graphical login is used.

But only affecting the RememberMe behavior.