### PR TITLE
Remove the need for PR context artifacts in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,30 +46,3 @@ jobs:
           name: jellyfin-web__prod
           path: |
             dist
-
-  pr_context:
-    name: Save PR context as artifact
-    if: ${{ always() && !cancelled() && github.event_name == 'pull_request' }}
-    runs-on: ubuntu-latest
-    needs:
-      - run-build-prod
-
-    steps:
-      - name: Save PR context
-        env:
-          PR_BRANCH: ${{ github.ref_name }}
-          PR_NUMBER: ${{ github.event.number }}
-          PR_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          echo $PR_BRANCH > PR_branch
-          echo $PR_NUMBER > PR_number
-          echo $PR_SHA > PR_sha
-
-      - name: Upload PR number as artifact
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
-        with:
-          name: PR_context
-          path: |
-            PR_branch
-            PR_number
-            PR_sha

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,42 +8,26 @@ on:
       - completed
 
 jobs:
-  pr-context:
-    name: PR context
-    if: ${{ github.event.workflow_run.event == 'pull_request' }}
-    runs-on: ubuntu-latest
-    outputs:
-      branch: ${{ env.pr_branch }}
-      commit: ${{ env.pr_sha }}
-      pr_number: ${{ env.pr_number }}
-
-    steps:
-      - name: Get PR context
-        uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
-        id: pr_context
-        with:
-          run_id: ${{ github.event.workflow_run.id }}
-          name: PR_context
-
-      - name: Set PR context environment variables
-        if: ${{ steps.pr_context.conclusion == 'success' }}
-        run: |
-          echo "pr_branch=$(cat PR_branch)" >> $GITHUB_ENV
-          echo "pr_number=$(cat PR_number)" >> $GITHUB_ENV
-          echo "pr_sha=$(cat PR_sha)" >> $GITHUB_ENV
-
   publish:
-    permissions:
-      contents: read
-      deployments: write
-
     name: Deploy to Cloudflare Pages
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    needs:
-      - pr-context
+    permissions:
+      contents: read
+      deployments: write
+    # We set the environment variable here (and as an output) because,
+    # given no real runner is dispatched in compose-comment job (it's dispatched in the reusable workflow) in this workflow definition,
+    # the env. context is not valid.
+    env:
+      TARGET_BRANCH: |
+        ${{
+          github.event.workflow_run.head_repository.full_name == github.repository
+          && github.event.workflow_run.head_branch
+          || format('{0}/{1}', github.event.workflow_run.head_repository.full_name, github.event.workflow_run.head_branch)
+        }}
     outputs:
       url: ${{ steps.cf.outputs.url }}
+      branch: ${{ env.TARGET_BRANCH }}
 
     steps:
       - name: Download workflow artifact
@@ -60,7 +44,7 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           projectName: jellyfin-web
-          branch: ${{ needs.pr-context.outputs.branch || github.ref_name }}
+          branch: ${{ env.TARGET_BRANCH }}
           directory: dist
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 
@@ -70,11 +54,10 @@ jobs:
     uses: ./.github/workflows/job-messages.yml
     needs:
       - publish
-      - pr-context
 
     with:
-      branch: ${{ needs.pr-context.outputs.branch || github.ref_name }}
-      commit: ${{ needs.pr-context.outputs.commit != '' && needs.pr-context.outputs.commit || github.event.workflow_run.head_sha }}
+      branch: ${{ needs.publish.outputs.branch }}
+      commit: ${{ github.event.workflow_run.head_commit.id }}
       preview_url: ${{ needs.publish.outputs.url }}
       build_workflow_run_id: ${{ github.event.workflow_run.id }}
       commenting_workflow_run_id: ${{ github.run_id }}
@@ -85,11 +68,10 @@ jobs:
     if: |
       always() &&
       github.event.workflow_run.event == 'pull_request' &&
-      needs.pr-context.outputs.pr_number != ''
+      github.event.workflow_run.pull_requests[0].number != ''
     runs-on: ubuntu-latest
     needs:
       - compose-comment
-      - pr-context
 
     steps:
       - name: Update job summary in PR comment
@@ -97,6 +79,6 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.JF_BOT_TOKEN }}
           message: ${{ needs.compose-comment.outputs.msg }}
-          pr_number: ${{ needs.pr-context.outputs.pr_number }}
+          pr_number: ${{ github.event.workflow_run.pull_requests[0].number }}
           comment_tag: ${{ needs.compose-comment.outputs.marker }}
           mode: recreate


### PR DESCRIPTION
* Changing the branch of CF Pages to be of the following form: user/repo_name/branch

* Took the liberty to move the permissions key down below, so the name is always the first item (for consistency)
