### PR TITLE
Remove getItemsForPlayback default limit

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -125,7 +125,7 @@ function getItemsForPlayback(serverId, query) {
             };
         });
     } else {
-        if (query.Limit === UNLIMITED_ITEMS) {
+        if (query.Limit === UNLIMITED_ITEMS || !query.Limit) {
             delete query.Limit;
         } else {
             query.Limit = query.Limit || 300;


### PR DESCRIPTION
**Changes**
Remove the limit of getItemsForPlayback function if a limit is not given

**Issues**
Fixes https://github.com/jellyfin/jellyfin-web/issues/5374
