### PR TITLE
Prevent modal close on mouse press up if outside the dialog

### DIFF
--- a/src/components/dialogHelper/dialogHelper.js
+++ b/src/components/dialogHelper/dialogHelper.js
@@ -42,7 +42,7 @@ function tryRemoveElement(elem) {
     }
 }
 
-function DialogHashHandler(dlg, hash, resolve) {
+function DialogHashHandler(dlg, hash, resolve, dlgOptions) {
     const self = this;
     self.originalUrl = window.location.href;
     const activeElement = document.activeElement;
@@ -157,7 +157,7 @@ function DialogHashHandler(dlg, hash, resolve) {
 
     dlg.classList.remove('hide');
 
-    addBackdropOverlay(dlg);
+    addBackdropOverlay(dlg, dlgOptions);
 
     dlg.classList.add('opened');
     dlg.dispatchEvent(new CustomEvent('open', {
@@ -192,7 +192,7 @@ function DialogHashHandler(dlg, hash, resolve) {
     }
 }
 
-function addBackdropOverlay(dlg) {
+function addBackdropOverlay(dlg, dlgOptions = {}) {
     const backdrop = document.createElement('div');
     backdrop.classList.add('dialogBackdrop');
 
@@ -204,29 +204,33 @@ function addBackdropOverlay(dlg) {
     void backdrop.offsetWidth;
     backdrop.classList.add('dialogBackdropOpened');
 
-    dom.addEventListener((dlg.dialogContainer || backdrop), 'click', e => {
-        if (e.target === dlg.dialogContainer) {
-            close(dlg);
-        }
-    }, {
-        passive: true
-    });
+    if (!dlgOptions.preventCloseOnClick) {
+        dom.addEventListener((dlg.dialogContainer || backdrop), 'click', e => {
+            if (e.target === dlg.dialogContainer) {
+                close(dlg);
+            }
+        }, {
+            passive: true
+        });
+    }
 
-    dom.addEventListener((dlg.dialogContainer || backdrop), 'contextmenu', e => {
-        if (e.target === dlg.dialogContainer) {
-            // Close the application dialog menu
-            close(dlg);
-            // Prevent the default browser context menu from appearing
-            e.preventDefault();
-        }
-    });
+    if (!dlgOptions.preventCloseOnRightClick) {
+        dom.addEventListener((dlg.dialogContainer || backdrop), 'contextmenu', e => {
+            if (e.target === dlg.dialogContainer) {
+                // Close the application dialog menu
+                close(dlg);
+                // Prevent the default browser context menu from appearing
+                e.preventDefault();
+            }
+        });
+    }
 }
 
 function isHistoryEnabled(dlg) {
     return dlg.getAttribute('data-history') === 'true';
 }
 
-export function open(dlg) {
+export function open(dlg, dlgOptions) {
     if (globalOnOpenCallback) {
         globalOnOpenCallback(dlg);
     }
@@ -243,7 +247,7 @@ export function open(dlg) {
     document.body.appendChild(dialogContainer);
 
     return new Promise((resolve) => {
-        new DialogHashHandler(dlg, `dlg${new Date().getTime()}`, resolve);
+        new DialogHashHandler(dlg, `dlg${new Date().getTime()}`, resolve, dlgOptions);
     });
 }
 

--- a/src/components/metadataEditor/metadataEditor.js
+++ b/src/components/metadataEditor/metadataEditor.js
@@ -1058,7 +1058,10 @@ function show(itemId, serverId, resolve) {
         centerFocus(dlg.querySelector('.formDialogContent'), false, true);
     }
 
-    dialogHelper.open(dlg);
+    dialogHelper.open(dlg, {
+        preventCloseOnClick : true,
+        preventCloseOnRightClick : true
+    });
 
     dlg.addEventListener('close', function () {
         if (layoutManager.tv) {


### PR DESCRIPTION
**Changes**
The dialog is being closed because of the click handler being attached inside the **_addBackdropOverlay_** in **_dialogHelper_**. As it is being used in multiple places, we cannot disable the adding of these listeners. From now, whenever we want to prevent a dialog to be closed on click or right click, we have to pass an **additional options** object to the **_dialog.open_** method and it should have **_preventCloseOnClick_**, **_preventCloseOnRightClick_** set to true which will prevent the attaching of the corresponding event listener and there by prevents the closing of dialog on click or right click.

This PR will prevent the closing of edit metadata dialog on both click and right click.

**Issues**
ex. Fixes #5723 
