### PR TITLE
Fix the behavior of HDR remuxing in HLS.js 1.5+

### DIFF
--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -443,6 +443,7 @@ export class HtmlVideoPlayer {
                     startPosition: options.playerStartPositionTicks / 10000000,
                     manifestLoadingTimeOut: 20000,
                     maxBufferLength: maxBufferLength,
+                    videoPreference: { preferHDR: true },
                     xhrSetup(xhr) {
                         xhr.withCredentials = includeCorsCredentials;
                     }


### PR DESCRIPTION
**Changes**
- Fix the behavior of HDR **remuxing** in HLS.js 1.5+

**Issues**
Without this change, HLS.js 1.5+ only allows HDR playback on displays/systems with HDR enabled. When the server provides two streams one HDR and one SDR for fallback, HLS.js will ignore the HDR stream, even if the browser supports client-side tone-mapping. This triggers unnecessary transcoding.
