### PR TITLE
User configurable codecs (DTS, TrueHD)

### DIFF
--- a/src/components/playbackSettings/playbackSettings.js
+++ b/src/components/playbackSettings/playbackSettings.js
@@ -174,6 +174,7 @@ function loadForm(context, user, userSettings, systemInfo, apiClient) {
     context.querySelector('.chkPlayDefaultAudioTrack').checked = user.Configuration.PlayDefaultAudioTrack || false;
     context.querySelector('.chkPreferFmp4HlsContainer').checked = userSettings.preferFmp4HlsContainer();
     context.querySelector('.chkEnableDts').checked = appSettings.enableDts();
+    context.querySelector('.chkEnableTrueHd').checked = appSettings.enableTrueHd();
     context.querySelector('.chkEnableCinemaMode').checked = userSettings.enableCinemaMode();
     context.querySelector('#selectAudioNormalization').value = userSettings.selectAudioNormalization();
     context.querySelector('.chkEnableNextVideoOverlay').checked = userSettings.enableNextVideoInfoOverlay();
@@ -218,6 +219,7 @@ function saveUser(context, user, userSettingsInstance, apiClient) {
     appSettings.limitSupportedVideoResolution(context.querySelector('.chkLimitSupportedVideoResolution').checked);
 
     appSettings.enableDts(context.querySelector('.chkEnableDts').checked);
+    appSettings.enableTrueHd(context.querySelector('.chkEnableTrueHd').checked);
 
     setMaxBitrateFromField(context.querySelector('.selectVideoInNetworkQuality'), true, 'Video');
     setMaxBitrateFromField(context.querySelector('.selectVideoInternetQuality'), false, 'Video');

--- a/src/components/playbackSettings/playbackSettings.js
+++ b/src/components/playbackSettings/playbackSettings.js
@@ -173,6 +173,7 @@ function loadForm(context, user, userSettings, systemInfo, apiClient) {
 
     context.querySelector('.chkPlayDefaultAudioTrack').checked = user.Configuration.PlayDefaultAudioTrack || false;
     context.querySelector('.chkPreferFmp4HlsContainer').checked = userSettings.preferFmp4HlsContainer();
+    context.querySelector('.chkEnableDts').checked = appSettings.enableDts();
     context.querySelector('.chkEnableCinemaMode').checked = userSettings.enableCinemaMode();
     context.querySelector('#selectAudioNormalization').value = userSettings.selectAudioNormalization();
     context.querySelector('.chkEnableNextVideoOverlay').checked = userSettings.enableNextVideoInfoOverlay();
@@ -215,6 +216,8 @@ function saveUser(context, user, userSettingsInstance, apiClient) {
     appSettings.maxChromecastBitrate(context.querySelector('.selectChromecastVideoQuality').value);
     appSettings.maxVideoWidth(context.querySelector('.selectMaxVideoWidth').value);
     appSettings.limitSupportedVideoResolution(context.querySelector('.chkLimitSupportedVideoResolution').checked);
+
+    appSettings.enableDts(context.querySelector('.chkEnableDts').checked);
 
     setMaxBitrateFromField(context.querySelector('.selectVideoInNetworkQuality'), true, 'Video');
     setMaxBitrateFromField(context.querySelector('.selectVideoInternetQuality'), false, 'Video');

--- a/src/components/playbackSettings/playbackSettings.template.html
+++ b/src/components/playbackSettings/playbackSettings.template.html
@@ -165,6 +165,14 @@
             </label>
             <div class="fieldDescription checkboxFieldDescription">${EnableDtsHelp}</div>
         </div>
+
+        <div class="checkboxContainer checkboxContainer-withDescription fldEnableTrueHd">
+            <label>
+                <input type="checkbox" is="emby-checkbox" class="chkEnableTrueHd" />
+                <span>${EnableTrueHd}</span>
+            </label>
+            <div class="fieldDescription checkboxFieldDescription">${EnableTrueHdHelp}</div>
+        </div>
     </div>
 
     <button is="emby-button" type="submit" class="raised button-submit block btnSave hide">

--- a/src/components/playbackSettings/playbackSettings.template.html
+++ b/src/components/playbackSettings/playbackSettings.template.html
@@ -157,6 +157,14 @@
         <div class="selectContainer">
             <select is="emby-select" class="selectSkipBackLength" label="${LabelSkipBackLength}"></select>
         </div>
+
+        <div class="checkboxContainer checkboxContainer-withDescription fldEnableDts">
+            <label>
+                <input type="checkbox" is="emby-checkbox" class="chkEnableDts" />
+                <span>${EnableDts}</span>
+            </label>
+            <div class="fieldDescription checkboxFieldDescription">${EnableDtsHelp}</div>
+        </div>
     </div>
 
     <button is="emby-button" type="submit" class="raised button-submit block btnSave hide">

--- a/src/components/playbackSettings/playbackSettings.template.html
+++ b/src/components/playbackSettings/playbackSettings.template.html
@@ -157,6 +157,12 @@
         <div class="selectContainer">
             <select is="emby-select" class="selectSkipBackLength" label="${LabelSkipBackLength}"></select>
         </div>
+    </div>
+
+    <div class="verticalSection verticalSection-extrabottompadding">
+        <h2 class="sectionTitle">
+            ${HeaderVideoAdvanced}
+        </h2>
 
         <div class="checkboxContainer checkboxContainer-withDescription fldEnableDts">
             <label>

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -562,7 +562,7 @@ export default function (options) {
         videoAudioCodecs.push('pcm_s24le');
     }
 
-    if (options.supportsTrueHd) {
+    if (appSettings.enableTrueHd() || options.supportsTrueHd) {
         videoAudioCodecs.push('truehd');
     }
 

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -94,6 +94,25 @@ function supportsAc3(videoTestElement) {
     return videoTestElement.canPlayType('audio/mp4; codecs="ac-3"').replace(/no/, '');
 }
 
+/**
+ * Checks if the device supports DTS (DCA).
+ * @param {HTMLVideoElement} videoTestElement The video test element
+ * @returns {boolean|null} _true_ if the device supports DTS (DCA). _false_ if the device doesn't support DTS (DCA). _null_ if support status is unknown.
+ */
+function canPlayDts(videoTestElement) {
+    // DTS audio is not supported by Samsung TV 2018+ (Tizen 4.0+) and LG TV 2020-2022 (webOS 5.0, 6.0 and 22) models
+    if (browser.tizenVersion >= 4 || (browser.web0sVersion >= 5 && browser.web0sVersion < 23)) {
+        return false;
+    }
+
+    if (videoTestElement.canPlayType('video/mp4; codecs="dts-"').replace(/no/, '')
+        || videoTestElement.canPlayType('video/mp4; codecs="dts+"').replace(/no/, '')) {
+        return true;
+    }
+
+    return null;
+}
+
 function supportsEac3(videoTestElement) {
     if (browser.tizen || browser.web0s) {
         return true;
@@ -530,12 +549,7 @@ export default function (options) {
 
     let supportsDts = options.supportsDts;
     if (supportsDts == null) {
-        supportsDts = browser.tizen || browser.web0sVersion || videoTestElement.canPlayType('video/mp4; codecs="dts-"').replace(/no/, '') || videoTestElement.canPlayType('video/mp4; codecs="dts+"').replace(/no/, '');
-
-        // DTS audio is not supported by Samsung TV 2018+ (Tizen 4.0+) and LG TV 2020-2022 (webOS 5.0, 6.0 and 22) models
-        if (browser.tizenVersion >= 4 || (browser.web0sVersion >= 5 && browser.web0sVersion < 23)) {
-            supportsDts = false;
-        }
+        supportsDts = canPlayDts(videoTestElement);
     }
 
     if (supportsDts) {

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -547,7 +547,7 @@ export default function (options) {
         hlsInFmp4VideoAudioCodecs.push('mp2');
     }
 
-    let supportsDts = options.supportsDts;
+    let supportsDts = appSettings.enableDts() || options.supportsDts;
     if (supportsDts == null) {
         supportsDts = canPlayDts(videoTestElement);
     }

--- a/src/scripts/settings/appSettings.js
+++ b/src/scripts/settings/appSettings.js
@@ -132,6 +132,19 @@ class AppSettings {
         return toBoolean(this.get('limitSupportedVideoResolution'), false);
     }
 
+    /**
+     * Get or set 'Enable DTS' state.
+     * @param {boolean|undefined} val - Flag to enable 'Enable DTS' or undefined.
+     * @return {boolean} 'Enable DTS' state.
+     */
+    enableDts(val) {
+        if (val !== undefined) {
+            return this.set('enableDts', val.toString());
+        }
+
+        return toBoolean(this.get('enableDts'), false);
+    }
+
     set(name, value, userId) {
         const currentValue = this.get(name, userId);
         localStorage.setItem(this.#getKey(name, userId), value);

--- a/src/scripts/settings/appSettings.js
+++ b/src/scripts/settings/appSettings.js
@@ -145,6 +145,19 @@ class AppSettings {
         return toBoolean(this.get('enableDts'), false);
     }
 
+    /**
+     * Get or set 'Enable TrueHD' state.
+     * @param {boolean|undefined} val - Flag to enable 'Enable TrueHD' or undefined.
+     * @return {boolean} 'Enable TrueHD' state.
+     */
+    enableTrueHd(val) {
+        if (val !== undefined) {
+            return this.set('enableTrueHd', val.toString());
+        }
+
+        return toBoolean(this.get('enableTrueHd'), false);
+    }
+
     set(name, value, userId) {
         const currentValue = this.get(name, userId);
         localStorage.setItem(this.#getKey(name, userId), value);

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -269,6 +269,8 @@
     "EnableThemeSongsHelp": "Play the theme songs in background while browsing the library.",
     "EnableThemeVideosHelp": "Play theme videos in the background while browsing the library.",
     "EnableTonemapping": "Enable Tone mapping",
+    "EnableTrueHd": "Enable TrueHD",
+    "EnableTrueHdHelp": "Only enable if your device supports TrueHD or is connected to a compatible audio receiver, otherwise it may cause playback failure.",
     "EncoderPresetHelp": "Pick a faster value to improve performance, or a slower value to improve quality.",
     "Ended": "Ended",
     "EndsAtValue": "Ends at {0}",

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -246,6 +246,8 @@
     "EnableDetailsBanner": "Details Banner",
     "EnableDetailsBannerHelp": "Display a banner image at the top of the item details page.",
     "EnableDisplayMirroring": "Display mirroring",
+    "EnableDts": "Enable DTS (DCA)",
+    "EnableDtsHelp": "Only enable if your device supports DTS or is connected to a compatible audio receiver, otherwise it may cause playback failure.",
     "EnableExternalVideoPlayers": "External video players",
     "EnableExternalVideoPlayersHelp": "An external player menu will be shown when starting video playback.",
     "EnableFasterAnimations": "Faster animations",

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -505,6 +505,7 @@
     "HeaderUploadSubtitle": "Upload Subtitle",
     "HeaderUser": "User",
     "HeaderUsers": "Users",
+    "HeaderVideoAdvanced": "Video Advanced",
     "HeaderVideoQuality": "Video Quality",
     "HeaderVideos": "Videos",
     "HeaderVideoType": "Video Type",


### PR DESCRIPTION
**Changes**
- Extract `canPlayDts` function.
- Add DTS enabling option.
- Add TrueHD enabling option.
- Add Video Advanced section.

**Issues**
Fixes https://github.com/jellyfin/jellyfin-webos/issues/190
Fixes https://github.com/jellyfin/jellyfin-tizen/issues/226

**Screenshots**
![video-advanced](https://github.com/jellyfin/jellyfin-web/assets/56478732/8505617b-7d02-4882-91e0-ebe303f05a8e)
