### PR TITLE
Fix season play button not including specials

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -1957,7 +1957,7 @@ class PlaybackManager {
                 episodesResult.StartIndex = undefined;
                 let seasonStartIndex;
                 for (const [index, e] of episodesResult.Items.entries()) {
-                    if (startSeasonId) {
+                    if (startSeasonId && items.length != 1) {
                         if (e.SeasonId == startSeasonId) {
                             if (seasonStartIndex === undefined) {
                                 seasonStartIndex = index;


### PR DESCRIPTION
**Changes**
Prevent player from skipping specials when clicking on the play button in a season.

**Issues**
Fixes https://github.com/jellyfin/jellyfin-web/issues/6049