### PR TITLE
Add user setting for whether to display ratings in Video Player and Up Next Dialog Window

### DIFF
--- a/src/components/playbackSettings/playbackSettings.js
+++ b/src/components/playbackSettings/playbackSettings.js
@@ -178,6 +178,7 @@ function loadForm(context, user, userSettings, systemInfo, apiClient) {
     context.querySelector('.chkEnableCinemaMode').checked = userSettings.enableCinemaMode();
     context.querySelector('#selectAudioNormalization').value = userSettings.selectAudioNormalization();
     context.querySelector('.chkEnableNextVideoOverlay').checked = userSettings.enableNextVideoInfoOverlay();
+    context.querySelector('.chkDisplayRatingsInPlayer').checked = userSettings.enableDisplayRatingsInPlayer();
     context.querySelector('.chkRememberAudioSelections').checked = user.Configuration.RememberAudioSelections || false;
     context.querySelector('.chkRememberSubtitleSelections').checked = user.Configuration.RememberSubtitleSelections || false;
     context.querySelector('.chkExternalVideoPlayer').checked = appSettings.enableSystemExternalPlayers();
@@ -240,6 +241,7 @@ function saveUser(context, user, userSettingsInstance, apiClient) {
     user.Configuration.CastReceiverId = context.querySelector('.selectChromecastVersion').value;
     userSettingsInstance.skipForwardLength(context.querySelector('.selectSkipForwardLength').value);
     userSettingsInstance.skipBackLength(context.querySelector('.selectSkipBackLength').value);
+    userSettingsInstance.enableDisplayRatingsInPlayer(context.querySelector('.chkDisplayRatingsInPlayer').checked);
 
     return apiClient.updateUserConfiguration(user.Id, user.Configuration);
 }

--- a/src/components/playbackSettings/playbackSettings.template.html
+++ b/src/components/playbackSettings/playbackSettings.template.html
@@ -146,6 +146,14 @@
             </div>
         </div>
 
+        <div class="checkboxContainer checkboxContainer-withDescription">
+            <label>
+                <input type="checkbox" is="emby-checkbox" class="chkDisplayRatingsInPlayer" />
+                <span>${EnableDisplayRatingsInPlayer}</span>
+            </label>
+            <div class="fieldDescription checkboxFieldDescription">${EnableDisplayRatingsInPlayerHelp}</div>
+        </div>
+
         <div class="selectContainer">
             <select is="emby-select" class="selectChromecastVersion" label="${LabelChromecastVersion}"></select>
         </div>

--- a/src/components/playbackSettings/playbackSettings.template.html
+++ b/src/components/playbackSettings/playbackSettings.template.html
@@ -136,6 +136,14 @@
             <div class="fieldDescription checkboxFieldDescription">${EnableNextVideoInfoOverlayHelp}</div>
         </div>
 
+        <div class="checkboxContainer checkboxContainer-withDescription">
+            <label>
+                <input type="checkbox" is="emby-checkbox" class="chkDisplayRatingsInPlayer" />
+                <span>${EnableDisplayRatingsInPlayer}</span>
+            </label>
+            <div class="fieldDescription checkboxFieldDescription">${EnableDisplayRatingsInPlayerHelp}</div>
+        </div>
+
         <div class="checkboxContainer fldExternalPlayer checkboxContainer-withDescription hide">
             <label>
                 <input type="checkbox" is="emby-checkbox" class="chkExternalVideoPlayer" />
@@ -144,14 +152,6 @@
             <div class="fieldDescription checkboxFieldDescription">
                 <div class="labelNativeExternalPlayers">${EnableExternalVideoPlayersHelp}</div>
             </div>
-        </div>
-
-        <div class="checkboxContainer checkboxContainer-withDescription">
-            <label>
-                <input type="checkbox" is="emby-checkbox" class="chkDisplayRatingsInPlayer" />
-                <span>${EnableDisplayRatingsInPlayer}</span>
-            </label>
-            <div class="fieldDescription checkboxFieldDescription">${EnableDisplayRatingsInPlayerHelp}</div>
         </div>
 
         <div class="selectContainer">

--- a/src/components/upnextdialog/upnextdialog.js
+++ b/src/components/upnextdialog/upnextdialog.js
@@ -67,9 +67,9 @@ function fillItem(item) {
     const elem = instance.options.parent;
 
     elem.querySelector('.upNextDialog-mediainfo').innerHTML = mediaInfo.getPrimaryMediaInfoHtml(item, {
-        criticRating: true,
+        criticRating: instance.options.displayRating,
         originalAirDate: false,
-        starRating: true,
+        starRating: instance.options.displayRating,
         subtitles: false
     });
 

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -108,6 +108,8 @@ export default function (view) {
                 originalAirDate: false,
                 episodeTitle: false
             });
+        } else {
+            ratingsText.innerHTML = '';
         }
 
         const secondaryMediaInfo = view.querySelector('.osdSecondaryMediaInfo');

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -95,18 +95,20 @@ export default function (view) {
         }
 
         setTitle(displayItem, parentName);
