### PR TITLE
play/pause when Enter is pressed on non-dragging position slider

### DIFF
--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1775,8 +1775,13 @@ export default function (view) {
         }
     });
 
-    nowPlayingPositionSlider.addEventListener('playpause', function () {
-        playbackManager.playPause(currentPlayer);
+    nowPlayingPositionSlider.addEventListener('keydown', function (e) {
+        if (e.defaultPrevented) return;
+
+        const key = keyboardnavigation.getKeyName(e);
+        if (key === 'Enter') {
+            playbackManager.playPause(currentPlayer);
+        }
     });
 
     nowPlayingPositionSlider.updateBubbleHtml = function(bubble, value) {

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1775,6 +1775,10 @@ export default function (view) {
         }
     });
 
+    nowPlayingPositionSlider.addEventListener('playpause', function () {
+        playbackManager.playPause(currentPlayer);
+    });
+
     nowPlayingPositionSlider.updateBubbleHtml = function(bubble, value) {
         showOsd();
 

--- a/src/elements/emby-slider/emby-slider.js
+++ b/src/elements/emby-slider/emby-slider.js
@@ -525,19 +525,6 @@ function stepKeyboard(elem, delta) {
 }
 
 /**
-     * Play or pause video.
-     *
-     * @param {Object} elem slider itself
-     */
-function playPauseKeyboard(elem) {
-    const event = new Event('playpause', {
-        bubbles: true,
-        cancelable: false
-    });
-    elem.dispatchEvent(event);
-}
-
-/**
      * Handle KeyDown event
      */
 function onKeyDown(e) {
@@ -557,11 +544,9 @@ function onKeyDown(e) {
         case 'Enter':
             if (this.keyboardDragging) {
                 finishKeyboardDragging(this);
-            } else {
-                playPauseKeyboard(this);
+                e.preventDefault();
+                e.stopPropagation();
             }
-            e.preventDefault();
-            e.stopPropagation();
             break;
     }
 }

--- a/src/elements/emby-slider/emby-slider.js
+++ b/src/elements/emby-slider/emby-slider.js
@@ -525,6 +525,19 @@ function stepKeyboard(elem, delta) {
 }
 
 /**
+     * Play or pause video.
+     *
+     * @param {Object} elem slider itself
+     */
+function playPauseKeyboard(elem) {
+    const event = new Event('playpause', {
+        bubbles: true,
+        cancelable: false
+    });
+    elem.dispatchEvent(event);
+}
+
+/**
      * Handle KeyDown event
      */
 function onKeyDown(e) {
@@ -544,9 +557,11 @@ function onKeyDown(e) {
         case 'Enter':
             if (this.keyboardDragging) {
                 finishKeyboardDragging(this);
-                e.preventDefault();
-                e.stopPropagation();
+            } else {
+                playPauseKeyboard(this);
             }
+            e.preventDefault();
+            e.stopPropagation();
             break;
     }
 }


### PR DESCRIPTION
Hey there, first time contributor here! Open to any and all feedback.

# Changes

Background:  This fixes a minor annoyance while using Jellyfin on my LG TV that does not have a play/pause media button on the remote (only an "OK" button between the navigation arrows):

![image](https://github.com/jellyfin/jellyfin-web/assets/2903742/e7f6ba77-8f8f-4fb4-b785-d3d948d73da9)

## **Current behavior**

Pressing "Enter" on the now playing position slider when it is not being dragged does nothing. *This means resuming playback after scrubbing the position slider requires 4 inputs every time to manually click the OSD Play button: `Down -> Right -> Right -> OK`*

## **New behavior**

Pressing "Enter" on the position slider when it is not being dragged will play/pause the current media. *Now resuming playback after scrubbing only requires one remote input: `OK`*

To achieve this, I needed to dispatch a new event "playpause" from the emby-slider component, and listen for that event in the playback/video controller.

## Manual testing

I tested these changes manually using LG's simulator.