### PR TITLE
Change "Last Seen" to "Last Logged In" to reduce confusion when translating

### DIFF
--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -969,7 +969,7 @@
     "LanNetworksHelp": "Comma separated list of IP addresses or IP/netmask entries for networks that will be considered on local network when enforcing bandwidth restrictions. If set, all other IP addresses will be considered to be on the external network and will be subject to the external bandwidth restrictions. If left blank, only the server's subnet is considered to be on the local network.",
     "Large": "Large",
     "Larger": "Larger",
-    "LastSeen": "Last logged in {0}",
+    "LastSeen": "Last activity: {0}",
     "LatestFromLibrary": "Recently Added in {0}",
     "LearnHowYouCanContribute": "Learn how you can contribute.",
     "LeaveBlankToNotSetAPassword": "You can leave this field blank to set no password.",

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -969,7 +969,7 @@
     "LanNetworksHelp": "Comma separated list of IP addresses or IP/netmask entries for networks that will be considered on local network when enforcing bandwidth restrictions. If set, all other IP addresses will be considered to be on the external network and will be subject to the external bandwidth restrictions. If left blank, only the server's subnet is considered to be on the local network.",
     "Large": "Large",
     "Larger": "Larger",
-    "LastSeen": "Last activity: {0}",
+    "LastSeen": "Last activity {0}",
     "LatestFromLibrary": "Recently Added in {0}",
     "LearnHowYouCanContribute": "Learn how you can contribute.",
     "LeaveBlankToNotSetAPassword": "You can leave this field blank to set no password.",

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -969,7 +969,7 @@
     "LanNetworksHelp": "Comma separated list of IP addresses or IP/netmask entries for networks that will be considered on local network when enforcing bandwidth restrictions. If set, all other IP addresses will be considered to be on the external network and will be subject to the external bandwidth restrictions. If left blank, only the server's subnet is considered to be on the local network.",
     "Large": "Large",
     "Larger": "Larger",
-    "LastSeen": "Last seen {0}",
+    "LastSeen": "Last logged in {0}",
     "LatestFromLibrary": "Recently Added in {0}",
     "LearnHowYouCanContribute": "Learn how you can contribute.",
     "LeaveBlankToNotSetAPassword": "You can leave this field blank to set no password.",


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->
The string "Last Seen" can easily be confused with other meanings when translating. "Last Logged In" would be more specific and eliminate the confusion.

**Changes**
Change "Last Seen" to "Last Logged In" in translations.

**Issues**
None
