### PR TITLE
Fix branch ref in publish action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,9 +57,11 @@ jobs:
     steps:
       - name: Save PR context
         env:
+          PR_BRANCH: ${{ github.ref_name }}
           PR_NUMBER: ${{ github.event.number }}
           PR_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
+          echo $PR_BRANCH > PR_branch
           echo $PR_NUMBER > PR_number
           echo $PR_SHA > PR_sha
 
@@ -68,5 +70,6 @@ jobs:
         with:
           name: PR_context
           path: |
+            PR_branch
             PR_number
             PR_sha

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,8 @@ jobs:
 
     name: Deploy to Cloudflare Pages
     runs-on: ubuntu-latest
+    needs:
+      - pr-context
     outputs:
       url: ${{ steps.cf.outputs.url }}
 
@@ -33,7 +35,7 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           projectName: jellyfin-web
-          branch: ${{ github.event.workflow_run.head_branch }}
+          branch: ${{ needs.pr-context.outputs.branch }}
           directory: dist
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 
@@ -42,6 +44,7 @@ jobs:
     if: ${{ always() && github.event.workflow_run.event == 'pull_request' }}
     runs-on: ubuntu-latest
     outputs:
+      branch: ${{ env.pr_branch }}
       commit: ${{ env.pr_sha }}
       pr_number: ${{ env.pr_number }}
 
@@ -56,6 +59,7 @@ jobs:
       - name: Set PR context environment variables
         if: ${{ steps.pr_context.conclusion == 'success' }}
         run: |
+          echo "pr_branch=$(cat PR_branch)" >> $GITHUB_ENV
           echo "pr_number=$(cat PR_number)" >> $GITHUB_ENV
           echo "pr_sha=$(cat PR_sha)" >> $GITHUB_ENV
 
@@ -68,7 +72,7 @@ jobs:
       - pr-context
 
     with:
-      branch: ${{ github.event.workflow_run.head_branch }}
+      branch: ${{ needs.pr-context.outputs.branch }}
       commit: ${{ needs.pr-context.outputs.commit != '' && needs.pr-context.outputs.commit || github.event.workflow_run.head_sha }}
       preview_url: ${{ needs.publish.outputs.url }}
       build_workflow_run_id: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
**Changes**
Attempting a fix for our CF pages workflow where PRs from a fork's `master` branch is considered a production build :upside_down_face: 

NOTE: We don't have a good way to test this since the publish workflow runs the version that is in `master`, but I can confirm that the branch ref is added to the build artifact.

**Issues**
N/A
