### PR TITLE
Fix video OSD not fully hiding

### DIFF
--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -323,18 +323,14 @@ export default function (view) {
     }
 
     function clearHideAnimationEventListeners(elem) {
-        dom.removeEventListener(elem, transitionEndEventName, onHideAnimationComplete, {
-            once: true
-        });
+        elem.removeEventListener(transitionEndEventName, onHideAnimationComplete);
     }
 
     function onHideAnimationComplete(e) {
         const elem = e.target;
         if (elem != osdBottomElement) return;
         elem.classList.add('hide');
-        dom.removeEventListener(elem, transitionEndEventName, onHideAnimationComplete, {
-            once: true
-        });
+        elem.removeEventListener(transitionEndEventName, onHideAnimationComplete);
     }
 
     const _focus = debounce((focusElement) => focusManager.focus(focusElement), 50);
@@ -364,9 +360,7 @@ export default function (view) {
             clearHideAnimationEventListeners(elem);
             elem.classList.add('videoOsdBottom-hidden');
 
-            dom.addEventListener(elem, transitionEndEventName, onHideAnimationComplete, {
-                once: true
-            });
+            elem.addEventListener(transitionEndEventName, onHideAnimationComplete);
             currentVisibleMenu = null;
             toggleSubtitleSync('hide');
 


### PR DESCRIPTION
Sometimes (maybe in some browsers) `onHideAnimationComplete` is called on `btnPause`, and the event listener is disconnecting because it was connected with `once: true`.

As a result, the `hide` class is not added to the OSD element, allowing the user to interact with transparent elements.

**Changes**
Don't connect listener with `once: true`.

**Issues**
Fixes #5647
Fixes #5650
Fixes #5652
Closes #5595
Closes #5651
