### PR TITLE
fix: load very large playlist

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -122,7 +122,7 @@ async function loadMoreItemsForPlayback(apiClient, query, initalResult) {
     query.startIndex = initalResult.TotalRecordCount;
 
     while (tryMore) {
-        let newItem = await getItems(apiClient, apiClient.getCurrentUserId(), query);
+        const newItem = await getItems(apiClient, apiClient.getCurrentUserId(), query);
         if (newItem.TotalRecordCount < query.Limit) {
             tryMore = false;
         }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

This change will break a very long playlist into multiple requests to prevent overloading the server and to ensure all items in the playlist are retrieved.  Tested with a playlist containing more than 800 items and all of them are loaded into the playback queue.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #5374
