### PR TITLE
move up next dialog to front

### DIFF
--- a/src/components/upnextdialog/upnextdialog.scss
+++ b/src/components/upnextdialog/upnextdialog.scss
@@ -3,6 +3,7 @@
     right: 0;
     bottom: 0;
     width: 30em;
+    z-index: 1000;
     padding: 1em;
     display: flex;
     flex-direction: column;

--- a/src/components/upnextdialog/upnextdialog.scss
+++ b/src/components/upnextdialog/upnextdialog.scss
@@ -3,7 +3,6 @@
     right: 0;
     bottom: 0;
     width: 30em;
-    z-index: 1000;
     padding: 1em;
     display: flex;
     flex-direction: column;

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -362,11 +362,11 @@ export default function (view) {
         if (currentVisibleMenu === 'osd') {
             const elem = osdBottomElement;
             clearHideAnimationEventListeners(elem);
-            elem.classList.add('videoOsdBottom-hidden');
 
             dom.addEventListener(elem, transitionEndEventName, onHideAnimationComplete, {
                 once: true
             });
+            elem.classList.add('videoOsdBottom-hidden');
             currentVisibleMenu = null;
             toggleSubtitleSync('hide');
 


### PR DESCRIPTION
**Changes**
Up next dialog was not at the upmost front of the page, so the buttons were rendered unclickable and instead triggered the click event on the fast forward/backward button. Z-index added to the dialog so that it as at the top of the screen when it appears and the buttons register the click event properly to operate as intended.

**Issues**
Fixes #5650 
