### PR TITLE
Update activity table column widths

### DIFF
--- a/src/apps/dashboard/routes/activity.tsx
+++ b/src/apps/dashboard/routes/activity.tsx
@@ -107,7 +107,7 @@ const Activity = () => {
         {
             field: 'Name',
             headerName: globalize.translate('LabelName'),
-            width: 200
+            width: 300
         },
         {
             field: 'Overview',
@@ -121,11 +121,12 @@ const Activity = () => {
         {
             field: 'Type',
             headerName: globalize.translate('LabelType'),
-            width: 120
+            width: 180
         },
         {
             field: 'actions',
             type: 'actions',
+            width: 50,
             getActions: ({ row }) => {
                 const actions = [];
 


### PR DESCRIPTION
**Changes**
Users are not able to resize the width of the columns in the user activity table until we upgrade the mui data grid component, so as a stop gap this resizes the columns to better fit their content

**Issues**
Related to #5524
