### PR TITLE
Remove apiClient parameters on Playback Stopped callback in experimental layout

### DIFF
--- a/src/elements/emby-itemscontainer/ItemsContainer.tsx
+++ b/src/elements/emby-itemscontainer/ItemsContainer.tsx
@@ -1,6 +1,8 @@
-import type {
-    LibraryUpdateInfo
+import {
+    MediaType,
+    type LibraryUpdateInfo
 } from '@jellyfin/sdk/lib/generated-client';
+import { ApiClient } from 'jellyfin-apiclient';
 import React, { type FC, useCallback, useEffect, useRef } from 'react';
 import classNames from 'classnames';
 import Box from '@mui/material/Box';
@@ -20,6 +22,7 @@ import MultiSelect from 'components/multiSelect/multiSelect';
 import loading from 'components/loading/loading';
 import focusManager from 'components/focusManager';
 import type { ParentId } from 'types/library';
+import type { PlaybackStopInfo } from 'types/playbackStopInfo';
 
 function disableEvent(e: MouseEvent) {
     e.preventDefault();
@@ -221,7 +224,7 @@ const ItemsContainer: FC<ItemsContainerProps> = ({
     );
 
     const onLibraryChanged = useCallback(
-        (_e: Event, apiClient, data: LibraryUpdateInfo) => {
+        (_e: Event, _apiClient: ApiClient, data: LibraryUpdateInfo) => {
             if (eventsToMonitor.includes('seriestimers') || eventsToMonitor.includes('timers')) {
                 // yes this is an assumption
                 return;
@@ -253,12 +256,12 @@ const ItemsContainer: FC<ItemsContainerProps> = ({
     );
 
     const onPlaybackStopped = useCallback(
-        (_e: Event, stopInfo) => {
+        ( _e: Event, stopInfo: PlaybackStopInfo ) => {
             const state = stopInfo.state;
 
             if (
                 state.NowPlayingItem
-                && state.NowPlayingItem.MediaType === 'Video'
+                && state.NowPlayingItem.MediaType === MediaType.Video
             ) {
                 if (eventsToMonitor.includes('videoplayback')) {
                     notifyRefreshNeeded(true);
@@ -266,8 +269,8 @@ const ItemsContainer: FC<ItemsContainerProps> = ({
                 }
             } else if (
                 state.NowPlayingItem
-                && state.NowPlayingItem.MediaType === 'Audio'
-                && eventsToMonitor.includes('videoplayback')
+                && state.NowPlayingItem.MediaType === MediaType.Audio
+                && eventsToMonitor.includes('audioplayback')
             ) {
                 notifyRefreshNeeded(true);
                 return;

--- a/src/elements/emby-itemscontainer/ItemsContainer.tsx
+++ b/src/elements/emby-itemscontainer/ItemsContainer.tsx
@@ -256,7 +256,7 @@ const ItemsContainer: FC<ItemsContainerProps> = ({
     );
 
     const onPlaybackStopped = useCallback(
-        ( _e: Event, stopInfo: PlaybackStopInfo ) => {
+        (_e: Event, stopInfo: PlaybackStopInfo) => {
             const state = stopInfo.state;
 
             if (

--- a/src/types/playbackStopInfo.ts
+++ b/src/types/playbackStopInfo.ts
@@ -26,7 +26,7 @@ export interface MediaSource extends MediaSourceInfo {
     enableDirectPlay?: boolean;
     DefaultSecondarySubtitleStreamIndex?: number | null;
     StreamUrl?: string | null;
-    albumLUFS?: number | null;
+    albumNormalizationGain?: number | null;
 }
 
 export interface PlayerState {

--- a/src/types/playbackStopInfo.ts
+++ b/src/types/playbackStopInfo.ts
@@ -1,0 +1,46 @@
+import type {
+    BaseItemDto,
+    GroupShuffleMode,
+    MediaSourceInfo,
+    MediaType,
+    PlayerStateInfo
+} from '@jellyfin/sdk/lib/generated-client';
+
+export interface BufferedRange {
+    start?: number;
+    end?: number;
+}
+
+export interface PlayState extends PlayerStateInfo {
+    ShuffleMode?: GroupShuffleMode;
+    MaxStreamingBitrate?: number | null;
+    PlaybackStartTimeTicks?: number | null;
+    PlaybackRate?: number | null;
+    SecondarySubtitleStreamIndex?: number | null;
+    BufferedRanges?: BufferedRange[];
+    PlaySessionId?: string | null;
+    PlaylistItemId?: string | null;
+}
+
+export interface MediaSource extends MediaSourceInfo {
+    enableDirectPlay?: boolean;
+    DefaultSecondarySubtitleStreamIndex?: number | null;
+    StreamUrl?: string | null;
+    albumLUFS?: number | null;
+}
+
+export interface PlayerState {
+    PlayState: PlayState;
+    NowPlayingItem: BaseItemDto | null;
+    NextItem: BaseItemDto | null;
+    NextMediaType: MediaType | null;
+    MediaSource: MediaSource | null;
+}
+
+export interface PlaybackStopInfo {
+    player: unknown; // FIXME: add a proper interface
+    state: PlayerState;
+    nextItem: BaseItemDto | null;
+    nextMediaType: MediaType | null;
+}
+

--- a/src/types/playbackStopInfo.ts
+++ b/src/types/playbackStopInfo.ts
@@ -38,7 +38,7 @@ export interface PlayerState {
 }
 
 export interface PlaybackStopInfo {
-    player: unknown; // FIXME: add a proper interface
+    player: unknown; // TODO: add a proper interface
     state: PlayerState;
     nextItem: BaseItemDto | null;
     nextMediaType: MediaType | null;


### PR DESCRIPTION
**Changes**
- Remove unnecessary `apiClient` parameters from `onPlaybackStopped` callback
- Add `PlaybackStopInfo` Interface for `stopInfo`
