### PR TITLE
Show "99+" in unplayed indicator when more 100 or more new items

### DIFF
--- a/src/components/indicators/indicators.js
+++ b/src/components/indicators/indicators.js
@@ -78,7 +78,7 @@ export function getPlayedIndicatorHtml(item) {
     if (enablePlayedIndicator(item)) {
         const userData = item.UserData || {};
         if (userData.UnplayedItemCount) {
-            return '<div class="countIndicator indicator">' + datetime.toLocaleString(userData.UnplayedItemCount) + '</div>';
+            return '<div class="countIndicator indicator">' + formatCountIndicator(userData.UnplayedItemCount) + '</div>';
         }
 
         if (userData.PlayedPercentage && userData.PlayedPercentage >= 100 || (userData.Played)) {
@@ -93,10 +93,14 @@ export function getChildCountIndicatorHtml(item, options) {
     const minCount = options?.minCount ? options.minCount : 0;
 
     if (item.ChildCount && item.ChildCount > minCount) {
-        return '<div class="countIndicator indicator">' + datetime.toLocaleString(item.ChildCount) + '</div>';
+        return '<div class="countIndicator indicator">' + formatCountIndicator(item.ChildCount) + '</div>';
     }
 
     return '';
+}
+
+function formatCountIndicator(count) {
+    return count >= 100 ? '99+' : count.toString();
 }
 
 export function getTimerIndicator(item) {

--- a/src/components/indicators/useIndicator.tsx
+++ b/src/components/indicators/useIndicator.tsx
@@ -60,6 +60,10 @@ const enablePlayedIndicator = (item: ItemDto) => {
     return itemHelper.canMarkPlayed(item);
 };
 
+const formatCountIndicator = (count: number) => {
+    return count >= 100 ? '99+' : count.toString();
+};
+
 const useIndicator = (item: ItemDto) => {
     const getMediaSourceIndicator = () => {
         const mediaSourceCount = item.MediaSourceCount ?? 0;
@@ -135,7 +139,7 @@ const useIndicator = (item: ItemDto) => {
         if (childCount > 1) {
             return (
                 <Box className='countIndicator indicator childCountIndicator'>
-                    {datetime.toLocaleString(item.ChildCount)}
+                    {formatCountIndicator(childCount)}
                 </Box>
             );
         }
@@ -149,7 +153,7 @@ const useIndicator = (item: ItemDto) => {
             if (userData.UnplayedItemCount) {
                 return (
                     <Box className='countIndicator indicator unplayedItemCount'>
-                        {datetime.toLocaleString(userData.UnplayedItemCount)}
+                        {formatCountIndicator(userData.UnplayedItemCount)}
                     </Box>
                 );
             }


### PR DESCRIPTION
The unplayed count does not fully fit inside the indicator when there are 1000 or more items. This PR changes the indicator to show "+" for any count greater or equal to 1000.

**Before**
![before](https://github.com/jellyfin/jellyfin-web/assets/6550543/9d7fece9-3159-4ed8-9e86-24b3b574c9b9)

**After**
![after](https://github.com/jellyfin/jellyfin-web/assets/6550543/6aca6ba8-3c5e-4686-a73d-977e8cd93720)

