### PR TITLE
Fix gap above backdrop on details screen in experimental layout

### DIFF
--- a/src/apps/experimental/AppOverrides.scss
+++ b/src/apps/experimental/AppOverrides.scss
@@ -36,3 +36,8 @@ $mui-bp-xl: 1536px;
         padding-top: 3.25rem !important;
     }
 }
+
+// Fix backdrop position on mobile item details page
+.layout-mobile .itemBackdrop {
+    margin-top: 0 !important;
+}


### PR DESCRIPTION
**Changes**
Fixes a random gap above the backdrop image on the item details page in the experimental layout.

![Screenshot 2024-04-23 at 02-42-37 Jellyfin](https://github.com/jellyfin/jellyfin-web/assets/3450688/bf34b45a-50b1-4e39-bcbc-5cd8579484c6)

**Issues**
N/A
