### PR TITLE
Fix overly strict dovi level testing

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -242,16 +242,16 @@ function supportedDolbyVisionProfilesHevc(videoTestElement) {
     if (browser.xboxOne) return [5, 8];
 
     const supportedProfiles = [];
-    // Profiles 5/8 4k@60fps
+    // Profiles 5/8 4k@24fps
     if (videoTestElement.canPlayType) {
         if (videoTestElement
-            .canPlayType('video/mp4; codecs="dvh1.05.09"')
+            .canPlayType('video/mp4; codecs="dvh1.05.06"')
             .replace(/no/, '')) {
             supportedProfiles.push(5);
         }
         if (
             videoTestElement
-                .canPlayType('video/mp4; codecs="dvh1.08.09"')
+                .canPlayType('video/mp4; codecs="dvh1.08.06"')
                 .replace(/no/, '')
             // LG TVs from at least 2020 onwards should support profile 8, but they don't report it.
             || (browser.web0sVersion >= 4)


### PR DESCRIPTION
4k@60fps is usually only seen in demos so it's a bit overkill for testing dovi caps. Lower it to the more common 4k@24fps.

Ref: https://professional.dolby.com/siteassets/content-creation/dolby-vision-for-content-creators/dolby-vision-streams-within-the-http-live-streaming-format-v2.0-13-november-2018.pdf

**Changes**
- Fix overly strict dovi level testing

**Issues**
- iPad Pro 2018 only reports up to 4k30 dovi support after upgrading to iPadOS 17, but can actually play 4k60 normally and it used to report 4k60 on older systems.