### PR TITLE
Set the minimum server version to match the sdk

### DIFF
--- a/src/components/ServerConnections.js
+++ b/src/components/ServerConnections.js
@@ -1,3 +1,4 @@
+import { MINIMUM_VERSION } from '@jellyfin/sdk/lib/versions';
 import { ConnectionManager, Credentials, ApiClient } from 'jellyfin-apiclient';
 
 import { appHost } from './apphost';
@@ -32,6 +33,9 @@ class ServerConnections extends ConnectionManager {
     constructor() {
         super(...arguments);
         this.localApiClient = null;
+
+        // Set the apiclient minimum version to match the SDK
+        this._minServerVersion = MINIMUM_VERSION;
 
         Events.on(this, 'localusersignedout', (_e, logoutInfo) => {
             setUserInfo(null, null);


### PR DESCRIPTION
**Changes**
Sets the minimum version of the apiclient to match the sdk minimum.

This version is checked when attempting to connect to a server and will display a modal if the server needs upgraded.

![Screenshot 2024-05-14 at 17-04-36 Jellyfin](https://github.com/jellyfin/jellyfin-web/assets/3450688/1f64c387-c1c0-4655-a8db-3bccebedec86)

**Issues**
N/A
