### PR TITLE
Add more supported audio codecs in HLS on webOS

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -555,11 +555,19 @@ export default function (options) {
     if (supportsDts) {
         videoAudioCodecs.push('dca');
         videoAudioCodecs.push('dts');
+        if (browser.web0s) {
+            hlsInTsVideoAudioCodecs.push('dts');
+            hlsInFmp4VideoAudioCodecs.push('dts');
+        }
     }
 
     if (browser.tizen || browser.web0s) {
         videoAudioCodecs.push('pcm_s16le');
         videoAudioCodecs.push('pcm_s24le');
+        if (browser.web0s) {
+            hlsInTsVideoAudioCodecs.push('pcm_s16le');
+            hlsInTsVideoAudioCodecs.push('pcm_s24le');
+        }
     }
 
     if (appSettings.enableTrueHd() || options.supportsTrueHd) {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
Allow DTS audio in both TS and fMP4 streams, and allow PCM audio in TS streams. I got the information that it's supported from <https://webostv.developer.lge.com/develop/specifications/video-audio-240>. According to [Samsung's site](https://developer.samsung.com/smarttv/develop/specifications/media-specifications/2024-tv-video-specifications.html), Tizen also supports PCM in TS, but I'm not able to test that so I haven't enabled it.

Unfortunately, I can't seem to get the server to transcode to DTS, so I can't test that this actually works. If someone could help me with what might be wrong, that would be much appreciated.

**Issues**
None
