### PR TITLE
Fix translation of the enhanced NVDEC decoder

### DIFF
--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1618,7 +1618,7 @@
     "Select": "Select",
     "ThemeSong": "Theme Song",
     "ThemeVideo": "Theme Video",
-    "EnableEnhancedNvdecDecoderHelp": "Experimental NVDEC implementation, do not enable this option unless you encounter decoding errors.",
+    "EnableEnhancedNvdecDecoderHelp": "Enhanced NVDEC implementation, disable this option to use CUVID if you encounter decoding errors.",
     "EnableSplashScreen": "Enable the splash screen",
     "LabelVppTonemappingBrightness": "VPP Tone mapping brightness gain",
     "LabelVppTonemappingBrightnessHelp": "Apply brightness gain in VPP tone mapping. The recommended and default values are 16 and 0.",


### PR DESCRIPTION
**Changes**
- Fix translation of the enhanced NVDEC decoder

**Issues**
- Enhanced NVDEC is now the default option in 10.9, which is required for parsing the Dolby Vision metadata.
The old CUVID impl can still be used by unchecking this option.
