### PR TITLE
Don't set content type to null for mixed libraries during creation

### DIFF
--- a/src/components/mediaLibraryCreator/mediaLibraryCreator.js
+++ b/src/components/mediaLibraryCreator/mediaLibraryCreator.js
@@ -42,11 +42,7 @@ function onAddLibrary(e) {
     loading.show();
     const dlg = dom.parentWithClass(this, 'dlg-librarycreator');
     const name = $('#txtValue', dlg).val();
-    let type = $('#selectCollectionType', dlg).val();
-
-    if (type == 'mixed') {
-        type = null;
-    }
+    const type = $('#selectCollectionType', dlg).val();
 
     const libraryOptions = libraryoptionseditor.getLibraryOptions(dlg.querySelector('.libraryOptions'));
     libraryOptions.PathInfos = pathInfos;


### PR DESCRIPTION
**Changes**
Removed code that set content type to null for mixed libraries during virtual folder creation. 

This was added in https://github.com/jellyfin/jellyfin-web/commit/81d936ff1cbb3a4b8c15098da5e159ea3096c800. There is no further information about what issue this fixed, however it is currently causing issues for parts of code that expect the content type to be correctly set.

I was not able to find any issues when creating a mixed library, viewing mixed library content, etc. after making this change but so much of the code has changed since 2015 it's hard to say if whatever issue that prompted this change has been fixed somewhere else or if it is just not obvious enough to find during preliminary testing.

Alternatively, code that checks for 'mixed' type could instead check for null.

**Issues**
Fixes #5490
Fixes https://github.com/jellyfin/jellyfin/issues/11284

Also fixes related issues such as library sub-heading showing "Other" instead of "Mixed Movies and Shows."
