### PR TITLE
Fix Dolby Vision playback on webOS

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -247,9 +247,13 @@ function supportedDolbyVisionProfilesHevc(videoTestElement) {
             .replace(/no/, '')) {
             supportedProfiles.push(5);
         }
-        if (videoTestElement
-            .canPlayType('video/mp4; codecs="dvh1.08.09"')
-            .replace(/no/, '')) {
+        if (
+            videoTestElement
+                .canPlayType('video/mp4; codecs="dvh1.08.09"')
+                .replace(/no/, '')
+            // LG TVs from at least 2020 onwards should support profile 8, but they don't report it.
+            || (browser.web0sVersion >= 4)
+        ) {
             supportedProfiles.push(8);
         }
     }

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -1263,17 +1263,16 @@ export default function (options) {
     });
 
     if (browser.web0s && supportsDolbyVision(options)) {
-        // Disallow direct playing of DOVI media in containers not mp4.
-        // This paired with the "Prefer fMP4-HLS Container" client playback setting enables DOVI playback on webOS.
+        // Disallow direct playing of DOVI media in containers not ts or mp4.
         profile.CodecProfiles.push({
             Type: 'Video',
-            Container: '-mp4',
+            Container: '-mp4,ts',
             Codec: 'hevc',
             Conditions: [
                 {
                     Condition: 'EqualsAny',
                     Property: 'VideoRangeType',
-                    Value: 'SDR|HDR10|HLG',
+                    Value: hevcVideoRangeTypes.split('|').filter((v) => !v.startsWith('DOVI')).join('|'),
                     IsRequired: false
                 }
             ]

--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -1,7 +1,7 @@
-import appSettings from './appSettings';
-import browser from '../browser';
 import Events from '../../utils/events.ts';
 import { toBoolean } from '../../utils/string.ts';
+import browser from '../browser';
+import appSettings from './appSettings';
 
 function onSaveTimeout() {
     const self = this;
@@ -142,7 +142,7 @@ export class UserSettings {
         }
 
         // Enable it by default only for the platforms that play fMP4 for sure.
-        return toBoolean(this.get('preferFmp4HlsContainer', false), browser.safari || browser.firefox || browser.chrome || browser.edgeChromium);
+        return toBoolean(this.get('preferFmp4HlsContainer', false), browser.safari || browser.firefox || (browser.chrome && !browser.web0s && !browser.tizen) || browser.edgeChromium);
     }
 
     /**


### PR DESCRIPTION
Force DoVi profile 8 support for LG TVs (CX etc.) that do support it but report otherwise.

**Changes**
browserDeviceProfile to force profile 8 support for TVs that support DoVi and run web0s version 5 and up.

**Issues**

Fixes
jellyfin/jellyfin#11705
