### PR TITLE
Fix padding issues in the metadata manager

### DIFF
--- a/src/apps/dashboard/AppOverrides.scss
+++ b/src/apps/dashboard/AppOverrides.scss
@@ -9,7 +9,7 @@ $drawer-width: 240px;
 
 // Fix dashboard pages layout to work with drawer
 .dashboardDocument {
-    .mainAnimatedPage {
+    .mainAnimatedPage:not(.metadataEditorPage) {
         @media all and (min-width: $mui-bp-md) {
             left: $drawer-width;
         }
@@ -30,5 +30,9 @@ $drawer-width: 240px;
         @media all and (min-width: $mui-bp-lg) {
             padding-top: 3.25rem;
         }
+    }
+
+    .metadataEditorPage {
+        padding-top: 3.25rem !important;
     }
 }

--- a/src/controllers/edititemmetadata.html
+++ b/src/controllers/edititemmetadata.html
@@ -11,7 +11,7 @@
         </div>
     </div>
     <div>
-        <div class="editPageInnerContent padded-top padded-bottom-page">
+        <div class="editPageInnerContent padded-bottom-page">
         </div>
     </div>
 </div>

--- a/src/styles/metadataeditor.scss
+++ b/src/styles/metadataeditor.scss
@@ -56,7 +56,7 @@
 @media all and (min-width: 50em) {
     .editPageSidebar {
         position: fixed;
-        top: 5.2em;
+        top: 3.25rem;
         bottom: 0;
         width: 30%;
         display: block;


### PR DESCRIPTION
**Changes**
* Fixes some padding issues in the metadata manager... it's not perfect, but much better imo

<table>
<tr>
<th>Before</th>
<td>

![Screenshot 2024-10-10 at 11-01-08 Metadata Manager](https://github.com/user-attachments/assets/f446cd7d-3de5-41e3-a31a-96e6c5327256)

</td>
</tr>
<th>After</th>
<td>

![Screenshot 2024-10-10 at 11-00-00 Metadata Manager](https://github.com/user-attachments/assets/d924316f-ba65-4d1e-ab27-99c00d783354)

</td>
<tr>
</tr>
</table>

**Issues**
N/A
