### PR TITLE
Use Error instead of literal for promise rejection

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -79,6 +79,7 @@ module.exports = {
         'operator-linebreak': ['error', 'before', { overrides: { '?': 'after', ':': 'after', '=': 'after' } }],
         'padded-blocks': ['error', 'never'],
         'prefer-const': ['error', { 'destructuring': 'all' }],
+        'prefer-promise-reject-errors': ['warn', { 'allowEmptyReject': true }],
         '@typescript-eslint/prefer-for-of': ['error'],
         '@typescript-eslint/prefer-optional-chain': ['error'],
         'quotes': ['error', 'single', { 'avoidEscape': true, 'allowTemplateLiterals': false }],

--- a/src/components/actionSheet/actionSheet.ts
+++ b/src/components/actionSheet/actionSheet.ts
@@ -366,7 +366,7 @@ export function show(options: Options) {
 
                     resolve(selectedId);
                 } else {
-                    reject('ActionSheet closed without resolving');
+                    reject(new Error('ActionSheet closed without resolving'));
                 }
             }
         });

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -2496,7 +2496,7 @@ class PlaybackManager {
             return Promise.resolve()
                 .then(() => {
                     if (!isServerItem(item) || itemHelper.isLocalItem(item)) {
-                        return Promise.reject('skip bitrate detection');
+                        return Promise.reject(new Error('skip bitrate detection'));
                     }
 
                     return apiClient.getEndpointInfo()
@@ -2508,7 +2508,7 @@ class PlaybackManager {
                                 });
                             }
 
-                            return Promise.reject('skip bitrate detection');
+                            return Promise.reject(new Error('skip bitrate detection'));
                         });
                 })
                 .catch(() => getSavedMaxStreamingBitrate(apiClient, mediaType));

--- a/src/components/router/appRouter.js
+++ b/src/components/router/appRouter.js
@@ -389,7 +389,7 @@ class AppRouter {
             if (firstResult.State === ConnectionState.ServerSignIn) {
                 const url = firstResult.ApiClient.serverAddress() + '/System/Info/Public';
                 fetch(url).then(response => {
-                    if (!response.ok) return Promise.reject('fetch failed');
+                    if (!response.ok) return Promise.reject(new Error('fetch failed'));
                     return response.json();
                 }).then(data => {
                     if (data !== null && data.StartupWizardCompleted === false) {

--- a/src/plugins/syncPlay/core/Helper.js
+++ b/src/plugins/syncPlay/core/Helper.js
@@ -26,7 +26,7 @@ export function waitForEventOnce(emitter, eventType, timeout, rejectEventTypes) 
         let rejectTimeout;
         if (timeout) {
             rejectTimeout = setTimeout(() => {
-                reject('Timed out.');
+                reject(new Error('Timed out.'));
             }, timeout);
         }
 

--- a/src/plugins/syncPlay/core/QueueCore.js
+++ b/src/plugins/syncPlay/core/QueueCore.js
@@ -123,7 +123,7 @@ class QueueCore {
 
         if (!itemIds.length) {
             if (this.lastPlayQueueUpdate && playQueueUpdate.LastUpdate.getTime() <= this.getLastUpdateTime()) {
-                return Promise.reject('Trying to apply old update');
+                return Promise.reject(new Error('Trying to apply old update'));
             }
 
             this.lastPlayQueueUpdate = playQueueUpdate;

--- a/src/plugins/syncPlay/core/timeSync/TimeSync.js
+++ b/src/plugins/syncPlay/core/timeSync/TimeSync.js
@@ -113,7 +113,7 @@ class TimeSync {
      */
     requestPing() {
         console.warn('SyncPlay TimeSync requestPing: override this method!');
-        return Promise.reject('Not implemented.');
+        return Promise.reject(new Error('Not implemented.'));
     }
 
     /**


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
- Replaced literal with an instance of the Error class in promise rejection where applicable.
- Added the eslint rule `prefer-promise-reject-errors` to prevent this type of issue in the future. I set it to `warn` instead of `error`, as there was one promise rejection that used an object instead of a literal and fixing that would mean creating a custom error, which I feel is beyond the scope of this change.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
None.
