### PR TITLE
Add support for H264 High 10 Profile on Safari

### DIFF
--- a/src/components/playbackSettings/playbackSettings.js
+++ b/src/components/playbackSettings/playbackSettings.js
@@ -1,5 +1,6 @@
 import appSettings from '../../scripts/settings/appSettings';
 import { appHost } from '../apphost';
+import browser from '../../scripts/browser';
 import focusManager from '../focusManager';
 import qualityoptions from '../qualityOptions';
 import globalize from '../../scripts/globalize';
@@ -143,6 +144,10 @@ function loadForm(context, user, userSettings, systemInfo, apiClient) {
 
     showHideQualityFields(context, user, apiClient);
 
+    if (browser.safari) {
+        context.querySelector('.enableHi10pSection').classList.remove('hide');
+    }
+
     context.querySelector('#selectAllowedAudioChannels').value = userSettings.allowedAudioChannels();
 
     apiClient.getCultures().then(allCultures => {
@@ -175,6 +180,7 @@ function loadForm(context, user, userSettings, systemInfo, apiClient) {
     context.querySelector('.chkPreferFmp4HlsContainer').checked = userSettings.preferFmp4HlsContainer();
     context.querySelector('.chkEnableDts').checked = appSettings.enableDts();
     context.querySelector('.chkEnableTrueHd').checked = appSettings.enableTrueHd();
+    context.querySelector('.chkEnableHi10p').checked = appSettings.enableHi10p();
     context.querySelector('.chkEnableCinemaMode').checked = userSettings.enableCinemaMode();
     context.querySelector('#selectAudioNormalization').value = userSettings.selectAudioNormalization();
     context.querySelector('.chkEnableNextVideoOverlay').checked = userSettings.enableNextVideoInfoOverlay();
@@ -224,6 +230,8 @@ function saveUser(context, user, userSettingsInstance, apiClient) {
 
     appSettings.enableDts(context.querySelector('.chkEnableDts').checked);
     appSettings.enableTrueHd(context.querySelector('.chkEnableTrueHd').checked);
+
+    appSettings.enableHi10p(context.querySelector('.chkEnableHi10p').checked);
 
     setMaxBitrateFromField(context.querySelector('.selectVideoInNetworkQuality'), true, 'Video');
     setMaxBitrateFromField(context.querySelector('.selectVideoInternetQuality'), false, 'Video');

--- a/src/components/playbackSettings/playbackSettings.js
+++ b/src/components/playbackSettings/playbackSettings.js
@@ -145,7 +145,7 @@ function loadForm(context, user, userSettings, systemInfo, apiClient) {
     showHideQualityFields(context, user, apiClient);
 
     if (browser.safari) {
-        context.querySelector('.enableHi10pSection').classList.remove('hide');
+        context.querySelector('.fldEnableHi10p').classList.remove('hide');
     }
 
     context.querySelector('#selectAllowedAudioChannels').value = userSettings.allowedAudioChannels();

--- a/src/components/playbackSettings/playbackSettings.template.html
+++ b/src/components/playbackSettings/playbackSettings.template.html
@@ -180,7 +180,7 @@
             <div class="fieldDescription checkboxFieldDescription">${EnableTrueHdHelp}</div>
         </div>
 
-        <div class="enableHi10pSection checkboxContainer checkboxContainer-withDescription fldEnableDts hide">
+        <div class="checkboxContainer checkboxContainer-withDescription fldEnableHi10p hide">
              <label>
                  <input type="checkbox" is="emby-checkbox" class="chkEnableHi10p" />
                  <span>${EnableHi10p}</span>

--- a/src/components/playbackSettings/playbackSettings.template.html
+++ b/src/components/playbackSettings/playbackSettings.template.html
@@ -180,6 +180,14 @@
             <div class="fieldDescription checkboxFieldDescription">${EnableTrueHdHelp}</div>
         </div>
 
+        <div class="enableHi10pSection checkboxContainer checkboxContainer-withDescription fldEnableDts hide">
+             <label>
+                 <input type="checkbox" is="emby-checkbox" class="chkEnableHi10p" />
+                 <span>${EnableHi10p}</span>
+             </label>
+             <div class="fieldDescription checkboxFieldDescription">${EnableHi10pHelp}</div>
+        </div>
+
         <div class="selectContainer">
             <select is="emby-select" id="selectPreferredTranscodeVideoCodec" label="${LabelSelectPreferredTranscodeVideoCodec}">
                 <option value="">${Auto}</option>

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -1281,6 +1281,23 @@ export default function (options) {
         });
     }
 
+    if (browser.safari && browser.version >= 17.5) {
+        profile.CodecProfiles.push({
+            Type: 'Video',
+            Container: 'hls',
+            SubContainer: 'mp4',
+            Codec: 'h264',
+            Conditions: [
+                {
+                   Condition: 'EqualsAny',
+                   Property: 'VideoProfile',
+                   Value: h264Profiles + '|high 10',
+                   IsRequired: false
+                }
+            ]
+        });
+    }
+
     profile.CodecProfiles.push({
         Type: 'Video',
         Codec: 'hevc',

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -1281,7 +1281,7 @@ export default function (options) {
         });
     }
 
-    if (browser.safari && browser.version >= 17.5) {
+    if (browser.safari && appSettings.enableHi10p()) {
         profile.CodecProfiles.push({
             Type: 'Video',
             Container: 'hls',

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -1258,6 +1258,23 @@ export default function (options) {
         profile.CodecProfiles.push(codecProfileMp4);
     }
 
+    if (browser.safari && appSettings.enableHi10p()) {
+        profile.CodecProfiles.push({
+            Type: 'Video',
+            Container: 'hls',
+            SubContainer: 'mp4',
+            Codec: 'h264',
+            Conditions: [
+                {
+                    Condition: 'EqualsAny',
+                    Property: 'VideoProfile',
+                    Value: h264Profiles + '|high 10',
+                    IsRequired: false
+                }
+            ]
+        });
+    }
+
     profile.CodecProfiles.push({
         Type: 'Video',
         Codec: 'h264',
@@ -1275,23 +1292,6 @@ export default function (options) {
                     Condition: 'EqualsAny',
                     Property: 'VideoRangeType',
                     Value: hevcVideoRangeTypes.split('|').filter((v) => !v.startsWith('DOVI')).join('|'),
-                    IsRequired: false
-                }
-            ]
-        });
-    }
-
-    if (browser.safari && appSettings.enableHi10p()) {
-        profile.CodecProfiles.push({
-            Type: 'Video',
-            Container: 'hls',
-            SubContainer: 'mp4',
-            Codec: 'h264',
-            Conditions: [
-                {
-                    Condition: 'EqualsAny',
-                    Property: 'VideoProfile',
-                    Value: h264Profiles + '|high 10',
                     IsRequired: false
                 }
             ]

--- a/src/scripts/settings/appSettings.js
+++ b/src/scripts/settings/appSettings.js
@@ -182,6 +182,19 @@ class AppSettings {
         return toBoolean(this.get('enableTrueHd'), false);
     }
 
+    /**
+     * Get or set 'Enable H.264 High 10 Profile' state.
+     * @param {boolean|undefined} val - Flag to enable 'Enable H.264 High 10 Profile' or undefined.
+     * @return {boolean} 'Enable H.264 High 10 Profile' state.
+     */
+    enableHi10p(val) {
+        if (val !== undefined) {
+            return this.set('enableHi10p', val.toString());
+        }
+
+        return toBoolean(this.get('enableHi10p'), false);
+    }
+
     set(name, value, userId) {
         const currentValue = this.get(name, userId);
         localStorage.setItem(this.#getKey(name, userId), value);

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -260,6 +260,8 @@
     "EnableFasterAnimations": "Faster animations",
     "EnableFasterAnimationsHelp": "Use faster animations and transitions.",
     "EnableHardwareEncoding": "Enable hardware encoding",
+    "EnableHi10p": "Enable H.264 High 10 Profile",
+    "EnableHi10pHelp": "Enable to avoid transcoding H.264 10-bit videos. Disable this option if the video displays blank frames.",
     "EnableLibrary": "Enable the library",
     "EnableLibraryHelp": "Disabling the library will hide it from all user views.",
     "EnableNextVideoInfoOverlay": "Show next video info during playback",


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

Both macOS and iOS Safari have enabled H.264 Hi10P decoding support with some restrictions. For our use case, we need to force all H.264 Hi10P video files to trigger remuxing, as this profile is only supported in fMP4 within HLS. Attempts to direct play the original video will fail.

To support this functionality, the server API needs to be modified to accept HLS-specific codec profiles.

This also added a user-configurable option to let the user to opt-in this feature, as the precise feature detection is impossible.

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Depends on Server change https://github.com/jellyfin/jellyfin/pull/12420
