### PR TITLE
Only connect to manual addresses specified by user

### DIFF
--- a/src/components/ServerConnections.js
+++ b/src/components/ServerConnections.js
@@ -65,7 +65,7 @@ class ServerConnections extends ConnectionManager {
         );
 
         apiClient.enableAutomaticNetworking = false;
-        apiClient.manualAddressOnly = false;
+        apiClient.manualAddressOnly = true;
 
         this.addApiClient(apiClient);
 


### PR DESCRIPTION
This should never be enabled on the web because users are not expected to connect to an address they don't specify. For specific use cases like auto endpoint switching between networks, this should be managed by DNS or the router itself, not by the application. 

Having an address that is not always connectable causes our Android users to be unable to reliably connect to the server. It also breaks many reverse-proxy setups, as this address exposed by the server usually bypasses the proxy unless explicitly configured by the user. This has far more negative impact than the benifit it brings.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
- apiClient.manualAddressOnly = true

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Reverts #3655

Fixes jellyfin/jellyfin-android#1382
Fixes jellyfin/jellyfin#11658

Maybe related: jellyfin/jellyfin-android#1385 jellyfin/jellyfin#11620

