### PR TITLE
Fix video osd not hiding in experimental layout

### DIFF
--- a/src/apps/experimental/components/AppToolbar/index.tsx
+++ b/src/apps/experimental/components/AppToolbar/index.tsx
@@ -24,11 +24,16 @@ const ExperimentalAppToolbar: FC<AppToolbarProps> = ({
     onDrawerButtonClick
 }) => {
     const location = useLocation();
+
+    // The video osd does not show the standard toolbar
+    if (location.pathname === '/video') return null;
+
     const isTabsAvailable = isTabPath(location.pathname);
+    const isPublicPath = location.pathname === '/selectserver.html';
 
     return (
         <AppToolbar
-            buttons={
+            buttons={!isPublicPath && (
                 <>
                     <SyncPlayButton />
                     <RemotePlayButton />
@@ -45,10 +50,11 @@ const ExperimentalAppToolbar: FC<AppToolbarProps> = ({
                         </IconButton>
                     </Tooltip>
                 </>
-            }
+            )}
             isDrawerAvailable={isDrawerAvailable}
             isDrawerOpen={isDrawerOpen}
             onDrawerButtonClick={onDrawerButtonClick}
+            isUserMenuAvailable={!isPublicPath}
         >
             {isTabsAvailable && (<AppTabs isDrawerOpen={isDrawerOpen} />)}
         </AppToolbar>

--- a/src/apps/experimental/components/AppToolbar/index.tsx
+++ b/src/apps/experimental/components/AppToolbar/index.tsx
@@ -18,6 +18,14 @@ interface AppToolbarProps {
     onDrawerButtonClick: (event: React.MouseEvent<HTMLElement>) => void
 }
 
+const PUBLIC_PATHS = [
+    '/addserver.html',
+    '/selectserver.html',
+    '/login.html',
+    '/forgotpassword.html',
+    '/forgotpasswordpin.html'
+];
+
 const ExperimentalAppToolbar: FC<AppToolbarProps> = ({
     isDrawerAvailable,
     isDrawerOpen,
@@ -29,7 +37,7 @@ const ExperimentalAppToolbar: FC<AppToolbarProps> = ({
     if (location.pathname === '/video') return null;
 
     const isTabsAvailable = isTabPath(location.pathname);
-    const isPublicPath = location.pathname === '/selectserver.html';
+    const isPublicPath = PUBLIC_PATHS.includes(location.pathname);
 
     return (
         <AppToolbar

--- a/src/apps/experimental/routes/legacyRoutes/user.ts
+++ b/src/apps/experimental/routes/legacyRoutes/user.ts
@@ -50,16 +50,6 @@ export const LEGACY_USER_ROUTES: LegacyRoute[] = [
             view: 'user/subtitles/index.html'
         }
     }, {
-        path: 'video',
-        pageProps: {
-            controller: 'playback/video/index',
-            view: 'playback/video/index.html',
-            type: 'video-osd',
-            isFullscreen: true,
-            isNowPlayingBarEnabled: false,
-            isThemeMediaSupported: true
-        }
-    }, {
         path: 'queue',
         pageProps: {
             controller: 'playback/queue/index',

--- a/src/apps/experimental/routes/routes.tsx
+++ b/src/apps/experimental/routes/routes.tsx
@@ -7,8 +7,10 @@ import { toAsyncPageRoute } from 'components/router/AsyncRoute';
 import { toViewManagerPageRoute } from 'components/router/LegacyRoute';
 import { toRedirectRoute } from 'components/router/Redirect';
 import AppLayout from '../AppLayout';
+
 import { ASYNC_USER_ROUTES } from './asyncRoutes';
 import { LEGACY_PUBLIC_ROUTES, LEGACY_USER_ROUTES } from './legacyRoutes';
+import VideoPage from './video';
 
 export const EXPERIMENTAL_APP_ROUTES: RouteObject[] = [
     {
@@ -20,7 +22,13 @@ export const EXPERIMENTAL_APP_ROUTES: RouteObject[] = [
                 element: <ConnectionRequired isUserRequired />,
                 children: [
                     ...ASYNC_USER_ROUTES.map(toAsyncPageRoute),
-                    ...LEGACY_USER_ROUTES.map(toViewManagerPageRoute)
+                    ...LEGACY_USER_ROUTES.map(toViewManagerPageRoute),
+
+                    // The video page is special since it combines new controls with the legacy view
+                    {
+                        path: 'video',
+                        element: <VideoPage />
+                    }
                 ]
             },
 

--- a/src/apps/experimental/routes/video/index.tsx
+++ b/src/apps/experimental/routes/video/index.tsx
@@ -6,6 +6,7 @@ import RemotePlayButton from 'apps/experimental/components/AppToolbar/RemotePlay
 import SyncPlayButton from 'apps/experimental/components/AppToolbar/SyncPlayButton';
 import AppToolbar from 'components/toolbar/AppToolbar';
 import ViewManagerPage from 'components/viewManager/ViewManagerPage';
+import { SHOW_OSD_EVENT } from 'controllers/playback/video';
 import Events, { type Event } from 'utils/events';
 
 /**
@@ -22,10 +23,10 @@ const VideoPage: FC = () => {
     useEffect(() => {
         const doc = documentRef.current;
 
-        if (doc) Events.on(doc, 'showVideoOsd', onShowVideoOsd);
+        if (doc) Events.on(doc, SHOW_OSD_EVENT, onShowVideoOsd);
 
         return () => {
-            if (doc) Events.off(doc, 'showVideoOsd', onShowVideoOsd);
+            if (doc) Events.off(doc, SHOW_OSD_EVENT, onShowVideoOsd);
         };
     }, []);
 

--- a/src/apps/experimental/routes/video/index.tsx
+++ b/src/apps/experimental/routes/video/index.tsx
@@ -1,0 +1,71 @@
+import Box from '@mui/material/Box/Box';
+import Fade from '@mui/material/Fade/Fade';
+import React, { useRef, type FC, useEffect, useState } from 'react';
+
+import RemotePlayButton from 'apps/experimental/components/AppToolbar/RemotePlayButton';
+import SyncPlayButton from 'apps/experimental/components/AppToolbar/SyncPlayButton';
+import AppToolbar from 'components/toolbar/AppToolbar';
+import ViewManagerPage from 'components/viewManager/ViewManagerPage';
+import Events, { type Event } from 'utils/events';
+
+/**
+ * Video player page component that renders mui controls for the top controls and the legacy view for everything else.
+ */
+const VideoPage: FC = () => {
+    const documentRef = useRef<Document>(document);
+    const [ isVisible, setIsVisible ] = useState(true);
+
+    const onShowVideoOsd = (_e: Event, isShowing: boolean) => {
+        setIsVisible(isShowing);
+    };
+
+    useEffect(() => {
+        const doc = documentRef.current;
+
+        if (doc) Events.on(doc, 'showVideoOsd', onShowVideoOsd);
+
+        return () => {
+            if (doc) Events.off(doc, 'showVideoOsd', onShowVideoOsd);
+        };
+    }, []);
+
+    return (
+        <>
+            <Fade
+                in={isVisible}
+                easing='fade-out'
+            >
+                <Box sx={{
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    right: 0,
+                    color: 'white'
+                }}>
+                    <AppToolbar
+                        isDrawerAvailable={false}
+                        isDrawerOpen={false}
+                        isUserMenuAvailable={false}
+                        buttons={
+                            <>
+                                <SyncPlayButton />
+                                <RemotePlayButton />
+                            </>
+                        }
+                    />
+                </Box>
+            </Fade>
+
+            <ViewManagerPage
+                controller='playback/video/index'
+                view='playback/video/index.html'
+                type='video-osd'
+                isFullscreen
+                isNowPlayingBarEnabled={false}
+                isThemeMediaSupported
+            />
+        </>
+    );
+};
+
+export default VideoPage;

--- a/src/apps/experimental/routes/video/index.tsx
+++ b/src/apps/experimental/routes/video/index.tsx
@@ -6,7 +6,7 @@ import RemotePlayButton from 'apps/experimental/components/AppToolbar/RemotePlay
 import SyncPlayButton from 'apps/experimental/components/AppToolbar/SyncPlayButton';
 import AppToolbar from 'components/toolbar/AppToolbar';
 import ViewManagerPage from 'components/viewManager/ViewManagerPage';
-import { SHOW_OSD_EVENT } from 'controllers/playback/video';
+import { EventType } from 'types/eventType';
 import Events, { type Event } from 'utils/events';
 
 /**
@@ -23,10 +23,10 @@ const VideoPage: FC = () => {
     useEffect(() => {
         const doc = documentRef.current;
 
-        if (doc) Events.on(doc, SHOW_OSD_EVENT, onShowVideoOsd);
+        if (doc) Events.on(doc, EventType.SHOW_VIDEO_OSD, onShowVideoOsd);
 
         return () => {
-            if (doc) Events.off(doc, SHOW_OSD_EVENT, onShowVideoOsd);
+            if (doc) Events.off(doc, EventType.SHOW_VIDEO_OSD, onShowVideoOsd);
         };
     }, []);
 

--- a/src/components/toolbar/AppToolbar.tsx
+++ b/src/components/toolbar/AppToolbar.tsx
@@ -5,7 +5,6 @@ import IconButton from '@mui/material/IconButton';
 import Toolbar from '@mui/material/Toolbar';
 import Tooltip from '@mui/material/Tooltip';
 import React, { FC, ReactNode } from 'react';
-import { useLocation } from 'react-router-dom';
 
 import { appRouter } from 'components/router/appRouter';
 import { useApi } from 'hooks/useApi';
@@ -17,7 +16,8 @@ interface AppToolbarProps {
     buttons?: ReactNode
     isDrawerAvailable: boolean
     isDrawerOpen: boolean
-    onDrawerButtonClick: (event: React.MouseEvent<HTMLElement>) => void
+    onDrawerButtonClick?: (event: React.MouseEvent<HTMLElement>) => void,
+    isUserMenuAvailable?: boolean
 }
 
 const onBackButtonClick = () => {
@@ -32,16 +32,13 @@ const AppToolbar: FC<AppToolbarProps> = ({
     children,
     isDrawerAvailable,
     isDrawerOpen,
-    onDrawerButtonClick
+    onDrawerButtonClick = () => { /* no-op */ },
+    isUserMenuAvailable = true
 }) => {
     const { user } = useApi();
     const isUserLoggedIn = Boolean(user);
-    const currentLocation = useLocation();
 
     const isBackButtonAvailable = appRouter.canGoBack();
-
-    // Handles a specific case to hide the user menu on the select server page while authenticated
-    const isUserMenuAvailable = currentLocation.pathname !== '/selectserver.html';
 
     return (
         <Toolbar
@@ -84,16 +81,14 @@ const AppToolbar: FC<AppToolbarProps> = ({
 
             {children}
 
-            {isUserLoggedIn && isUserMenuAvailable && (
-                <>
-                    <Box sx={{ display: 'flex', flexGrow: 1, justifyContent: 'flex-end' }}>
-                        {buttons}
-                    </Box>
+            <Box sx={{ display: 'flex', flexGrow: 1, justifyContent: 'flex-end' }}>
+                {buttons}
+            </Box>
 
-                    <Box sx={{ flexGrow: 0 }}>
-                        <UserMenuButton />
-                    </Box>
-                </>
+            {isUserLoggedIn && isUserMenuAvailable && (
+                <Box sx={{ flexGrow: 0 }}>
+                    <UserMenuButton />
+                </Box>
             )}
         </Toolbar>
     );

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -32,6 +32,8 @@ import { PluginType } from '../../../types/plugin.ts';
 const TICKS_PER_MINUTE = 600000000;
 const TICKS_PER_SECOND = 10000000;
 
+export const SHOW_OSD_EVENT = 'showVideoOsd';
+
 function getOpenedDialog() {
     return document.querySelector('.dialogContainer .dialog.opened');
 }
@@ -280,14 +282,14 @@ export default function (view) {
     let mouseIsDown = false;
 
     function showOsd(focusElement) {
-        Events.trigger(document, 'showVideoOsd', [ true ]);
+        Events.trigger(document, SHOW_OSD_EVENT, [ true ]);
         slideDownToShow(headerElement);
         showMainOsdControls(focusElement);
         resetIdle();
     }
 
     function hideOsd() {
-        Events.trigger(document, 'showVideoOsd', [ false ]);
+        Events.trigger(document, SHOW_OSD_EVENT, [ false ]);
         slideUpToHide(headerElement);
         hideMainOsdControls();
         mouseManager.hideCursor();

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -280,12 +280,14 @@ export default function (view) {
     let mouseIsDown = false;
 
     function showOsd(focusElement) {
+        Events.trigger(document, 'showVideoOsd', [ true ]);
         slideDownToShow(headerElement);
         showMainOsdControls(focusElement);
         resetIdle();
     }
 
     function hideOsd() {
+        Events.trigger(document, 'showVideoOsd', [ false ]);
         slideUpToHide(headerElement);
         hideMainOsdControls();
         mouseManager.hideCursor();

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -28,11 +28,10 @@ import LibraryMenu from '../../../scripts/libraryMenu';
 import { setBackdropTransparency, TRANSPARENCY_LEVEL } from '../../../components/backdrop/backdrop';
 import { pluginManager } from '../../../components/pluginManager';
 import { PluginType } from '../../../types/plugin.ts';
+import { EventType } from 'types/eventType';
 
 const TICKS_PER_MINUTE = 600000000;
 const TICKS_PER_SECOND = 10000000;
-
-export const SHOW_OSD_EVENT = 'showVideoOsd';
 
 function getOpenedDialog() {
     return document.querySelector('.dialogContainer .dialog.opened');
@@ -282,14 +281,14 @@ export default function (view) {
     let mouseIsDown = false;
 
     function showOsd(focusElement) {
-        Events.trigger(document, SHOW_OSD_EVENT, [ true ]);
+        Events.trigger(document, EventType.SHOW_VIDEO_OSD, [ true ]);
         slideDownToShow(headerElement);
         showMainOsdControls(focusElement);
         resetIdle();
     }
 
     function hideOsd() {
-        Events.trigger(document, SHOW_OSD_EVENT, [ false ]);
+        Events.trigger(document, EventType.SHOW_VIDEO_OSD, [ false ]);
         slideUpToHide(headerElement);
         hideMainOsdControls();
         mouseManager.hideCursor();

--- a/src/types/eventType.ts
+++ b/src/types/eventType.ts
@@ -1,0 +1,6 @@
+/**
+ * Custom event types.
+ */
+export enum EventType {
+    SHOW_VIDEO_OSD = 'SHOW_VIDEO_OSD'
+}


### PR DESCRIPTION
**Changes**
Fixes the toolbar always being displayed during video playback when the experimental layout is enabled

**Issues**
Related to #4815 
