### PR TITLE
Fix playback sequence of episodes in a series/season

### DIFF
--- a/src/components/shortcuts.js
+++ b/src/components/shortcuts.js
@@ -116,7 +116,7 @@ function showContextMenu(card, options) {
                     item: item,
                     play: true,
                     queue: true,
-                    playAllFromHere: !item.IsFolder,
+                    playAllFromHere: item.Type === 'Season' || !item.IsFolder,
                     queueAllFromHere: !item.IsFolder,
                     playlistId: playlistId,
                     collectionId: collectionId,


### PR DESCRIPTION
**Changes**
- Adds an option to a season's menu to `Play All From Here` (default behavior is to play only the specific season)
- Playback will start on the first unplayed episode, or at the beginning of the season
- Fixes the previous episode OSD button. (Ex. starting playback on episode 2 will now allow the previous button to navigate to episode 1).


**Issues**
Relates to https://github.com/jellyfin/jellyfin-web/pull/5415#pullrequestreview-2020486301
