### PR TITLE
Fix loading hides too early

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -2295,7 +2295,7 @@ class PlaybackManager {
                     return playAfterBitrateDetect(bitrate, item, playOptions, onPlaybackStartedFn, prevSource)
                         .catch(onPlaybackRejection);
                 })
-                .finally(() => {
+                .catch(() => {
                     if (playOptions.fullscreen) {
                         loading.hide();
                     }
@@ -2353,8 +2353,6 @@ class PlaybackManager {
                     resolve();
                     return;
                 }
-
-                loading.hide();
 
                 const options = Object.assign({}, playOptions);
 


### PR DESCRIPTION
Some regressions:
#5402 - `loading.hide` is called on any Promise result.
#5573 - `loading.show` is called before `runInterceptors`.

**Changes**
- Hide loading indicator on fail only.
In case of resolved promise, loading is controlled by player and player events (at least that's how it's designed).
- Don't hide loading indicator in interceptors.

**Issues**
#5674
This doesn't fixes the problem completely, but reverts :crossed_fingers: to its original behavior.
