### PR TITLE
Show error when library ids are invalid

### DIFF
--- a/src/components/mediaLibraryEditor/mediaLibraryEditor.js
+++ b/src/components/mediaLibraryEditor/mediaLibraryEditor.js
@@ -33,7 +33,7 @@ function onEditLibrary() {
     const dlg = dom.parentWithClass(this, 'dlg-libraryeditor');
     // when the library has moved or symlinked, the ItemId is not correct anymore
     // this can lead to a forever spinning value on edit the library parameters
-    if (currentOptions.library.ItemId == undefined) {
+    if (!currentOptions.library.ItemId) {
         loading.hide();
         dialogHelper.close(dlg);
         alert({

--- a/src/components/mediaLibraryEditor/mediaLibraryEditor.js
+++ b/src/components/mediaLibraryEditor/mediaLibraryEditor.js
@@ -18,6 +18,7 @@ import '../formdialog.scss';
 import '../../elements/emby-toggle/emby-toggle';
 import '../../styles/flexstyles.scss';
 import './style.scss';
+import alert from '../alert';
 import toast from '../toast/toast';
 import confirm from '../confirm/confirm';
 import template from './mediaLibraryEditor.template.html';
@@ -30,15 +31,17 @@ function onEditLibrary() {
     isCreating = true;
     loading.show();
     const dlg = dom.parentWithClass(this, 'dlg-libraryeditor');
-    let libraryOptions = libraryoptionseditor.getLibraryOptions(dlg.querySelector('.libraryOptions'));
     // when the library has moved or symlinked, the ItemId is not correct anymore
     // this can lead to a forever spinning value on edit the library parameters
     if (currentOptions.library.ItemId == undefined) {
-        toast('The library setting is in an invalid state, cannot edit. You are most likely suffering from a bug where the path in the database is not the absolute path in the filesystem');
         loading.hide();
         dialogHelper.close(dlg);
+        alert({
+            text: globalize.translate('LibraryInvalidItemIdError')
+        });
         return false;
     }
+    let libraryOptions = libraryoptionseditor.getLibraryOptions(dlg.querySelector('.libraryOptions'));
     libraryOptions = Object.assign(currentOptions.library.LibraryOptions || {}, libraryOptions);
     ApiClient.updateVirtualFolderOptions(currentOptions.library.ItemId, libraryOptions).then(() => {
         hasChanges = true;

--- a/src/components/mediaLibraryEditor/mediaLibraryEditor.js
+++ b/src/components/mediaLibraryEditor/mediaLibraryEditor.js
@@ -31,6 +31,14 @@ function onEditLibrary() {
     loading.show();
     const dlg = dom.parentWithClass(this, 'dlg-libraryeditor');
     let libraryOptions = libraryoptionseditor.getLibraryOptions(dlg.querySelector('.libraryOptions'));
+    // when the library has moved or symlinked, the ItemId is not correct anymore
+    // this can lead to a forever spinning value on edit the library parameters
+    if (currentOptions.library.ItemId == undefined) {
+        toast('The library setting is in an invalid state, cannot edit. You are most likely suffering from a bug where the path in the database is not the absolute path in the filesystem');
+        loading.hide();
+        dialogHelper.close(dlg);
+        return false;
+    }
     libraryOptions = Object.assign(currentOptions.library.LibraryOptions || {}, libraryOptions);
     ApiClient.updateVirtualFolderOptions(currentOptions.library.ItemId, libraryOptions).then(() => {
         hasChanges = true;

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -968,7 +968,7 @@
     "LibraryAccessHelp": "Select the libraries to share with this user. Administrators will be able to edit all folders using the metadata manager.",
     "LibraryScanFanoutConcurrency": "Parallel library scan tasks limit",
     "LibraryScanFanoutConcurrencyHelp": "Maximum number of parallel tasks during library scans. Setting this to 0 will choose a limit based on your systems core count. WARNING: Setting this number too high may cause issues with network file systems; if you encounter problems lower this number.",
-    "LibraryInvalidItemIdError": "The library setting is in an invalid state and cannot be edited. You are most likely suffering from a bug where the path in the database is not the absolute path in the filesystem",
+    "LibraryInvalidItemIdError": "The library is in an invalid state and cannot be edited. You are possibly encountering a bug: the path in the database is not the correct path on the filesystem.",
     "LimitSupportedVideoResolution": "Limit maximum supported video resolution",
     "LimitSupportedVideoResolutionHelp": "Use 'Maximum Allowed Video Transcoding Resolution' as maximum supported video resolution.",
     "List": "List",

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -968,6 +968,7 @@
     "LibraryAccessHelp": "Select the libraries to share with this user. Administrators will be able to edit all folders using the metadata manager.",
     "LibraryScanFanoutConcurrency": "Parallel library scan tasks limit",
     "LibraryScanFanoutConcurrencyHelp": "Maximum number of parallel tasks during library scans. Setting this to 0 will choose a limit based on your systems core count. WARNING: Setting this number too high may cause issues with network file systems; if you encounter problems lower this number.",
+    "LibraryInvalidItemIdError": "The library setting is in an invalid state and cannot be edited. You are most likely suffering from a bug where the path in the database is not the absolute path in the filesystem",
     "LimitSupportedVideoResolution": "Limit maximum supported video resolution",
     "LimitSupportedVideoResolutionHelp": "Use 'Maximum Allowed Video Transcoding Resolution' as maximum supported video resolution.",
     "List": "List",


### PR DESCRIPTION
When the library has some invalid items, the api requests can return an undefined ItemId. In the current version after editing the library it spins endlessly instead of changing or erroring out.
This PR gives at least a helpful error message when this happens. This relates to issues such as this:
https://github.com/jellyfin/jellyfin/issues/12100#issue-2354924002
https://github.com/jellyfin/jellyfin-web/issues/1012

Two things that might need to change: 
- At the moment the error message is hardcoded in english because I do not know how to get the translation involved.
- Perhaps it would be better to catch the undefined ItemId when loading the dialog instead of closing the dialog but I am not sure when this is done.