### PR TITLE
Fix incorrect commit input

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -43,7 +43,7 @@ jobs:
     uses: ./.github/workflows/__quality_checks.yml
     permissions: {}
     with:
-      commit: ${{ github.event.pull_request.head.ref }}
+      commit: ${{ github.event.pull_request.head.sha }}
 
   codeql:
     name: GitHub CodeQL 🔬


### PR DESCRIPTION
Other reusable workflows get cloned successfully and this one is the only being different, so I missed it completely.
