### PR TITLE
Fix MP3 audio playback capability checking with HLS

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -487,7 +487,7 @@ export default function (options) {
     }
 
     // Safari supports mp3 with HLS, but only in mpegts container, and the supportsMp3VideoAudio will return false.
-    if (!browser.ps4 && (browser.safari || supportsMp3VideoAudio)) {
+    if (browser.safari || (supportsMp3VideoAudio && !browser.ps4)) {
         hlsInTsVideoAudioCodecs.push('mp3');
     }
 

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -123,8 +123,8 @@ function supportsAc3InHls(videoTestElement) {
 
 function supportsMp3InHls(videoTestElement) {
     if (videoTestElement.canPlayType) {
-        return videoTestElement.canPlayType('application/x-mpegurl; codecs="avc1.42E01E, mp4a.40.34"').replace(/no/, '')
-                || videoTestElement.canPlayType('application/vnd.apple.mpegURL; codecs="avc1.42E01E, mp4a.40.34"').replace(/no/, '');
+        return videoTestElement.canPlayType('application/x-mpegurl; codecs="avc1.64001E, mp4a.40.34"').replace(/no/, '')
+                || videoTestElement.canPlayType('application/vnd.apple.mpegURL; codecs="avc1.64001E, mp4a.40.34"').replace(/no/, '');
     }
 
     return false;
@@ -486,9 +486,8 @@ export default function (options) {
         videoAudioCodecs.push('mp3');
     }
 
-    // Safari is the only browser that supports mp3 with HLS, but only in mpegts container.
-    // The detect function will return false on Safari, which reflects the fmp4 support, so we have to hard-code it here.
-    if (browser.safari || canPlayMp3VideoAudioInHls || options.supportsMp3InTs) {
+    // Safari supports mp3 with HLS, but only in mpegts container, and the supportsMp3VideoAudio will return false.
+    if (browser.safari || supportsMp3VideoAudio) {
         hlsInTsVideoAudioCodecs.push('mp3');
     }
 

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -487,7 +487,7 @@ export default function (options) {
     }
 
     // Safari supports mp3 with HLS, but only in mpegts container, and the supportsMp3VideoAudio will return false.
-    if (browser.safari || supportsMp3VideoAudio) {
+    if (!browser.ps4 && (browser.safari || supportsMp3VideoAudio)) {
         hlsInTsVideoAudioCodecs.push('mp3');
     }
 

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -122,7 +122,6 @@ function supportsAc3InHls(videoTestElement) {
 }
 
 function supportsMp3InHls(videoTestElement) {
-
     if (videoTestElement.canPlayType) {
         return videoTestElement.canPlayType('application/x-mpegurl; codecs="avc1.42E01E, mp4a.40.34"').replace(/no/, '')
                 || videoTestElement.canPlayType('application/vnd.apple.mpegURL; codecs="avc1.42E01E, mp4a.40.34"').replace(/no/, '');

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -488,7 +488,7 @@ export default function (options) {
 
     // Safari is the only browser that supports mp3 with HLS, but only in mpegts container.
     // The detect function will return false on Safari, which reflects the fmp4 support, so we have to hard-code it here.
-    if (browser.safari || canPlayMp3VideoAudioInHls) {
+    if (browser.safari || canPlayMp3VideoAudioInHls || options.supportsMp3InTs) {
         hlsInTsVideoAudioCodecs.push('mp3');
     }
 

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -121,6 +121,16 @@ function supportsAc3InHls(videoTestElement) {
     return false;
 }
 
+function supportsMp3InHls(videoTestElement) {
+
+    if (videoTestElement.canPlayType) {
+        return videoTestElement.canPlayType('application/x-mpegurl; codecs="avc1.42E01E, mp4a.40.34"').replace(/no/, '')
+                || videoTestElement.canPlayType('application/vnd.apple.mpegURL; codecs="avc1.42E01E, mp4a.40.34"').replace(/no/, '');
+    }
+
+    return false;
+}
+
 function canPlayAudioFormat(format) {
     let typeString;
 
@@ -460,6 +470,7 @@ export default function (options) {
     }
 
     const canPlayAacVideoAudio = videoTestElement.canPlayType('video/mp4; codecs="avc1.640029, mp4a.40.2"').replace(/no/, '');
+    const canPlayMp3VideoAudioInHls = supportsMp3InHls(videoTestElement);
     const canPlayAc3VideoAudio = supportsAc3(videoTestElement);
     const canPlayEac3VideoAudio = supportsEac3(videoTestElement);
     const canPlayAc3VideoAudioInHls = supportsAc3InHls(videoTestElement);
@@ -474,12 +485,16 @@ export default function (options) {
 
     if (supportsMp3VideoAudio) {
         videoAudioCodecs.push('mp3');
+    }
 
-        // PS4 fails to load HLS with mp3 audio
-        if (!browser.ps4) {
-            hlsInTsVideoAudioCodecs.push('mp3');
-        }
+    // Safari is the only browser that supports mp3 with HLS, but only in mpegts container.
+    // The detect function will return false on Safari, which reflects the fmp4 support, so we have to hard-code it here.
+    if (browser.safari || canPlayMp3VideoAudioInHls) {
+        hlsInTsVideoAudioCodecs.push('mp3');
+    }
 
+    // Most browsers won't support mp3 with HLS, so this is usually false, but just in case.
+    if (canPlayMp3VideoAudioInHls) {
         hlsInFmp4VideoAudioCodecs.push('mp3');
     }
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

The previous check was too naive, assuming that most browsers that support playing MP3 directly in an mp4 file can support MP3 with HLS. However, this assumption is wrong. In fact, most browsers won’t play MP3 with HLS, with Safari being the only exception. Even on Safari, MP3 support with HLS is limited to the mpegts container, and it won’t play MP3 in the fmp4 container.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

See forum comment: https://forum.jellyfin.org/t-directplay-not-working-but-transcoding-no-issues?pid=21248#pid21248
