### PR TITLE
Enable software tonemapping options

### DIFF
--- a/src/controllers/dashboard/encodingsettings.html
+++ b/src/controllers/dashboard/encodingsettings.html
@@ -173,8 +173,8 @@
                             <input type="checkbox" is="emby-checkbox" id="chkTonemapping" />
                             <span>${EnableTonemapping}</span>
                         </label>
-                        <div class="fieldDescription checkboxFieldDescription AllowTonemappingHardwareHelp">${AllowTonemappingHelp}</div>
-                        <div class="fieldDescription checkboxFieldDescription AllowTonemappingSoftwareHelp">${AllowTonemappingSoftwareHelp}</div>
+                        <div class="fieldDescription checkboxFieldDescription allowTonemappingHardwareHelp">${AllowTonemappingHelp}</div>
+                        <div class="fieldDescription checkboxFieldDescription allowTonemappingSoftwareHelp">${AllowTonemappingSoftwareHelp}</div>
                     </div>
                     <div class="selectContainer">
                         <select is="emby-select" id="selectTonemappingAlgorithm" label="${LabelTonemappingAlgorithm}">

--- a/src/controllers/dashboard/encodingsettings.html
+++ b/src/controllers/dashboard/encodingsettings.html
@@ -173,7 +173,8 @@
                             <input type="checkbox" is="emby-checkbox" id="chkTonemapping" />
                             <span>${EnableTonemapping}</span>
                         </label>
-                        <div class="fieldDescription checkboxFieldDescription">${AllowTonemappingHelp}</div>
+                        <div class="fieldDescription checkboxFieldDescription AllowTonemappingHardwareHelp">${AllowTonemappingHelp}</div>
+                        <div class="fieldDescription checkboxFieldDescription AllowTonemappingSoftwareHelp">${AllowTonemappingSoftwareHelp}</div>
                     </div>
                     <div class="selectContainer">
                         <select is="emby-select" id="selectTonemappingAlgorithm" label="${LabelTonemappingAlgorithm}">
@@ -190,7 +191,7 @@
                             <a is="emby-linkbutton" rel="noopener noreferrer" class="button-link" href="http://ffmpeg.org/ffmpeg-all.html#tonemap_005fopencl" target="_blank">${TonemappingAlgorithmHelp}</a>
                         </div>
                     </div>
-                    <div class="selectContainer">
+                    <div class="tonemappingModeOptions selectContainer">
                         <select is="emby-select" id="selectTonemappingMode" label="${LabelTonemappingMode}">
                             <option value="auto">${Auto}</option>
                             <option value="max">MAX</option>

