### PR TITLE
Fix dashboard body class sometimes missing

### DIFF
--- a/src/apps/dashboard/AppLayout.tsx
+++ b/src/apps/dashboard/AppLayout.tsx
@@ -2,7 +2,7 @@ import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
 import { type Theme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
-import React, { FC, useCallback, useState } from 'react';
+import React, { FC, useCallback, useEffect, useState } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 
 import AppBody from 'components/AppBody';
@@ -35,6 +35,15 @@ const AppLayout: FC<AppLayoutProps> = ({
     const onToggleDrawer = useCallback(() => {
         setIsDrawerActive(!isDrawerActive);
     }, [ isDrawerActive, setIsDrawerActive ]);
+
+    // Update body class
+    useEffect(() => {
+        document.body.classList.add('dashboardDocument');
+
+        return () => {
+            document.body.classList.remove('dashboardDocument');
+        };
+    }, []);
 
     return (
         <Box sx={{ display: 'flex' }}>

--- a/src/scripts/libraryMenu.js
+++ b/src/scripts/libraryMenu.js
@@ -581,7 +581,6 @@ function updateMenuForPageType(isDashboardPage, isLibraryPage) {
 
         if (isLibraryPage) {
             bodyClassList.add('libraryDocument');
-            bodyClassList.remove('dashboardDocument');
             bodyClassList.remove('hideMainDrawer');
 
             if (navDrawerInstance) {
@@ -589,7 +588,6 @@ function updateMenuForPageType(isDashboardPage, isLibraryPage) {
             }
         } else if (isDashboardPage) {
             bodyClassList.remove('libraryDocument');
-            bodyClassList.add('dashboardDocument');
             bodyClassList.remove('hideMainDrawer');
 
             if (navDrawerInstance) {
@@ -597,7 +595,6 @@ function updateMenuForPageType(isDashboardPage, isLibraryPage) {
             }
         } else {
             bodyClassList.remove('libraryDocument');
-            bodyClassList.remove('dashboardDocument');
             bodyClassList.add('hideMainDrawer');
 
             if (navDrawerInstance) {


### PR DESCRIPTION
**Changes**
Fixes an issue where the `dashboardDocument` class is not added to the body element if your initial page load is on a react dashboard page causing styles to be broken until navigating to a different page.

**Issues**
N/A