### PR TITLE
Fix autocast listener

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -74,7 +74,7 @@ build: ${__JF_BUILD_VERSION__}`);
     }
 
     // Initialize automatic (default) cast target
-    initializeAutoCast(ServerConnections.currentApiClient());
+    initializeAutoCast();
 
     // Load the translation dictionary
     await loadCoreDictionary();

--- a/src/scripts/autocast.js
+++ b/src/scripts/autocast.js
@@ -45,6 +45,7 @@ function onOpen() {
 }
 
 export function initialize() {
+    console.debug('[autoCast] initializing connection listener');
     ServerConnections.getApiClients().forEach(apiClient => {
         Events.off(apiClient, 'websocketopen', onOpen);
         Events.on(apiClient, 'websocketopen', onOpen);

--- a/src/scripts/autocast.js
+++ b/src/scripts/autocast.js
@@ -1,3 +1,4 @@
+import ServerConnections from 'components/ServerConnections';
 import { playbackManager } from '../components/playback/playbackmanager';
 import Events from '../utils/events.ts';
 
@@ -43,16 +44,14 @@ function onOpen() {
     });
 }
 
-export function initialize(apiClient) {
-    if (apiClient) {
-        if (apiClient.isWebSocketOpen()) {
-            console.debug('[autoCast] connection ready');
-            onOpen();
-        } else {
-            console.debug('[autoCast] initializing connection listener');
-            Events.on(apiClient, 'websocketopen', onOpen);
-        }
-    } else {
-        console.warn('[autoCast] cannot initialize missing apiClient');
-    }
+export function initialize() {
+    ServerConnections.getApiClients().forEach(apiClient => {
+        Events.off(apiClient, 'websocketopen', onOpen);
+        Events.on(apiClient, 'websocketopen', onOpen);
+    });
+
+    Events.on(ServerConnections, 'apiclientcreated', (e, apiClient) => {
+        Events.off(apiClient, 'websocketopen', onOpen);
+        Events.on(apiClient, 'websocketopen', onOpen);
+    });
 }


### PR DESCRIPTION
When debugging the release version, I noticed that the 'websocketopen' event isn't assigned to the api client when it's triggered:
![image](https://github.com/user-attachments/assets/52fdc5ab-16cf-45c4-b373-fa44461f7cb2)
But it's still triggered after the "initializing connection listener" log message, so I can only assume it's being assigned to the wrong api client.

**Changes**
Add the websocket event to all api clients and listen for new ones

**Issues**
May fix https://github.com/jellyfin/jellyfin-web/issues/5878