### PR TITLE
Fix playback interceptor rejecting

### DIFF
--- a/src/plugins/playAccessValidation/plugin.js
+++ b/src/plugins/playAccessValidation/plugin.js
@@ -35,7 +35,8 @@ class PlayAccessValidation {
                 return Promise.reject();
             }
 
-            return showErrorMessage().finally(Promise.reject);
+            return showErrorMessage()
+                .finally(() => Promise.reject());
         });
     }
 }


### PR DESCRIPTION
**Changes**
* Fixes a regression from #5402 where access checks fall through to getting the saved bitrate when rejecting allowing users to play media they don't have access to after closing the dialog

The code is pretty gross, but I don't want to touch this too much in a backport PR

**Issues**
Fixes #5568 
