### PR TITLE
Fix HEVC playback on Hisense Vidaa OS

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -197,6 +197,10 @@ function canPlayAudioFormat(format) {
 }
 
 function testCanPlayMkv(videoTestElement) {
+    if (browser.vidaa) {
+        return false;
+    }
+
     if (browser.tizen || browser.web0s) {
         return true;
     }
@@ -658,7 +662,7 @@ export default function (options) {
 
     if (canPlayHevc(videoTestElement, options)) {
         mp4VideoCodecs.push('hevc');
-        if (browser.tizen || browser.web0s) {
+        if (browser.tizen || browser.web0s || browser.vidaa) {
             hlsInTsVideoCodecs.push('hevc');
         }
     }


### PR DESCRIPTION
Vidaa OS web browser reports it supports HEVC but playback is extremely glitchy (See links below).
Tested on 2 models (Hisense U7 & U8). This commit disables HEVC on Vidaa OS browser profile to stop HEVC Direct Play and allows transcoding HEVC files without resorting to very low bitrates to trigger transcoding.

[Before](https://thecodeninja.net/wp-content/uploads/2024/09/20240928_155147-1024x577.jpg)

[After](https://thecodeninja.net/wp-content/uploads/2024/09/20240928_160451-scaled.jpg)

Without this fix, only way to play videos on Hisense TVs with Vidaa OS is to set the bitrate below the video's native bitrate to trigger transcoding which often takes the video in to 480p and below territory and is not watchable.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
Changed the canPlayHevc(...) function in browserDeviceProfile to return false when it detects browser.vidaa
This essentially tells rest of the Jellyfin-web client that Vidaa does not support HEVC, therefore allowing transcoding at native video resolution.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
