### PR TITLE
Add missing ref fallback in publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,7 +73,7 @@ jobs:
       - pr-context
 
     with:
-      branch: ${{ needs.pr-context.outputs.branch }}
+      branch: ${{ needs.pr-context.outputs.branch || github.ref_name }}
       commit: ${{ needs.pr-context.outputs.commit != '' && needs.pr-context.outputs.commit || github.event.workflow_run.head_sha }}
       preview_url: ${{ needs.publish.outputs.url }}
       build_workflow_run_id: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
**Changes**
Adds the missing ref fallback when preparing the status comment

This doesn't matter _too_ much since the comment doesn't actually get posted when there is no PR, but you can see in the job summary that it doesn't get the correct branch information.

**Issues**
N/A