### PR TITLE
Discard `chrome` and `safari` on Tizen and webOS

### DIFF
--- a/src/scripts/browser.js
+++ b/src/scripts/browser.js
@@ -293,12 +293,17 @@ browser.edgeUwp = browser.edge && (userAgent.toLowerCase().indexOf('msapphost') 
 
 if (browser.web0s) {
     browser.web0sVersion = web0sVersion(browser);
-} else if (browser.tizen) {
-    // UserAgent string contains 'Safari' and 'safari' is set by matched browser, but we only want 'tizen' to be true
-    delete browser.safari;
 
+    // UserAgent string contains 'Chrome' and 'Safari', but we only want 'web0s' to be true
+    delete browser.chrome;
+    delete browser.safari;
+} else if (browser.tizen) {
     const v = (navigator.appVersion).match(/Tizen (\d+).(\d+)/);
     browser.tizenVersion = parseInt(v[1], 10);
+
+    // UserAgent string contains 'Chrome' and 'Safari', but we only want 'tizen' to be true
+    delete browser.chrome;
+    delete browser.safari;
 } else {
     browser.orsay = userAgent.toLowerCase().indexOf('smarthub') !== -1;
 }

--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -142,7 +142,7 @@ export class UserSettings {
         }
 
         // Enable it by default only for the platforms that play fMP4 for sure.
-        return toBoolean(this.get('preferFmp4HlsContainer', false), browser.safari || browser.firefox || (browser.chrome && !browser.web0s && !browser.tizen) || browser.edgeChromium);
+        return toBoolean(this.get('preferFmp4HlsContainer', false), browser.safari || browser.firefox || browser.chrome || browser.edgeChromium);
     }
 
     /**


### PR DESCRIPTION
We consider `safari` to be an actual Safari browser and `chrome` to be an actual Chrome browser.
Tizen and webOS may be "Safari" (WebKit) or "Chrome", but their capabilities are different from Safari and Chrome.

When testing https://github.com/jellyfin/jellyfin-web/pull/6073 webOS 1.2 (WebKit) tried to play TS+H264 using HLS.js.
Here we should check the transcoding codec, but we check the codec of the original media source:
https://github.com/jellyfin/jellyfin-web/blob/e5df4dd56bc180dfa24a52a99c718459a4074d56/src/components/htmlMediaHelper.js#L35

Although the use of HLS.js is caused by another bug, the mentioned inconsistency can cause problems when generating a device profile.

**Changes**
Discard `chrome` and `safari` on Tizen and webOS.

**Issues**
N/A

Alternatively, we could add `&& !browser.web0s && !browser.tizen` everywhere, but that's too wordy.

**Notes**
Chromecast will be disabled on Tizen and webOS.
https://github.com/jellyfin/jellyfin-web/blob/0ae080a15065cba2ab134e5d9d3faf6213b6c2ef/src/index.jsx#L150-L152
