### PR TITLE
Fix `TypeError: Failed to construct 'Headers': No matching constructor signature.`

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -34,6 +34,7 @@ import './legacy/domParserTextHtml';
 import './legacy/focusPreventScroll';
 import './legacy/htmlMediaElement';
 import './legacy/keyboardEvent';
+import './legacy/patchHeaders';
 import './legacy/vendorStyles';
 import { currentSettings } from './scripts/settings/userSettings';
 import taskButton from './scripts/taskbutton';

--- a/src/legacy/patchHeaders.js
+++ b/src/legacy/patchHeaders.js
@@ -1,0 +1,26 @@
+/**
+ * Patch 'Headers' to accept 'undefined'.
+ * Fixes `TypeError: Failed to construct 'Headers': No matching constructor signature.`
+ * Affected platforms:
+ *   - Tizen 3
+ *   - Tizen 4
+ *   - webOS 4
+ */
+
+(function (window) {
+    'use strict';
+
+    if (window.Headers) {
+        try {
+            new window.Headers(undefined);
+        } catch (_) {
+            console.debug('patch \'Headers\' to accept \'undefined\'');
+
+            const _Headers = window.Headers;
+
+            window.Headers = function (init) {
+                return init ? new _Headers(init) : new _Headers();
+            };
+        }
+    }
+}(window));


### PR DESCRIPTION
Affected platforms:
  - Tizen 3
  - Tizen 4
  - webOS 4

**Changes**
Patch `Headers` to accept `undefined`.

**Issues**
Fixes https://github.com/jellyfin/jellyfin-tizen/issues/260
Closes https://github.com/jellyfin/jellyfin-tizen/pull/261
