### PR TITLE
Fix changing filters not resetting multiselected media cards

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -88,6 +88,7 @@
 - [David Angel](https://github.com/davidangel)
 - [Pithaya](https://github.com/Pithaya)
 - [Chaitanya Shahare](https://github.com/Chaitanya-Shahare)
+- [Connor Smith](https://github.com/ConnorS1110)
 
 ## Emby Contributors
 

--- a/src/components/filterdialog/filterdialog.js
+++ b/src/components/filterdialog/filterdialog.js
@@ -7,6 +7,7 @@ import '../../elements/emby-collapse/emby-collapse';
 import './style.scss';
 import ServerConnections from '../ServerConnections';
 import template from './filterdialog.template.html';
+import { stopMultiSelect } from '../../components/multiSelect/multiSelect';
 
 function renderOptions(context, selector, cssClass, items, isCheckedFn) {
     const elem = context.querySelector(selector);
@@ -104,6 +105,7 @@ function updateFilterControls(context, options) {
      * @param instance {FilterDialog} An instance of FilterDialog
      */
 function triggerChange(instance) {
+    stopMultiSelect();
     Events.trigger(instance, 'filterchange');
 }
 

--- a/src/components/multiSelect/multiSelect.js
+++ b/src/components/multiSelect/multiSelect.js
@@ -571,3 +571,7 @@ export default function (options) {
 export const startMultiSelect = (card) => {
     showSelections(card);
 };
+
+export const stopMultiSelect = () => {
+    hideSelections();
+};

--- a/src/controllers/list.js
+++ b/src/controllers/list.js
@@ -14,6 +14,7 @@ import ServerConnections from '../components/ServerConnections';
 import LibraryMenu from '../scripts/libraryMenu';
 import { CollectionType } from '@jellyfin/sdk/lib/generated-client/models/collection-type';
 import { ItemSortBy } from '@jellyfin/sdk/lib/generated-client/models/item-sort-by';
+import { stopMultiSelect } from 'components/multiSelect/multiSelect';
 
 function getInitialLiveTvQuery(instance, params, startIndex = 0, limit = 300) {
     const query = {
@@ -1139,6 +1140,9 @@ class ItemsView {
 
     setFilterStatus(hasFilters) {
         this.hasFilters = hasFilters;
+        if (this.hasFilters) {
+            stopMultiSelect();
+        }
         const filterButtons = this.filterButtons;
 
         if (filterButtons.length) {
@@ -1301,4 +1305,3 @@ class ItemsView {
 }
 
 export default ItemsView;
-

--- a/src/controllers/movies/movies.js
+++ b/src/controllers/movies/movies.js
@@ -321,4 +321,3 @@ export default function (view, params, tabContent, options) {
         itemsContainer = null;
     };
 }
-


### PR DESCRIPTION
**Changes**
Multi-selected options are now cleared by calling `hideSelections` from the `multiSelect` component when a change is triggered in the `filterdialog` component. `hideSelections` is also called in the `list` controller when filters have been changed and there actually filters being applied instead of removed.

**Issues**
Fixes #5209 
