### PR TITLE
Only add gain node and AudioContext when normalization enabled

### DIFF
--- a/src/plugins/htmlAudioPlayer/plugin.js
+++ b/src/plugins/htmlAudioPlayer/plugin.js
@@ -128,6 +128,7 @@ class HtmlAudioPlayer {
 
                 if (!self.gainNode) {
                     addGainElement(elem);
+                    if (!self.gainNode) return;
                 }
 
                 if (normalizationGain) {

--- a/src/plugins/htmlAudioPlayer/plugin.js
+++ b/src/plugins/htmlAudioPlayer/plugin.js
@@ -121,6 +121,13 @@ class HtmlAudioPlayer {
                     normalizationGain =
                         options.mediaSource.albumNormalizationGain
                         ?? options.item.NormalizationGain;
+                } else {
+                    console.debug('normalization disabled')
+                    return;
+                }
+
+                if (!self.gainNode) {
+                    addGainElement(elem);
                 }
 
                 if (normalizationGain) {
@@ -276,7 +283,7 @@ class HtmlAudioPlayer {
 
             self._mediaElement = elem;
 
-            addGainElement(elem);
+            // addGainElement(elem);
 
             return elem;
         }
@@ -317,7 +324,7 @@ class HtmlAudioPlayer {
         function onVolumeChange() {
             if (!self._isFadingOut) {
                 htmlMediaHelper.saveVolume(this.volume);
-                if (browser.safari) {
+                if (browser.safari && self.gainNode) {
                     self.gainNode.gain.value = this.volume * self.normalizationGain;
                 }
                 Events.trigger(self, 'volumechange');

--- a/src/plugins/htmlAudioPlayer/plugin.js
+++ b/src/plugins/htmlAudioPlayer/plugin.js
@@ -283,8 +283,6 @@ class HtmlAudioPlayer {
 
             self._mediaElement = elem;
 
-            // addGainElement(elem);
-
             return elem;
         }
 

--- a/src/plugins/htmlAudioPlayer/plugin.js
+++ b/src/plugins/htmlAudioPlayer/plugin.js
@@ -122,7 +122,7 @@ class HtmlAudioPlayer {
                         options.mediaSource.albumNormalizationGain
                         ?? options.item.NormalizationGain;
                 } else {
-                    console.debug('normalization disabled')
+                    console.debug('normalization disabled');
                     return;
                 }
 

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -156,7 +156,7 @@
     "ChannelNumber": "Channel number",
     "Channels": "Channels",
     "CinemaModeConfigurationHelp": "Cinema mode brings the theater experience straight to your living room with the ability to play trailers and custom intros before the main feature.",
-    "SelectAudioNormalizationHelp": "Track gain - adjusts the volume of each track so they playback with the same loudness. Album gain - adjusts the volume of all the tracks in an album only, keeping the album's dynamic range.",
+    "SelectAudioNormalizationHelp": "Track gain - adjusts the volume of each track so they playback with the same loudness. Album gain - adjusts the volume of all the tracks in an album only, keeping the album's dynamic range. Switching between \"Off\" and other options requires restarting the current playback.",
     "ClearQueue": "Clear queue",
     "ClientSettings": "Client Settings",
     "Collections": "Collections",


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

Currently, we create a Web Audio session and connect to it regardless of the normalization status, hoping it will work. However, it turns out that some devices exhibit buggy behavior when the Web Audio session is connected to a gain node, causing distorted audio playback. This PR makes that the gain element is only created when normalization is not off. The downside is that users must manually stop the currently playing song and start a new one to apply the state change between on and off. By doing this, users experiencing bugged playback can turn off the normalization so that the playback behavior would be the same as 10.8 which *should* be fine.

We do need this workaround because:

- Device and/or OS vendors are less concerned about this issue than we are, meaning it might take a long time to be fixed upstream.
- Not all devices have the option to update to the latest software. We need to provide users with such devices a workaround so that they can at least have a normal playback, even if it means losing a feature.

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

- Only create gain element when normalization is not off.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

See jellyfin/jellyfin#11614, hopefully will workaround that.
