### PR TITLE
Fix "Download All" for Safari

### DIFF
--- a/src/scripts/multiDownload.js
+++ b/src/scripts/multiDownload.js
@@ -27,13 +27,6 @@ function fallback(urls) {
     })();
 }
 
-function sameDomain(url) {
-    const a = document.createElement('a');
-    a.href = url;
-
-    return window.location.hostname === a.hostname && window.location.protocol === a.protocol;
-}
-
 function download(url) {
     const a = document.createElement('a');
     a.download = '';
@@ -54,14 +47,6 @@ export default function (urls) {
     let delay = 0;
 
     urls.forEach(function (url) {
-        // the download init has to be sequential for firefox if the urls are not on the same domain
-        // desktop safari also requires the delay
-        if ((browser.firefox && !sameDomain(url))
-            || browser.safari) {
-            setTimeout(download.bind(null, url), 100 * ++delay);
-            return;
-        }
-
-        download(url);
+        setTimeout(download.bind(null, url), 100 * ++delay);
     });
 }

--- a/src/scripts/multiDownload.js
+++ b/src/scripts/multiDownload.js
@@ -38,8 +38,7 @@ function download(url) {
     const a = document.createElement('a');
     a.download = '';
     a.href = url;
-    // firefox doesn't support `a.click()`...
-    a.dispatchEvent(new MouseEvent('click'));
+    a.click();
 }
 
 export default function (urls) {
@@ -47,7 +46,8 @@ export default function (urls) {
         throw new Error('`urls` required');
     }
 
-    if (typeof document.createElement('a').download === 'undefined') {
+    if (typeof document.createElement('a').download === 'undefined'
+        || browser.iOS) {
         return fallback(urls);
     }
 
@@ -55,7 +55,9 @@ export default function (urls) {
 
     urls.forEach(function (url) {
         // the download init has to be sequential for firefox if the urls are not on the same domain
-        if (browser.firefox && !sameDomain(url)) {
+        // desktop safari also requires the delay
+        if ((browser.firefox && !sameDomain(url))
+            || browser.safari) {
             setTimeout(download.bind(null, url), 100 * ++delay);
             return;
         }

--- a/src/scripts/multiDownload.js
+++ b/src/scripts/multiDownload.js
@@ -39,8 +39,7 @@ export default function (urls) {
         throw new Error('`urls` required');
     }
 
-    if (typeof document.createElement('a').download === 'undefined'
-        || browser.iOS) {
+    if (typeof document.createElement('a').download === 'undefined' || browser.iOS) {
         return fallback(urls);
     }
 


### PR DESCRIPTION
Changes

Added check to use fallback downloader for iOS
Changed download to always use `setTimeout` instead of conditionally on browser.
Remove old comment about firefox, as `a.click()` supported since Firefox 75 (2020) [ref](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click#browser_compatibility)

Issues

Fixes https://github.com/jellyfin/jellyfin-web/issues/5672

Related #5744 (reopened against 10.9)