### PR TITLE
Fix empty playlists tab in music libraries

### DIFF
--- a/src/apps/experimental/routes/music/index.tsx
+++ b/src/apps/experimental/routes/music/index.tsx
@@ -79,7 +79,10 @@ const Music: FC = () => {
             <PageTabContent
                 key={`${currentTab.viewType} - ${libraryId}`}
                 currentTab={currentTab}
-                parentId={libraryId}
+                parentId={
+                    // Playlists exist outside of the scope of the library
+                    currentTab.viewType === LibraryTab.Playlists ? undefined : libraryId
+                }
             />
         </Page>
     );

--- a/src/controllers/music/musicplaylists.js
+++ b/src/controllers/music/musicplaylists.js
@@ -20,7 +20,6 @@ export default function (view, params, tabContent) {
                 },
                 view: userSettings.getSavedView(key) || 'Poster'
             };
-            pageData.query.ParentId = params.topParentId;
             userSettings.loadQuerySettings(key, pageData.query);
         }
 


### PR DESCRIPTION
**Changes**
Fixes the playlists tab in music libraries being empty since playlists don't have libraries as a parent

**Issues**
N/A