### PR TITLE
fix: only display mjpeg hw encoding in qsv and vaapi

### DIFF
--- a/src/controllers/dashboard/encodingsettings.html
+++ b/src/controllers/dashboard/encodingsettings.html
@@ -135,7 +135,7 @@
                             <span>${AllowAv1Encoding}</span>
                         </label>
                     </div>
-                    <div class="checkboxList">
+                    <div class="checkboxList allowMjpegEncodingOption hide">
                         <label>
                             <input type="checkbox" is="emby-checkbox" id="chkAllowMjpegEncoding" />
                             <span>${AllowMjpegEncoding}</span>

--- a/src/controllers/dashboard/encodingsettings.js
+++ b/src/controllers/dashboard/encodingsettings.js
@@ -221,8 +221,10 @@ $(document).on('pageinit', '#encodingSettingsPage', function () {
 
         if (this.value == 'qsv' || this.value == 'vaapi') {
             page.querySelector('.fldIntelLp').classList.remove('hide');
+            page.querySelector('.allowMjpegEncodingOption').classList.remove('hide');
         } else {
             page.querySelector('.fldIntelLp').classList.add('hide');
+            page.querySelector('.allowMjpegEncodingOption').classList.add('hide');
         }
 
         if (this.value === 'videotoolbox') {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Hardware-accelerated MJPEG encoding is currently only implemented in QSV and VAAPI, and this option will have no effect if other hardware acceleration methods are in use. Displaying this option will confuse our users when they are using other hardware acceleration methods, therefore hide the option.


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
