### PR TITLE
Update slideshow.js with new default from 3 to 7 seconds per slide

### DIFF
--- a/src/components/slideshow/slideshow.js
+++ b/src/components/slideshow/slideshow.js
@@ -617,7 +617,7 @@ export default function (options) {
      */
     function startHideTimer() {
         stopHideTimer();
-        hideTimeout = setTimeout(hideOsd, 3000);
+        hideTimeout = setTimeout(hideOsd, 7000);
     }
 
     /**


### PR DESCRIPTION
Changed default 3 seconds slide hide function to 7 seconds. 3 seconds per slide as a default is very short and unreasonable value. Maybe in the future this can be implemented as a parameter.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
