### PR TITLE
Fix marker names breaking HTML class syntax

### DIFF
--- a/src/elements/emby-slider/emby-slider.js
+++ b/src/elements/emby-slider/emby-slider.js
@@ -211,7 +211,10 @@ function updateMarkers(range, currentValue) {
 
             if (typeof markerInfo.name === 'string' && markerInfo.name.length) {
                 // limit the class length in case the name contains half a novel
-                markerTypeSpecificClasses = `${markerInfo.className} marker-${markerInfo.name.substring(0, 100).toLowerCase().replace(' ', '-')}`;
+                let processedMarkerName = markerInfo.name.substring(0, 100).toLowerCase();
+                // formats the marker name to not break class syntax
+                processedMarkerName = processedMarkerName.replaceAll(' ', '-').replaceAll('"', '').replaceAll('\'', '');
+                markerTypeSpecificClasses = `${markerInfo.className} marker-${processedMarkerName}`;
             }
         }
 


### PR DESCRIPTION
**Changes**
Adds extra processing to the chapter name before it is included as an HTML class in the video player track-bar, e.g. converting spaces to dashes, and stripping quotes and apostrophes.

**Issues**
Fixes #5561 