### PR TITLE
Fix audio/subtitle index reset when switching episodes

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -2407,20 +2407,20 @@ class PlaybackManager {
             });
         }
 
-        function rankStreamType(prevIndex, prevSource, mediaSource, streamType, isSecondarySubtitle) {
+        function rankStreamType(prevIndex, prevSource, mediaStreams, trackOptions, streamType, isSecondarySubtitle) {
             if (prevIndex == -1) {
                 console.debug(`AutoSet ${streamType} - No Stream Set`);
                 if (streamType == 'Subtitle') {
                     if (isSecondarySubtitle) {
-                        mediaSource.DefaultSecondarySubtitleStreamIndex = -1;
+                        trackOptions.DefaultSecondarySubtitleStreamIndex = -1;
                     } else {
-                        mediaSource.DefaultSubtitleStreamIndex = -1;
+                        trackOptions.DefaultSubtitleStreamIndex = -1;
                     }
                 }
                 return;
             }
 
-            if (!prevSource.MediaStreams || !mediaSource.MediaStreams) {
+            if (!prevSource.MediaStreams || !mediaStreams) {
                 console.debug(`AutoSet ${streamType} - No MediaStreams`);
                 return;
             }
@@ -2446,7 +2446,7 @@ class PlaybackManager {
             }
 
             let newRelIndex = 0;
-            for (const stream of mediaSource.MediaStreams) {
+            for (const stream of mediaStreams) {
                 if (stream.Type != streamType) continue;
 
                 let score = 0;
@@ -2469,38 +2469,38 @@ class PlaybackManager {
                 console.debug(`AutoSet ${streamType} - Using ${bestStreamIndex} score ${bestStreamScore}.`);
                 if (streamType == 'Subtitle') {
                     if (isSecondarySubtitle) {
-                        mediaSource.DefaultSecondarySubtitleStreamIndex = bestStreamIndex;
+                        trackOptions.DefaultSecondarySubtitleStreamIndex = bestStreamIndex;
                     } else {
-                        mediaSource.DefaultSubtitleStreamIndex = bestStreamIndex;
+                        trackOptions.DefaultSubtitleStreamIndex = bestStreamIndex;
                     }
                 }
                 if (streamType == 'Audio') {
-                    mediaSource.DefaultAudioStreamIndex = bestStreamIndex;
+                    trackOptions.DefaultAudioStreamIndex = bestStreamIndex;
                 }
             } else {
                 console.debug(`AutoSet ${streamType} - Threshold not met. Using default.`);
             }
         }
 
-        function autoSetNextTracks(prevSource, mediaSource, audio, subtitle) {
+        function autoSetNextTracks(prevSource, mediaStreams, trackOptions, audio, subtitle) {
             try {
                 if (!prevSource) return;
 
-                if (!mediaSource) {
-                    console.warn('AutoSet - No mediaSource');
+                if (!mediaStreams) {
+                    console.warn('AutoSet - No mediaStreams');
                     return;
                 }
 
                 if (audio && typeof prevSource.DefaultAudioStreamIndex == 'number') {
-                    rankStreamType(prevSource.DefaultAudioStreamIndex, prevSource, mediaSource, 'Audio');
+                    rankStreamType(prevSource.DefaultAudioStreamIndex, prevSource, mediaStreams, trackOptions, 'Audio');
                 }
 
                 if (subtitle && typeof prevSource.DefaultSubtitleStreamIndex == 'number') {
-                    rankStreamType(prevSource.DefaultSubtitleStreamIndex, prevSource, mediaSource, 'Subtitle');
+                    rankStreamType(prevSource.DefaultSubtitleStreamIndex, prevSource, mediaStreams, trackOptions, 'Subtitle');
                 }
 
                 if (subtitle && typeof prevSource.DefaultSecondarySubtitleStreamIndex == 'number') {
-                    rankStreamType(prevSource.DefaultSecondarySubtitleStreamIndex, prevSource, mediaSource, 'Subtitle', true);
+                    rankStreamType(prevSource.DefaultSecondarySubtitleStreamIndex, prevSource, mediaStreams, trackOptions, 'Subtitle', true);
                 }
             } catch (e) {
                 console.error(`AutoSet - Caught unexpected error: ${e}`);
@@ -2572,12 +2572,18 @@ class PlaybackManager {
                 });
             }
 
-            return Promise.all([promise, player.getDeviceProfile(item)]).then(function (responses) {
+            const apiClient = ServerConnections.getApiClient(item.ServerId);
+            const mediaSourceId = playOptions.mediaSourceId || item.Id;
+            const getMediaStreams = apiClient.getItem(apiClient.getCurrentUserId(), mediaSourceId)
+                .then(fullItem => {
+                    return fullItem.MediaStreams;
+                });
+
+            return Promise.all([promise, player.getDeviceProfile(item), apiClient.getCurrentUser(), getMediaStreams]).then(function (responses) {
                 const deviceProfile = responses[1];
+                const user = responses[2];
+                const mediaStreams = responses[3];
 
-                const apiClient = ServerConnections.getApiClient(item.ServerId);
-
-                const mediaSourceId = playOptions.mediaSourceId;
                 const audioStreamIndex = playOptions.audioStreamIndex;
                 const subtitleStreamIndex = playOptions.subtitleStreamIndex;
                 const options = {
@@ -2600,9 +2606,20 @@ class PlaybackManager {
                 // this reference was only needed by sendPlaybackListToPlayer
                 playOptions.items = null;
 
+                const trackOptions = {};
+
+                autoSetNextTracks(prevSource, mediaStreams, trackOptions, user.Configuration.RememberAudioSelections, user.Configuration.RememberSubtitleSelections);
+                if (trackOptions.DefaultAudioStreamIndex != null) {
+                    options.audioStreamIndex = trackOptions.DefaultAudioStreamIndex;
+                }
+                if (trackOptions.DefaultSubtitleStreamIndex != null) {
+                    options.subtitleStreamIndex = trackOptions.DefaultSubtitleStreamIndex;
+                }
+
                 return getPlaybackMediaSource(player, apiClient, deviceProfile, item, mediaSourceId, options).then(async (mediaSource) => {
-                    const user = await apiClient.getCurrentUser();
-                    autoSetNextTracks(prevSource, mediaSource, user.Configuration.RememberAudioSelections, user.Configuration.RememberSubtitleSelections);
+                    if (trackOptions.DefaultSecondarySubtitleStreamIndex != null) {
+                        mediaSource.DefaultSecondarySubtitleStreamIndex = trackOptions.DefaultSecondarySubtitleStreamIndex;
+                    }
 
                     if (mediaSource.DefaultSubtitleStreamIndex == null || mediaSource.DefaultSubtitleStreamIndex < 0) {
                         mediaSource.DefaultSubtitleStreamIndex = mediaSource.DefaultSecondarySubtitleStreamIndex;


### PR DESCRIPTION
Based on the comment from here https://github.com/jellyfin/jellyfin-web/pull/5998#issuecomment-2331224096.

Fixes audio/subtitle track not being set according to the UI's selected tracks.

I've tested this on a variety of different media with "Set audio/subtitle track based on previous item" on and off and it seems to work as expected, but any further testing would be appreciated.

**Changes**
Set `audioStreamIndex` & `subtitleStreamIndex` to match player.

**Issues**
Fixes https://github.com/jellyfin/jellyfin-web/issues/3994
Fixes https://github.com/jellyfin/jellyfin-web/issues/5873
