### PR TITLE
Remove nonexistent ItemField AudioInfo

### DIFF
--- a/src/controllers/music/musicrecommended.js
+++ b/src/controllers/music/musicrecommended.js
@@ -86,7 +86,7 @@ function loadRecentlyPlayed(page, parentId) {
         IncludeItemTypes: 'Audio',
         Limit: itemsPerRow(),
         Recursive: true,
-        Fields: 'PrimaryImageAspectRatio,AudioInfo',
+        Fields: 'PrimaryImageAspectRatio',
         Filters: 'IsPlayed',
         ParentId: parentId,
         ImageTypeLimit: 1,
@@ -128,7 +128,7 @@ function loadFrequentlyPlayed(page, parentId) {
         IncludeItemTypes: 'Audio',
         Limit: itemsPerRow(),
         Recursive: true,
-        Fields: 'PrimaryImageAspectRatio,AudioInfo',
+        Fields: 'PrimaryImageAspectRatio',
         Filters: 'IsPlayed',
         ParentId: parentId,
         ImageTypeLimit: 1,
@@ -399,4 +399,3 @@ export default function (view, params) {
         });
     });
 }
-

--- a/src/controllers/music/songs.js
+++ b/src/controllers/music/songs.js
@@ -23,7 +23,7 @@ export default function (view, params, tabContent) {
                     SortOrder: 'Ascending',
                     IncludeItemTypes: 'Audio',
                     Recursive: true,
-                    Fields: 'AudioInfo,ParentId',
+                    Fields: 'ParentId',
                     StartIndex: 0,
                     ImageTypeLimit: 1,
                     EnableImageTypes: 'Primary'

--- a/src/scripts/itemsByName.js
+++ b/src/scripts/itemsByName.js
@@ -343,7 +343,7 @@ function getQuery(options, item) {
         SortOrder: 'Ascending',
         IncludeItemTypes: '',
         Recursive: true,
-        Fields: 'AudioInfo,ParentId,PrimaryImageAspectRatio',
+        Fields: 'ParentId,PrimaryImageAspectRatio',
         Limit: 100,
         StartIndex: 0,
         CollapseBoxSetItems: false


### PR DESCRIPTION
Fixes
```
System.FormatException: AudioInfo is not a valid value for ItemFields.
 ---> System.ArgumentException: Requested value 'AudioInfo' was not found.
   at System.Enum.TryParseByName[TStorage](RuntimeType enumType, ReadOnlySpan`1 value, Boolean ignoreCase, Boolean throwOnFailure, TStorage& result)
   at System.Enum.TryParseByValueOrName[TUnderlying,TStorage](RuntimeType enumType, ReadOnlySpan`1 value, Boolean ignoreCase, Boolean throwOnFailure, TUnderlying& result)
   at System.Enum.TryParse(Type enumType, ReadOnlySpan`1 value, Boolean ignoreCase, Boolean throwOnFailure, Object& result)
   at System.ComponentModel.EnumConverter.ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, Object value)
   --- End of inner exception stack trace ---
   at System.ComponentModel.EnumConverter.ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, Object value)
   at Jellyfin.Api.ModelBinders.CommaDelimitedArrayModelBinder.GetParsedResult(IReadOnlyList`1 values, Type elementType, TypeConverter converter) in /home/bond/dev/jellyfin/Jellyfin.Api/ModelBinders/CommaDelimitedArrayModelBinder.cs:line 67
```
