### PR TITLE
Fix missing transcoding speed info

### DIFF
--- a/src/components/playerstats/playerstats.js
+++ b/src/components/playerstats/playerstats.js
@@ -200,7 +200,7 @@ function getDisplayTranscodeFps(session, player) {
     const mediaSource = playbackManager.currentMediaSource(player) || {};
     const videoStream = (mediaSource.MediaStreams || []).find((s) => s.Type === 'Video') || {};
 
-    const originalFramerate = videoStream.AverageFrameRate;
+    const originalFramerate = videoStream.AverageFrameRate || videoStream.RealFrameRate;
     const transcodeFramerate = session.TranscodingInfo.Framerate;
 
     if (!originalFramerate) {

--- a/src/components/playerstats/playerstats.js
+++ b/src/components/playerstats/playerstats.js
@@ -200,7 +200,7 @@ function getDisplayTranscodeFps(session, player) {
     const mediaSource = playbackManager.currentMediaSource(player) || {};
     const videoStream = (mediaSource.MediaStreams || []).find((s) => s.Type === 'Video') || {};
 
-    const originalFramerate = videoStream.AverageFrameRate || videoStream.RealFrameRate;
+    const originalFramerate = videoStream.ReferenceFrameRate || videoStream.RealFrameRate;
     const transcodeFramerate = session.TranscodingInfo.Framerate;
 
     if (!originalFramerate) {


### PR DESCRIPTION
I noticed that the MediaInfoItem https://github.com/jellyfin/jellyfin-web/blob/39ec804a5ae787ad47161ab6ddd9150b93a8751c/src/components/itemMediaInfo/itemMediaInfo.js#L131-L133 uses `stream.AverageFrameRate || stream.RealFrameRate`. However in the Playback Info Widget only `videoStream.AverageFrameRate` is used. This results in the Playback Info Widget not showing how much faster the transcoding process is compared to the original frames per seconds.

**Changes**
To also use the RealFrameRate in `getDisplayTranscodeFps`, in case the AverageFrameRate is null.

**Issues**
Fixes https://github.com/jellyfin/jellyfin-web/issues/6198
