### PR TITLE
Fix track getting skipped when open book is closed

### DIFF
--- a/src/plugins/bookPlayer/plugin.js
+++ b/src/plugins/bookPlayer/plugin.js
@@ -61,12 +61,6 @@ export class BookPlayer {
     stop() {
         this.unbindEvents();
 
-        const stopInfo = {
-            src: this.item
-        };
-
-        Events.trigger(this, 'stopped', [stopInfo]);
-
         const elem = this.mediaElement;
         const tocElement = this.tocElement;
         const rendition = this.rendition;


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Removed `Events.trigger(this, 'stopped', [stopInfo]);`  from `src/plugins/bookerPlayer/plugin.js`. This line creates a bug where closing a book triggers this function which cause the current track to be skipped if music is also playing while reading a book. Does not affect the actual opening/closing of a book.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
#5288 
