### PR TITLE
Change encoding preset and play stats for server change

### DIFF
--- a/src/components/playerstats/playerstats.js
+++ b/src/components/playerstats/playerstats.js
@@ -172,12 +172,17 @@ function getTranscodingStats(session, player, displayPlayMethod) {
                 value: session.TranscodingInfo.TranscodeReasons.map(translateReason).join('<br/>')
             });
         }
-        if (session.TranscodingInfo.HardwareAccelerationType) {
-            sessionStats.push({
-                label: globalize.translate('LabelHardwareEncoding'),
-                value: session.TranscodingInfo.HardwareAccelerationType
-            });
-        }
+        // Hide this for now because it is not useful in its current state.
+        // This only reflects the configuration in the dashboard, but the actual
+        // decoder/encoder selection is more complex. As a result, the hardware
+        // encoder may not be used even if hardware acceleration is configured,
+        // making the display of hardware acceleration misleading.
+        // if (session.TranscodingInfo.HardwareAccelerationType) {
+        //     sessionStats.push({
+        //         label: globalize.translate('LabelHardwareEncoding'),
+        //         value: session.TranscodingInfo.HardwareAccelerationType
+        //     });
+        // }
     }
 
     return sessionStats;

--- a/src/controllers/dashboard/encodingsettings.html
+++ b/src/controllers/dashboard/encodingsettings.html
@@ -11,7 +11,7 @@
 
                 <div class="selectContainer">
                     <select is="emby-select" id="selectVideoDecoder" label="${LabelHardwareAccelerationType}">
-                        <option value="">${None}</option>
+                        <option value="none">${None}</option>
                         <option value="amf">AMD AMF</option>
                         <option value="nvenc">Nvidia NVENC</option>
                         <option value="qsv">Intel QuickSync (QSV)</option>

--- a/src/controllers/dashboard/encodingsettings.html
+++ b/src/controllers/dashboard/encodingsettings.html
@@ -312,7 +312,7 @@
 
                 <div class="selectContainer">
                     <select is="emby-select" id="selectEncoderPreset" label="${LabelEncoderPreset}">
-                        <option value="">${Auto}</option>
+                        <option value="auto">${Auto}</option>
                         <option value="veryslow">veryslow</option>
                         <option value="slower">slower</option>
                         <option value="slow">slow</option>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

- Use correct "auto" string value for encoding presets because server is now using enum for it
- Hide the hardware acceleration type info in play stats because can be misleading. 

The hardware acceleration type currently only reflects the configuration in the dashboard, without accounting for potential software fallback and/or situations like QSV interop with VAAPI. This can result in displaying that a hardware encoder of certain type is in use when it's actually not. In 10.9 and earlier, we did not display this field due to an enum type mismatch. However, this issue has been fixed on the server side, causing the field to now appear, though with inaccurate data. We need to hide that until the server refactored the transcoding pipeline so that the actual encoder can be reported.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Changes made for jellyfin/jellyfin#12561

Fixes jellyfin/jellyfin#12630
