### PR TITLE
Log current version to console to help out with issue triage and debugging

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -265,7 +265,9 @@ module.exports = {
                 // Build time definitions
                 __JF_BUILD_VERSION__: 'readonly',
                 __USE_SYSTEM_FONTS__: 'readonly',
-                __WEBPACK_SERVE__: 'readonly'
+                __WEBPACK_SERVE__: 'readonly',
+                __PACKAGE_JSON_NAME__: 'readonly',
+                __PACKAGE_JSON_VERSION__: 'readonly'
             },
             rules: {
                 '@typescript-eslint/prefer-string-starts-ends-with': ['error']

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -264,10 +264,10 @@ module.exports = {
                 'Windows': 'readonly',
                 // Build time definitions
                 __JF_BUILD_VERSION__: 'readonly',
-                __USE_SYSTEM_FONTS__: 'readonly',
-                __WEBPACK_SERVE__: 'readonly',
                 __PACKAGE_JSON_NAME__: 'readonly',
-                __PACKAGE_JSON_VERSION__: 'readonly'
+                __PACKAGE_JSON_VERSION__: 'readonly',
+                __USE_SYSTEM_FONTS__: 'readonly',
+                __WEBPACK_SERVE__: 'readonly'
             },
             rules: {
                 '@typescript-eslint/prefer-string-starts-ends-with': ['error']

--- a/src/components/apphost.js
+++ b/src/components/apphost.js
@@ -1,4 +1,3 @@
-import Package from '../../package.json';
 import appSettings from '../scripts/settings/appSettings';
 import browser from '../scripts/browser';
 import Events from '../utils/events.ts';
@@ -36,7 +35,7 @@ function getDeviceProfile(item) {
         let profile;
 
         if (window.NativeShell) {
-            profile = window.NativeShell.AppHost.getDeviceProfile(profileBuilder, Package.version);
+            profile = window.NativeShell.AppHost.getDeviceProfile(profileBuilder, __PACKAGE_JSON_VERSION__);
         } else {
             const builderOpts = getBaseProfileOptions(item);
             profile = profileBuilder(builderOpts);
@@ -378,7 +377,7 @@ export const appHost = {
     },
     appVersion: function () {
         return window.NativeShell?.AppHost?.appVersion ?
-            window.NativeShell.AppHost.appVersion() : Package.version;
+            window.NativeShell.AppHost.appVersion() : __PACKAGE_JSON_VERSION__;
     },
     getPushTokenInfo: function () {
         return {};

--- a/src/controllers/dashboard/dashboard.js
+++ b/src/controllers/dashboard/dashboard.js
@@ -26,8 +26,6 @@ import { getSystemInfoQuery } from 'hooks/useSystemInfo';
 import { toApi } from 'utils/jellyfin-apiclient/compat';
 import { queryClient } from 'utils/query/queryClient';
 
-import { version as WEB_VERSION } from '../../../package.json';
-
 import '../../elements/emby-button/emby-button';
 import '../../elements/emby-itemscontainer/emby-itemscontainer';
 
@@ -210,7 +208,7 @@ function refreshActiveRecordings(view, apiClient) {
 
 function reloadSystemInfo(view, apiClient) {
     view.querySelector('#buildVersion').innerText = __JF_BUILD_VERSION__;
-    view.querySelector('#webVersion').innerText = WEB_VERSION;
+    view.querySelector('#webVersion').innerText = __PACKAGE_JSON_VERSION__;
 
     queryClient
         .fetchQuery(getSystemInfoQuery(toApi(apiClient)))

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -18,4 +18,6 @@ export declare global {
     const __JF_BUILD_VERSION__: string;
     const __USE_SYSTEM_FONTS__: string;
     const __WEBPACK_SERVE__: string;
+    const __PACKAGE_JSON_NAME__: string;
+    const __PACKAGE_JSON_VERSION__: string;
 }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -16,8 +16,8 @@ export declare global {
     }
 
     const __JF_BUILD_VERSION__: string;
-    const __USE_SYSTEM_FONTS__: string;
-    const __WEBPACK_SERVE__: string;
     const __PACKAGE_JSON_NAME__: string;
     const __PACKAGE_JSON_VERSION__: string;
+    const __USE_SYSTEM_FONTS__: string;
+    const __WEBPACK_SERVE__: string;
 }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -38,7 +38,6 @@ import './legacy/vendorStyles';
 import { currentSettings } from './scripts/settings/userSettings';
 import taskButton from './scripts/taskbutton';
 import RootApp from './RootApp.tsx';
-import { name as WEB_NAME, version as WEB_VERSION } from '../package.json';
 
 import './styles/livetv.scss';
 import './styles/dashboard.scss';
@@ -61,7 +60,7 @@ function loadCoreDictionary() {
 
 function init() {
     // Log current version to console to help out with issue triage and debugging
-    console.log(`${WEB_NAME} version ${WEB_VERSION} build ${__JF_BUILD_VERSION__}`);
+    console.log(`${__PACKAGE_JSON_NAME__} version ${__PACKAGE_JSON_VERSION__} build ${__JF_BUILD_VERSION__}`);
 
     // This is used in plugins
     window.Events = Events;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -38,6 +38,7 @@ import './legacy/vendorStyles';
 import { currentSettings } from './scripts/settings/userSettings';
 import taskButton from './scripts/taskbutton';
 import RootApp from './RootApp.tsx';
+import { name as WEB_NAME, version as WEB_VERSION } from '../package.json';
 
 import './styles/livetv.scss';
 import './styles/dashboard.scss';
@@ -59,6 +60,9 @@ function loadCoreDictionary() {
 }
 
 function init() {
+    // Log current version to console to help out with issue triage and debugging
+    console.log(`${WEB_NAME} version ${WEB_VERSION} build ${__JF_BUILD_VERSION__}`);
+
     // This is used in plugins
     window.Events = Events;
     window.TaskButton = taskButton;

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -5,6 +5,7 @@ const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { DefinePlugin } = require('webpack');
+const packageJson = require('./package.json');
 
 const Assets = [
     'native-promise-only/npo.js',
@@ -52,7 +53,9 @@ const config = {
                     'Dev Server' :
                     process.env.JELLYFIN_VERSION || 'Release'),
             __USE_SYSTEM_FONTS__: JSON.stringify(!!process.env.USE_SYSTEM_FONTS),
-            __WEBPACK_SERVE__: JSON.stringify(!!process.env.WEBPACK_SERVE)
+            __WEBPACK_SERVE__: JSON.stringify(!!process.env.WEBPACK_SERVE),
+            __PACKAGE_JSON_NAME__: JSON.stringify(packageJson.name),
+            __PACKAGE_JSON_VERSION__: JSON.stringify(packageJson.version)
         }),
         new CleanWebpackPlugin(),
         new HtmlWebpackPlugin({

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -52,10 +52,10 @@ const config = {
                 process.env.WEBPACK_SERVE ?
                     'Dev Server' :
                     process.env.JELLYFIN_VERSION || 'Release'),
-            __USE_SYSTEM_FONTS__: JSON.stringify(!!process.env.USE_SYSTEM_FONTS),
-            __WEBPACK_SERVE__: JSON.stringify(!!process.env.WEBPACK_SERVE),
             __PACKAGE_JSON_NAME__: JSON.stringify(packageJson.name),
-            __PACKAGE_JSON_VERSION__: JSON.stringify(packageJson.version)
+            __PACKAGE_JSON_VERSION__: JSON.stringify(packageJson.version),
+            __USE_SYSTEM_FONTS__: JSON.stringify(!!process.env.USE_SYSTEM_FONTS),
+            __WEBPACK_SERVE__: JSON.stringify(!!process.env.WEBPACK_SERVE)
         }),
         new CleanWebpackPlugin(),
         new HtmlWebpackPlugin({


### PR DESCRIPTION
This is a small change that adds some additional logging. As soon as the frontend initializes (via the init function) it will print a message with the package name, package version and build version. This is helpful when sharing browser logs as it could indicate which specific unstable build is used when there is no dashboard access. It could also be helpful to know if an older cached version of the frontend is loading.

There are some other messages in the logs before this one because some files contain top-level log statements. It didn't really matter if I placed this log statement in the init function or also make it top-level, so I opted for the side-effect free variant.

Sample output in dev mode:
> `jellyfin-web version 10.9.0 build Dev Server`

**Changes**
- Log current version to console to help out with issue triage and debugging

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
