### PR TITLE
Updated theme media playback to play in Random order

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -94,6 +94,7 @@
 - [iFraan](https://github.com/iFraan)
 - [Ali](https://github.com/bu3alwa)
 - [K. Kyle Puchkov](https://github.com/kepper104)
+- [ItsAllAboutTheCode](https://github.com/ItsAllAboutTheCode)
 
 ## Emby Contributors
 

--- a/src/components/themeMediaPlayer.js
+++ b/src/components/themeMediaPlayer.js
@@ -10,6 +10,7 @@ import { queryClient } from 'utils/query/queryClient';
 
 import { playbackManager } from './playback/playbackmanager';
 import ServerConnections from './ServerConnections';
+import { ItemSortBy } from '@jellyfin/sdk/lib/generated-client';
 
 let currentOwnerId;
 let currentThemeIds = [];
@@ -96,8 +97,12 @@ async function loadThemeMedia(serverId, itemId) {
             return;
         }
 
-        const { data: themeMedia } = await getLibraryApi(api)
-            .getThemeMedia({ userId, itemId: item.Id, inheritFromParent: true });
+        const { data: themeMedia } = await getLibraryApi(api).getThemeMedia({
+            userId,
+            itemId: item.Id,
+            inheritFromParent: true,
+            sortBy: [ItemSortBy.Random]
+        });
 
         const result = userSettings.enableThemeVideos() && themeMedia.ThemeVideosResult?.Items?.length ? themeMedia.ThemeVideosResult : themeMedia.ThemeSongsResult;
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
The ThemeMusicPlayer code has been updated to playback theme media using the Random sort order which causes theme media to be added to the play queue in a Random order.



**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
This is the implementation for the feature request located https://features.jellyfin.org/posts/2740/select-audio-from-the-theme-music-folder-at-random.
#5958


