### PR TITLE
Cleanup babel plugins

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -15,8 +15,5 @@ module.exports = {
         '@babel/preset-react'
     ],
     plugins: [
-        '@babel/plugin-transform-class-properties',
-        '@babel/plugin-transform-private-methods',
-        'babel-plugin-dynamic-import-polyfill'
     ]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,9 +66,7 @@
       },
       "devDependencies": {
         "@babel/core": "7.25.2",
-        "@babel/plugin-transform-class-properties": "7.25.4",
         "@babel/plugin-transform-modules-umd": "7.24.7",
-        "@babel/plugin-transform-private-methods": "7.25.4",
         "@babel/preset-env": "7.25.4",
         "@babel/preset-react": "7.24.7",
         "@stylistic/eslint-plugin": "2.7.2",
@@ -86,7 +84,6 @@
         "@vitest/coverage-v8": "2.0.5",
         "autoprefixer": "10.4.20",
         "babel-loader": "9.1.3",
-        "babel-plugin-dynamic-import-polyfill": "1.0.0",
         "clean-webpack-plugin": "4.0.0",
         "confusing-browser-globals": "1.0.11",
         "copy-webpack-plugin": "12.0.2",
@@ -7833,15 +7830,6 @@
       "peerDependencies": {
         "@babel/core": "^7.12.0",
         "webpack": ">=5"
-      }
-    },
-    "node_modules/babel-plugin-dynamic-import-polyfill": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-polyfill/-/babel-plugin-dynamic-import-polyfill-1.0.0.tgz",
-      "integrity": "sha512-fqdut9hGeaAgdX3sbAY25TkqA7LPmZB+Hf1XI67AppvhUw1cBST58BPwl5kPwDZYIvmqRwnsVKM0lppsQAsxhg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-module-imports": "7.x"
       }
     },
     "node_modules/babel-plugin-macros": {
@@ -31361,15 +31349,6 @@
       "requires": {
         "find-cache-dir": "^4.0.0",
         "schema-utils": "^4.0.0"
-      }
-    },
-    "babel-plugin-dynamic-import-polyfill": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-polyfill/-/babel-plugin-dynamic-import-polyfill-1.0.0.tgz",
-      "integrity": "sha512-fqdut9hGeaAgdX3sbAY25TkqA7LPmZB+Hf1XI67AppvhUw1cBST58BPwl5kPwDZYIvmqRwnsVKM0lppsQAsxhg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-module-imports": "7.x"
       }
     },
     "babel-plugin-macros": {

--- a/package.json
+++ b/package.json
@@ -6,9 +6,7 @@
   "license": "GPL-2.0-or-later",
   "devDependencies": {
     "@babel/core": "7.25.2",
-    "@babel/plugin-transform-class-properties": "7.25.4",
     "@babel/plugin-transform-modules-umd": "7.24.7",
-    "@babel/plugin-transform-private-methods": "7.25.4",
     "@babel/preset-env": "7.25.4",
     "@babel/preset-react": "7.24.7",
     "@stylistic/eslint-plugin": "2.7.2",
@@ -26,7 +24,6 @@
     "@vitest/coverage-v8": "2.0.5",
     "autoprefixer": "10.4.20",
     "babel-loader": "9.1.3",
-    "babel-plugin-dynamic-import-polyfill": "1.0.0",
     "clean-webpack-plugin": "4.0.0",
     "confusing-browser-globals": "1.0.11",
     "copy-webpack-plugin": "12.0.2",


### PR DESCRIPTION
**Changes**
These plugins are already part of `@babel/preset-env` so there is no reason to include them again. (The dynamic import polyfill is also an unmaintained version.)

**Issues**
N/A
