### PR TITLE
Better codec profile for Safari  with 10.10 features

### DIFF
--- a/src/components/htmlMediaHelper.js
+++ b/src/components/htmlMediaHelper.js
@@ -33,9 +33,9 @@ export function enableHlsJsPlayerForCodecs(mediaSource, mediaType) {
     // Force using HLS.js because desktop Safari's native HLS player does not play VP9 over HLS
     // browser.osx will return true on iPad, cannot use
     if (!browser.iOS && browser.safari && mediaSource.MediaStreams.some(x => x.Codec === 'vp9')) {
-        return true
+        return true;
     }
-    return enableHlsJsPlayer(mediaSource.RunTimeTicks, mediaType)
+    return enableHlsJsPlayer(mediaSource.RunTimeTicks, mediaType);
 }
 
 export function enableHlsJsPlayer(runTimeTicks, mediaType) {

--- a/src/components/htmlMediaHelper.js
+++ b/src/components/htmlMediaHelper.js
@@ -28,6 +28,16 @@ function canPlayNativeHls() {
             || media.canPlayType('application/vnd.apple.mpegURL').replace(/no/, ''));
 }
 
+export function enableHlsJsPlayerForCodecs(mediaSource, mediaType) {
+    // Workaround for VP9 HLS support on desktop Safari
+    // Force using HLS.js because desktop Safari's native HLS player does not play VP9 over HLS
+    // browser.osx will return true on iPad, cannot use
+    if (!browser.iOS && browser.safari && mediaSource.MediaStreams.some(x => x.Codec === 'vp9')) {
+        return true
+    }
+    return enableHlsJsPlayer(mediaSource.RunTimeTicks, mediaType)
+}
+
 export function enableHlsJsPlayer(runTimeTicks, mediaType) {
     if (window.MediaSource == null) {
         return false;

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -13,6 +13,7 @@ import {
     destroyCastPlayer,
     getCrossOriginValue,
     enableHlsJsPlayer,
+    enableHlsJsPlayerForCodecs,
     applySrc,
     resetSrc,
     playWithPromise,
@@ -515,7 +516,7 @@ export class HtmlVideoPlayer {
             elem.crossOrigin = crossOrigin;
         }
 
-        if (enableHlsJsPlayer(options.mediaSource.RunTimeTicks, 'Video') && isHls(options.mediaSource)) {
+        if (enableHlsJsPlayerForCodecs(options.mediaSource, 'Video') && isHls(options.mediaSource)) {
             return this.setSrcWithHlsJs(elem, options, val);
         } else if (options.playMethod !== 'Transcode' && options.mediaSource.Container?.toUpperCase() === 'FLV') {
             return this.setSrcWithFlvJs(elem, options, val);

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -12,7 +12,6 @@ import {
     destroyFlvPlayer,
     destroyCastPlayer,
     getCrossOriginValue,
-    enableHlsJsPlayer,
     enableHlsJsPlayerForCodecs,
     applySrc,
     resetSrc,

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -584,12 +584,10 @@ export default function (options) {
         hlsInFmp4VideoAudioCodecs.push('opus');
     }
 
-    if (browser.safari) {
-        if (safariSupportsOpus) {
-            videoAudioCodecs.push('opus');
-            webmAudioCodecs.push('opus');
-            hlsInFmp4VideoAudioCodecs.push('opus');
-        }
+    if (safariSupportsOpus) {
+        videoAudioCodecs.push('opus');
+        webmAudioCodecs.push('opus');
+        hlsInFmp4VideoAudioCodecs.push('opus');
     }
 
     // FLAC audio in video plays with a delay on Tizen

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -582,9 +582,7 @@ export default function (options) {
             hlsInTsVideoAudioCodecs.push('opus');
         }
         hlsInFmp4VideoAudioCodecs.push('opus');
-    }
-
-    if (safariSupportsOpus) {
+    } else if (safariSupportsOpus) {
         videoAudioCodecs.push('opus');
         webmAudioCodecs.push('opus');
         hlsInFmp4VideoAudioCodecs.push('opus');


### PR DESCRIPTION
This uses the new VP9 remuxing and audio remuxing features to reduce transcoding on Safari, also removed some problematic direct play profiles.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

- Add opus profile for Safari
- Add VP9 remuxing profile for Safari
- Remove Vorbis profile on non-webm container for Safari
- Remove direct VP9 playback in mp4 container for iOS Safari

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Depends on https://github.com/jellyfin/jellyfin/pull/11399
Depends on https://github.com/jellyfin/jellyfin/pull/11489
