### PR TITLE
Allow VideoStreamCopy for remote source fallback

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -3309,7 +3309,7 @@ class PlaybackManager {
 
                     changeStream(player, startTime, {
                         EnableDirectPlay: false,
-                        EnableDirectStream: false,
+                        EnableDirectStream: tryVideoStreamCopy,
                         AllowVideoStreamCopy: tryVideoStreamCopy,
                         AllowAudioStreamCopy: currentlyPreventsAudioStreamCopy || currentlyPreventsVideoStreamCopy ? false : null
                     });

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -3296,18 +3296,21 @@ class PlaybackManager {
             const streamInfo = error.streamInfo || getPlayerData(player).streamInfo;
 
             if (streamInfo?.url) {
+                const isAlreadyFallbacking = streamInfo.url.toLowerCase().includes('transcodereasons=directplayerror');
                 const currentlyPreventsVideoStreamCopy = streamInfo.url.toLowerCase().indexOf('allowvideostreamcopy=false') !== -1;
                 const currentlyPreventsAudioStreamCopy = streamInfo.url.toLowerCase().indexOf('allowaudiostreamcopy=false') !== -1;
 
                 // Auto switch to transcoding
                 if (enablePlaybackRetryWithTranscoding(streamInfo, errorType, currentlyPreventsVideoStreamCopy, currentlyPreventsAudioStreamCopy)) {
                     const startTime = getCurrentTicks(player) || streamInfo.playerStartPositionTicks;
+                    const isRemoteSource = streamInfo.item.LocationType === 'Remote';
+                    // force transcoding and only allow remuxing for remote source like liveTV, but only for initial trial
+                    const tryVideoStreamCopy = isRemoteSource && !isAlreadyFallbacking;
 
                     changeStream(player, startTime, {
-                        // force transcoding and only allow remuxing for remote source like liveTV
                         EnableDirectPlay: false,
                         EnableDirectStream: false,
-                        AllowVideoStreamCopy: streamInfo.item.LocationType === 'Remote',
+                        AllowVideoStreamCopy: tryVideoStreamCopy,
                         AllowAudioStreamCopy: currentlyPreventsAudioStreamCopy || currentlyPreventsVideoStreamCopy ? false : null
                     });
 

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -3304,10 +3304,10 @@ class PlaybackManager {
                     const startTime = getCurrentTicks(player) || streamInfo.playerStartPositionTicks;
 
                     changeStream(player, startTime, {
-                        // force transcoding
+                        // force transcoding and only allow remuxing for remote source like liveTV
                         EnableDirectPlay: false,
                         EnableDirectStream: false,
-                        AllowVideoStreamCopy: false,
+                        AllowVideoStreamCopy: streamInfo.item.LocationType === 'Remote' ? true : false,
                         AllowAudioStreamCopy: currentlyPreventsAudioStreamCopy || currentlyPreventsVideoStreamCopy ? false : null
                     });
 

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -3307,7 +3307,7 @@ class PlaybackManager {
                         // force transcoding and only allow remuxing for remote source like liveTV
                         EnableDirectPlay: false,
                         EnableDirectStream: false,
-                        AllowVideoStreamCopy: streamInfo.item.LocationType === 'Remote' ? true : false,
+                        AllowVideoStreamCopy: streamInfo.item.LocationType === 'Remote',
                         AllowAudioStreamCopy: currentlyPreventsAudioStreamCopy || currentlyPreventsVideoStreamCopy ? false : null
                     });
 

--- a/src/utils/mediaSource.ts
+++ b/src/utils/mediaSource.ts
@@ -6,9 +6,6 @@ import type { MediaSourceInfo } from '@jellyfin/sdk/lib/generated-client';
  * @returns _true_ if the media source is an HLS stream, _false_ otherwise.
  */
 export function isHls(mediaSource: MediaSourceInfo|null|undefined): boolean {
-    if (mediaSource?.TranscodingSubProtocol?.toUpperCase() === 'HLS') {
-        return true;
-    }
-
-    return mediaSource?.Container?.toUpperCase() === 'HLS';
+    return mediaSource?.TranscodingSubProtocol?.toUpperCase() === 'HLS'
+        || mediaSource?.Container?.toUpperCase() === 'HLS';
 }

--- a/src/utils/mediaSource.ts
+++ b/src/utils/mediaSource.ts
@@ -6,6 +6,9 @@ import type { MediaSourceInfo } from '@jellyfin/sdk/lib/generated-client';
  * @returns _true_ if the media source is an HLS stream, _false_ otherwise.
  */
 export function isHls(mediaSource: MediaSourceInfo|null|undefined): boolean {
-    const protocol = mediaSource?.TranscodingSubProtocol || mediaSource?.Container;
-    return protocol?.toUpperCase() === 'HLS';
+    if (mediaSource?.TranscodingSubProtocol?.toUpperCase() === 'HLS') {
+        return true;
+    }
+
+    return mediaSource?.Container?.toUpperCase() === 'HLS';
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

During LiveTV playback, a fallback is usually needed because the first attempt would be try to direct play the remote url of that channel. If that failed we should still allow stream copy because the playback would still success in this case. The server side will enforce the most compatible format (h264+ts) and still do transcoding if that condition is not met.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Depends on jellyfin/jellyfin#11851 to guarantee the stream compatibility and actually doing remux for certain input videos