### PR TITLE
Complement recent DoVi fallback handling changes server-side

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -82,6 +82,7 @@
 - [András Maróy](https://github.com/andrasmaroy)
 - [Chris-Codes-It](https://github.com/Chris-Codes-It)
 - [Vedant](https://github.com/viktory36)
+- [GeorgeH005](https://github.com/GeorgeH005)
 
 ## Emby Contributors
 

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -216,10 +216,14 @@ function supportedDolbyVisionProfilesHevc(videoTestElement) {
     if (videoTestElement.canPlayType) {
         if (videoTestElement
             .canPlayType('video/mp4; codecs="dvh1.05.09"')
-            .replace(/no/, '')) supportedProfiles.push(5);
+            .replace(/no/, '')) {
+            supportedProfiles.push(5);
+        }
         if (videoTestElement
             .canPlayType('video/mp4; codecs="dvh1.08.09"')
-            .replace(/no/, '')) supportedProfiles.push(8);
+            .replace(/no/, '')) {
+            supportedProfiles.push(8);
+        }
     }
     return supportedProfiles;
 }

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -217,7 +217,7 @@ function supportedDolbyVisionProfilesHevc(videoTestElement) {
         if (videoTestElement
             .canPlayType('video/mp4; codecs="dvh1.05.09"')
             .replace(/no/, '')) supportedProfiles.push(5);
-        if ( videoTestElement
+        if (videoTestElement
             .canPlayType('video/mp4; codecs="dvh1.08.09"')
             .replace(/no/, '')) supportedProfiles.push(8);
     }

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -212,7 +212,7 @@ function supportsDolbyVision(options) {
 
 function supportedDolbyVisionProfilesHevc(videoTestElement) {
     const supportedProfiles = [];
-    // Profiles 5/7/8 4k@60fps
+    // Profiles 5/8 4k@60fps
     if (videoTestElement.canPlayType) {
         if (videoTestElement
             .canPlayType('video/mp4; codecs="dvh1.05.09"')

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -933,17 +933,17 @@ export default function (options) {
     if (supportsHdr10(options)) {
         hevcVideoRangeTypes += '|HDR10';
         // Should also be able to play DoVi with HDR10 fallback
-        hevcVideoRangeTypes += '|DOVIWithHDR10'
+        hevcVideoRangeTypes += '|DOVIWithHDR10';
         vp9VideoRangeTypes += '|HDR10';
         av1VideoRangeTypes += '|HDR10';
     }
 
     if (supportsHlg(options)) {
-        hevcVideoRangeTypes += "|HLG";
+        hevcVideoRangeTypes += '|HLG';
         // Should also be able to play DoVi with HLG fallback
-        hevcVideoRangeTypes += "|DOVIWithHLG";
-        vp9VideoRangeTypes += "|HLG";
-        av1VideoRangeTypes += "|HLG";
+        hevcVideoRangeTypes += '|DOVIWithHLG';
+        vp9VideoRangeTypes += '|HLG';
+        av1VideoRangeTypes += '|HLG';
     }
 
     if (supportsDolbyVision(options) && canPlayDolbyVisionHevc(videoTestElement)) {

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -218,9 +218,6 @@ function supportedDolbyVisionProfilesHevc(videoTestElement) {
             .canPlayType('video/mp4; codecs="dvh1.05.09"')
             .replace(/no/, '')) supportedProfiles.push(5);
         if ( videoTestElement
-            .canPlayType('video/mp4; codecs="dvh1.07.09"')
-            .replace(/no/, '')) supportedProfiles.push(7);
-        if ( videoTestElement
             .canPlayType('video/mp4; codecs="dvh1.08.09"')
             .replace(/no/, '')) supportedProfiles.push(8);
     }
@@ -953,11 +950,11 @@ export default function (options) {
 
     if (supportsDolbyVision(options)) {
         const profiles = supportedDolbyVisionProfilesHevc(videoTestElement);
-        if (profiles.includes(5) || profiles.includes(7)) {
+        if (profiles.includes(5)) {
             hevcVideoRangeTypes += '|DOVI';
         }
         if (profiles.includes(8)) {
-            hevcVideoRangeTypes += '|DOVIWithHDR10|DOVIWithHLG';
+            hevcVideoRangeTypes += '|DOVIWithHDR10|DOVIWithHLG|DOVIWithSDR';
         }
     }
 

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -210,12 +210,21 @@ function supportsDolbyVision(options) {
     );
 }
 
-function canPlayDolbyVisionHevc(videoTestElement) {
+function supportedDolbyVisionProfilesHevc(videoTestElement) {
+    const supportedProfiles = [];
     // Profiles 5/7/8 4k@60fps
-    return !!videoTestElement.canPlayType
-        && (videoTestElement.canPlayType('video/mp4; codecs="dvh1.05.09"').replace(/no/, '')
-        && videoTestElement.canPlayType('video/mp4; codecs="dvh1.07.09"').replace(/no/, '')
-        && videoTestElement.canPlayType('video/mp4; codecs="dvh1.08.09"').replace(/no/, ''));
+    if (videoTestElement.canPlayType) {
+        if (videoTestElement
+            .canPlayType('video/mp4; codecs="dvh1.05.09"')
+            .replace(/no/, '')) supportedProfiles.push(5);
+        if ( videoTestElement
+            .canPlayType('video/mp4; codecs="dvh1.07.09"')
+            .replace(/no/, '')) supportedProfiles.push(7);
+        if ( videoTestElement
+            .canPlayType('video/mp4; codecs="dvh1.08.09"')
+            .replace(/no/, '')) supportedProfiles.push(8);
+    }
+    return supportedProfiles;
 }
 
 function getDirectPlayProfileForVideoContainer(container, videoAudioCodecs, videoTestElement, options) {
@@ -932,22 +941,24 @@ export default function (options) {
 
     if (supportsHdr10(options)) {
         hevcVideoRangeTypes += '|HDR10';
-        // Should also be able to play DoVi with HDR10 fallback
-        hevcVideoRangeTypes += '|DOVIWithHDR10';
         vp9VideoRangeTypes += '|HDR10';
         av1VideoRangeTypes += '|HDR10';
     }
 
     if (supportsHlg(options)) {
         hevcVideoRangeTypes += '|HLG';
-        // Should also be able to play DoVi with HLG fallback
-        hevcVideoRangeTypes += '|DOVIWithHLG';
         vp9VideoRangeTypes += '|HLG';
         av1VideoRangeTypes += '|HLG';
     }
 
-    if (supportsDolbyVision(options) && canPlayDolbyVisionHevc(videoTestElement)) {
-        hevcVideoRangeTypes += '|DOVI';
+    if (supportsDolbyVision(options)) {
+        const profiles = supportedDolbyVisionProfilesHevc(videoTestElement);
+        if (profiles.includes(5) || profiles.includes(7)) {
+            hevcVideoRangeTypes += '|DOVI';
+        }
+        if (profiles.includes(8)) {
+            hevcVideoRangeTypes += '|DOVIWithHDR10|DOVIWithHLG';
+        }
     }
 
     const h264CodecProfileConditions = [

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -1,6 +1,6 @@
+import browser from './browser';
 import appSettings from './settings/appSettings';
 import * as userSettings from './settings/userSettings';
-import browser from './browser';
 
 function canPlayH264(videoTestElement) {
     return !!(videoTestElement.canPlayType?.('video/mp4; codecs="avc1.42E01E, mp4a.40.2"').replace(/no/, ''));
@@ -932,14 +932,18 @@ export default function (options) {
 
     if (supportsHdr10(options)) {
         hevcVideoRangeTypes += '|HDR10';
+        // Should also be able to play DoVi with HDR10 fallback
+        hevcVideoRangeTypes += '|DOVIWithHDR10'
         vp9VideoRangeTypes += '|HDR10';
         av1VideoRangeTypes += '|HDR10';
     }
 
     if (supportsHlg(options)) {
-        hevcVideoRangeTypes += '|HLG';
-        vp9VideoRangeTypes += '|HLG';
-        av1VideoRangeTypes += '|HLG';
+        hevcVideoRangeTypes += "|HLG";
+        // Should also be able to play DoVi with HLG fallback
+        hevcVideoRangeTypes += "|DOVIWithHLG";
+        vp9VideoRangeTypes += "|HLG";
+        av1VideoRangeTypes += "|HLG";
     }
 
     if (supportsDolbyVision(options) && canPlayDolbyVisionHevc(videoTestElement)) {
@@ -1250,4 +1254,3 @@ export default function (options) {
 
     return profile;
 }
-


### PR DESCRIPTION
This pull request modifies the client to comply with the recent changes regarding proper Dolby Vision with compatibility format handling on webOS and probably other platforms as well. (jellyfin/jellyfin#10469)

**Changes**
Modify supported hevcVideoRangeTypes to conform with VideoRangeType additions server-side.

**Issues**
Not aware of any in this repository.
Fixes jellyfin/jellyfin#10468
