### PR TITLE
Fix swipe gestures on android for book reader

### DIFF
--- a/src/plugins/bookPlayer/plugin.js
+++ b/src/plugins/bookPlayer/plugin.js
@@ -45,6 +45,7 @@ export class BookPlayer {
         this.previous = this.previous.bind(this);
         this.next = this.next.bind(this);
         this.onWindowKeyUp = this.onWindowKeyUp.bind(this);
+        this.addSwipeGestures = this.addSwipeGestures.bind(this);
     }
 
     play(options) {
@@ -155,6 +156,12 @@ export class BookPlayer {
         }
     }
 
+    addSwipeGestures(e, i) {
+        this.touchHelper = new TouchHelper(i.document.documentElement);
+        Events.on(this.touchHelper, 'swipeleft', () => this.next());
+        Events.on(this.touchHelper, 'swiperight', () => this.previous());
+    }
+
     onDialogClosed() {
         this.stop();
     }
@@ -179,10 +186,7 @@ export class BookPlayer {
         document.addEventListener('keyup', this.onWindowKeyUp);
         this.rendition?.on('keyup', this.onWindowKeyUp);
 
-        const player = document.getElementById('bookPlayerContainer');
-        this.touchHelper = new TouchHelper(player);
-        Events.on(this.touchHelper, 'swipeleft', () => this.next());
-        Events.on(this.touchHelper, 'swiperight', () => this.previous());
+        this.rendition?.on('rendered', this.addSwipeGestures);
     }
 
     unbindMediaElementEvents() {
@@ -206,6 +210,8 @@ export class BookPlayer {
 
         document.removeEventListener('keyup', this.onWindowKeyUp);
         this.rendition?.off('keyup', this.onWindowKeyUp);
+
+        this.rendition?.off('rendered', this.addSwipeGestures);
 
         this.touchHelper?.destroy();
     }

--- a/src/plugins/bookPlayer/plugin.js
+++ b/src/plugins/bookPlayer/plugin.js
@@ -188,8 +188,8 @@ export class BookPlayer {
         this.rendition?.on('keyup', this.onWindowKeyUp);
 
         if (browser.safari) {
-            const player = document.getElementById('bookPlayerContainer')
-            this.addSwipeGestures(player)
+            const player = document.getElementById('bookPlayerContainer');
+            this.addSwipeGestures(player);
         } else {
             this.rendition?.on('rendered', (e, i) => this.addSwipeGestures(i.document.documentElement));
         }

--- a/src/plugins/bookPlayer/plugin.js
+++ b/src/plugins/bookPlayer/plugin.js
@@ -7,6 +7,7 @@ import ServerConnections from '../../components/ServerConnections';
 import Screenfull from 'screenfull';
 import TableOfContents from './tableOfContents';
 import { translateHtml } from '../../scripts/globalize';
+import browser from 'scripts/browser';
 import * as userSettings from '../../scripts/settings/userSettings';
 import TouchHelper from 'scripts/touchHelper';
 import { PluginType } from '../../types/plugin.ts';
@@ -156,8 +157,8 @@ export class BookPlayer {
         }
     }
 
-    addSwipeGestures(e, i) {
-        this.touchHelper = new TouchHelper(i.document.documentElement);
+    addSwipeGestures(element) {
+        this.touchHelper = new TouchHelper(element);
         Events.on(this.touchHelper, 'swipeleft', () => this.next());
         Events.on(this.touchHelper, 'swiperight', () => this.previous());
     }
@@ -186,7 +187,12 @@ export class BookPlayer {
         document.addEventListener('keyup', this.onWindowKeyUp);
         this.rendition?.on('keyup', this.onWindowKeyUp);
 
-        this.rendition?.on('rendered', this.addSwipeGestures);
+        if (browser.safari) {
+            const player = document.getElementById('bookPlayerContainer')
+            this.addSwipeGestures(player)
+        } else {
+            this.rendition?.on('rendered', (e, i) => this.addSwipeGestures(i.document.documentElement));
+        }
     }
 
     unbindMediaElementEvents() {
@@ -211,7 +217,9 @@ export class BookPlayer {
         document.removeEventListener('keyup', this.onWindowKeyUp);
         this.rendition?.off('keyup', this.onWindowKeyUp);
 
-        this.rendition?.off('rendered', this.addSwipeGestures);
+        if (!browser.safari) {
+            this.rendition?.off('rendered', this.addSwipeGestures);
+        }
 
         this.touchHelper?.destroy();
     }

--- a/src/plugins/bookPlayer/plugin.js
+++ b/src/plugins/bookPlayer/plugin.js
@@ -218,7 +218,7 @@ export class BookPlayer {
         this.rendition?.off('keyup', this.onWindowKeyUp);
 
         if (!browser.safari) {
-            this.rendition?.off('rendered', this.addSwipeGestures);
+            this.rendition?.off('rendered', (e, i) => this.addSwipeGestures(i.document.documentElement));
         }
 
         this.touchHelper?.destroy();


### PR DESCRIPTION
Fixes swipe gestures not working on android.

**Changes**
Changes the swipe gestures to use the element loaded by epubjs which seems to fix this issue.

**Issues**
Fixes https://github.com/jellyfin/jellyfin-web/issues/5830