### PR TITLE
Fix invisible headings

### DIFF
--- a/src/apps/experimental/AppLayout.tsx
+++ b/src/apps/experimental/AppLayout.tsx
@@ -29,7 +29,7 @@ const AppLayout = () => {
     }, [ isDrawerActive, setIsDrawerActive ]);
 
     return (
-        <Box sx={{ display: 'flex' }}>
+        <Box sx={{ position: 'relative', display: 'flex' }}>
             <ElevationScroll elevate={false}>
                 <AppBar
                     position='fixed'


### PR DESCRIPTION
**Changes**
I don't really understand why, but for some reason the backdrop container seems to display over MUI heading elements in the experimental layout. Reverting the `z-index` change in https://github.com/jellyfin/jellyfin-web/pull/5640 caused the text to disappear (again this was caught in the PR for the user display settings page initially). Setting `position: relative` on the main app layout element seems to fix the issue without messing with `z-index`.

| Before | After |
|---|---|
| ![Screenshot 2024-07-12 at 15-45-38 Display](https://github.com/user-attachments/assets/c541df02-4f2e-44dc-aab0-ffda0329da71) | ![Screenshot 2024-07-12 at 15-46-23 Display](https://github.com/user-attachments/assets/b54debcf-8f51-4795-a75e-693f536d7069) |


**Issues**
N/A
