### PR TITLE
Fix remux detection for pure audio session

### DIFF
--- a/src/components/playback/playmethodhelper.js
+++ b/src/components/playback/playmethodhelper.js
@@ -2,7 +2,8 @@ export function getDisplayPlayMethod(session) {
     if (!session.NowPlayingItem) {
         return null;
     }
-    if ((!session.TranscodingInfo?.VideoCodec && session.TranscodingInfo.IsAudioDirect) || (session.TranscodingInfo?.IsVideoDirect && session.TranscodingInfo.IsAudioDirect)) {
+
+    if ((session.TranscodingInfo?.IsVideoDirect || !session.TranscodingInfo?.VideoCodec) && session.TranscodingInfo?.IsAudioDirect) {
         return 'Remux';
     } else if (session.TranscodingInfo?.IsVideoDirect) {
         return 'DirectStream';

--- a/src/components/playback/playmethodhelper.js
+++ b/src/components/playback/playmethodhelper.js
@@ -2,8 +2,7 @@ export function getDisplayPlayMethod(session) {
     if (!session.NowPlayingItem) {
         return null;
     }
-
-    if (session.TranscodingInfo?.IsVideoDirect && session.TranscodingInfo.IsAudioDirect) {
+    if ((!session.TranscodingInfo?.VideoCodec && session.TranscodingInfo.IsAudioDirect) || (session.TranscodingInfo?.IsVideoDirect && session.TranscodingInfo.IsAudioDirect)) {
         return 'Remux';
     } else if (session.TranscodingInfo?.IsVideoDirect) {
         return 'DirectStream';


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

- Correctly check remuxing for audio only playback session for 10.10 audio remux.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
