### PR TITLE
Remove usage of deprecated getItemImageUrl

### DIFF
--- a/src/components/listview/List/listHelper.ts
+++ b/src/components/listview/List/listHelper.ts
@@ -138,23 +138,23 @@ export function getChannelImageUrl(
     let itemId;
     const fillWidth = size;
     const fillHeight = size;
-    const imgType = ImageType.Primary;
 
     if (item.ChannelId && item.ChannelPrimaryImageTag) {
         imgTag = item.ChannelPrimaryImageTag;
         itemId = item.ChannelId;
     }
 
-    if (api && imgTag && imgType && itemId) {
-        const response = api.getItemImageUrl(itemId, imgType, {
-            fillWidth: fillWidth,
-            fillHeight: fillHeight,
-            tag: imgTag
-        });
+    if (api && imgTag && itemId) {
+        const response = getImageApi(api)
+            .getItemImageUrlById(itemId, ImageType.Primary, {
+                fillWidth,
+                fillHeight,
+                tag: imgTag
+            });
 
         return {
             imgUrl: response,
-            blurhash: item.ImageBlurHashes?.[imgType]?.[imgTag]
+            blurhash: item.ImageBlurHashes?.[ImageType.Primary]?.[imgTag]
         };
     }
 


### PR DESCRIPTION
**Changes**
Removes a usage of the deprecated `getItemImageUrl` sdk function that has been removed in the unstable sdk.

Refs: https://github.com/jellyfin/jellyfin-sdk-typescript/pull/731

**Issues**
N/A