### PR TITLE
Fix the broken LoginAttemptsBeforeLockout

### DIFF
--- a/src/apps/dashboard/routes/users/profile.tsx
+++ b/src/apps/dashboard/routes/users/profile.tsx
@@ -168,8 +168,8 @@ const UserEdit = () => {
         (page.querySelector('.chkRemoteAccess') as HTMLInputElement).checked = user.Policy?.EnableRemoteAccess == null || user.Policy?.EnableRemoteAccess;
         (page.querySelector('#txtRemoteClientBitrateLimit') as HTMLInputElement).value = user.Policy?.RemoteClientBitrateLimit && user.Policy?.RemoteClientBitrateLimit > 0 ?
             (user.Policy?.RemoteClientBitrateLimit / 1e6).toLocaleString(undefined, { maximumFractionDigits: 6 }) : '';
-        (page.querySelector('#txtLoginAttemptsBeforeLockout') as HTMLInputElement).value = String(user.Policy?.MaxActiveSessions) || '0';
-        (page.querySelector('#txtMaxActiveSessions') as HTMLInputElement).value = String(user.Policy?.SyncPlayAccess) || '0';
+        (page.querySelector('#txtLoginAttemptsBeforeLockout') as HTMLInputElement).value = String(user.Policy?.LoginAttemptsBeforeLockout) || '-1';
+        (page.querySelector('#txtMaxActiveSessions') as HTMLInputElement).value = String(user.Policy?.MaxActiveSessions) || '0';
         if (window.ApiClient.isMinServerVersion('10.6.0')) {
             (page.querySelector('#selectSyncPlayAccess') as HTMLSelectElement).value = String(user.Policy?.SyncPlayAccess);
         }


### PR DESCRIPTION
**Changes**
- Fix the broken LoginAttemptsBeforeLockout

**Issues**
- fixes a typo made in be891c3, to reproduce:

1. Upgrade to 10.10
2. Save settings in Dashboard->User
3. Happened to enter the wrong admin password once when logging in
4. You are locked out of your server

![1](https://github.com/user-attachments/assets/7a046d07-8c2f-4d7a-a808-ba7b1023e3b3)