### PR TITLE
Add support for native PGS subtitle rendering without transcoding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "jquery": "3.7.1",
         "jstree": "3.3.16",
         "libarchive.js": "2.0.2",
+        "libpgs": "0.2.0",
         "lodash-es": "4.17.21",
         "markdown-it": "14.1.0",
         "material-design-icons-iconfont": "6.7.0",
@@ -136,6 +137,22 @@
       },
       "optionalDependencies": {
         "sass-embedded": "1.77.8"
+      }
+    },
+    "../libpgs-js": {
+      "name": "libpgs",
+      "version": "0.2.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@tsconfig/recommended": "^1.0.6",
+        "@types/jest": "^29.5.12",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.1.4",
+        "ts-loader": "^9.5.1",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.4.5",
+        "webpack": "^5.91.0",
+        "webpack-cli": "^5.1.4"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -14970,6 +14987,10 @@
       "dependencies": {
         "comlink": "^4.4.1"
       }
+    },
+    "node_modules/libpgs": {
+      "resolved": "../libpgs-js",
+      "link": true
     },
     "node_modules/lie": {
       "version": "3.1.1",
@@ -36527,6 +36548,20 @@
       "integrity": "sha512-JHb+P4suNSjvz/dMdRgOe7JAxluXJeialzSFkKHU5y0ZK+m175drPOaIYW6I9WXSDcPcQ13eCUgMnpgY0ggmoQ==",
       "requires": {
         "comlink": "^4.4.1"
+      }
+    },
+    "libpgs": {
+      "version": "file:../libpgs-js",
+      "requires": {
+        "@tsconfig/recommended": "^1.0.6",
+        "@types/jest": "^29.5.12",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.1.4",
+        "ts-loader": "^9.5.1",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.4.5",
+        "webpack": "^5.91.0",
+        "webpack-cli": "^5.1.4"
       }
     },
     "lie": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "jquery": "3.7.1",
         "jstree": "3.3.16",
         "libarchive.js": "2.0.2",
-        "libpgs": "0.2.0",
+        "libpgs": "0.2.1",
         "lodash-es": "4.17.21",
         "markdown-it": "14.1.0",
         "material-design-icons-iconfont": "6.7.0",
@@ -141,7 +141,8 @@
     },
     "../libpgs-js": {
       "name": "libpgs",
-      "version": "0.2.0",
+      "version": "0.2.1",
+      "extraneous": true,
       "license": "MIT",
       "devDependencies": {
         "@tsconfig/recommended": "^1.0.6",
@@ -14989,8 +14990,10 @@
       }
     },
     "node_modules/libpgs": {
-      "resolved": "../libpgs-js",
-      "link": true
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/libpgs/-/libpgs-0.2.1.tgz",
+      "integrity": "sha512-4aYbQZ7UavFTFCmr1uqTJpQWjtbt1mefvjYWJl4nq3uPVWKp5L/GeGrVWPinoNd2fAXAzuMmvjgKwuYaGff2BQ==",
+      "license": "MIT"
     },
     "node_modules/lie": {
       "version": "3.1.1",
@@ -36551,18 +36554,9 @@
       }
     },
     "libpgs": {
-      "version": "file:../libpgs-js",
-      "requires": {
-        "@tsconfig/recommended": "^1.0.6",
-        "@types/jest": "^29.5.12",
-        "jest": "^29.7.0",
-        "ts-jest": "^29.1.4",
-        "ts-loader": "^9.5.1",
-        "ts-node": "^10.9.2",
-        "typescript": "^5.4.5",
-        "webpack": "^5.91.0",
-        "webpack-cli": "^5.1.4"
-      }
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/libpgs/-/libpgs-0.2.1.tgz",
+      "integrity": "sha512-4aYbQZ7UavFTFCmr1uqTJpQWjtbt1mefvjYWJl4nq3uPVWKp5L/GeGrVWPinoNd2fAXAzuMmvjgKwuYaGff2BQ=="
     },
     "lie": {
       "version": "3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "jquery": "3.7.1",
         "jstree": "3.3.16",
         "libarchive.js": "2.0.2",
-        "libpgs": "0.4.1",
+        "libpgs": "0.6.0",
         "lodash-es": "4.17.21",
         "markdown-it": "14.1.0",
         "material-design-icons-iconfont": "6.7.0",
@@ -14973,9 +14973,9 @@
       }
     },
     "node_modules/libpgs": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/libpgs/-/libpgs-0.4.1.tgz",
