### PR TITLE
Fix chapter name XSS injection in progress bar

### DIFF
--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1843,7 +1843,6 @@ export default function (view) {
         if (item?.Chapters?.length) {
             item.Chapters.forEach(currentChapter => {
                 markers.push({
-                    className: 'chapterMarker',
                     name: currentChapter.Name,
                     progress: currentChapter.StartPositionTicks / item.RunTimeTicks
                 });

--- a/src/elements/emby-slider/emby-slider.js
+++ b/src/elements/emby-slider/emby-slider.js
@@ -203,28 +203,13 @@ function setMarker(range, valueMarker, marker, valueProgress) {
 }
 
 function updateMarkers(range, currentValue) {
-    function getMarkerHtml(markerInfo) {
-        let markerTypeSpecificClasses = '';
-
-        if (markerInfo.className === 'chapterMarker') {
-            markerTypeSpecificClasses = markerInfo.className;
-
-            if (typeof markerInfo.name === 'string' && markerInfo.name.length) {
-                // limit the class length in case the name contains half a novel
-                markerTypeSpecificClasses = `${markerInfo.className} marker-${markerInfo.name.substring(0, 100).toLowerCase().replace(' ', '-')}`;
-            }
-        }
-
-        return `<span class="material-icons sliderMarker ${markerTypeSpecificClasses}" aria-hidden="true"></span>`;
-    }
-
     if (range.getMarkerInfo) {
         range.markerInfo = range.getMarkerInfo();
 
         range.markerContainerElement.innerHTML = '';
 
-        range.markerInfo.forEach(info => {
-            range.markerContainerElement.insertAdjacentHTML('beforeend', getMarkerHtml(info));
+        range.markerInfo.forEach(() => {
+            range.markerContainerElement.insertAdjacentHTML('beforeend', '<span class="sliderMarker" aria-hidden="true"></span>');
         });
 
         range.markerElements = range.markerContainerElement.querySelectorAll('.sliderMarker');


### PR DESCRIPTION
The chapter markers in the video player seekbar, introduced in 10.9, have some issues. First they add unsanitized user values to the seekbar (chapter name). And secondly, those names can be anything which could cause serious issues when they clash with existing CSS classes. I have no idea why we add these names as a class as this does not provide any benefit. For now, just add the specific className (which is currently always `chapterMarker`).

**Changes**
- Fix chapter name XSS injection in progress bar

**Issues**
Fixes #5561