--- a/src/controllers/dashboard/encodingsettings.js
+++ b/src/controllers/dashboard/encodingsettings.js
@@ -194,10 +194,22 @@ $(document).on('pageinit', '#encodingSettingsPage', function () {
             page.querySelector('.fld10bitHevcVp9HwDecoding').classList.add('hide');
         }
 
-        if (this.value == 'amf' || this.value == 'nvenc' || this.value == 'qsv' || this.value == 'vaapi' || this.value == 'rkmpp' || this.value == 'videotoolbox') {
+    console.log(this.value)
+
+        if (this.value === '' || this.value === 'amf' || this.value === 'nvenc' || this.value === 'qsv' || this.value === 'vaapi' || this.value === 'rkmpp' || this.value === 'videotoolbox') {
             page.querySelector('.tonemappingOptions').classList.remove('hide');
         } else {
             page.querySelector('.tonemappingOptions').classList.add('hide');
+        }
+
+        if (this.value === 'amf' || this.value === 'nvenc' || this.value === 'qsv' || this.value === 'vaapi' || this.value === 'rkmpp' || this.value === 'videotoolbox') {
+            page.querySelector('.tonemappingModeOptions').classList.remove('hide');
+            page.querySelector('.AllowTonemappingHardwareHelp').classList.remove('hide');
+            page.querySelector('.AllowTonemappingSoftwareHelp').classList.add('hide');
+        } else {
+            page.querySelector('.tonemappingModeOptions').classList.add('hide');
+            page.querySelector('.AllowTonemappingHardwareHelp').classList.add('hide');
+            page.querySelector('.AllowTonemappingSoftwareHelp').classList.remove('hide');
         }
 
         if (this.value == 'qsv' || this.value == 'vaapi') {

--- a/src/controllers/dashboard/encodingsettings.js
+++ b/src/controllers/dashboard/encodingsettings.js
@@ -201,15 +201,19 @@ $(document).on('pageinit', '#encodingSettingsPage', function () {
             page.querySelector('.tonemappingOptions').classList.add('hide');
         }
 
-        if (isHwaSelected) {
-            page.querySelector('.tonemappingModeOptions').classList.remove('hide');
-            page.querySelector('.allowTonemappingHardwareHelp').classList.remove('hide');
-            page.querySelector('.allowTonemappingSoftwareHelp').classList.add('hide');
-        } else {
-            page.querySelector('.tonemappingModeOptions').classList.add('hide');
-            page.querySelector('.allowTonemappingHardwareHelp').classList.add('hide');
-            page.querySelector('.allowTonemappingSoftwareHelp').classList.remove('hide');
-        }
+        // if (isHwaSelected) {
+        //     page.querySelector('.tonemappingModeOptions').classList.remove('hide');
+        //     page.querySelector('.allowTonemappingHardwareHelp').classList.remove('hide');
+        //     page.querySelector('.allowTonemappingSoftwareHelp').classList.add('hide');
+        // } else {
+        //     page.querySelector('.tonemappingModeOptions').classList.add('hide');
+        //     page.querySelector('.allowTonemappingHardwareHelp').classList.add('hide');
+        //     page.querySelector('.allowTonemappingSoftwareHelp').classList.remove('hide');
+        // }
+
+        page.querySelector('.tonemappingModeOptions').classList.toggle('hide', !isHwaSelected);
+        page.querySelector('.allowTonemappingHardwareHelp').classList.toggle('hide', !isHwaSelected);
+        page.querySelector('.allowTonemappingSoftwareHelp').classList.toggle('hide', isHwaSelected);
 
         if (this.value == 'qsv' || this.value == 'vaapi') {
             page.querySelector('.fldIntelLp').classList.remove('hide');

--- a/src/controllers/dashboard/encodingsettings.js
+++ b/src/controllers/dashboard/encodingsettings.js
@@ -201,16 +201,6 @@ $(document).on('pageinit', '#encodingSettingsPage', function () {
             page.querySelector('.tonemappingOptions').classList.add('hide');
         }
 
-        // if (isHwaSelected) {
-        //     page.querySelector('.tonemappingModeOptions').classList.remove('hide');
-        //     page.querySelector('.allowTonemappingHardwareHelp').classList.remove('hide');
-        //     page.querySelector('.allowTonemappingSoftwareHelp').classList.add('hide');
-        // } else {
-        //     page.querySelector('.tonemappingModeOptions').classList.add('hide');
-        //     page.querySelector('.allowTonemappingHardwareHelp').classList.add('hide');
-        //     page.querySelector('.allowTonemappingSoftwareHelp').classList.remove('hide');
-        // }
-
         page.querySelector('.tonemappingModeOptions').classList.toggle('hide', !isHwaSelected);
         page.querySelector('.allowTonemappingHardwareHelp').classList.toggle('hide', !isHwaSelected);
         page.querySelector('.allowTonemappingSoftwareHelp').classList.toggle('hide', isHwaSelected);

--- a/src/controllers/dashboard/encodingsettings.js
+++ b/src/controllers/dashboard/encodingsettings.js
@@ -203,12 +203,12 @@ $(document).on('pageinit', '#encodingSettingsPage', function () {
 
         if (isHwaSelected) {
             page.querySelector('.tonemappingModeOptions').classList.remove('hide');
-            page.querySelector('.AllowTonemappingHardwareHelp').classList.remove('hide');
-            page.querySelector('.AllowTonemappingSoftwareHelp').classList.add('hide');
+            page.querySelector('.allowTonemappingHardwareHelp').classList.remove('hide');
+            page.querySelector('.allowTonemappingSoftwareHelp').classList.add('hide');
         } else {
             page.querySelector('.tonemappingModeOptions').classList.add('hide');
-            page.querySelector('.AllowTonemappingHardwareHelp').classList.add('hide');
-            page.querySelector('.AllowTonemappingSoftwareHelp').classList.remove('hide');
+            page.querySelector('.allowTonemappingHardwareHelp').classList.add('hide');
+            page.querySelector('.allowTonemappingSoftwareHelp').classList.remove('hide');
         }
 
         if (this.value == 'qsv' || this.value == 'vaapi') {

--- a/src/controllers/dashboard/encodingsettings.js
+++ b/src/controllers/dashboard/encodingsettings.js
@@ -194,8 +194,6 @@ $(document).on('pageinit', '#encodingSettingsPage', function () {
             page.querySelector('.fld10bitHevcVp9HwDecoding').classList.add('hide');
         }
 
-    console.log(this.value)
-
         if (this.value === '' || this.value === 'amf' || this.value === 'nvenc' || this.value === 'qsv' || this.value === 'vaapi' || this.value === 'rkmpp' || this.value === 'videotoolbox') {
             page.querySelector('.tonemappingOptions').classList.remove('hide');
         } else {

--- a/src/controllers/dashboard/encodingsettings.js
+++ b/src/controllers/dashboard/encodingsettings.js
@@ -194,13 +194,14 @@ $(document).on('pageinit', '#encodingSettingsPage', function () {
             page.querySelector('.fld10bitHevcVp9HwDecoding').classList.add('hide');
         }
 
-        if (this.value === '' || this.value === 'amf' || this.value === 'nvenc' || this.value === 'qsv' || this.value === 'vaapi' || this.value === 'rkmpp' || this.value === 'videotoolbox') {
+        const isHwaSelected = [ 'amf', 'nvenc', 'qsv', 'vaapi', 'rkmpp', 'videotoolbox' ].includes(this.value);
+        if (this.value === '' || isHwaSelected) {
             page.querySelector('.tonemappingOptions').classList.remove('hide');
         } else {
             page.querySelector('.tonemappingOptions').classList.add('hide');
         }
 
-        if (this.value === 'amf' || this.value === 'nvenc' || this.value === 'qsv' || this.value === 'vaapi' || this.value === 'rkmpp' || this.value === 'videotoolbox') {
+        if (isHwaSelected) {
             page.querySelector('.tonemappingModeOptions').classList.remove('hide');
             page.querySelector('.AllowTonemappingHardwareHelp').classList.remove('hide');
             page.querySelector('.AllowTonemappingSoftwareHelp').classList.add('hide');

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -44,6 +44,7 @@
     "AllowRemoteAccess": "Allow remote connections to this server",
     "AllowRemoteAccessHelp": "If unchecked, all remote connections will be blocked.",
     "AllowTonemappingHelp": "Tone-mapping can transform the dynamic range of a video from HDR to SDR while maintaining image details and colors, which are very important information for representing the original scene. Currently works only with 10bit HDR10, HLG and DoVi videos. This requires the corresponding GPGPU runtime.",
+    "AllowTonemappingSoftwareHelp": "Tone-mapping can transform the dynamic range of a video from HDR to SDR while maintaining image details and colors, which are very important information for representing the original scene. Currently works only with 10bit HDR10 and HLG videos.",
     "AlwaysPlaySubtitles": "Always Play",
     "AlwaysPlaySubtitlesHelp": "Subtitles matching the language preference will be loaded regardless of the audio language.",
     "AnyLanguage": "Any Language",


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

This enables the tonemapping options for pure software transcoding pipeline. The software implementation currently has less feature than the hardware ones so the help text is also modified for it. Notably:

- The tonemapping mode is always MAX
- Does not support Dolby Vision reshaping

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Depends on https://github.com/jellyfin/jellyfin/pull/12270
