### PR TITLE
Fix home section resume error

### DIFF
--- a/src/components/homesections/homesections.js
+++ b/src/components/homesections/homesections.js
@@ -131,9 +131,11 @@ export function resume(elem, options) {
     const elems = elem.querySelectorAll('.itemsContainer');
     const promises = [];
 
-    for (let i = 0, length = elems.length; i < length; i++) {
-        promises.push(elems[i].resume(options));
-    }
+    Array.prototype.forEach.call(elems, section => {
+        if (section.resume) {
+            promises.push(section.resume(options));
+        }
+    });
 
     return Promise.all(promises);
 }


### PR DESCRIPTION
**Changes**
Fixes an error when the home screen loads. It seems like there is a bit of a race condition where we are trying to call `resume` on sections before they are fully loaded.

**Issues**
N/A