### PR TITLE
Make movie's shuffle button use the current filters

### DIFF
--- a/src/controllers/movies/movies.js
+++ b/src/controllers/movies/movies.js
@@ -36,6 +36,8 @@ export default function (view, params, tabContent, options) {
         const newQuery = { ...query, SortBy: 'Random', Limit: 1 };
         return ApiClient.getItems(ApiClient.getCurrentUserId(), newQuery).then(({ Items }) => {
             playbackManager.shuffle(Items[0]);
+        }).finally(() => {
+            isLoading = false;
         });
     }
 

--- a/src/controllers/movies/movies.js
+++ b/src/controllers/movies/movies.js
@@ -33,7 +33,7 @@ export default function (view, params, tabContent, options) {
     function shuffle() {
         isLoading = true;
         loading.show();
-        const newQuery = { ...query, SortBy: 'Random' };
+        const newQuery = { ...query, SortBy: 'Random', Limit: 1 };
         return ApiClient.getItems(ApiClient.getCurrentUserId(), newQuery).then(({ Items }) => {
             playbackManager.shuffle(Items[0]);
         });

--- a/src/controllers/movies/movies.js
+++ b/src/controllers/movies/movies.js
@@ -33,9 +33,12 @@ export default function (view, params, tabContent, options) {
     function shuffle() {
         isLoading = true;
         loading.show();
-        const newQuery = { ...query, SortBy: 'Random', Limit: 1 };
+        const newQuery = { ...query, SortBy: 'Random', StartIndex: 0, Limit: 300 };
         return ApiClient.getItems(ApiClient.getCurrentUserId(), newQuery).then(({ Items }) => {
-            playbackManager.shuffle(Items[0]);
+            playbackManager.play({
+                items: Items,
+                autoplay: true
+            });
         }).finally(() => {
             isLoading = false;
         });

--- a/src/controllers/movies/movies.js
+++ b/src/controllers/movies/movies.js
@@ -31,11 +31,11 @@ export default function (view, params, tabContent, options) {
     }
 
     function shuffle() {
-        ApiClient.getItem(
-            ApiClient.getCurrentUserId(),
-            params.topParentId
-        ).then((item) => {
-            playbackManager.shuffle(item);
+        isLoading = true;
+        loading.show();
+        const newQuery = { ...query, SortBy: 'Random' };
+        return ApiClient.getItems(ApiClient.getCurrentUserId(), newQuery).then(({ Items }) => {
+            playbackManager.shuffle(Items[0]);
         });
     }
 


### PR DESCRIPTION
**Changes**

Updates the random movies button so it chooses a random movie from the _filtered_ list, instead of choosing a random movie from all movies.

Note: I do think this was the original intent of the movie's Shuffle button, as the button is removed from the UI when the applied filters return 0 movies.

**Issues**
Fixes [#3732](https://github.com/jellyfin/jellyfin-web/issues/3732)
