### PR TITLE
add catch for itemContextMenu.show

### DIFF
--- a/src/components/metadataEditor/metadataEditor.js
+++ b/src/components/metadataEditor/metadataEditor.js
@@ -271,7 +271,7 @@ function showMoreMenu(context, button, user) {
             } else if (result.updated) {
                 reload(context, item.Id, item.ServerId);
             }
-        });
+        }).catch(() => { /* no-op */ });
     });
 }
 


### PR DESCRIPTION
Change
Adds no-op catch to the itemContextMenu.show() promise

Issue
Fixes 'ActionSheet closed without resolving' error from editmetadata context menu

Steps to recreate:
1. From home.html page click on context menu for any collection (or any item from any collection)
2. Click on 'Edit metadata'
3. Open context menu from the top of the Edit metadata popup
4. Click anywhere outside of the context menu

