### PR TITLE
Fix Up upNextDialog blocked by transparent video controls

### DIFF
--- a/src/components/upnextdialog/upnextdialog.scss
+++ b/src/components/upnextdialog/upnextdialog.scss
@@ -24,6 +24,7 @@
 
 .upNextDialog-hidden {
     opacity: 0;
+    z-index: -9999!important;
 }
 
 .upNextDialog-countdownText {
@@ -52,5 +53,6 @@
 @media all and (orientation: landscape) {
     .upNextDialog {
         flex-direction: row;
+        z-index: 9999;
     }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -102,6 +102,7 @@
         .mouseIdle .hide-mouse-idle,
         .mouseIdle-tv .hide-mouse-idle-tv {
             display: none !important;
+            z-index: -9999;
         }
 
         .mainDrawerHandle {


### PR DESCRIPTION
On high display scaling, the controls sit over the up next dialog, i know its a sloppy change but i hope you wont mind :)

**Changes**
src\components\upnextdialog\upnextdialog.scss

**Issues**
Fix Up upNextDialog blocked by transparent video controls