-        ratingsText.innerHTML = mediaInfo.getPrimaryMediaInfoHtml(displayItem, {
-            officialRating: false,
-            criticRating: true,
-            starRating: true,
-            endsAt: false,
-            year: false,
-            programIndicator: false,
-            runtime: false,
-            subtitles: false,
-            originalAirDate: false,
-            episodeTitle: false
-        });
+        if (userSettings.enableDisplayRatingsInPlayer()) {
+            ratingsText.innerHTML = mediaInfo.getPrimaryMediaInfoHtml(displayItem, {
+                officialRating: false,
+                criticRating: true,
+                starRating: true,
+                endsAt: false,
+                year: false,
+                programIndicator: false,
+                runtime: false,
+                subtitles: false,
+                originalAirDate: false,
+                episodeTitle: false
+            });
+        }
 
         const secondaryMediaInfo = view.querySelector('.osdSecondaryMediaInfo');
         const secondaryMediaInfoHtml = mediaInfo.getSecondaryMediaInfoHtml(displayItem, {
@@ -673,7 +675,8 @@ export default function (view) {
                     currentUpNextDialog = new UpNextDialog({
                         parent: view.querySelector('.upNextContainer'),
                         player: player,
-                        nextItem: nextItem
+                        nextItem: nextItem,
+                        displayRating: userSettings.enableDisplayRatingsInPlayer()
                     });
                     Events.on(currentUpNextDialog, 'hide', onUpNextHidden);
                 }, onUpNextHidden);

--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -194,7 +194,7 @@ export class UserSettings {
             return this.set('enableDisplayRatingsInPlayer', val.toString());
         }
 
-        return toBoolean(this.get('enableDisplayRatingsInPlayer', false));
+        return toBoolean(this.get('enableDisplayRatingsInPlayer', false), true);
     }
 
     /**

--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -185,6 +185,19 @@ export class UserSettings {
     }
 
     /**
+     * Get or set 'Enable Display Ratings in Player' state.
+     * @param {boolean|undefined} val - Flag to enable 'Enable Display Ratings in Player' or undefined.
+     * @return {boolean} 'Enable Display Ratings in Player' state.
+     */
+    enableDisplayRatingsInPlayer(val) {
+        if (val !== undefined) {
+            return this.set('enableDisplayRatingsInPlayer', val.toString());
+        }
+
+        return toBoolean(this.get('enableDisplayRatingsInPlayer', false));
+    }
+
+    /**
      * Get or set 'Video Remaining/Total Time' state.
      * @param {boolean|undefined} val - Flag to enable 'Video Remaining/Total Time' or undefined.
      * @return {boolean} 'Video Remaining/Total Time' state.
@@ -662,6 +675,7 @@ export const backdropScreensaverInterval = currentSettings.backdropScreensaverIn
 export const libraryPageSize = currentSettings.libraryPageSize.bind(currentSettings);
 export const maxDaysForNextUp = currentSettings.maxDaysForNextUp.bind(currentSettings);
 export const enableRewatchingInNextUp = currentSettings.enableRewatchingInNextUp.bind(currentSettings);
+export const enableDisplayRatingsInPlayer = currentSettings.enableDisplayRatingsInPlayer.bind(currentSettings);
 export const soundEffects = currentSettings.soundEffects.bind(currentSettings);
 export const loadQuerySettings = currentSettings.loadQuerySettings.bind(currentSettings);
 export const saveQuerySettings = currentSettings.saveQuerySettings.bind(currentSettings);

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -253,6 +253,8 @@
     "EnableDetailsBanner": "Details Banner",
     "EnableDetailsBannerHelp": "Display a banner image at the top of the item details page.",
     "EnableDisplayMirroring": "Display mirroring",
+    "EnableDisplayRatingsInPlayer": "Display ratings during playback",
+    "EnableDisplayRatingsInPlayerHelp": "Displays ratings for the video in the player bar and next video upcoming overlay.",
     "EnableDts": "Enable DTS (DCA)",
     "EnableDtsHelp": "Only enable if your device supports DTS or is connected to a compatible audio receiver, otherwise it may cause playback failure.",
     "EnableExternalVideoPlayers": "External video players",


### PR DESCRIPTION
**Changes**
Adds user setting under Playback section to control whether ratings should be displayed in the Video Player and Up Next Dialog Window.

Image of setting:
![msedge_l3vXxguNka](https://github.com/jellyfin/jellyfin-web/assets/175349397/19e92033-d9cf-48ac-9b9a-01cb267f4ccf)

Player bar with setting disabled and enabled:
![msedge_I4pBRBPSsk](https://github.com/jellyfin/jellyfin-web/assets/175349397/1338324c-510f-44cd-bdde-a30dd441b8d2)
![msedge_4s7VKNrZ4n](https://github.com/jellyfin/jellyfin-web/assets/175349397/496def1f-6585-46b0-8432-292dbb8509c0)

Next up window with setting disabled and enabled:

![msedge_FqFuvfhY0C](https://github.com/jellyfin/jellyfin-web/assets/175349397/0c6c133d-db10-4fa9-b5da-0da8ccf641c5)
![msedge_2KZLxc9q9b](https://github.com/jellyfin/jellyfin-web/assets/175349397/9a8a2ef5-7cca-477c-8d09-b78df6e47757)