### PR TITLE
Fix branch name passed to CF Pages for forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,12 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           projectName: jellyfin-web
-          branch: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          branch: |
+            ${{
+              github.event.pull_request.head.repo.full_name == github.repository
+              && (github.event.pull_request.head.ref || github.ref_name)
+              || format('{0}/{1}', github.event.pull_request.head.repo.full_name, github.event.pull_request.head.ref)
+            }}
           directory: dist
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
**Changes**
We were only passing the branch name for forks (not repo/branch) and the CF action does not like that

**Issues**
https://github.com/jellyfin/jellyfin-web/actions/runs/10289023129/job/28475913635?pr=5880
