### PR TITLE
Fix chapter marker re-rendering

### DIFF
--- a/src/elements/emby-slider/emby-slider.js
+++ b/src/elements/emby-slider/emby-slider.js
@@ -203,14 +203,14 @@ function setMarker(range, valueMarker, marker, valueProgress) {
 }
 
 function updateMarkers(range, currentValue) {
-    if (range.getMarkerInfo) {
+    if (range.getMarkerInfo && !range.markerInfo) {
         range.markerInfo = range.getMarkerInfo();
 
-        range.markerContainerElement.innerHTML = '';
-
+        let markersHtml = '';
         range.markerInfo.forEach(() => {
-            range.markerContainerElement.insertAdjacentHTML('beforeend', '<span class="sliderMarker" aria-hidden="true"></span>');
+            markersHtml += '<span class="sliderMarker" aria-hidden="true"></span>';
         });
+        range.markerContainerElement.innerHTML = markersHtml;
 
         range.markerElements = range.markerContainerElement.querySelectorAll('.sliderMarker');
     }

--- a/src/elements/emby-slider/emby-slider.scss
+++ b/src/elements/emby-slider/emby-slider.scss
@@ -263,7 +263,7 @@
 .sliderMarker {
     position: absolute;
     width: 2px;
-    height: 0.5em;
+    height: 12px;
     transform: translate3d(0, 25%, 0);
 }
 


### PR DESCRIPTION
**Changes**
* Prevents the marker html from being constantly re-rendered if `markerInfo` is already populated
* Fixes a small style regression from #5563 due to the size being dependent on the font-size set by the `material-icons` class

**Issues**
I can't find one, but I saw the chapter markers flashing being reported somewhere...
