### PR TITLE
Fix UI freeze when opening same path

### DIFF
--- a/src/components/router/appRouter.js
+++ b/src/components/router/appRouter.js
@@ -39,6 +39,9 @@ class AppRouter {
     constructor() {
         document.addEventListener('viewshow', () => this.onViewShow());
 
+        this.lastPath = history.location.pathname + history.location.search;
+        this.listen();
+
         // TODO: Can this baseRoute logic be simplified?
         this.baseRoute = window.location.href.split('?')[0].replace(this.#getRequestFile(), '');
         // support hashbang
@@ -98,6 +101,20 @@ class AppRouter {
         });
 
         return this.promiseShow;
+    }
+
+    listen() {
+        history.listen(({ location }) => {
+            const normalizedPath = location.pathname.replace(/^!/, '');
+            const fullPath = normalizedPath + location.search;
+
+            if (fullPath === this.lastPath) {
+                console.debug('[appRouter] path did not change, resolving promise');
+                this.onViewShow();
+            }
+
+            this.lastPath = fullPath;
+        });
     }
 
     baseUrl() {


### PR DESCRIPTION
When clicking on a link that leads to the same path (such as for example the same episode under the 'More from' section in the details page), the UI will freeze because it's waiting on a promise that will never resolve. Regression from https://github.com/jellyfin/jellyfin-web/pull/6024

**Changes**
Listen for path changes and call `this.onViewShow()` if the path did not change.

**Issues**
