### PR TITLE
Show slideshow controls when touched

### DIFF
--- a/src/components/slideshow/slideshow.js
+++ b/src/components/slideshow/slideshow.js
@@ -732,9 +732,8 @@ export default function (options) {
 
             obj.x = eventX;
             obj.y = eventY;
-
-            showOsd();
         }
+        showOsd();
     }
 
     /**


### PR DESCRIPTION
It appears that a previous commit changed the blocks so that only mouse events were recognized.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Moved the `showOsd` call outside of the "mouse" block.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
