### PR TITLE
Fix scheduled task dialog z-index

### DIFF
--- a/src/controllers/dashboard/scheduledtasks/scheduledtask.html
+++ b/src/controllers/dashboard/scheduledtasks/scheduledtask.html
@@ -20,7 +20,7 @@
             </div>
         </div>
     </div>
-    <div data-role="popup" id="popupAddTrigger" class="dialog dialog-fixedSize dialog-medium hide" style="position: fixed; top: 10%;">
+    <div data-role="popup" id="popupAddTrigger" class="dialog dialog-fixedSize dialog-medium hide" style="position: fixed; top: 10%; z-index: 999999;">
         <form class="addTriggerForm" style="padding:1em;">
             <div class="ui-bar-a">
                 <h3>${ButtonAddScheduledTaskTrigger}</h3>


### PR DESCRIPTION
**Changes**
* Fixes the z-index of the add scheduled task trigger dialog so the dialog renders over other ui components. This z-index value matches what is used for dialog containers in other areas of the app.

**Issues**
Fixes #5522
