### PR TITLE
Fixed being unable to properly long press on cards to multiselect on Firefox

### DIFF
--- a/src/components/multiSelect/multiSelect.js
+++ b/src/components/multiSelect/multiSelect.js
@@ -99,9 +99,7 @@ function showSelection(item, isChecked) {
         parent.appendChild(itemSelectionPanel);
 
         let cssClass = 'chkItemSelect';
-        if (isChecked && !browser.firefox) {
-            // In firefox, the initial tap hold doesnt' get treated as a click
-            // In other browsers it does, so we need to make sure that initial click is ignored
+        if (isChecked) {
             cssClass += ' checkedInitial';
         }
         const checkedAttribute = isChecked ? ' checked' : '';


### PR DESCRIPTION
**Changes**
In `showSelected` we were not adding the `checkedInitial` class for Firefox when selecting an element. This did not allow for proper selection of the cards. There was a comment that claimed this was because Firefox did not handle click events the same as other browsers, but it seems this was either not true, or was maybe misunderstood. I simply removed the condition and it has restored proper multiselect functionality on Firefox.

**Issues**
None that I know of, but this has been bothering me for many months now

