### PR TITLE
Fix subtitle delete permission

### DIFF
--- a/src/components/subtitleeditor/subtitleeditor.js
+++ b/src/components/subtitleeditor/subtitleeditor.js
@@ -114,8 +114,9 @@ function fillSubtitleList(context, item) {
             itemHtml += '</a>';
             itemHtml += '</div>';
 
+            const buttonVisibility = item.CanDelete ? '' : 'hide';
             if (!layoutManager.tv && s.Path) {
-                itemHtml += '<button is="paper-icon-button-light" data-index="' + s.Index + '" title="' + globalize.translate('Delete') + '" class="btnDelete listItemButton"><span class="material-icons delete" aria-hidden="true"></span></button>';
+                itemHtml += '<button is="paper-icon-button-light" data-index="' + s.Index + '" title="' + globalize.translate('Delete') + '" class="btnDelete listItemButton ' + buttonVisibility + '"><span class="material-icons delete" aria-hidden="true"></span></button>';
             }
 
             itemHtml += '</' + tagName + '>';

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -25,7 +25,7 @@
     "AllowedRemoteAddressesHelp": "Comma separated list of IP addresses or IP/netmask entries for networks that will be allowed to connect remotely. If left blank, all remote addresses will be allowed.",
     "AllowCollectionManagement": "Allow this user to manage collections",
     "AllowContentWithTagsHelp": "Only show media with at least one of the specified tags.",
-    "AllowSubtitleManagement": "Allow this user to edit subtitles",
+    "AllowSubtitleManagement": "Allow this user to add subtitles",
     "AllowFfmpegThrottling": "Throttle Transcodes",
     "AllowFfmpegThrottlingHelp": "When a transcode or remux gets far enough ahead from the current playback position, pause the process so it will consume fewer resources. This is most useful when watching without seeking often. Turn this off if you experience playback issues.",
     "AllowSegmentDeletion": "Delete segments",


### PR DESCRIPTION
Clarify for the user the usage of the SubtitleManagement permission by doing the following modifications:
1. "Allow this user to ~~edit~~ subtitles" is changed to "Allow this user to __add__ subtitles"
2. the trash logo from the "edit subtitle" menu is hidden if the user do not have "deletion authorization"

**Changes**
The first change is made because if the user has only SubtitleManagement right, it is not enough to delete subtitle, he also needs "allow media deletion" right

**Issues**
Origin issue: https://github.com/jellyfin/jellyfin/issues/11318
Jellyfin PR with discussion about how to implement: https://github.com/jellyfin/jellyfin/pull/11507
