### PR TITLE
Increase .cardText-secondary height from 3em to 4em to fix cutoff

### DIFF
--- a/src/styles/dashboard.scss
+++ b/src/styles/dashboard.scss
@@ -215,7 +215,7 @@ div[data-role=controlgroup] a.ui-btn-active {
 
 .localUsers .cardText-secondary {
     white-space: pre-wrap;
-    height: 3em;
+    height: 4em;
 }
 
 .customCssContainer textarea {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

change src/styles/dashboard.scss .localUsers .cardText-secondary from height 3em to height 4em to fix the text cutoff demonstrated below.

**Issues**
<!-- Tag any issues that this PR solves here.

ex. Fixes # -->

**Before**
![before](https://github.com/jellyfin/jellyfin-web/assets/95017494/6d3957e6-580f-4d5f-9d2e-225440bc94d7)
**After**
![after](https://github.com/jellyfin/jellyfin-web/assets/95017494/3535ae05-2c2f-4db3-b852-0ec132c44c4c)

