### PR TITLE
Added Next Up to Collections

### DIFF
--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -814,7 +814,7 @@ function setInitialCollapsibleState(page, item, apiClient, context, user) {
         page.querySelector('#childrenCollapsible').classList.add('hide');
     }
 
-    if (item.Type == 'Series') {
+    if (item.Type == 'Series' || item.Type == 'BoxSet') {
         renderSeriesSchedule(page, item);
         renderNextUp(page, item, user);
     } else {


### PR DESCRIPTION
**Changes**
Extends the "Next Up" function in Jellyfin to include Collections. Currently the "Next Up" feature only applies to Seasons but with this change it will now also apply to Collections.

**Issues**
None
