### PR TITLE
Update HDR and WebM device checks

### DIFF
--- a/src/scripts/browser.js
+++ b/src/scripts/browser.js
@@ -99,6 +99,19 @@ function iOSversion() {
     return [];
 }
 
+function osxVersion() {
+    const matches = /Mac OS X (\d+)[._](\d+)[._]?(\d+)?/i.test(navigator.userAgent);
+    if (matches) {
+        return [
+            parseInt(matches[1], 10),
+            parseInt(matches[2], 10),
+            parseInt(matches[3] || 0, 10)
+        ];
+    }
+
+    return [];
+}
+
 function web0sVersion(browser) {
     // Detect webOS version by web engine version
 
@@ -228,16 +241,21 @@ const uaMatch = function (ua) {
     version = version || match[2] || '0';
 
     let versionMajor = parseInt(version.split('.')[0], 10);
-
     if (isNaN(versionMajor)) {
         versionMajor = 0;
+    }
+
+    let versionMinor = parseInt(version.split('.')[1], 10);
+    if (isNaN(versionMinor)) {
+        versionMinor = 0;
     }
 
     return {
         browser: browser,
         version: version,
         platform: platform_match[0] || '',
-        versionMajor: versionMajor
+        versionMajor: versionMajor,
+        versionMinor: versionMinor
     };
 };
 
@@ -250,6 +268,7 @@ if (matched.browser) {
     browser[matched.browser] = true;
     browser.version = matched.version;
     browser.versionMajor = matched.versionMajor;
+    browser.versionMinor = matched.versionMinor;
 }
 
 if (matched.platform) {
@@ -269,6 +288,18 @@ browser.osx = userAgent.toLowerCase().indexOf('mac os x') !== -1;
 // https://forums.developer.apple.com/thread/119186
 if (browser.osx && !browser.iphone && !browser.ipod && !browser.ipad && navigator.maxTouchPoints > 1) {
     browser.ipad = true;
+}
+
+if (browser.osx && !browser.iphone && !browser.ipod && !browser.ipad) {
+    browser.osxVersion = osxVersion();
+
+    if (browser.osxVersion) {
+        if (browser.osxVersion.length >= 2) {
+            browser.osxVersion = browser.osxVersion[0] + (browser.osxVersion[1] / 10);
+        } else {
+            browser.osxVersion = browser.osxVersion[0];
+        }
+    }
 }
 
 if (userAgent.toLowerCase().indexOf('playstation 4') !== -1) {


### PR DESCRIPTION
This updates some of the device checks for browser compatibility.

**Changes**

* WebM support is partial/unreliable from Safari versions 17.0-17.4. It was fixed in 17.4:
  * https://developer.apple.com/documentation/safari-release-notes/safari-17_4-release-notes
* Be more precise about Dolby Vision support on Apple devices. Specifically, Safari 13.1 added support:
  * https://developer.apple.com/documentation/safari-release-notes/safari-13_1-release_notes
* Enable HDR support for all browsers on iOS since all browsers are required to use WebKit underneath. HDR support in browsers was added in iOS 13.4 when Safari 13.1 was released.
  * https://developer.apple.com/documentation/safari-release-notes/safari-13_1-release_notes
* Firefox 100+ has support for HDR on macOS/OS X. It requires OS support, which was added in macOS 10.15 Catalina.
  * https://www.mozilla.org/en-US/firefox/100.0/releasenotes/
* Chrome on mobile now has client side tone-mapping. Tested on Chrome Android 128 but first support version is unknown.
