### PR TITLE
Prioritise HEVC over H264 in HLS TS streams on webOS

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -619,7 +619,7 @@ export default function (options) {
         && (browser.edgeChromium || browser.safari || browser.tizen || browser.web0s || (browser.chrome && (!browser.android || browser.versionMajor >= 105)))) {
         // Chromium used to support HEVC on Android but not via MSE
         hlsInFmp4VideoCodecs.push('hevc');
-        if (browser.web0s) {
+        if (browser.tizen || browser.web0s) {
             hlsInTsVideoCodecs.push('hevc');
         }
     }
@@ -632,9 +632,6 @@ export default function (options) {
 
     if (canPlayHevc(videoTestElement, options)) {
         mp4VideoCodecs.push('hevc');
-        if (browser.tizen) {
-            hlsInTsVideoCodecs.push('hevc');
-        }
     }
 
     if (supportsMpeg2Video()) {

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -619,6 +619,9 @@ export default function (options) {
         && (browser.edgeChromium || browser.safari || browser.tizen || browser.web0s || (browser.chrome && (!browser.android || browser.versionMajor >= 105)))) {
         // Chromium used to support HEVC on Android but not via MSE
         hlsInFmp4VideoCodecs.push('hevc');
+        if (browser.web0s) {
+            hlsInTsVideoCodecs.push('hevc');
+        }
     }
 
     if (canPlayH264(videoTestElement)) {
@@ -629,7 +632,7 @@ export default function (options) {
 
     if (canPlayHevc(videoTestElement, options)) {
         mp4VideoCodecs.push('hevc');
-        if (browser.tizen || browser.web0s) {
+        if (browser.tizen) {
             hlsInTsVideoCodecs.push('hevc');
         }
     }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
Moved the HEVC codec higher in the priority ranking over H264 when transcoding to an HLS stream in a TS container.

**Issues**
None
