### PR TITLE
Fix creating & deleting access schedules

### DIFF
--- a/src/apps/dashboard/routes/users/parentalcontrol.tsx
+++ b/src/apps/dashboard/routes/users/parentalcontrol.tsx
@@ -367,7 +367,7 @@ const UserParentalControl = () => {
         });
 
         (page.querySelector('.userParentalControlForm') as HTMLFormElement).addEventListener('submit', onSubmit);
-    }, [loadAllowedTags, loadBlockedTags, loadData]);
+    }, [loadAllowedTags, loadBlockedTags, loadData, userId]);
 
     useEffect(() => {
         const page = element.current;

--- a/src/apps/dashboard/routes/users/parentalcontrol.tsx
+++ b/src/apps/dashboard/routes/users/parentalcontrol.tsx
@@ -381,10 +381,8 @@ const UserParentalControl = () => {
 
         for (const btnDelete of accessScheduleList.querySelectorAll('.btnDelete')) {
             btnDelete.addEventListener('click', function () {
-                const schedules = [ ...accessSchedules ];
                 const index = parseInt(btnDelete.getAttribute('data-index') ?? '0', 10);
-                schedules.splice(index, 1);
-                const newindex = schedules.filter(i => i != index);
+                const newindex = accessSchedules.filter((_e, i) => i != index);
                 setAccessSchedules(newindex);
             });
         }

--- a/src/apps/dashboard/routes/users/parentalcontrol.tsx
+++ b/src/apps/dashboard/routes/users/parentalcontrol.tsx
@@ -188,28 +188,6 @@ const UserParentalControl = () => {
         }
     }, []);
 
-    const renderAccessSchedule = useCallback((schedules: AccessSchedule[]) => {
-        const page = element.current;
-
-        if (!page) {
-            console.error('[userparentalcontrol] Unexpected null page reference');
-            return;
-        }
-
-        setAccessSchedules(schedules);
-
-        const accessScheduleList = page.querySelector('.accessScheduleList') as HTMLDivElement;
-
-        for (const btnDelete of accessScheduleList.querySelectorAll('.btnDelete')) {
-            btnDelete.addEventListener('click', function () {
-                const index = parseInt(btnDelete.getAttribute('data-index') ?? '0', 10);
-                schedules.splice(index, 1);
-                const newindex = schedules.filter((_, i) => i != index);
-                renderAccessSchedule(newindex);
-            });
-        }
-    }, []);
-
     const loadUser = useCallback((user: UserDto, allParentalRatings: ParentalRating[]) => {
         const page = element.current;
 
@@ -242,9 +220,9 @@ const UserParentalControl = () => {
         } else {
             (page.querySelector('.accessScheduleSection') as HTMLDivElement).classList.remove('hide');
         }
-        renderAccessSchedule(user.Policy?.AccessSchedules || []);
+        setAccessSchedules(user.Policy?.AccessSchedules || []);
         loading.hide();
-    }, [loadAllowedTags, loadBlockedTags, loadUnratedItems, populateRatings, renderAccessSchedule]);
+    }, [loadAllowedTags, loadBlockedTags, loadUnratedItems, populateRatings]);
 
     const loadData = useCallback(() => {
         if (!userId) {
@@ -285,7 +263,7 @@ const UserParentalControl = () => {
                     }
 
                     schedules[index] = updatedSchedule;
-                    renderAccessSchedule(schedules);
+                    setAccessSchedules(schedules);
                 }).catch(() => {
                     // access schedule closed
                 });
@@ -389,7 +367,28 @@ const UserParentalControl = () => {
         });
 
         (page.querySelector('.userParentalControlForm') as HTMLFormElement).addEventListener('submit', onSubmit);
-    }, [loadAllowedTags, loadBlockedTags, loadData, renderAccessSchedule]);
+    }, [loadAllowedTags, loadBlockedTags, loadData]);
+
+    useEffect(() => {
+        const page = element.current;
+
+        if (!page) {
+            console.error('[userparentalcontrol] Unexpected null page reference');
+            return;
+        }
+
+        const accessScheduleList = page.querySelector('.accessScheduleList') as HTMLDivElement;
+
+        for (const btnDelete of accessScheduleList.querySelectorAll('.btnDelete')) {
+            btnDelete.addEventListener('click', function () {
+                const schedules = [ ...accessSchedules ];
+                const index = parseInt(btnDelete.getAttribute('data-index') ?? '0', 10);
+                schedules.splice(index, 1);
+                const newindex = schedules.filter(i => i != index);
+                setAccessSchedules(newindex);
+            });
+        }
+    }, [accessSchedules])
 
     const optionMaxParentalRating = () => {
         let content = '';

--- a/src/apps/dashboard/routes/users/parentalcontrol.tsx
+++ b/src/apps/dashboard/routes/users/parentalcontrol.tsx
@@ -386,7 +386,7 @@ const UserParentalControl = () => {
                 setAccessSchedules(newindex);
             });
         }
-    }, [accessSchedules])
+    }, [accessSchedules]);
 
     const optionMaxParentalRating = () => {
         let content = '';

--- a/src/elements/IconButtonElement.tsx
+++ b/src/elements/IconButtonElement.tsx
@@ -37,7 +37,7 @@ const IconButtonElement: FunctionComponent<IProps> = ({ is, id, className, title
                 className: className,
                 title: title ? `title="${globalize.translate(title)}"` : '',
                 icon: icon,
-                dataIndex: dataIndex != null ? `data-index="${dataIndex}"` : '',
+                dataIndex: (dataIndex || dataIndex === 0) ? `data-index="${dataIndex}"` : '',
                 dataTag: dataTag ? `data-tag="${dataTag}"` : '',
                 dataProfileid: dataProfileid ? `data-profileid="${dataProfileid}"` : ''
             })}

--- a/src/elements/IconButtonElement.tsx
+++ b/src/elements/IconButtonElement.tsx
@@ -37,7 +37,7 @@ const IconButtonElement: FunctionComponent<IProps> = ({ is, id, className, title
                 className: className,
                 title: title ? `title="${globalize.translate(title)}"` : '',
                 icon: icon,
-                dataIndex: dataIndex ? `data-index="${dataIndex}"` : '',
+                dataIndex: dataIndex != null ? `data-index="${dataIndex}"` : '',
                 dataTag: dataTag ? `data-tag="${dataTag}"` : '',
                 dataProfileid: dataProfileid ? `data-profileid="${dataProfileid}"` : ''
             })}


### PR DESCRIPTION
Update to React 18 caused some issues with this.

**Changes**
Move deletion to a separate useEffect hook
Fix delete button from incorrectly deleting two schedules

**Issues**
Fixes https://github.com/jellyfin/jellyfin-web/issues/6119