### PR TITLE
Use correct artifact download action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
           mode: recreate
 
       - name: Download workflow artifact
-        uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: jellyfin-web__prod
           path: dist


### PR DESCRIPTION
**Changes**
Uses the correct action for downloading build artifacts

**Issues**
N/A but hopefully fixes pages.dev deployment flakiness