### PR TITLE
Fix minimum release age type in renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,7 @@
     {
       "matchPackageNames": [ "@jellyfin/sdk" ],
       "followTag": "unstable",
-      "minimumReleaseAge": 0,
+      "minimumReleaseAge": null,
       "schedule": [ "after 7:00 am" ]
     }
   ]


### PR DESCRIPTION
**Changes**
The old configuration `stabilityDays` used numbers but that isn't supported by the new `minimumReleaseAge` configuration

**Issues**
Fixes #6154 