### PR TITLE
Use % for playback slider marker postions

### DIFF
--- a/src/elements/emby-slider/emby-slider.js
+++ b/src/elements/emby-slider/emby-slider.js
@@ -239,7 +239,7 @@ function setMarker(range, valueMarker, marker, valueProgress) {
             return;
         }
 
-        marker.style.left = 'calc(' + valueMarker + '% - ' + markerRect.width / 2 + 'px)';
+        marker.style.left = `calc(${valueMarker}% - ${markerRect.width / 2}px)`;
 
         if (valueProgress >= valueMarker) {
             marker.classList.remove('unwatched');


### PR DESCRIPTION
**Changes**
Use correct position, even on large windows resize and all cases. The value exists. if the offset of width is the issue. Use CSS calc. `'calc(' + valueMarker + '% - ' + markerRect.width / 2 + 'px)'`

**Issues**
Currently the position is often off windows with `px` values on GT webkit/blink and so on.
