### PR TITLE
5968: prevent create library from crashing with no path specified

### DIFF
--- a/src/components/mediaLibraryCreator/mediaLibraryCreator.js
+++ b/src/components/mediaLibraryCreator/mediaLibraryCreator.js
@@ -25,6 +25,8 @@ import alert from '../alert';
 import template from './mediaLibraryCreator.template.html';
 
 function onAddLibrary(e) {
+    e.preventDefault();
+
     if (isCreating) {
         return false;
     }
@@ -61,7 +63,6 @@ function onAddLibrary(e) {
         isCreating = false;
         loading.hide();
     });
-    e.preventDefault();
 }
 
 function getCollectionTypeOptionsHtml(collectionTypeOptions) {


### PR DESCRIPTION
**Changes**
Resolves library creation closing when no path is specified.  The promise powering the media creator was crashing on chrome as it needed the prevent default call to be moved to the top of the function.  

**Issues**
Fixes #5968 
