### PR TITLE
Support HDR in Firefox for macOS

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -666,7 +666,7 @@ export default function (options) {
     }
 
     if (canPlayVp9) {
-        if (!browser.iOS && (!browser.firefox || !browser.osx)) {
+        if (!browser.iOS && !(browser.firefox && browser.osx)) {
             // iOS safari may fail to direct play vp9 in mp4 container
             //
             // Firefox can play vp9 in mp4 container but fails to detect HDR. Since HDR is

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -225,6 +225,12 @@ function supportsHdr10(options) {
             // Edge Chromium 121+ fixed the tone-mapping color issue on Nvidia
             || browser.edgeChromium && (browser.versionMajor >= 121)
             || browser.chrome && !browser.mobile
+            // Firefox 100+ has support for HDR on macOS/OS X. It requires OS support, which was
+            // added in macOS 10.15 Catalina. If enabling HDR on other platforms, be careful about
+            // allowing HDR VP9 in mp4 containers.
+            //  * https://www.mozilla.org/en-US/firefox/100.0/releasenotes/
+            //  * https://bugzilla.mozilla.org/show_bug.cgi?id=1915265
+            || browser.firefox && browser.osx && (!browser.iphone && !browser.ipod && !browser.ipad) && (browser.versionMajor >= 100)
     );
 }
 
@@ -660,8 +666,12 @@ export default function (options) {
     }
 
     if (canPlayVp9) {
-        if (!browser.iOS) {
+        if (!browser.iOS && (!browser.firefox || !browser.osx)) {
             // iOS safari may fail to direct play vp9 in mp4 container
+            //
+            // Firefox can play vp9 in mp4 container but fails to detect HDR. Since HDR is
+            // unsupported for all other non-Mac platforms, it's fine to allow vp9 in mp4 for them.
+            //   * https://bugzilla.mozilla.org/show_bug.cgi?id=1915265
             mp4VideoCodecs.push('vp9');
         }
         // Only iOS Safari's native HLS player understands vp9 in fmp4


### PR DESCRIPTION
Firefox 100 introduced HDR playback:
  * https://www.mozilla.org/en-US/firefox/100.0/releasenotes/

This patches the issue where HDR detection is broken for HDR videos in VP9 (video codec) in an MP4 container by marking any VP9 + MP4 combination as needing container remuxing.
  * **See:** https://bugzilla.mozilla.org/show_bug.cgi?id=1915265

This follows a discussion from #5969 with @gnattu.

The following files were tested as working (download and use in Jellyfin collection):
  1. https://drive.google.com/drive/folders/1dSPUmJ_Y99-VL6TxfndPbISyUfRJ3SAY
  2. https://github.com/user-attachments/assets/681ee89b-2e43-4a80-b3df-01e54813542d (AV1 + AAC + MP4)
  3. https://mega.nz/file/5lsGUYpT#B_KNF251rODrq5lWwGYHxSuBsiqEZQsGCRCWO83iAdY (VP9 + AAC + MP4)
  4. (too large to upload to GitHub) but taking file number 3 and running `ffmpeg -i <file_in> -map 0:v:0 -map 0:a:0 -c:v copy -c:a libopus <file_out>` on it. This results in the file being packaged in a compatible webm container (VP9 + Opus + WebM).

