### PR TITLE
Fix Safari volume control

### DIFF
--- a/src/components/apphost.js
+++ b/src/components/apphost.js
@@ -242,7 +242,7 @@ const supportedFeatures = function () {
         features.push('fullscreenchange');
     }
 
-    if (browser.tv || browser.xboxOne || browser.ps4 || browser.mobile) {
+    if (browser.tv || browser.xboxOne || browser.ps4 || browser.mobile || browser.ipad) {
         features.push('physicalvolumecontrol');
     }
 

--- a/src/plugins/htmlAudioPlayer/plugin.js
+++ b/src/plugins/htmlAudioPlayer/plugin.js
@@ -125,8 +125,10 @@ class HtmlAudioPlayer {
 
                 if (normalizationGain) {
                     self.gainNode.gain.value = Math.pow(10, normalizationGain / 20);
+                    self.normalizationGain = self.gainNode.gain.value;
                 } else {
                     self.gainNode.gain.value = 1;
+                    self.normalizationGain = 1;
                 }
                 console.debug('gain: ' + self.gainNode.gain.value);
             }).catch((err) => {
@@ -311,6 +313,9 @@ class HtmlAudioPlayer {
         function onVolumeChange() {
             if (!self._isFadingOut) {
                 htmlMediaHelper.saveVolume(this.volume);
+                if (browser.safari) {
+                    self.gainNode.gain.value = this.volume * self.normalizationGain;
+                }
                 Events.trigger(self, 'volumechange');
             }
         }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

Our audio normalization gain node does not consider the webkit implementation where the gain is an absolute volume value, causing the volume not be able to be changed as the gain is always locked to a pre-defined value even the normalization has being disabled. This multiplies the volume value to the defined gain value ratio to control the final volume on Safari.

This also hides the volume slider on iPads because it will not work, and is not detected by `browser.mobile`.

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

- Fixes volume control on Safari where the gain value is an absolute value
- Hide volume slider on iPad because it will not work and cannot be detected by `browser.mobile`

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #5758
