### PR TITLE
Only connect to ServerConnections once

### DIFF
--- a/src/components/ConnectionRequired.tsx
+++ b/src/components/ConnectionRequired.tsx
@@ -151,6 +151,7 @@ const ConnectionRequired: FunctionComponent<ConnectionRequiredProps> = ({
         // Check connection status on initial page load
         const firstConnection = ServerConnections.firstConnection;
         console.debug('[ConnectionRequired] connection state', firstConnection?.State);
+        ServerConnections.firstConnection = null;
 
         if (firstConnection && firstConnection.State !== ConnectionState.SignedIn) {
             handleIncompleteWizard(firstConnection)

--- a/src/components/ConnectionRequired.tsx
+++ b/src/components/ConnectionRequired.tsx
@@ -149,19 +149,20 @@ const ConnectionRequired: FunctionComponent<ConnectionRequiredProps> = ({
 
     useEffect(() => {
         // Check connection status on initial page load
-        ServerConnections.connect()
-            .then(firstConnection => {
-                console.debug('[ConnectionRequired] connection state', firstConnection?.State);
+        const firstConnection = ServerConnections.firstConnection;
+        console.debug('[ConnectionRequired] connection state', firstConnection?.State);
 
-                if (firstConnection && firstConnection.State !== ConnectionState.SignedIn) {
-                    return handleIncompleteWizard(firstConnection);
-                } else {
-                    return validateUserAccess();
-                }
-            })
-            .catch(err => {
-                console.error('[ConnectionRequired] failed to connect to server', err);
-            });
+        if (firstConnection && firstConnection.State !== ConnectionState.SignedIn) {
+            handleIncompleteWizard(firstConnection)
+                .catch(err => {
+                    console.error('[ConnectionRequired] could not start wizard', err);
+                });
+        } else {
+            validateUserAccess()
+                .catch(err => {
+                    console.error('[ConnectionRequired] could not validate user access', err);
+                });
+        }
     }, [handleIncompleteWizard, validateUserAccess]);
 
     if (isLoading) {

--- a/src/components/ConnectionRequired.tsx
+++ b/src/components/ConnectionRequired.tsx
@@ -149,11 +149,12 @@ const ConnectionRequired: FunctionComponent<ConnectionRequiredProps> = ({
 
     useEffect(() => {
         // Check connection status on initial page load
+        const apiClient = ServerConnections.currentApiClient();
         const firstConnection = ServerConnections.firstConnection;
         console.debug('[ConnectionRequired] connection state', firstConnection?.State);
         ServerConnections.firstConnection = null;
 
-        if (firstConnection && firstConnection.State !== ConnectionState.SignedIn) {
+        if (firstConnection && firstConnection.State !== ConnectionState.SignedIn && !apiClient?.isLoggedIn()) {
             handleIncompleteWizard(firstConnection)
                 .catch(err => {
                     console.error('[ConnectionRequired] could not start wizard', err);

--- a/src/components/ServerConnections.js
+++ b/src/components/ServerConnections.js
@@ -33,6 +33,7 @@ class ServerConnections extends ConnectionManager {
     constructor() {
         super(...arguments);
         this.localApiClient = null;
+        this.firstConnection = null;
 
         // Set the apiclient minimum version to match the SDK
         this._minServerVersion = MINIMUM_VERSION;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -110,6 +110,9 @@ build: ${__JF_BUILD_VERSION__}`);
         Events.on(apiClient, 'requestfail', appRouter.onRequestFail);
     });
 
+    // Connect to server
+    ServerConnections.firstConnection = await ServerConnections.connect();
+
     // Render the app
     await renderApp();
 


### PR DESCRIPTION
Currently, the client will send a request to `ServerConnections.connect` every time we switch pages.  With this, the behaviour should now be the same as prior to app routing being removed.

**Changes**
Change it so that we only connect to ServerConnections once with each session, reducing unnecessary calls to `/System/Info/Public` with each navigation.
Fix issue with logging in after refreshing login/select server page.

**Issues**
Fixes https://github.com/jellyfin/jellyfin-web/issues/6143