### PR TITLE
Replace deprecated babel dependencies

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -15,8 +15,8 @@ module.exports = {
         '@babel/preset-react'
     ],
     plugins: [
-        '@babel/plugin-proposal-class-properties',
-        '@babel/plugin-proposal-private-methods',
+        '@babel/plugin-transform-class-properties',
+        '@babel/plugin-transform-private-methods',
         'babel-plugin-dynamic-import-polyfill'
     ]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,9 +65,9 @@
       },
       "devDependencies": {
         "@babel/core": "7.24.9",
-        "@babel/plugin-proposal-class-properties": "7.18.6",
-        "@babel/plugin-proposal-private-methods": "7.18.6",
+        "@babel/plugin-transform-class-properties": "7.24.7",
         "@babel/plugin-transform-modules-umd": "7.24.7",
+        "@babel/plugin-transform-private-methods": "7.24.7",
         "@babel/preset-env": "7.24.8",
         "@babel/preset-react": "7.24.7",
         "@types/dompurify": "3.0.5",
@@ -688,38 +688,6 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@babel/plugin-proposal-class-properties": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz",
-      "integrity": "sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.18.6",
-        "@babel/helper-plugin-utils": "^7.18.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-private-methods": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.18.6.tgz",
-      "integrity": "sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.18.6",
-        "@babel/helper-plugin-utils": "^7.18.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
       "version": "7.21.0-placeholder-for-preset-env.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
@@ -1075,7 +1043,6 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.24.7.tgz",
       "integrity": "sha512-vKbfawVYayKcSeSR5YYzzyXvsDFWU2mD8U5TFeXtbCPLFUqe7GyCgvO6XDHzje862ODrOwy6WCPmKeWHbCFJ4w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.24.7",
         "@babel/helper-plugin-utils": "^7.24.7"
@@ -1576,7 +1543,6 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.24.7.tgz",
       "integrity": "sha512-COTCOkG2hn4JKGEKBADkA8WNb35TGkkRbI5iT845dB+NyqgO8Hn+ajPbSnIQznneJTa3d30scb6iz/DhH8GsJQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.24.7",
         "@babel/helper-plugin-utils": "^7.24.7"
@@ -25072,26 +25038,6 @@
       "requires": {
         "@babel/helper-environment-visitor": "^7.24.7",
         "@babel/helper-plugin-utils": "^7.24.7"
-      }
-    },
-    "@babel/plugin-proposal-class-properties": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz",
-      "integrity": "sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.18.6",
-        "@babel/helper-plugin-utils": "^7.18.6"
-      }
-    },
-    "@babel/plugin-proposal-private-methods": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.18.6.tgz",
-      "integrity": "sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.18.6",
-        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-proposal-private-property-in-object": {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "license": "GPL-2.0-or-later",
   "devDependencies": {
     "@babel/core": "7.24.9",
-    "@babel/plugin-proposal-class-properties": "7.18.6",
-    "@babel/plugin-proposal-private-methods": "7.18.6",
+    "@babel/plugin-transform-class-properties": "7.24.7",
+    "@babel/plugin-transform-private-methods": "7.24.7",
     "@babel/plugin-transform-modules-umd": "7.24.7",
     "@babel/preset-env": "7.24.8",
     "@babel/preset-react": "7.24.7",


### PR DESCRIPTION

**Changes**
replaced `@babel/plugin-proposal-class-properties` with `@babel/plugin-transform-class-properties` and `@babel/plugin-proposal-private-methods` with `@babel/plugin-transform-private-methods` to remove deprecated babel dependencies

**Issues**
Fixes #5794  
