### PR TITLE
Fix unplayed count styling when navigating back

### DIFF
--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -1285,8 +1285,7 @@ function updateUserData(card, userData) {
 
         if (!playedIndicator) {
             playedIndicator = document.createElement('div');
-            playedIndicator.classList.add('playedIndicator');
-            playedIndicator.classList.add('indicator');
+            playedIndicator.classList.add('playedIndicator', 'indicator');
             indicatorsElem = ensureIndicators(card, indicatorsElem);
             indicatorsElem.appendChild(playedIndicator);
         }
@@ -1302,7 +1301,7 @@ function updateUserData(card, userData) {
 
         if (!countIndicator) {
             countIndicator = document.createElement('div');
-            countIndicator.classList.add('countIndicator');
+            countIndicator.classList.add('countIndicator', 'indicator');
             indicatorsElem = ensureIndicators(card, indicatorsElem);
             indicatorsElem.appendChild(countIndicator);
         }


### PR DESCRIPTION
Fixes the style of the unplayed count indicator in certain situations.

**Repoducing**
1. Have a season that is marked as played.
3. Navigate to the season's page
4. Mark an episode as unwatched
5. Navigate back to the previous page to see the styling issue.
![2024-05-01_14-26](https://github.com/jellyfin/jellyfin-web/assets/6550543/b41412eb-25be-42b9-85f9-f1be860fd36c)
