### PR TITLE
Allow to display detailLogo on TV with CSS customization

### DIFF
--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -533,10 +533,9 @@ function reloadFromItem(instance, page, params, item, user) {
 
     // Start rendering the artwork first
     renderImage(page, item, apiClient);
-    // Save some screen real estate in TV mode
-    if (!layoutManager.tv) {
-        renderLogo(page, item, apiClient);
-    }
+
+    renderLogo(page, item, apiClient);
+
     // Render the mobile header backdrop
     if (layoutManager.mobile) {
         renderHeaderBackdrop(page, item, apiClient);

--- a/src/styles/librarybrowser.scss
+++ b/src/styles/librarybrowser.scss
@@ -921,8 +921,11 @@
     position: relative;
 }
 
-.layout-mobile .detailLogo {
-    display: none;
+.layout-mobile,
+.layout-tv {
+    .detailLogo {
+        display: none;
+    }
 }
 
 @media all and (max-width: 68.75em) {


### PR DESCRIPTION
**Changes**

Add the possibility to display the detailLogo on TV with CSS customization.
If you don't customize your CSS, you won't see any difference and the detailLogo will still be hidden.
