### PR TITLE
Hide empty message box if there isn't text

### DIFF
--- a/src/components/directorybrowser/directorybrowser.js
+++ b/src/components/directorybrowser/directorybrowser.js
@@ -87,7 +87,7 @@ function getEditorHtml(options, systemInfo) {
     let html = '';
     html += '<div class="formDialogContent scrollY">';
     html += '<div class="dialogContentInner dialog-content-centered" style="padding-top:2em;">';
-    if (!options.pathReadOnly) {
+    if (!options.pathReadOnly && systemInfo.OperatingSystem) {
         const instruction = options.instruction ? `${escapeHtml(options.instruction)}<br/><br/>` : '';
         html += '<div class="infoBanner" style="margin-bottom:1.5em;">';
         html += instruction;


### PR DESCRIPTION
**Changes**
Hide the message box when there won't be text.

**Issues**
Fixes https://github.com/jellyfin/jellyfin-web/issues/6144