### PR TITLE
Fix hidden scheduled task progress updates causing errors

### DIFF
--- a/src/controllers/dashboard/scheduledtasks/scheduledtasks.js
+++ b/src/controllers/dashboard/scheduledtasks/scheduledtasks.js
@@ -132,8 +132,11 @@ function updateTaskButton(elem, state) {
 export default function(view) {
     function updateTasks(tasks) {
         for (const task of tasks) {
-            view.querySelector('#taskProgress' + task.Id).innerHTML = getTaskProgressHtml(task);
-            updateTaskButton(view.querySelector('#btnTask' + task.Id), task.State);
+            const taskProgress = view.querySelector(`#taskProgress${task.Id}`);
+            if (taskProgress) taskProgress.innerHTML = getTaskProgressHtml(task);
+
+            const taskButton = view.querySelector(`#btnTask${task.Id}`);
+            if (taskButton) updateTaskButton(taskButton, task.State);
         }
     }
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
An `IConfigurableScheduledTask` can be defined with `IsHidden => true`, which as expected causes it to not be drawn in the UI, nor are its elements created. However, task progress updates would still arrive and cause an error in code that assumed the elements would exist.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
N/A, but merging jellyfin/jellyfin#12511 has a chance of exposing this bug if someone opens admin panel on scheduled tasks page quickly enough after server startup (overall a rather minor bug probably as such)
