### PR TITLE
Add ability to select QSV device in the UI

### DIFF
--- a/src/controllers/dashboard/encodingsettings.html
+++ b/src/controllers/dashboard/encodingsettings.html
@@ -30,6 +30,11 @@
                     <div class="fieldDescription">${LabelVaapiDeviceHelp}</div>
                 </div>
 
+                <div class="inputContainer hide fldQsvDevice">
+                    <input is="emby-input" type="text" id="txtQsvDevice" label="${LabelQsvDevice}" />
+                    <div class="fieldDescription">${LabelQsvDeviceHelp}</div>
+                </div>
+
                 <div class="hardwareAccelerationOptions hide">
                     <div class="checkboxListContainer decodingCodecsList">
                         <h3 class="checkboxListLabel">${LabelEnableHardwareDecodingFor}</h3>

--- a/src/controllers/dashboard/encodingsettings.js
+++ b/src/controllers/dashboard/encodingsettings.js
@@ -31,6 +31,7 @@ function loadPage(page, config, systemInfo) {
     page.querySelector('#txtFallbackFontPath').value = config.FallbackFontPath || '';
     page.querySelector('#chkEnableFallbackFont').checked = config.EnableFallbackFont;
     $('#txtVaapiDevice', page).val(config.VaapiDevice || '');
+    page.querySelector('#txtQsvDevice').value = config.QsvDevice || '';
     page.querySelector('#chkTonemapping').checked = config.EnableTonemapping;
     page.querySelector('#chkVppTonemapping').checked = config.EnableVppTonemapping;
     page.querySelector('#chkVideoToolboxTonemapping').checked = config.EnableVideoToolboxTonemapping;
@@ -93,6 +94,7 @@ function onSubmit() {
             config.EncodingThreadCount = $('#selectThreadCount', form).val();
             config.HardwareAccelerationType = $('#selectVideoDecoder', form).val();
             config.VaapiDevice = $('#txtVaapiDevice', form).val();
+            config.QsvDevice = form.querySelector('#txtQsvDevice').value;
             config.EnableTonemapping = form.querySelector('#chkTonemapping').checked;
             config.EnableVppTonemapping = form.querySelector('#chkVppTonemapping').checked;
             config.EnableVideoToolboxTonemapping = form.querySelector('#chkVideoToolboxTonemapping').checked;
@@ -235,8 +237,12 @@ $(document).on('pageinit', '#encodingSettingsPage', function () {
 
         if (this.value == 'qsv') {
             page.querySelector('.fldSysNativeHwDecoder').classList.remove('hide');
+            page.querySelector('.fldQsvDevice').classList.remove('hide');
+            page.querySelector('#txtQsvDevice').setAttribute('required', 'required');
         } else {
             page.querySelector('.fldSysNativeHwDecoder').classList.add('hide');
+            page.querySelector('.fldQsvDevice').classList.add('hide');
+            page.querySelector('#txtQsvDevice').removeAttribute('required');
         }
 
         if (this.value == 'nvenc') {

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -840,6 +840,8 @@
     "LabelPublicHttpsPortHelp": "The public port number that should be mapped to the local HTTPS port.",
     "LabelPublishedServerUri": "Published Server URIs",
     "LabelPublishedServerUriHelp": "Override the URI used by Jellyfin, based on the interface, or client IP address. For example: internal=http://jellyfin.example.com, external=https://jellyfin.example.com, or all=https://jellyfin.example.com",
+    "LabelQsvDevice": "QSV Device",
+    "LabelQsvDeviceHelp": "This is the render node that is used for hardware acceleration.",
     "LabelQuickConnectCode": "Quick Connect code",
     "LabelReasonForTranscoding": "Reason for transcoding",
     "LabelRecord": "Record",

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -841,7 +841,7 @@
     "LabelPublishedServerUri": "Published Server URIs",
     "LabelPublishedServerUriHelp": "Override the URI used by Jellyfin, based on the interface, or client IP address. For example: internal=http://jellyfin.example.com, external=https://jellyfin.example.com, or all=https://jellyfin.example.com",
     "LabelQsvDevice": "QSV Device",
-    "LabelQsvDeviceHelp": "This is the render node that is used for hardware acceleration.",
+    "LabelQsvDeviceHelp": "Specify the device for Intel QSV on a multi-GPU system. On Linux, this is the render node, e.g., /dev/dri/renderD128. On Windows, this is the device index starting from 0. Leave blank unless you know what you are doing.",
     "LabelQuickConnectCode": "Quick Connect code",
     "LabelReasonForTranscoding": "Reason for transcoding",
     "LabelRecord": "Record",


### PR DESCRIPTION
**Changes**

This provides an input field to specify the device used for QSV rendering.

**Issues**
This depends on the backend PR here: https://github.com/jellyfin/jellyfin/pull/12384
