### PR TITLE
Fix unreleased status missing in metadata editor

### DIFF
--- a/src/components/metadataEditor/metadataEditor.js
+++ b/src/components/metadataEditor/metadataEditor.js
@@ -22,6 +22,7 @@ import ServerConnections from '../ServerConnections';
 import toast from '../toast/toast';
 import { appRouter } from '../router/appRouter';
 import template from './metadataEditor.template.html';
+import { SeriesStatus } from '@jellyfin/sdk/lib/generated-client';
 
 let currentContext;
 let metadataEditorInfo;
@@ -886,10 +887,10 @@ function populateRatings(allParentalRatings, select, currentValue) {
 
 function populateStatus(select) {
     let html = '';
-
-    html += "<option value=''></option>";
-    html += "<option value='Continuing'>" + globalize.translate('Continuing') + '</option>';
-    html += "<option value='Ended'>" + globalize.translate('Ended') + '</option>';
+    html += '<option value=""></option>';
+    html += `<option value="${SeriesStatus.Continuing}">${escapeHtml(globalize.translate('Continuing'))}</option>`;
+    html += `<option value="${SeriesStatus.Ended}">${escapeHtml(globalize.translate('Ended'))}</option>`;
+    html += `<option value="${SeriesStatus.Unreleased}">${escapeHtml(globalize.translate('Unreleased'))}</option>`;
     select.innerHTML = html;
 }
 


### PR DESCRIPTION
Forgot one place in #4120

**Changes**
- Fix unreleased status missing in metadata editor
- Use SeriesStatus enum from SDK in option building
- Escape names (as i18n is effectively user input) in option building

![image](https://github.com/jellyfin/jellyfin-web/assets/2305178/d86b3237-397c-4dfc-9d73-ee7c3657a659)


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
