### PR TITLE
Don’t bind to keyevents of media keys when browser support mediaSession

### DIFF
--- a/src/scripts/keyboardNavigation.js
+++ b/src/scripts/keyboardNavigation.js
@@ -133,7 +133,7 @@ export function enable() {
         }
 
         // Ignore Media Keys for non-TV platform having MediaSession API
-        if (!layoutManager.tv && isMediaKey(key) && hasMediaSession) {
+        if (!browser.tv && isMediaKey(key) && hasMediaSession) {
             return;
         }
 

--- a/src/scripts/keyboardNavigation.js
+++ b/src/scripts/keyboardNavigation.js
@@ -46,6 +46,11 @@ const KeyNames = {
 const NavigationKeys = ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'];
 
 /**
+ * Keys used for media playback control.
+ */
+const MediaKeys = ['MediaRewind', 'MediaStop', 'MediaPlay', 'MediaFastForward', 'MediaTrackPrevious', 'MediaTrackNext', 'MediaPlayPause'];
+
+/**
  * Elements for which navigation should be constrained.
  */
 const InteractiveElements = ['INPUT', 'TEXTAREA'];
@@ -90,6 +95,16 @@ export function isNavigationKey(key) {
 }
 
 /**
+ * Returns _true_ if key is used for media playback control.
+ *
+ * @param {string} key - Key name.
+ * @return {boolean} _true_ if key is used for media playback control.
+ */
+export function isMediaKey(key) {
+    return MediaKeys.indexOf(key) != -1;
+}
+
+/**
  * Returns _true_ if the element is interactive.
  *
  * @param {Element} element - Element.
@@ -113,6 +128,11 @@ export function enable() {
 
         // Ignore navigation keys for non-TV
         if (!layoutManager.tv && isNavigationKey(key)) {
+            return;
+        }
+
+        // Ignore Media Keys for non-TV platform having MediaSession API
+        if (!layoutManager.tv && isMediaKey(key) && 'mediaSession' in navigator) {
             return;
         }
 
@@ -166,6 +186,24 @@ export function enable() {
                 break;
             case 'Pause':
                 inputManager.handleCommand('pause');
+                break;
+            case 'MediaPlayPause':
+                inputManager.handleCommand('playpause');
+                break;
+            case 'MediaRewind':
+                inputManager.handleCommand('rewind');
+                break;
+            case 'MediaFastForward':
+                inputManager.handleCommand('fastforward');
+                break;
+            case 'MediaStop':
+                inputManager.handleCommand('stop');
+                break;
+            case 'MediaTrackPrevious':
+                inputManager.handleCommand('previoustrack');
+                break;
+            case 'MediaTrackNext':
+                inputManager.handleCommand('nexttrack');
                 break;
 
             default:

--- a/src/scripts/keyboardNavigation.js
+++ b/src/scripts/keyboardNavigation.js
@@ -101,7 +101,7 @@ export function isNavigationKey(key) {
  * @return {boolean} _true_ if key is used for media playback control.
  */
 export function isMediaKey(key) {
-    return MediaKeys.indexOf(key) != -1;
+    return MediaKeys.includes(key);
 }
 
 /**
@@ -123,6 +123,7 @@ export function isInteractiveElement(element) {
 }
 
 export function enable() {
+    const hasMediaSession = 'mediaSession' in navigator;
     window.addEventListener('keydown', function (e) {
         const key = getKeyName(e);
 
@@ -132,7 +133,7 @@ export function enable() {
         }
 
         // Ignore Media Keys for non-TV platform having MediaSession API
-        if (!layoutManager.tv && isMediaKey(key) && 'mediaSession' in navigator) {
+        if (!layoutManager.tv && isMediaKey(key) && hasMediaSession) {
             return;
         }
 

--- a/src/scripts/keyboardNavigation.js
+++ b/src/scripts/keyboardNavigation.js
@@ -167,24 +167,6 @@ export function enable() {
             case 'Pause':
                 inputManager.handleCommand('pause');
                 break;
-            case 'MediaPlayPause':
-                inputManager.handleCommand('playpause');
-                break;
-            case 'MediaRewind':
-                inputManager.handleCommand('rewind');
-                break;
-            case 'MediaFastForward':
-                inputManager.handleCommand('fastforward');
-                break;
-            case 'MediaStop':
-                inputManager.handleCommand('stop');
-                break;
-            case 'MediaTrackPrevious':
-                inputManager.handleCommand('previoustrack');
-                break;
-            case 'MediaTrackNext':
-                inputManager.handleCommand('nexttrack');
-                break;
 
             default:
                 capture = false;


### PR DESCRIPTION
These events are already handled by MediaSession. On some operating systems, like Windows, the browser will send both the MediaSession event and the keydown event to the webpage, causing the event to be handled twice and resulting in issues.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

Remove media key binding in keyboardNavigation

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #5523
