### PR TITLE
Update VSCode ESLint config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "eslint.format.enable": true,
   "editor.formatOnSave": false


### PR DESCRIPTION
VSCode changed the config format for the ESLint plugin a while ago according to the linked SO post. This PR updates the config to the new format. Currently VSCode will try to change that option every time I try to work on web and create a new branch from master

![圖片](https://github.com/jellyfin/jellyfin-web/assets/25688628/fb45948b-48e9-4c6a-8d43-6e78ba6c4008)

https://stackoverflow.com/questions/77637621/vscode-workspace-settings-change-on-its-own

**Changes**
change source.fixall.eslint from true to "explicit"

**Issues**
None