### PR TITLE
Fix safari volume being reset when track changed

### DIFF
--- a/src/plugins/htmlAudioPlayer/plugin.js
+++ b/src/plugins/htmlAudioPlayer/plugin.js
@@ -126,7 +126,6 @@ class HtmlAudioPlayer {
                 if (normalizationGain) {
                     self.normalizationGain = Math.pow(10, normalizationGain / 20);
                     self.gainNode.gain.value = self.normalizationGain;
-
                 } else {
                     self.gainNode.gain.value = 1;
                     self.normalizationGain = 1;

--- a/src/plugins/htmlAudioPlayer/plugin.js
+++ b/src/plugins/htmlAudioPlayer/plugin.js
@@ -125,10 +125,15 @@ class HtmlAudioPlayer {
 
                 if (normalizationGain) {
                     self.normalizationGain = Math.pow(10, normalizationGain / 20);
-                    self.gainNode.gain.value = browser.safari ? elem.volume * self.normalizationGain : self.normalizationGain;
+                    self.gainNode.gain.value = self.normalizationGain;
+
                 } else {
-                    self.gainNode.gain.value = browser.safari ? elem.volume : 1;
+                    self.gainNode.gain.value = 1;
                     self.normalizationGain = 1;
+                }
+                if (browser.safari) {
+                    // Gain value is absolute in Safari. Add volume from the slider
+                    self.gainNode.gain.value *= elem.volume;
                 }
                 console.debug('gain: ' + self.normalizationGain);
             }).catch((err) => {

--- a/src/plugins/htmlAudioPlayer/plugin.js
+++ b/src/plugins/htmlAudioPlayer/plugin.js
@@ -124,13 +124,13 @@ class HtmlAudioPlayer {
                 }
 
                 if (normalizationGain) {
-                    self.gainNode.gain.value = Math.pow(10, normalizationGain / 20);
-                    self.normalizationGain = self.gainNode.gain.value;
+                    self.normalizationGain = Math.pow(10, normalizationGain / 20);
+                    self.gainNode.gain.value = browser.safari ? elem.volume * self.normalizationGain : self.normalizationGain;
                 } else {
-                    self.gainNode.gain.value = 1;
+                    self.gainNode.gain.value = browser.safari ? elem.volume : 1;
                     self.normalizationGain = 1;
                 }
-                console.debug('gain: ' + self.gainNode.gain.value);
+                console.debug('gain: ' + self.normalizationGain);
             }).catch((err) => {
                 console.error('Failed to add/change gainNode', err);
             });


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

This is a follow-up of #5920. That PR missed the case that the gain value will be reset during track change. This PR always set the gain value relative to current volume on Safari

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
