### PR TITLE
Fix background being invisible with theme videos

### DIFF
--- a/src/styles/site.scss
+++ b/src/styles/site.scss
@@ -39,7 +39,6 @@ body {
     right: 0;
     bottom: 0;
     contain: strict;
-    z-index: -1;
 }
 
 .layout-mobile,


### PR DESCRIPTION
**Changes**
I noticed that since I updated to 10.9 the skin's background would disappear when a theme video was playing and therefore some text would be unreadable depending on the video in the background.

Before:
![image](https://github.com/jellyfin/jellyfin-web/assets/556162/2680d896-bedf-423b-8309-d255d372251f)

After:
![image](https://github.com/jellyfin/jellyfin-web/assets/556162/8c65aa9e-5499-4679-b231-e3735f76c6b3)

This basically restores pre-10.9 behaviour.

**Issues**
Couldn't find any open issues for this.

---

Calling in @grhallenbeck since the cause was introduced in ce4c7aed5e2f9315e62b7e9aa364700d112aebc3 / #5076 and there might have been a reason I'm not seeing.

The `videoPlayerContainer` and `backgroundContainer` elements are the first 2 elements in the DOM structure though. They are already at the lowest layer of elements, making `z-index` seem redundant here. The issue is that the `videoPlayerContainer` specifies no `z-index` at all so the `-1` made the `backgroundContainer` be rendered behind the video (or culled entirely, not sure how the actual rendering pipeline works :P ).