### PR TITLE
Translate the newly added VideoCodecTagNotSupported

### DIFF
--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1659,6 +1659,7 @@
     "ContainerNotSupported": "The container is not supported",
     "SubtitleCodecNotSupported": "The subtitle codec is not supported",
     "VideoCodecNotSupported": "The video codec is not supported",
+    "VideoCodecTagNotSupported": "The video codec tag is not supported",
     "AudioBitrateNotSupported": "The audio's bitrate is not supported",
     "AudioChannelsNotSupported": "The number of audio channels is not supported",
     "VideoResolutionNotSupported": "The video's resolution is not supported",


### PR DESCRIPTION
Server PR is merged https://github.com/jellyfin/jellyfin/pull/12430

**Changes**
- Translate the newly added `VideoCodecTagNotSupported`