-      "integrity": "sha512-I4mIGz7Lf23xy/8mwSx0qlStz0oZFCz9dLC1xXNaqv5MbVdFhZWE+OMhVBLGjfVkjugyboM9XJ+4bCSibAIGuA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/libpgs/-/libpgs-0.6.0.tgz",
+      "integrity": "sha512-k8ic6VTJTCun8Ump8iAe+tZi3pa1ZhDlq1v4hmZOmYQzSQ44QpZoClMXuSfJ1B91eRWOO6q50rXhyCPuB9dXbg==",
       "license": "MIT"
     },
     "node_modules/lie": {
@@ -36537,9 +36537,9 @@
       }
     },
     "libpgs": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/libpgs/-/libpgs-0.4.1.tgz",
-      "integrity": "sha512-I4mIGz7Lf23xy/8mwSx0qlStz0oZFCz9dLC1xXNaqv5MbVdFhZWE+OMhVBLGjfVkjugyboM9XJ+4bCSibAIGuA=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/libpgs/-/libpgs-0.6.0.tgz",
+      "integrity": "sha512-k8ic6VTJTCun8Ump8iAe+tZi3pa1ZhDlq1v4hmZOmYQzSQ44QpZoClMXuSfJ1B91eRWOO6q50rXhyCPuB9dXbg=="
     },
     "lie": {
       "version": "3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "jquery": "3.7.1",
         "jstree": "3.3.16",
         "libarchive.js": "2.0.2",
-        "libpgs": "0.2.1",
+        "libpgs": "0.4.1",
         "lodash-es": "4.17.21",
         "markdown-it": "14.1.0",
         "material-design-icons-iconfont": "6.7.0",
@@ -137,23 +137,6 @@
       },
       "optionalDependencies": {
         "sass-embedded": "1.77.8"
-      }
-    },
-    "../libpgs-js": {
-      "name": "libpgs",
-      "version": "0.2.1",
-      "extraneous": true,
-      "license": "MIT",
-      "devDependencies": {
-        "@tsconfig/recommended": "^1.0.6",
-        "@types/jest": "^29.5.12",
-        "jest": "^29.7.0",
-        "ts-jest": "^29.1.4",
-        "ts-loader": "^9.5.1",
-        "ts-node": "^10.9.2",
-        "typescript": "^5.4.5",
-        "webpack": "^5.91.0",
-        "webpack-cli": "^5.1.4"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -14990,9 +14973,9 @@
       }
     },
     "node_modules/libpgs": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/libpgs/-/libpgs-0.2.1.tgz",
-      "integrity": "sha512-4aYbQZ7UavFTFCmr1uqTJpQWjtbt1mefvjYWJl4nq3uPVWKp5L/GeGrVWPinoNd2fAXAzuMmvjgKwuYaGff2BQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/libpgs/-/libpgs-0.4.1.tgz",
+      "integrity": "sha512-I4mIGz7Lf23xy/8mwSx0qlStz0oZFCz9dLC1xXNaqv5MbVdFhZWE+OMhVBLGjfVkjugyboM9XJ+4bCSibAIGuA==",
       "license": "MIT"
     },
     "node_modules/lie": {
@@ -36554,9 +36537,9 @@
       }
     },
     "libpgs": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/libpgs/-/libpgs-0.2.1.tgz",
-      "integrity": "sha512-4aYbQZ7UavFTFCmr1uqTJpQWjtbt1mefvjYWJl4nq3uPVWKp5L/GeGrVWPinoNd2fAXAzuMmvjgKwuYaGff2BQ=="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/libpgs/-/libpgs-0.4.1.tgz",
+      "integrity": "sha512-I4mIGz7Lf23xy/8mwSx0qlStz0oZFCz9dLC1xXNaqv5MbVdFhZWE+OMhVBLGjfVkjugyboM9XJ+4bCSibAIGuA=="
     },
     "lie": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "jquery": "3.7.1",
     "jstree": "3.3.16",
     "libarchive.js": "2.0.2",
