### PR TITLE
Keybind C to auto select subtitle track

### DIFF
--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1431,7 +1431,7 @@ export default function (view) {
             case 'C':
                 if (!e.shiftKey) {
                     e.preventDefault();
-                    autoSelectSubtitleTrack();
+                    toggleDefaultSubtitleTrack();
                 }
                 break;
             case 'g':

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1204,8 +1204,8 @@ export default function (view) {
         const currentIndex = playbackManager.getSubtitleStreamIndex(player) ?? -1;
         const defaultIndex = player?.streamInfo?.mediaSource?.DefaultSubtitleStreamIndex ?? -1;
 
-        if (currentIndex === -1 && streams.length > 0) {
-            const subtitleIndex = defaultIndex != -1 ? defaultIndex : streams[0].Index;
+        if (currentIndex === -1 && subtitleTracks.length > 0) {
+            const subtitleIndex = defaultIndex != -1 ? defaultIndex : subtitleTracks[0].Index;
             playbackManager.setSubtitleStreamIndex(subtitleIndex, player);
         } else {
             playbackManager.setSubtitleStreamIndex(-1, player);

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1200,17 +1200,20 @@ export default function (view) {
 
     function autoSelectSubtitleTrack() {
         const player = currentPlayer;
-        const streams = playbackManager.subtitleTracks(player);
+        const streams = playbackManager.subtitleTracks(player) ?? [];
         const currentIndex = playbackManager.getSubtitleStreamIndex(player) ?? -1;
+        const defaultIndex = player?.streamInfo?.mediaSource?.DefaultSubtitleStreamIndex ?? -1;
 
         if (currentIndex === -1 && streams.length > 0) {
-            const firstSubtitleIndex = streams[0].Index;
-            playbackManager.setSubtitleStreamIndex(firstSubtitleIndex, player);
+            if (defaultIndex > -1) {
+                playbackManager.setSubtitleStreamIndex(defaultIndex, player);
+            } else {
+                const firstSubtitleIndex = streams[0].Index;
+                playbackManager.setSubtitleStreamIndex(firstSubtitleIndex, player);
+            }
         } else {
             playbackManager.setSubtitleStreamIndex(-1, player);
         }
-
-        toggleSubtitleSync();
     }
 
     /**

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1200,7 +1200,7 @@ export default function (view) {
 
     function autoSelectSubtitleTrack() {
         const player = currentPlayer;
-        const streams = playbackManager.subtitleTracks(player) ?? [];
+        const streams = playbackManager.subtitleTracks(player);
         const currentIndex = playbackManager.getSubtitleStreamIndex(player) ?? -1;
         const defaultIndex = player?.streamInfo?.mediaSource?.DefaultSubtitleStreamIndex ?? -1;
 

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1198,8 +1198,7 @@ export default function (view) {
         }
     }
 
-    function toggleDefaultSubtitleTrack() {
-        const player = currentPlayer;
+    function toggleDefaultSubtitleTrack(player) {
         const subtitleTracks = playbackManager.subtitleTracks(player);
         const currentIndex = playbackManager.getSubtitleStreamIndex(player) ?? -1;
         const defaultIndex = player?.streamInfo?.mediaSource?.DefaultSubtitleStreamIndex ?? -1;
@@ -1431,7 +1430,7 @@ export default function (view) {
             case 'C':
                 if (!e.shiftKey) {
                     e.preventDefault();
-                    toggleDefaultSubtitleTrack();
+                    toggleDefaultSubtitleTrack(currentPlayer);
                 }
                 break;
             case 'g':

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1200,7 +1200,7 @@ export default function (view) {
 
     function autoSelectSubtitleTrack() {
         const player = currentPlayer;
-        const streams = playbackManager.subtitleTracks(player);
+        const subtitleTracks = playbackManager.subtitleTracks(player);
         const currentIndex = playbackManager.getSubtitleStreamIndex(player) ?? -1;
         const defaultIndex = player?.streamInfo?.mediaSource?.DefaultSubtitleStreamIndex ?? -1;
 

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1198,6 +1198,21 @@ export default function (view) {
         }
     }
 
+    function autoSelectSubtitleTrack() {
+        const player = currentPlayer;
+        const streams = playbackManager.subtitleTracks(player);
+        const currentIndex = playbackManager.getSubtitleStreamIndex(player) ?? -1;
+
+        if (currentIndex === -1 && streams.length > 0) {
+            const firstSubtitleIndex = streams[0].Index;
+            playbackManager.setSubtitleStreamIndex(firstSubtitleIndex, player);
+        } else {
+            playbackManager.setSubtitleStreamIndex(-1, player);
+        }
+
+        toggleSubtitleSync();
+    }
+
     /**
          * Clicked element.
          * To skip 'click' handling on Firefox/Edge.
@@ -1411,6 +1426,13 @@ export default function (view) {
                 if (!e.shiftKey) {
                     e.preventDefault();
                     playbackManager.previousChapter(currentPlayer);
+                }
+                break;
+            case 'c':
+            case 'C':
+                if (!e.shiftKey) {
+                    e.preventDefault();
+                    autoSelectSubtitleTrack();
                 }
                 break;
             case 'g':

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1205,12 +1205,8 @@ export default function (view) {
         const defaultIndex = player?.streamInfo?.mediaSource?.DefaultSubtitleStreamIndex ?? -1;
 
         if (currentIndex === -1 && streams.length > 0) {
-            if (defaultIndex > -1) {
-                playbackManager.setSubtitleStreamIndex(defaultIndex, player);
-            } else {
-                const firstSubtitleIndex = streams[0].Index;
-                playbackManager.setSubtitleStreamIndex(firstSubtitleIndex, player);
-            }
+            const subtitleIndex = defaultIndex != -1 ? defaultIndex : streams[0].Index;
+            playbackManager.setSubtitleStreamIndex(subtitleIndex, player);
         } else {
             playbackManager.setSubtitleStreamIndex(-1, player);
         }

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1198,7 +1198,7 @@ export default function (view) {
         }
     }
 
-    function autoSelectSubtitleTrack() {
+    function toggleDefaultSubtitleTrack() {
         const player = currentPlayer;
         const subtitleTracks = playbackManager.subtitleTracks(player);
         const currentIndex = playbackManager.getSubtitleStreamIndex(player) ?? -1;


### PR DESCRIPTION
Keybind C to auto select subtitle track

**Changes**
Add `c` case to `onKeyDown`. The function selects the first available subtitle track, or if subtitles are already selected, disables them. 

**Issues**
Feature Request: https://features.jellyfin.org/posts/1245/enable-disable-subtitles-using-a-keyboard-shortcut
