### PR TITLE
Remove OS check for VPP option

### DIFF
--- a/src/controllers/dashboard/encodingsettings.js
+++ b/src/controllers/dashboard/encodingsettings.js
@@ -229,7 +229,7 @@ $(document).on('pageinit', '#encodingSettingsPage', function () {
             page.querySelector('.videoToolboxTonemappingOptions').classList.add('hide');
         }
 
-        if (systemInfo.OperatingSystem.toLowerCase() === 'linux' && (this.value == 'qsv' || this.value == 'vaapi')) {
+        if (this.value == 'qsv' || this.value == 'vaapi') {
             page.querySelector('.vppTonemappingOptions').classList.remove('hide');
         } else {
             page.querySelector('.vppTonemappingOptions').classList.add('hide');


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

This removed the Linux OS check for displaying VPP Tone Mapping options, as the OS info is no longer available, and we don't agree with adding them back.

This option currently does nothing on Windows, so it is safe to be displayed

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Closes jellyfin/jellyfin#11388

Fixes jellyfin/jellyfin#11382
