### PR TITLE
Support for Home and Search media keys in TV mode

### DIFF
--- a/src/scripts/keyboardNavigation.js
+++ b/src/scripts/keyboardNavigation.js
@@ -43,7 +43,7 @@ const KeyNames = {
 /**
  * Keys used for keyboard navigation.
  */
-const NavigationKeys = ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'];
+const NavigationKeys = ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'BrowserHome', 'Find'];
 
 /**
  * Keys used for media playback control.
@@ -180,6 +180,13 @@ export function enable() {
                 } else {
                     capture = false;
                 }
+                break;
+
+            case 'Find':
+                inputManager.handleCommand('search');
+                break;
+            case 'BrowserHome':
+                inputManager.handleCommand('home');
                 break;
 
             case 'MediaPlay':


### PR DESCRIPTION
The remote I have has some extra "media" buttons besides the already supported playback controls.

This adds support for "_Find_" button to navigate to search page and "_BrowserHome_" button to navigate back to main screen.

Adding these to the `NavigationKeys` only enables functionality for TV mode which I think is pretty reasonable constraint - on actual desktop people might prefer to use these keys to control the browser rather than Jellyfin interface.
