### PR TITLE
Limit maximum FLAC audio channels in video to 2 on webOS

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -899,6 +899,30 @@ export default function (options) {
             Codec: 'flac',
             Conditions: flacConditions
         });
+
+        const flacTranscodingProfiles = [];
+
+        // Split each video transcoding profile with FLAC so that the containing FLAC is only applied to 2 channels audio
+        profile.TranscodingProfiles.forEach(transcodingProfile => {
+            if (transcodingProfile.Type !== 'Video') return;
+
+            const audioCodecs = transcodingProfile.AudioCodec.split(',');
+
+            if (!audioCodecs.includes('flac')) return;
+
+            const flacTranscodingProfile = { ...transcodingProfile };
+            flacTranscodingProfile.AudioCodec = 'flac';
+            flacTranscodingProfile.ApplyConditions = [
+                ...flacTranscodingProfile.ApplyConditions || [],
+                ...flacConditions
+            ];
+
+            flacTranscodingProfiles.push(flacTranscodingProfile);
+
+            transcodingProfile.AudioCodec = audioCodecs.filter(codec => codec != 'flac').join(',');
+        });
+
+        profile.TranscodingProfiles.push(...flacTranscodingProfiles);
     }
 
     let maxH264Level = 42;

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -883,6 +883,24 @@ export default function (options) {
         });
     }
 
+    if (browser.web0s) {
+        const flacConditions = [
+            // webOS doesn't seem to support FLAC with more than 2 channels
+            {
+                Condition: 'LessThanEqual',
+                Property: 'AudioChannels',
+                Value: '2',
+                IsRequired: false
+            }
+        ];
+
+        profile.CodecProfiles.push({
+            Type: 'VideoAudio',
+            Codec: 'flac',
+            Conditions: flacConditions
+        });
+    }
+
     let maxH264Level = 42;
     let h264Profiles = 'high|main|baseline|constrained baseline';
 


### PR DESCRIPTION
webOS doesn't seem to support FLAC with more than 2 channels in video.

**Changes**
- Limit maximum FLAC channels to 2 on webOS.
- Split each video transcoding profile with FLAC so that the containing FLAC is only applied to 2 channels audio.

**Issues**
Fixes https://github.com/jellyfin/jellyfin-webos/issues/146
