### PR TITLE
Don't sort media streams for media info

### DIFF
--- a/src/components/itemMediaInfo/itemMediaInfo.js
+++ b/src/components/itemMediaInfo/itemMediaInfo.js
@@ -71,7 +71,7 @@ function getMediaSourceHtml(user, item, version) {
         const size = `${(version.Size / (1024 * 1024)).toFixed(0)} MB`;
         html += `${createAttribute(globalize.translate('MediaInfoSize'), size)}<br/>`;
     }
-    version.MediaStreams.sort(itemHelper.sortTracks);
+
     for (const stream of version.MediaStreams) {
         if (stream.Type === 'Data') {
             continue;


### PR DESCRIPTION
This way it keeps a logical order i.e. video info first, followed by audio and subtitles
