### PR TITLE
Enable 'Prefer fMP4-HLS Container' by default on certain platforms

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -68,7 +68,7 @@ function canPlayNativeHls() {
 }
 
 function canPlayNativeHlsInFmp4() {
-    if (browser.tizenVersion >= 3 || browser.web0sVersion >= 3.5) {
+    if (browser.tizenVersion >= 5 || browser.web0sVersion >= 3.5) {
         return true;
     }
 

--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -1,4 +1,5 @@
 import appSettings from './appSettings';
+import browser from '../browser';
 import Events from '../../utils/events.ts';
 import { toBoolean } from '../../utils/string.ts';
 
@@ -140,7 +141,8 @@ export class UserSettings {
             return this.set('preferFmp4HlsContainer', val.toString(), false);
         }
 
-        return toBoolean(this.get('preferFmp4HlsContainer', false), false);
+        // Enable it by default only for the platforms that play fMP4 for sure.
+        return toBoolean(this.get('preferFmp4HlsContainer', false), browser.safari || browser.firefox || browser.chrome || browser.edgeChromium);
     }
 
     /**


### PR DESCRIPTION
fMP4 is enabled by default only on verified patforms. This
largely avoids transcoding HEVC and AV1, instead letting
the client handle them.

**Changes**
- Enable 'Prefer fMP4-HLS Container' by default on certain platforms
- Increase the minimum version of Tizen that supports native fMP4 to 5

**Issues**
- Many users are unaware that this option exists and it was disabled by default.
