### PR TITLE
Use `aspectRatio` `cover` for theme video backdrop

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -629,7 +629,8 @@ function truncatePlayOptions(playOptions) {
         mediaSourceId: playOptions.mediaSourceId,
         audioStreamIndex: playOptions.audioStreamIndex,
         subtitleStreamIndex: playOptions.subtitleStreamIndex,
-        startPositionTicks: playOptions.startPositionTicks
+        startPositionTicks: playOptions.startPositionTicks,
+        aspectRatio: playOptions.aspectRatio
     };
 }
 
@@ -2277,6 +2278,8 @@ class PlaybackManager {
                 playOptions.isFirstItem = false;
             } else {
                 playOptions.isFirstItem = true;
+                // resetting the aspectRatio from a previous theme video playback
+                if (!playOptions.aspectRatio) playOptions.aspectRatio = 'auto';
             }
 
             const apiClient = ServerConnections.getApiClient(item.ServerId);
@@ -2604,6 +2607,7 @@ class PlaybackManager {
                     const streamInfo = createStreamInfo(apiClient, item.MediaType, item, mediaSource, startPosition, player);
 
                     streamInfo.fullscreen = playOptions.fullscreen;
+                    streamInfo.aspectRatio = playOptions.aspectRatio;
 
                     const playerData = getPlayerData(player);
 

--- a/src/components/themeMediaPlayer.js
+++ b/src/components/themeMediaPlayer.js
@@ -33,14 +33,16 @@ function playThemeMedia(items, ownerId) {
         currentThemeItems.forEach((i) => {
             i.playOptions = {
                 fullscreen: false,
-                enableRemotePlayers: false
+                enableRemotePlayers: false,
+                aspectRatio: 'cover'
             };
         });
 
         playbackManager.play({
             items: currentThemeItems,
             fullscreen: false,
-            enableRemotePlayers: false
+            enableRemotePlayers: false,
+            aspectRatio: 'cover'
         }).then(function () {
             currentOwnerId = ownerId;
         });

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -390,6 +390,7 @@ export class HtmlVideoPlayer {
         if (options.resetSubtitleOffset !== false) this.resetSubtitleOffset();
 
         return this.createMediaElement(options).then(elem => {
+            if (options.aspectRatio) this.setAspectRatio(options.aspectRatio);
             return this.updateVideoUrl(options).then(() => {
                 return this.setCurrentSrc(elem, options);
             });


### PR DESCRIPTION
## Changes
This has bothered me for a long time. Currently, [theme video backdrops](https://jellyfin.org/docs/general/server/media/shows/#theme-videos) use the default aspect ratio of the video player, resulting in black areas around the video, which just looks awkward depending on the viewport.
This change essentially mimics what static backdrops do and uses the `cover` aspect ratio for this purpose.

**Before:**
![image](https://github.com/jellyfin/jellyfin-web/assets/556162/d319462f-9a2d-4edd-9a17-df636d55c325)

**After:**
![image](https://github.com/jellyfin/jellyfin-web/assets/556162/be075df5-1b63-402f-8a91-62da238b598d)


## Issues
None I'm aware of or could find

edit:
Force-pushed because CI was being a Diva :sweat_smile: 