### PR TITLE
Fix infinite spinner on favorites and next up lists

### DIFF
--- a/src/controllers/list.js
+++ b/src/controllers/list.js
@@ -856,7 +856,7 @@ class ItemsView {
             setTitle(null);
             getItem(params).then(function (item) {
                 setTitle(item);
-                if (item.Type == 'Genre') {
+                if (item && item.Type == 'Genre') {
                     item.ParentId = params.parentId;
                 }
 


### PR DESCRIPTION
Fix: Infinite spinner on 'Favorites' and 'Next Up' lists.

**Changes**
On list controller, added null check on 'item' due to it resolving as null in favorites and next up lists.

**Issues**
Fixes #6069 