### PR TITLE
Redirect legacy URLs

### DIFF
--- a/src/hooks/useLegacyRouterSync.ts
+++ b/src/hooks/useLegacyRouterSync.ts
@@ -2,8 +2,6 @@ import { Update } from 'history';
 import { useLayoutEffect, useState } from 'react';
 import type { History, Router } from '@remix-run/router';
 
-const normalizePath = (pathname: string) => pathname.replace(/^!/, '');
-
 interface UseLegacyRouterSyncProps {
   router: Router;
   history: History;
@@ -20,8 +18,18 @@ export function useLegacyRouterSync({ router, history }: UseLegacyRouterSyncProp
              * implementation, so we need to remove the leading `!` from the pathname. React Router already removes the
              * hash for us.
              */
-            if (update.location.pathname.startsWith('!')) {
-                history.replace(normalizePath(update.location.pathname), update.location.state);
+            if (update.location.pathname.startsWith('/!/')) {
+                history.replace(
+                    { ...update.location, pathname: update.location.pathname.replace(/^\/!/, '') },
+                    update.location.state);
+            } else if (update.location.pathname.startsWith('/!')) {
+                history.replace(
+                    { ...update.location, pathname: update.location.pathname.replace(/^\/!/, '/') },
+                    update.location.state);
+            } else if (update.location.pathname.startsWith('!')) {
+                history.replace(
+                    { ...update.location, pathname: update.location.pathname.replace(/^!/, '') },
+                    update.location.state);
             } else if (!isSynced) {
                 await router.navigate(update.location, { replace: true });
             }


### PR DESCRIPTION
**Changes**
Fixes a blank screen when using bookmarks made with older versions of Jellyfin (pre v10.9)

**Issues**
Resolves https://github.com/jellyfin/jellyfin-web/issues/5388