### PR TITLE
fix: use correct hls containers for audio

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -718,9 +718,13 @@ export default function (options) {
     const hlsBreakOnNonKeyFrames = browser.iOS || browser.osx || browser.edge || !canPlayNativeHls();
 
     if (canPlayHls() && browser.enableHlsAudio !== false) {
+        let enableFmp4Hls = userSettings.preferFmp4HlsContainer();
+        if ((browser.safari || browser.tizen || browser.web0s) && !canPlayNativeHlsInFmp4()) {
+            enableFmp4Hls = false;
+        }
         profile.TranscodingProfiles.push({
             // hlsjs, edge, and android all seem to require ts container
-            Container: !canPlayNativeHls() || browser.edge || browser.android ? 'ts' : 'aac',
+            Container: enableFmp4Hls ? 'mp4' : 'ts',
             Type: 'Audio',
             AudioCodec: 'aac',
             Context: 'Streaming',

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -716,12 +716,12 @@ export default function (options) {
     profile.TranscodingProfiles = [];
 
     const hlsBreakOnNonKeyFrames = browser.iOS || browser.osx || browser.edge || !canPlayNativeHls();
+    let enableFmp4Hls = userSettings.preferFmp4HlsContainer();
+    if ((browser.safari || browser.tizen || browser.web0s) && !canPlayNativeHlsInFmp4()) {
+        enableFmp4Hls = false;
+    }
 
     if (canPlayHls() && browser.enableHlsAudio !== false) {
-        let enableFmp4Hls = userSettings.preferFmp4HlsContainer();
-        if ((browser.safari || browser.tizen || browser.web0s) && !canPlayNativeHlsInFmp4()) {
-            enableFmp4Hls = false;
-        }
         profile.TranscodingProfiles.push({
             Container: enableFmp4Hls ? 'mp4' : 'ts',
             Type: 'Audio',
@@ -760,10 +760,6 @@ export default function (options) {
     });
 
     if (canPlayHls() && options.enableHls !== false) {
-        let enableFmp4Hls = userSettings.preferFmp4HlsContainer();
-        if ((browser.safari || browser.tizen || browser.web0s) && !canPlayNativeHlsInFmp4()) {
-            enableFmp4Hls = false;
-        }
         if (hlsInFmp4VideoCodecs.length && hlsInFmp4VideoAudioCodecs.length && enableFmp4Hls) {
             // HACK: Since there is no filter for TS/MP4 in the API, specify HLS support in general and rely on retry after DirectPlay error
             // FIXME: Need support for {Container: 'mp4', Protocol: 'hls'} or {Container: 'hls', SubContainer: 'mp4'}

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -723,7 +723,6 @@ export default function (options) {
             enableFmp4Hls = false;
         }
         profile.TranscodingProfiles.push({
-            // hlsjs, edge, and android all seem to require ts container
             Container: enableFmp4Hls ? 'mp4' : 'ts',
             Type: 'Audio',
             AudioCodec: 'aac',


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

The current container setting was set 4 years ago and does not reflect current browsers. The value `aac` is not a valid container for hls either, as ffmpeg only supports hls in `ts` or `mp4` container.
We should prioritize using fmp4 when possible and fallback to mpegts if necessary.


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #5221
