### PR TITLE
Fix search for tab library in experimental layout

### DIFF
--- a/src/apps/experimental/components/AppToolbar/SearchButton.tsx
+++ b/src/apps/experimental/components/AppToolbar/SearchButton.tsx
@@ -3,6 +3,7 @@ import {
     Link,
     URLSearchParamsInit,
     createSearchParams,
+    useLocation,
     useSearchParams
 } from 'react-router-dom';
 import SearchIcon from '@mui/icons-material/Search';
@@ -11,7 +12,8 @@ import Tooltip from '@mui/material/Tooltip';
 import globalize from 'scripts/globalize';
 
 const getUrlParams = (searchParams: URLSearchParams) => {
-    const parentId = searchParams.get('parentId') || searchParams.get('topParentId');
+    const parentId =
+        searchParams.get('parentId') || searchParams.get('topParentId');
     const collectionType = searchParams.get('collectionType');
     const params: URLSearchParamsInit = {};
 
@@ -27,15 +29,13 @@ const getUrlParams = (searchParams: URLSearchParams) => {
 
 interface SearchButtonProps {
     isTabsAvailable: boolean;
-    isSearchPath: boolean;
 }
 
-const SearchButton: FC<SearchButtonProps> = ({
-    isTabsAvailable,
-    isSearchPath
-}) => {
+const SearchButton: FC<SearchButtonProps> = ({ isTabsAvailable }) => {
+    const location = useLocation();
     const [searchParams] = useSearchParams();
 
+    const isSearchPath = location.pathname === '/search.html';
     const createSearchLink = isTabsAvailable ?
         {
             pathname: '/search.html',

--- a/src/apps/experimental/components/AppToolbar/SearchButton.tsx
+++ b/src/apps/experimental/components/AppToolbar/SearchButton.tsx
@@ -1,0 +1,62 @@
+import React, { type FC } from 'react';
+import {
+    Link,
+    URLSearchParamsInit,
+    createSearchParams,
+    useSearchParams
+} from 'react-router-dom';
+import SearchIcon from '@mui/icons-material/Search';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import globalize from 'scripts/globalize';
+
+const getUrlParams = (searchParams: URLSearchParams) => {
+    const parentId = searchParams.get('parentId') || searchParams.get('topParentId');
+    const collectionType = searchParams.get('collectionType');
+    const params: URLSearchParamsInit = {};
+
+    if (parentId) {
+        params.parentId = parentId;
+    }
+
+    if (collectionType) {
+        params.collectionType = collectionType;
+    }
+    return params;
+};
+
+interface SearchButtonProps {
+    isTabsAvailable: boolean;
+    isSearchPath: boolean;
+}
+
+const SearchButton: FC<SearchButtonProps> = ({
+    isTabsAvailable,
+    isSearchPath
+}) => {
+    const [searchParams] = useSearchParams();
+
+    const createSearchLink = isTabsAvailable ?
+        {
+            pathname: '/search.html',
+            search: `?${createSearchParams(getUrlParams(searchParams))}`
+        } :
+        '/search.html';
+
+    return (
+        <Tooltip title={globalize.translate('Search')}>
+            <IconButton
+                size='large'
+                aria-label={globalize.translate('Search')}
+                color='inherit'
+                component={Link}
+                disabled={isSearchPath}
+                to={createSearchLink}
+            >
+                <SearchIcon />
+            </IconButton>
+        </Tooltip>
+    );
+};
+
+export default SearchButton;

--- a/src/apps/experimental/components/AppToolbar/index.tsx
+++ b/src/apps/experimental/components/AppToolbar/index.tsx
@@ -33,7 +33,6 @@ const ExperimentalAppToolbar: FC<AppToolbarProps> = ({
 
     const isTabsAvailable = isTabPath(location.pathname);
     const isPublicPath = PUBLIC_PATHS.includes(location.pathname);
-    const isSearchPath = location.pathname === '/search.html';
 
     return (
         <AppToolbar
@@ -41,7 +40,7 @@ const ExperimentalAppToolbar: FC<AppToolbarProps> = ({
                 <>
                     <SyncPlayButton />
                     <RemotePlayButton />
-                    <SearchButton isTabsAvailable={isTabsAvailable} isSearchPath={isSearchPath} />
+                    <SearchButton isTabsAvailable={isTabsAvailable} />
                 </>
             )}
             isDrawerAvailable={isDrawerAvailable}

--- a/src/apps/experimental/components/AppToolbar/index.tsx
+++ b/src/apps/experimental/components/AppToolbar/index.tsx
@@ -1,15 +1,10 @@
-import SearchIcon from '@mui/icons-material/Search';
-import IconButton from '@mui/material/IconButton';
-import Tooltip from '@mui/material/Tooltip';
-import React, { FC } from 'react';
-import { Link, useLocation } from 'react-router-dom';
-
+import React, { type FC } from 'react';
+import { useLocation } from 'react-router-dom';
 import AppToolbar from 'components/toolbar/AppToolbar';
-import globalize from 'scripts/globalize';
-
 import AppTabs from '../tabs/AppTabs';
 import RemotePlayButton from './RemotePlayButton';
 import SyncPlayButton from './SyncPlayButton';
+import SearchButton from './SearchButton';
 import { isTabPath } from '../tabs/tabRoutes';
 
 interface AppToolbarProps {
@@ -38,6 +33,7 @@ const ExperimentalAppToolbar: FC<AppToolbarProps> = ({
 
     const isTabsAvailable = isTabPath(location.pathname);
     const isPublicPath = PUBLIC_PATHS.includes(location.pathname);
+    const isSearchPath = location.pathname === '/search.html';
 
     return (
         <AppToolbar
@@ -45,18 +41,7 @@ const ExperimentalAppToolbar: FC<AppToolbarProps> = ({
                 <>
                     <SyncPlayButton />
                     <RemotePlayButton />
-
-                    <Tooltip title={globalize.translate('Search')}>
-                        <IconButton
-                            size='large'
-                            aria-label={globalize.translate('Search')}
-                            color='inherit'
-                            component={Link}
-                            to='/search.html'
-                        >
-                            <SearchIcon />
-                        </IconButton>
-                    </Tooltip>
+                    <SearchButton isTabsAvailable={isTabsAvailable} isSearchPath={isSearchPath} />
                 </>
             )}
             isDrawerAvailable={isDrawerAvailable}

--- a/src/components/router/appRouter.js
+++ b/src/components/router/appRouter.js
@@ -637,7 +637,7 @@ class AppRouter {
         }
 
         if (item.CollectionType == CollectionType.Livetv) {
-            return '#/livetv.html';
+            return `#/livetv.html?collectionType=${item.CollectionType}`;
         }
 
         if (item.Type === 'Genre') {
@@ -676,7 +676,7 @@ class AppRouter {
 
         if (context !== 'folders' && !itemHelper.isLocalItem(item)) {
             if (item.CollectionType == CollectionType.Movies) {
-                url = '#/movies.html?topParentId=' + item.Id;
+                url = `#/movies.html?topParentId=${item.Id}&collectionType=${item.CollectionType}`;
 
                 if (options && options.section === 'latest') {
                     url += '&tab=1';
@@ -686,7 +686,7 @@ class AppRouter {
             }
 
             if (item.CollectionType == CollectionType.Tvshows) {
-                url = '#/tv.html?topParentId=' + item.Id;
+                url = `#/tv.html?topParentId=${item.Id}&collectionType=${item.CollectionType}`;
 
                 if (options && options.section === 'latest') {
                     url += '&tab=1';
@@ -696,7 +696,7 @@ class AppRouter {
             }
 
             if (item.CollectionType == CollectionType.Music) {
-                url = '#/music.html?topParentId=' + item.Id;
+                url = `#/music.html?topParentId=${item.Id}&collectionType=${item.CollectionType}`;
 
                 if (options?.section === 'latest') {
                     url += '&tab=1';


### PR DESCRIPTION
**Changes**
- Extract Search Button to component
- Fix Search for tab library based on url params `parentId` and `collectionType`
- Disable the `SearchButton` in the AppToolbar if the current location is the Search page.

