### PR TITLE
Limit activity table to screen size

### DIFF
--- a/src/apps/dashboard/routes/activity.tsx
+++ b/src/apps/dashboard/routes/activity.tsx
@@ -223,7 +223,14 @@ const Activity = () => {
             title={globalize.translate('HeaderActivity')}
             className='mainAnimatedPage type-interior'
         >
-            <div className='content-primary'>
+            <Box
+                className='content-primary'
+                sx={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    height: '100%'
+                }}
+            >
                 <Box
                     sx={{
                         display: 'flex',
@@ -262,11 +269,8 @@ const Activity = () => {
                     rowCount={rowCount}
                     getRowId={getRowId}
                     loading={isLoading}
-                    sx={{
-                        minHeight: 500
-                    }}
                 />
-            </div>
+            </Box>
         </Page>
     );
 };


### PR DESCRIPTION
**Changes**
* Updates the styling of the user activity page so the table does not overflow the screen. Additional content will scroll within the table.

| Before | After |
|---|---|
| ![Screenshot 2024-08-21 at 12-55-27 Activity](https://github.com/user-attachments/assets/28a7b93e-edaa-4cf5-bd89-4026abbfd35c) | ![Screenshot 2024-08-21 at 12-55-42 Jellyfin](https://github.com/user-attachments/assets/2965897d-5455-435a-afea-535e65334e9b) |


**Issues**
N/A