### PR TITLE
Fix drawer covering now playing bar in experimental layout

### DIFF
--- a/src/apps/experimental/AppOverrides.scss
+++ b/src/apps/experimental/AppOverrides.scss
@@ -10,6 +10,11 @@ $mui-bp-xl: 1536px;
     position: relative;
 }
 
+// Ensure the footer renders over the drawer
+.appfooter {
+    z-index: 1201 !important; // mui drawer uses z-index 1200
+}
+
 // Hide some items from the user "settings" page that are in the drawer
 #myPreferencesMenuPage {
     .lnkQuickConnectPreferences,

--- a/src/components/ResponsiveDrawer.tsx
+++ b/src/components/ResponsiveDrawer.tsx
@@ -31,6 +31,7 @@ const ResponsiveDrawer: FC<ResponsiveDrawerProps> = ({
                 flexShrink: 0,
                 '& .MuiDrawer-paper': {
                     width: DRAWER_WIDTH,
+                    paddingBottom: '4.2rem', // Padding for now playing bar
                     boxSizing: 'border-box'
                 }
             }}


### PR DESCRIPTION
**Changes**
Fixes the now playing bar being covered by the navigation drawer in the experimental layout

**Issues**
Fixes #5334
