### PR TITLE
Override mp3 remux container

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -720,10 +720,10 @@ export default function (options) {
             // mp3 is a special case because it is allowed in hls-fmp4 on the server-side
             // but not really supported in most browsers
             profile.DirectPlayProfiles.push({
-                 Container: 'ts',
-                 AudioCodec: 'mp3',
-                 Type: 'Audio'
-             });
+                Container: 'ts',
+                AudioCodec: 'mp3',
+                Type: 'Audio'
+            });
         }
 
         profile.DirectPlayProfiles.push({

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -715,6 +715,17 @@ export default function (options) {
     });
 
     ['opus', 'mp3', 'mp2', 'aac', 'flac', 'alac', 'webma', 'wma', 'wav', 'ogg', 'oga'].filter(canPlayAudioFormat).forEach(function (audioFormat) {
+        // Place container overrides before direct profile for remux container override
+        if (audioFormat == 'mp3' && !canPlayMp3VideoAudioInHls) {
+            // mp3 is a special case because it is allowed in hls-fmp4 on the server-side
+            // but not really supported in most browsers
+            profile.DirectPlayProfiles.push({
+                 Container: 'ts',
+                 AudioCodec: 'mp3',
+                 Type: 'Audio'
+             });
+        }
+
         profile.DirectPlayProfiles.push({
             Container: audioFormat,
             Type: 'Audio'


### PR DESCRIPTION
The server generally filters out invalid containers for HLS in most cases. However, MP3 is a special case because, while it is technically possible and allowed as a codec for fMP4 on the server side, most browsers do not support it. Override the remux container to force MPEG-TS for MP3. The server will still direct play MP3 in an MP3 container. This is useful for supporting universal containers like MKA.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

- Override the remuxing container to mpegts for mp3

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
