### PR TITLE
Fix trailing slash when adding server causes connection faliure.

### DIFF
--- a/src/controllers/session/selectServer/index.js
+++ b/src/controllers/session/selectServer/index.js
@@ -105,6 +105,7 @@ function showServerConnectionFailure() {
 export default function (view, params) {
     function connectToServer(server) {
         loading.show();
+        server = server.replace("/$", "")
         ServerConnections.connectToServer(server, {
             enableAutoLogin: appSettings.enableAutoLogin()
         }).then(function (result) {


### PR DESCRIPTION
Addresses a bug where a trailing "/" will prevent a connection to a server. 

Initial issues from [jellyfin-media-player](https://github.com/jellyfin/jellyfin-media-player/issues/280)
Corresponding PR found [here](https://github.com/jellyfin/jellyfin-media-player/pull/601).
