### PR TITLE
Reset query cache on user logout

### DIFF
--- a/src/components/ServerConnections.js
+++ b/src/components/ServerConnections.js
@@ -6,6 +6,7 @@ import Dashboard from '../utils/dashboard';
 import Events from '../utils/events.ts';
 import { setUserInfo } from '../scripts/settings/userSettings';
 import appSettings from '../scripts/settings/appSettings';
+import { queryClient } from 'utils/query/queryClient';
 
 const normalizeImageOptions = options => {
     if (!options.quality && (options.maxWidth || options.width || options.maxHeight || options.height || options.fillWidth || options.fillHeight)) {
@@ -41,6 +42,8 @@ class ServerConnections extends ConnectionManager {
             setUserInfo(null, null);
             // Ensure the updated credentials are persisted to storage
             credentialProvider.credentials(credentialProvider.credentials());
+            // Reset the query cache
+            queryClient.resetQueries();
 
             if (window.NativeShell && typeof window.NativeShell.onLocalUserSignedOut === 'function') {
                 window.NativeShell.onLocalUserSignedOut(logoutInfo);


### PR DESCRIPTION
**Changes**
* Resets the query cache on user logout

I haven't been able to reproduce the issue, but users are reporting seeing old data when they first login as a different user.

**Issues**
N/A
