### PR TITLE
Add finer playback speed between 0.75x and 1.25x (in 0.05 increments)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -87,6 +87,7 @@
 - [JPUC1143](https://github.com/Jpuc1143)
 - [David Angel](https://github.com/davidangel)
 - [Pithaya](https://github.com/Pithaya)
+- [Maatss](https://github.com/Maatss)
 
 ## Emby Contributors
 

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1954,8 +1954,32 @@ export class HtmlVideoPlayer {
             name: '0.75x',
             id: 0.75
         }, {
-            name: '1x',
-            id: 1.0
+            name: "0.80x",
+            id: 0.80
+        }, {
+            name: "0.85x",
+            id: 0.85
+        }, {
+            name: "0.90x",
+            id: 0.90
+        }, {
+            name: "0.95x",
+            id: 0.95
+        }, {
+            name: "1x",
+            id: 1
+        }, {
+            name: "1.05x",
+            id: 1.05
+        }, {
+            name: "1.10x",
+            id: 1.10
+        }, {
+            name: "1.15x",
+            id: 1.15
+        }, {
+            name: "1.20x",
+            id: 1.20
         }, {
             name: '1.25x',
             id: 1.25


### PR DESCRIPTION
**Changes**
Adds additional 8 playback speeds for finer playback control. Speeds are between 0.75x and 1.25x in 0.05 increments.

**Feature request**
https://features.jellyfin.org/posts/2662/finer-playback-speeds-0-95x-1x-1-05x-1-1x
