### PR TITLE
Fix missing emby-collapse import in add plugin page

### DIFF
--- a/src/controllers/dashboard/plugins/add/index.js
+++ b/src/controllers/dashboard/plugins/add/index.js
@@ -3,10 +3,12 @@ import markdownIt from 'markdown-it';
 import DOMPurify from 'dompurify';
 import loading from '../../../../components/loading/loading';
 import globalize from '../../../../scripts/globalize';
-import '../../../../elements/emby-button/emby-button';
 import Dashboard from '../../../../utils/dashboard';
 import alert from '../../../../components/alert';
 import confirm from '../../../../components/confirm/confirm';
+
+import 'elements/emby-button/emby-button';
+import 'elements/emby-collapse/emby-collapse';
 
 function populateHistory(packageInfo, page) {
     let html = '';

--- a/src/controllers/dashboard/plugins/add/index.js
+++ b/src/controllers/dashboard/plugins/add/index.js
@@ -9,6 +9,7 @@ import confirm from '../../../../components/confirm/confirm';
 
 import 'elements/emby-button/emby-button';
 import 'elements/emby-collapse/emby-collapse';
+import 'elements/emby-select/emby-select';
 
 function populateHistory(packageInfo, page) {
     let html = '';


### PR DESCRIPTION
**Changes**
Fixes a missing import for the `emby-collapse` element on the add plugin page

**Issues**
Fixes #5335 
