### PR TITLE
Fix episode overview markdown render

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -87,6 +87,7 @@
 - [JPUC1143](https://github.com/Jpuc1143)
 - [David Angel](https://github.com/davidangel)
 - [Pithaya](https://github.com/Pithaya)
+- [Chaitanya Shahare](https://github.com/Chaitanya-Shahare)
 
 ## Emby Contributors
 

--- a/src/components/listview/listview.js
+++ b/src/components/listview/listview.js
@@ -17,6 +17,8 @@ import '../../elements/emby-ratingbutton/emby-ratingbutton';
 import '../../elements/emby-playstatebutton/emby-playstatebutton';
 import ServerConnections from '../ServerConnections';
 import { getDefaultBackgroundClass } from '../cardbuilder/cardBuilderUtils';
+import markdownIt from 'markdown-it';
+import DOMPurify from 'dompurify';
 
 function getIndex(item, options) {
     if (options.index === 'disc') {
@@ -415,8 +417,9 @@ export function getListViewHtml(options) {
         }
 
         if (enableOverview && item.Overview) {
+            const overview = DOMPurify.sanitize(markdownIt({ html: true }).render(item.Overview || ''));
             html += '<div class="secondary listItem-overview listItemBodyText">';
-            html += '<bdi>' + item.Overview + '</bdi>';
+            html += '<bdi>' + overview + '</bdi>';
             html += '</div>';
         }
 


### PR DESCRIPTION

**Changes**

- used `markdownIt` to render the markdown in the episode's overview, as expected (and done in detail view of the episode)

**Issues**
Fixes #5679 

**Screenshots**

### Before

![image](https://github.com/jellyfin/jellyfin-web/assets/108579856/4b9bb256-115f-4021-af3b-42b75cba5ff7)

### After

![image](https://github.com/jellyfin/jellyfin-web/assets/108579856/5e3134dc-f720-4373-93e6-d1b7fe662211)