-    "libpgs": "0.4.1",
+    "libpgs": "0.6.0",
     "lodash-es": "4.17.21",
     "markdown-it": "14.1.0",
     "material-design-icons-iconfont": "6.7.0",

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "jquery": "3.7.1",
     "jstree": "3.3.16",
     "libarchive.js": "2.0.2",
+    "libpgs": "0.2.1",
     "lodash-es": "4.17.21",
     "markdown-it": "14.1.0",
     "material-design-icons-iconfont": "6.7.0",
@@ -123,8 +124,7 @@
     "swiper": "11.1.12",
     "usehooks-ts": "3.1.0",
     "webcomponents.js": "0.7.24",
-    "whatwg-fetch": "3.6.20",
-    "libpgs": "0.2.0"
+    "whatwg-fetch": "3.6.20"
   },
   "optionalDependencies": {
     "sass-embedded": "1.77.8"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "jquery": "3.7.1",
     "jstree": "3.3.16",
     "libarchive.js": "2.0.2",
-    "libpgs": "0.2.1",
+    "libpgs": "0.4.1",
     "lodash-es": "4.17.21",
     "markdown-it": "14.1.0",
     "material-design-icons-iconfont": "6.7.0",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,8 @@
     "swiper": "11.1.12",
     "usehooks-ts": "3.1.0",
     "webcomponents.js": "0.7.24",
-    "whatwg-fetch": "3.6.20"
+    "whatwg-fetch": "3.6.20",
+    "libpgs": "0.2.0"
   },
   "optionalDependencies": {
     "sass-embedded": "1.77.8"

--- a/src/components/subtitlesettings/subtitlesettings.js
+++ b/src/components/subtitlesettings/subtitlesettings.js
@@ -117,15 +117,10 @@ function onSubtitleModeChange(e) {
 
 function onSubtitleBurnInChange(e) {
     const view = dom.parentWithClass(e.target, 'subtitlesettings');
-
     const fieldRenderPgs = view.querySelector('.fldRenderPgs');
 
     // Pgs option is only available if burn-in mode is set to 'auto' (empty string)
-    if (this.value) {
-        fieldRenderPgs.classList.add('hide');
-    } else {
-        fieldRenderPgs.classList.remove('hide');
-    }
+    fieldRenderPgs.classList.toggle('hide', !!this.value);
 }
 
 function onAppearanceFieldChange(e) {

--- a/src/components/subtitlesettings/subtitlesettings.js
+++ b/src/components/subtitlesettings/subtitlesettings.js
@@ -61,6 +61,9 @@ function loadForm(context, user, userSettings, appearanceSettings, apiClient) {
         context.querySelector('#sliderVerticalPosition').value = appearanceSettings.verticalPosition;
 
         context.querySelector('#selectSubtitleBurnIn').value = appSettings.get('subtitleburnin') || '';
+        context.querySelector('#chkSubtitleRenderPgs').checked = appSettings.get('subtitlerenderpgs') === 'true';
+
+        context.querySelector('#selectSubtitleBurnIn').dispatchEvent(new CustomEvent('change', {}));
 
         onAppearanceFieldChange({
             target: context.querySelector('#selectTextSize')
@@ -86,6 +89,7 @@ function save(instance, context, userId, userSettings, apiClient, enableSaveConf
     loading.show();
 
     appSettings.set('subtitleburnin', context.querySelector('#selectSubtitleBurnIn').value);
+    appSettings.set('subtitlerenderpgs', context.querySelector('#chkSubtitleRenderPgs').checked);
 
     apiClient.getUser(userId).then(function (user) {
         saveUser(context, user, userSettings, instance.appearanceKey, apiClient).then(function () {
@@ -109,6 +113,19 @@ function onSubtitleModeChange(e) {
         subtitlesHelp[i].classList.add('hide');
     }
     view.querySelector('.subtitles' + this.value + 'Help').classList.remove('hide');
+}
+
+function onSubtitleBurnInChange(e) {
+    const view = dom.parentWithClass(e.target, 'subtitlesettings');
+
+    const fieldRenderPgs = view.querySelector('.fldRenderPgs');
+
+    // Pgs option is only available if burn-in mode is set to 'auto' (empty string)
+    if (this.value) {
+        fieldRenderPgs.classList.add('hide');
+    } else {
+        fieldRenderPgs.classList.remove('hide');
+    }
 }
 
 function onAppearanceFieldChange(e) {
@@ -166,6 +183,7 @@ function embed(options, self) {
     options.element.querySelector('form').addEventListener('submit', self.onSubmit.bind(self));
 
     options.element.querySelector('#selectSubtitlePlaybackMode').addEventListener('change', onSubtitleModeChange);
+    options.element.querySelector('#selectSubtitleBurnIn').addEventListener('change', onSubtitleBurnInChange);
     options.element.querySelector('#selectTextSize').addEventListener('change', onAppearanceFieldChange);
     options.element.querySelector('#selectTextWeight').addEventListener('change', onAppearanceFieldChange);
     options.element.querySelector('#selectDropShadow').addEventListener('change', onAppearanceFieldChange);

--- a/src/components/subtitlesettings/subtitlesettings.template.html
+++ b/src/components/subtitlesettings/subtitlesettings.template.html
@@ -37,7 +37,6 @@
             <label>
                 <input is="emby-checkbox" type="checkbox" id="chkSubtitleRenderPgs" />
                 <span>${RenderPgsSubtitle}</span>
-
             </label>
             <div class="fieldDescription checkboxFieldDescription">${RenderPgsSubtitleHelp}</div>
         </div>

--- a/src/components/subtitlesettings/subtitlesettings.template.html
+++ b/src/components/subtitlesettings/subtitlesettings.template.html
@@ -32,6 +32,15 @@
             </select>
             <div class="fieldDescription">${BurnSubtitlesHelp}</div>
         </div>
+
+        <div class="checkboxContainer checkboxContainer-withDescription fldRenderPgs hide">
+            <label>
+                <input is="emby-checkbox" type="checkbox" id="chkSubtitleRenderPgs" />
+                <span>${RenderPgsSubtitle}</span>
+
+            </label>
+            <div class="fieldDescription checkboxFieldDescription">${RenderPgsSubtitleHelp}</div>
+        </div>
     </div>
 
     <div class="verticalSection subtitleAppearanceSection hide">

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1337,6 +1337,7 @@ export class HtmlVideoPlayer {
             const options = {
                 video: videoElement,
                 subUrl: getTextTrackUrl(track, item),
+                workerUrl: `${appRouter.baseUrl()}/libraries/libpgs.worker.js`,
                 timeOffset: (this._currentPlayOptions.transcodingOffsetTicks || 0) / 10000000
             };
             this.#currentPgsRenderer = new libpgs.PgsRenderer(options);

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -594,6 +594,9 @@ export class HtmlVideoPlayer {
         if (this.#currentAssRenderer) {
             this.updateCurrentTrackOffset(offsetValue);
             this.#currentAssRenderer.timeOffset = (this._currentPlayOptions.transcodingOffsetTicks || 0) / 10000000 + offsetValue;
+        } else if (this.#currentPgsRenderer) {
+            this.updateCurrentTrackOffset(offsetValue);
+            this.#currentPgsRenderer.timeOffset = (this._currentPlayOptions.transcodingOffsetTicks || 0) / 10000000 + offsetValue;
         } else {
             const trackElements = this.getTextTracks();
             // if .vtt currently rendering
@@ -1333,7 +1336,8 @@ export class HtmlVideoPlayer {
         import('libpgs').then((libpgs) => {
             const options = {
                 video: videoElement,
-                subUrl: getTextTrackUrl(track, item)
+                subUrl: getTextTrackUrl(track, item),
+                timeOffset: (this._currentPlayOptions.transcodingOffsetTicks || 0) / 10000000
             };
             this.#currentPgsRenderer = new libpgs.PgsRenderer(options);
         });

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -48,6 +48,15 @@ function supportsTextTracks() {
     return _supportsTextTracks;
 }
 
+let _supportsCanvas2D;
+function supportsCanvas2D() {
+    if (_supportsCanvas2D == null) {
+        _supportsCanvas2D = document.createElement('canvas').getContext('2d') != null;
+    }
+
+    return _supportsCanvas2D;
+}
+
 let _canPlayHls;
 function canPlayHls() {
     if (_canPlayHls == null) {
@@ -1429,6 +1438,13 @@ export default function (options) {
             });
             profile.SubtitleProfiles.push({
                 Format: 'ssa',
+                Method: 'External'
+            });
+        }
+
+        if (supportsCanvas2D()) {
+            profile.SubtitleProfiles.push({
+                Format: 'pgssub',
                 Method: 'External'
             });
         }

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -1424,6 +1424,7 @@ export default function (options) {
     // External vtt or burn in
     profile.SubtitleProfiles = [];
     const subtitleBurninSetting = appSettings.get('subtitleburnin');
+    const subtitleRenderPgsSetting = appSettings.get('subtitlerenderpgs') === 'true';
     if (subtitleBurninSetting !== 'all') {
         if (supportsTextTracks()) {
             profile.SubtitleProfiles.push({
@@ -1442,7 +1443,7 @@ export default function (options) {
             });
         }
 
-        if (supportsCanvas2D() && options.enablePgsRender !== false && !options.isRetry
+        if (supportsCanvas2D() && options.enablePgsRender !== false && !options.isRetry && subtitleRenderPgsSetting
             && subtitleBurninSetting !== 'allcomplexformats' && subtitleBurninSetting !== 'onlyimageformats') {
             profile.SubtitleProfiles.push({
                 Format: 'pgssub',

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -1442,7 +1442,8 @@ export default function (options) {
             });
         }
 
-        if (supportsCanvas2D()) {
+        if (supportsCanvas2D() && options.enablePgsRender !== false && !options.isRetry
+            && subtitleBurninSetting !== 'allcomplexformats' && subtitleBurninSetting !== 'onlyimageformats') {
             profile.SubtitleProfiles.push({
                 Format: 'pgssub',
                 Method: 'External'

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1383,6 +1383,8 @@
     "Remixer": "Remixer",
     "RemoveFromCollection": "Remove from collection",
     "RemoveFromPlaylist": "Remove from playlist",
+    "RenderPgsSubtitle": "Experimental PGS subtitle rendering",
+    "RenderPgsSubtitleHelp": "Determine if the client should render PGS subtitles instead of using burned in subtitles. This can avoid server-side transcoding in exchange of client-side rendering performance.",
     "Repeat": "Repeat",
     "RepeatAll": "Repeat all",
     "RepeatEpisodes": "Repeat episodes",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -15,7 +15,8 @@ const Assets = [
     '@jellyfin/libass-wasm/dist/js/subtitles-octopus-worker.js',
     '@jellyfin/libass-wasm/dist/js/subtitles-octopus-worker.wasm',
     '@jellyfin/libass-wasm/dist/js/subtitles-octopus-worker-legacy.js',
-    'pdfjs-dist/build/pdf.worker.js'
+    'pdfjs-dist/build/pdf.worker.js',
+    'libpgs/dist/libpgs.worker.js'
 ];
 
 const DEV_MODE = process.env.NODE_ENV !== 'production';


### PR DESCRIPTION
**Changes**
This PR allows the client to request and render native PGS subtitle streams without transcoding. PGS is a graphical subtitle format. The subtitles are rendered locally by the client on-top of the video element.

This adds a new dependency [`libpgs-js`](https://github.com/Arcus92/libpgs-js). I just created this library for the Jellyfin project. If desired, you can fork it into the @jellyfin domain.

**Tasks**
- [x] Disable native PGS support if 'Subtitle burn-in' is not set to 'auto'.
- [x] Improve performance by using WebWorkers to render subtitles in a separate thread.

**Related Pull Request (backend):** https://github.com/jellyfin/jellyfin/pull/12056
**Related Pull Request (vue):** https://github.com/jellyfin/jellyfin-vue/pull/2404