### PR TITLE
Update @jellyfin/sdk to 0.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@fontsource/noto-sans-sc": "5.0.18",
         "@fontsource/noto-sans-tc": "5.0.18",
         "@jellyfin/libass-wasm": "4.2.1",
-        "@jellyfin/sdk": "0.0.0-unstable.202405050501",
+        "@jellyfin/sdk": "0.9.0",
         "@loadable/component": "5.16.3",
         "@mui/icons-material": "5.15.11",
         "@mui/material": "5.15.11",
@@ -3728,9 +3728,9 @@
       "integrity": "sha512-oWK2yz8fFlMXkIuxUc9g/bqN2h56AB+8b6vF/Ikns6WZ/nmcGJ/5lcVaLI4csE83yWgmco4gHO3HyJDsM9EXcQ=="
     },
     "node_modules/@jellyfin/sdk": {
-      "version": "0.0.0-unstable.202405050501",
-      "resolved": "https://registry.npmjs.org/@jellyfin/sdk/-/sdk-0.0.0-unstable.202405050501.tgz",
-      "integrity": "sha512-d7TvTH3gGltNH7WrcuJsC+NiTV4HMCxKhzEeW1dGchA6aXRS1aEcnTqsR/ArONQDzlM6ac9Y+y9gfvJYJ6Bgyg==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@jellyfin/sdk/-/sdk-0.9.0.tgz",
+      "integrity": "sha512-C8XmAE1LFIAJRYC8F9umlkjWW1lKrcQhCiILme5Da3XYhA8fvu57I1cucuOyFc5NqVPKeaQEOcoJMkuiNMejJw==",
       "peerDependencies": {
         "axios": "^1.3.4"
       }
@@ -25587,9 +25587,9 @@
       "integrity": "sha512-oWK2yz8fFlMXkIuxUc9g/bqN2h56AB+8b6vF/Ikns6WZ/nmcGJ/5lcVaLI4csE83yWgmco4gHO3HyJDsM9EXcQ=="
     },
     "@jellyfin/sdk": {
-      "version": "0.0.0-unstable.202405050501",
-      "resolved": "https://registry.npmjs.org/@jellyfin/sdk/-/sdk-0.0.0-unstable.202405050501.tgz",
-      "integrity": "sha512-d7TvTH3gGltNH7WrcuJsC+NiTV4HMCxKhzEeW1dGchA6aXRS1aEcnTqsR/ArONQDzlM6ac9Y+y9gfvJYJ6Bgyg==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@jellyfin/sdk/-/sdk-0.9.0.tgz",
+      "integrity": "sha512-C8XmAE1LFIAJRYC8F9umlkjWW1lKrcQhCiILme5Da3XYhA8fvu57I1cucuOyFc5NqVPKeaQEOcoJMkuiNMejJw==",
       "requires": {}
     },
     "@jest/schemas": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@fontsource/noto-sans-sc": "5.0.18",
     "@fontsource/noto-sans-tc": "5.0.18",
     "@jellyfin/libass-wasm": "4.2.1",
-    "@jellyfin/sdk": "0.0.0-unstable.202405050501",
+    "@jellyfin/sdk": "0.9.0",
     "@loadable/component": "5.16.3",
     "@mui/icons-material": "5.15.11",
     "@mui/material": "5.15.11",


### PR DESCRIPTION
**Changes**
Updates @jellyfin/sdk to the 0.9.0 release

This update fixes some references to removed APIs and sets the minimum server version to 10.9.0

**Issues**
N/A

**SHOULD NOT BE BACKPORTED**