### PR TITLE
Fix stuck page titles on admin dashboard

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -89,6 +89,7 @@
 - [Pithaya](https://github.com/Pithaya)
 - [Peter Santos](https://github.com/prsantos-com)
 - [Chaitanya Shahare](https://github.com/Chaitanya-Shahare)
+- [Venkat Karasani](https://github.com/venkat-karasani)
 
 ## Emby Contributors
 

--- a/src/apps/dashboard/routes/playback/trickplay.tsx
+++ b/src/apps/dashboard/routes/playback/trickplay.tsx
@@ -142,6 +142,7 @@ const PlaybackTrickplay: FC = () => {
         <Page
             id='trickplayConfigurationPage'
             className='mainAnimatedPage type-interior playbackConfigurationPage'
+            title={globalize.translate('Trickplay')}
         >
             <div ref={element} className='content-primary'>
                 <div className='verticalSection'>

--- a/src/apps/dashboard/routes/users/index.tsx
+++ b/src/apps/dashboard/routes/users/index.tsx
@@ -159,6 +159,7 @@ const UserProfiles = () => {
         <Page
             id='userProfilesPage'
             className='mainAnimatedPage type-interior userProfilesPage fullWidthContent'
+            title={globalize.translate('HeaderUsers')}
         >
             <div ref={element} className='content-primary'>
                 <div className='verticalSection'>

--- a/src/controllers/dashboard/apikeys.html
+++ b/src/controllers/dashboard/apikeys.html
@@ -1,4 +1,4 @@
-<div id="apiKeysPage" data-role="page" class="page type-interior advancedConfigurationPage fullWidthContent">
+<div id="apiKeysPage" data-role="page" class="page type-interior advancedConfigurationPage fullWidthContent" data-title="${HeaderApiKeys}">
     <div>
         <div class="content-primary">
             <div class="detailSectionHeader">

--- a/src/controllers/dashboard/dashboard.html
+++ b/src/controllers/dashboard/dashboard.html
@@ -1,4 +1,4 @@
-<div id="dashboardPage" data-role="page" class="page type-interior dashboardHomePage fullWidthContent">
+<div id="dashboardPage" data-role="page" class="page type-interior dashboardHomePage fullWidthContent" data-title="${TabDashboard}">
     <div class="content-primary">
         <div class="dashboardSections" style="padding-top:.5em;">
             <div class="dashboardColumn dashboardColumn-2-60 dashboardColumn-3-46">

--- a/src/controllers/dashboard/devices/devices.html
+++ b/src/controllers/dashboard/devices/devices.html
@@ -1,4 +1,4 @@
-<div id="devicesPage" data-role="page" class="page type-interior devicesPage noSecondaryNavPage">
+<div id="devicesPage" data-role="page" class="page type-interior devicesPage noSecondaryNavPage" data-title="${HeaderDevices}">
     <div>
         <div class="content-primary">
             <div class="verticalSection verticalSection">

--- a/src/controllers/dashboard/encodingsettings.html
+++ b/src/controllers/dashboard/encodingsettings.html
@@ -1,4 +1,4 @@
-<div id="encodingSettingsPage" data-role="page" class="page type-interior playbackConfigurationPage">
+<div id="encodingSettingsPage" data-role="page" class="page type-interior playbackConfigurationPage" data-title="${TitlePlayback}">
     <div>
         <div class="content-primary">
             <form class="encodingSettingsForm">

--- a/src/controllers/dashboard/general.html
+++ b/src/controllers/dashboard/general.html
@@ -1,4 +1,4 @@
-<div id="dashboardGeneralPage" data-role="page" class="page type-interior dashboardHomePage">
+<div id="dashboardGeneralPage" data-role="page" class="page type-interior dashboardHomePage" data-title="${General}">
     <div>
         <div class="content-primary">
             <form class="dashboardGeneralForm">

--- a/src/controllers/dashboard/library.html
+++ b/src/controllers/dashboard/library.html
@@ -1,4 +1,4 @@
-<div id="mediaLibraryPage" data-role="page" class="page type-interior mediaLibraryPage librarySectionPage fullWidthContent">
+<div id="mediaLibraryPage" data-role="page" class="page type-interior mediaLibraryPage librarySectionPage fullWidthContent" data-title="${HeaderLibraries}">
     <div>
         <div class="content-primary">
             <div class="padded-top padded-bottom">

--- a/src/controllers/dashboard/librarydisplay.html
+++ b/src/controllers/dashboard/librarydisplay.html
@@ -1,4 +1,4 @@
-<div id="libraryDisplayPage" data-role="page" class="page type-interior librarySectionPage">
+<div id="libraryDisplayPage" data-role="page" class="page type-interior librarySectionPage" data-title="${Display}">
     <div>
         <div class="content-primary">
             <form>

--- a/src/controllers/dashboard/logs.html
+++ b/src/controllers/dashboard/logs.html
@@ -1,4 +1,4 @@
-<div id="logPage" data-role="page" class="page type-interior">
+<div id="logPage" data-role="page" class="page type-interior" data-title="${TabLogs}">
     <div>
         <div class="content-primary">
             <form class="logsForm">

--- a/src/controllers/dashboard/metadataimages.html
+++ b/src/controllers/dashboard/metadataimages.html
@@ -1,4 +1,4 @@
-<div id="metadataImagesConfigurationPage" data-role="page" class="page type-interior metadataConfigurationPage">
+<div id="metadataImagesConfigurationPage" data-role="page" class="page type-interior metadataConfigurationPage" data-title="${Metadata}">
 
     <div>
 

--- a/src/controllers/dashboard/metadatanfo.html
+++ b/src/controllers/dashboard/metadatanfo.html
@@ -1,4 +1,4 @@
-<div id="metadataNfoPage" data-role="page" class="page type-interior metadataConfigurationPage">
+<div id="metadataNfoPage" data-role="page" class="page type-interior metadataConfigurationPage" data-title="${TabNfoSettings}">
 
     <div>
 

--- a/src/controllers/dashboard/networking.html
+++ b/src/controllers/dashboard/networking.html
@@ -1,4 +1,4 @@
-<div id="networkingPage" data-role="page" class="page type-interior advancedConfigurationPage">
+<div id="networkingPage" data-role="page" class="page type-interior advancedConfigurationPage" data-title="${TabNetworking}">
     <div>
         <div class="content-primary">
             <form class="dashboardHostingForm">

--- a/src/controllers/dashboard/playback.html
+++ b/src/controllers/dashboard/playback.html
@@ -1,4 +1,4 @@
-<div id="playbackConfigurationPage" data-role="page" class="page type-interior playbackConfigurationPage">
+<div id="playbackConfigurationPage" data-role="page" class="page type-interior playbackConfigurationPage" data-title="${ButtonResume}">
     <div>
         <div class="content-primary">
             <form class="playbackConfigurationForm">

--- a/src/controllers/dashboard/plugins/available/index.html
+++ b/src/controllers/dashboard/plugins/available/index.html
@@ -1,4 +1,4 @@
-<div id="pluginCatalogPage" data-role="page" class="page type-interior pluginConfigurationPage fullWidthContent">
+<div id="pluginCatalogPage" data-role="page" class="page type-interior pluginConfigurationPage fullWidthContent" data-title="${TabCatalog}">
     <div>
         <div class="content-primary">
             <div class="inputContainer">

--- a/src/controllers/dashboard/plugins/installed/index.html
+++ b/src/controllers/dashboard/plugins/installed/index.html
@@ -1,4 +1,4 @@
-<div id="pluginsPage" data-role="page" class="page type-interior pluginConfigurationPage fullWidthContent">
+<div id="pluginsPage" data-role="page" class="page type-interior pluginConfigurationPage fullWidthContent" data-title="${TabPlugins}">
     <div>
         <div class="content-primary">
             <div class="inputContainer">

--- a/src/controllers/dashboard/plugins/repositories/index.html
+++ b/src/controllers/dashboard/plugins/repositories/index.html
@@ -1,4 +1,4 @@
-<div id="repositories" data-role="page" class="page type-interior fullWidthContent">
+<div id="repositories" data-role="page" class="page type-interior fullWidthContent" data-title="${TabRepositories}">
     <div>
         <div class="content-primary">
             <div class="sectionTitleContainer flex align-items-center">

--- a/src/controllers/dashboard/scheduledtasks/scheduledtasks.html
+++ b/src/controllers/dashboard/scheduledtasks/scheduledtasks.html
@@ -1,4 +1,4 @@
-<div id="scheduledTasksPage" data-role="page" class="page type-interior scheduledTasksConfigurationPage">
+<div id="scheduledTasksPage" data-role="page" class="page type-interior scheduledTasksConfigurationPage" data-title="${TabScheduledTasks}">
     <style>
         .taskProgressOuter {
             height: 6px;

--- a/src/controllers/dashboard/streaming.html
+++ b/src/controllers/dashboard/streaming.html
@@ -1,4 +1,4 @@
-<div id="streamingSettingsPage" data-role="page" class="page type-interior playbackConfigurationPage">
+<div id="streamingSettingsPage" data-role="page" class="page type-interior playbackConfigurationPage" data-title="${TabStreaming}">
     <div>
         <div class="content-primary">
             <form class="streamingSettingsForm">

--- a/src/controllers/livetvsettings.html
+++ b/src/controllers/livetvsettings.html
@@ -1,4 +1,4 @@
-<div id="liveTvSettingsPage" data-role="page" class="page type-interior liveTvPage">
+<div id="liveTvSettingsPage" data-role="page" class="page type-interior liveTvPage" data-title="${HeaderDVR}">
     <div>
         <div class="content-primary">
             <div class="verticalSection">

--- a/src/controllers/livetvstatus.html
+++ b/src/controllers/livetvstatus.html
@@ -1,4 +1,4 @@
-<div id="liveTvStatusPage" data-role="page" class="page type-interior liveTvSettingsPage">
+<div id="liveTvStatusPage" data-role="page" class="page type-interior liveTvSettingsPage" data-title="${LiveTV}">
     <div>
         <div class="content-primary">
             <div class="verticalSection verticalSection-extrabottompadding">


### PR DESCRIPTION
**Changes**
The page title is being updated at setTitle method inside libraryMenu.js. Inside it we are listening to **pageshow** event and then getting the data-title attribute value and updating it as the page title. But, the admin views except some are missing these. I added these **data-title** attributes for the respective div and **title** prop for the respective Page components.

**Issues**
Fixes #5686 
