### PR TITLE
Show correct release date

### DIFF
--- a/src/scripts/datetime.js
+++ b/src/scripts/datetime.js
@@ -49,7 +49,7 @@ export function parseISO8601Date(s, toLocal) {
             ms += offset;
         }
     } else if (toLocal === false) {
-        ms += new Date().getTimezoneOffset() * 60000;
+        ms += new Date(ms).getTimezoneOffset() * 60000;
     }
 
     return new Date(ms);


### PR DESCRIPTION
**Changes**
Calculate timezone offset based on provided date instead of today's date. 

**Issues**
Fixes #5598

**Additional Context**
What essentially happens is that a standard time date (e.g. 2024-01-12T00:00:00.0000000Z) gets parsed into "Sat Jan 11 2014 23:00:00 GMT-0500" because the offset during daylight time is -4. However, the offset at the release date was -5, the script gets the current timezone offset and applies it to the release date which had a different offset.

This is an old issue still present in emby, see [Bug #1](https://emby.media/community/index.php?/topic/26050-premiered-date-is-showing-up-wrong/), [Bug #2](https://emby.media/community/index.php?/topic/99525-all-dates-are-off-problem-with-timezone/)
See https://github.com/jellyfin/jellyfin/issues/11811, https://github.com/jellyfin/jellyfin-web/issues/369