### PR TITLE
Revert "Fix extra requests in standalone mode"

### DIFF
--- a/src/utils/dashboard.js
+++ b/src/utils/dashboard.js
@@ -21,7 +21,7 @@ export function getCurrentUser() {
 
 // TODO: investigate url prefix support for serverAddress function
 export async function serverAddress() {
-    const apiClient = window.ApiClient ?? ServerConnections.currentApiClient();
+    const apiClient = window.ApiClient;
 
     if (apiClient) {
         return Promise.resolve(apiClient.serverAddress());


### PR DESCRIPTION
**Changes**
This reverts https://github.com/jellyfin/jellyfin-web/pull/4620

Our startup code is a mess of weird edge cases between jellyfin-web and the apiclient. We should probably avoid touching it until we rip it out for the sdk.

**Issues**
Fixes #5648 
