### PR TITLE
Fix square posters

### DIFF
--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -89,7 +89,7 @@ export function setCardData(items, options) {
                 options.coverImage = true;
             } else if (primaryImageAspectRatio >= 1.33) {
                 options.shape = getBackdropShape(requestedShape === 'autooverflow');
-            } else if (primaryImageAspectRatio > 0.71) {
+            } else if (primaryImageAspectRatio > 0.8) {
                 options.shape = getSquareShape(requestedShape === 'autooverflow');
             } else {
                 options.shape = getPortraitShape(requestedShape === 'autooverflow');

--- a/src/components/cardbuilder/cardBuilderUtils.test.ts
+++ b/src/components/cardbuilder/cardBuilderUtils.test.ts
@@ -454,15 +454,15 @@ describe('resolveMixedShapeByAspectRatio', () => {
         expect(resolveMixedShapeByAspectRatio(1.34)).toEqual('mixedBackdrop');
     });
 
-    test('primary aspect ratio is > 0.71', () => {
-        expect(resolveMixedShapeByAspectRatio(0.72)).toEqual('mixedSquare');
-        expect(resolveMixedShapeByAspectRatio(0.73)).toEqual('mixedSquare');
+    test('primary aspect ratio is > 0.8', () => {
+        expect(resolveMixedShapeByAspectRatio(0.82)).toEqual('mixedSquare');
+        expect(resolveMixedShapeByAspectRatio(0.83)).toEqual('mixedSquare');
         expect(resolveMixedShapeByAspectRatio(1.32)).toEqual('mixedSquare');
     });
 
-    test('primary aspect ratio is <= 0.71', () => {
-        expect(resolveMixedShapeByAspectRatio(0.71)).toEqual('mixedPortrait');
-        expect(resolveMixedShapeByAspectRatio(0.70)).toEqual('mixedPortrait');
+    test('primary aspect ratio is <= 0.8', () => {
+        expect(resolveMixedShapeByAspectRatio(0.8)).toEqual('mixedPortrait');
+        expect(resolveMixedShapeByAspectRatio(0.79)).toEqual('mixedPortrait');
         expect(resolveMixedShapeByAspectRatio(0.01)).toEqual('mixedPortrait');
     });
 

--- a/src/components/cardbuilder/cardBuilderUtils.test.ts
+++ b/src/components/cardbuilder/cardBuilderUtils.test.ts
@@ -455,8 +455,8 @@ describe('resolveMixedShapeByAspectRatio', () => {
     });
 
     test('primary aspect ratio is > 0.8', () => {
+        expect(resolveMixedShapeByAspectRatio(0.81)).toEqual('mixedSquare');
         expect(resolveMixedShapeByAspectRatio(0.82)).toEqual('mixedSquare');
-        expect(resolveMixedShapeByAspectRatio(0.83)).toEqual('mixedSquare');
         expect(resolveMixedShapeByAspectRatio(1.32)).toEqual('mixedSquare');
     });
 

--- a/src/components/cardbuilder/cardBuilderUtils.ts
+++ b/src/components/cardbuilder/cardBuilderUtils.ts
@@ -60,7 +60,7 @@ export const resolveMixedShapeByAspectRatio = (primaryImageAspectRatio: number |
 
     if (primaryImageAspectRatio >= 1.33) {
         return CardShape.MixedBackdrop;
-    } else if (primaryImageAspectRatio > 0.71) {
+    } else if (primaryImageAspectRatio > 0.8) {
         return CardShape.MixedSquare;
     } else {
         return CardShape.MixedPortrait;

--- a/src/components/cardbuilder/cardImage.ts
+++ b/src/components/cardbuilder/cardImage.ts
@@ -21,7 +21,7 @@ export function buildCardImage(
             shape = CardShape.Banner;
         } else if (item.PrimaryImageAspectRatio >= 1.33) {
             shape = CardShape.Backdrop;
-        } else if (item.PrimaryImageAspectRatio > 0.71) {
+        } else if (item.PrimaryImageAspectRatio > 0.8) {
             shape = CardShape.Square;
         } else {
             shape = CardShape.Portrait;


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->
According to TMDB, posters can also come in 1:1.33 (≈0.75) aspect ratio. So set aspect ratio less than 0.75 + 0.5 (for buffer) to be Portrait.
**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Change aspect ratio threshold to 0.8
**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes https://github.com/jellyfin/jellyfin-web/issues/5560
