### PR TITLE
Add clear help text for encoding format options

### DIFF
--- a/src/controllers/dashboard/encodingsettings.html
+++ b/src/controllers/dashboard/encodingsettings.html
@@ -123,13 +123,15 @@
                 </div>
 
                 <div class="checkboxListContainer">
+                    <h3 class="checkboxListLabel">${LabelEncodingFormatOptions}</h3>
+                    <div class="fieldDescription">${EncodingFormatHelp}</div>
                     <div class="checkboxList">
                         <label>
                             <input type="checkbox" is="emby-checkbox" id="chkAllowHevcEncoding" />
                             <span>${AllowHevcEncoding}</span>
                         </label>
                     </div>
-                    <div class="checkboxList allowAv1EncodingOption">
+                    <div class="checkboxList">
                         <label>
                             <input type="checkbox" is="emby-checkbox" id="chkAllowAv1Encoding" />
                             <span>${AllowAv1Encoding}</span>

--- a/src/controllers/dashboard/encodingsettings.js
+++ b/src/controllers/dashboard/encodingsettings.js
@@ -227,10 +227,8 @@ $(document).on('pageinit', '#encodingSettingsPage', function () {
 
         if (this.value === 'videotoolbox') {
             page.querySelector('.videoToolboxTonemappingOptions').classList.remove('hide');
-            page.querySelector('.allowAv1EncodingOption').classList.add('hide');
         } else {
             page.querySelector('.videoToolboxTonemappingOptions').classList.add('hide');
-            page.querySelector('.allowAv1EncodingOption').classList.remove('hide');
         }
 
         if (systemInfo.OperatingSystem.toLowerCase() === 'linux' && (this.value == 'qsv' || this.value == 'vaapi')) {

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1602,6 +1602,8 @@
     "EnableIntelLowPowerHevcHwEncoder": "Enable Intel Low-Power HEVC hardware encoder",
     "IntelLowPowerEncHelp": "Low-Power Encoding can keep unnecessary CPU-GPU sync. On Linux they must be disabled if the i915 HuC firmware is not configured.",
     "LabelHardwareEncodingOptions": "Hardware encoding options",
+    "LabelEncodingFormatOptions": "Encoding format options",
+    "EncodingFormatHelp": "Select the video encoding that Jellyfin should transcode to. Jellyfin will use software encoding when hardware acceleration for the selected format is not available.",
     "AudioIsExternal": "The audio stream is external",
     "VideoBitrateNotSupported": "The video's bitrate is not supported",
     "UnknownVideoStreamInfo": "The video stream info is unknown",

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1603,7 +1603,7 @@
     "IntelLowPowerEncHelp": "Low-Power Encoding can keep unnecessary CPU-GPU sync. On Linux they must be disabled if the i915 HuC firmware is not configured.",
     "LabelHardwareEncodingOptions": "Hardware encoding options",
     "LabelEncodingFormatOptions": "Encoding format options",
-    "EncodingFormatHelp": "Select the video encoding that Jellyfin should transcode to. Jellyfin will use software encoding when hardware acceleration for the selected format is not available.",
+    "EncodingFormatHelp": "Select the video encoding that Jellyfin should transcode to. Jellyfin will use software encoding when hardware acceleration for the selected format is not available. H264 encoding will always be enabled.",
     "AudioIsExternal": "The audio stream is external",
     "VideoBitrateNotSupported": "The video's bitrate is not supported",
     "UnknownVideoStreamInfo": "The video stream info is unknown",


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

These options are often misunderstood as part of the hardware encoding options, but they are actually not. Add a helper text and make it in its own section.

This PR also restored the AV1 encoding option for VideoToolbox as the clear instruction is present, so that users can opt-in to use the software encoder if really want to.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
