### PR TITLE
Remove open graph tags to fight "safe browsing" idiocy

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -12,11 +12,6 @@
     <meta name="application-name" content="Jellyfin">
     <meta name="robots" content="noindex, nofollow, noarchive">
     <meta name="referrer" content="no-referrer">
-    <meta property="og:title" content="Jellyfin">
-    <meta property="og:site_name" content="Jellyfin">
-    <meta property="og:url" content="https://jellyfin.org">
-    <meta property="og:description" content="The Free Software Media System">
-    <meta property="og:type" content="article">
 
     <meta id="themeColor" name="theme-color" content="#202020">
 


### PR DESCRIPTION
**Changes**
Removes the open graph tags in an attempt to stop instances being flagged as "unsafe" by Google's Internet policing... imo I don't think removing these is a big deal for Jellyfin since they are primarily used when sharing links to social sites :man_shrugging: 

**Issues**
Related to #4076 but unclear if this alone will fix it