### PR TITLE
Fix network mode for localhost server

### DIFF
--- a/src/utils/query/queryClient.ts
+++ b/src/utils/query/queryClient.ts
@@ -1,3 +1,12 @@
 import { QueryClient } from '@tanstack/react-query';
 
-export const queryClient = new QueryClient();
+export const queryClient = new QueryClient({
+    defaultOptions: {
+        mutations: {
+            networkMode: 'always' // network connection is not required if running on localhost
+        },
+        queries: {
+            networkMode: 'always' // network connection is not required if running on localhost
+        }
+    }
+});


### PR DESCRIPTION
**Changes**
Changes the network mode setting for tanstack query to "always" so requests will still be made if there is no network connection (servers can be on localhost)

**Issues**
Fixes #5993 
