### PR TITLE
Force DoVi on browser.xboxOne as edgeUWP says it can't play it

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -239,6 +239,8 @@ function supportsDolbyVision(options) {
 }
 
 function supportedDolbyVisionProfilesHevc(videoTestElement) {
+    if (browser.xboxOne) return [5, 8];
+
     const supportedProfiles = [];
     // Profiles 5/8 4k@60fps
     if (videoTestElement.canPlayType) {


### PR DESCRIPTION
Unsure if DoVi can be used with profile 8 on Xbox but video play

https://ott.dolby.com/codec_test/index.html
<img width="543" alt="Screenshot 2024-06-10 at 8 50 16 PM" src="https://github.com/jellyfin/jellyfin-web/assets/1393949/cd96afea-0a85-4c53-8880-02d4378b4936">
