### PR TITLE
Rollback to dompurify v2 for legacy support

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,11 @@
       "followTag": "unstable",
       "minimumReleaseAge": null,
       "schedule": [ "after 7:00 am" ]
+    },
+    {
+      "matchPackageNames": ["dompurify"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "classnames": "2.5.1",
         "core-js": "3.38.1",
         "date-fns": "2.30.0",
-        "dompurify": "3.0.1",
+        "dompurify": "2.5.7",
         "epubjs": "0.3.93",
         "escape-html": "1.0.3",
         "fast-text-encoding": "1.0.6",
@@ -10191,9 +10191,9 @@
       ]
     },
     "node_modules/dompurify": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.1.tgz",
-      "integrity": "sha512-60tsgvPKwItxZZdfLmamp0MTcecCta3avOhsLgPZ0qcWt96OasFfhkeIRbJ6br5i0fQawT1/RBGB5L58/Jpwuw=="
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.7.tgz",
+      "integrity": "sha512-2q4bEI+coQM8f5ez7kt2xclg1XsecaV9ASJk/54vwlfRRNQfDqJz2pzQ8t0Ix/ToBpXlVjrRIx7pFC/o8itG2Q=="
     },
     "node_modules/domutils": {
       "version": "1.7.0",
@@ -32794,9 +32794,9 @@
       }
     },
     "dompurify": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.1.tgz",
-      "integrity": "sha512-60tsgvPKwItxZZdfLmamp0MTcecCta3avOhsLgPZ0qcWt96OasFfhkeIRbJ6br5i0fQawT1/RBGB5L58/Jpwuw=="
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.7.tgz",
+      "integrity": "sha512-2q4bEI+coQM8f5ez7kt2xclg1XsecaV9ASJk/54vwlfRRNQfDqJz2pzQ8t0Ix/ToBpXlVjrRIx7pFC/o8itG2Q=="
     },
     "domutils": {
       "version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "classnames": "2.5.1",
     "core-js": "3.38.1",
     "date-fns": "2.30.0",
-    "dompurify": "3.0.1",
+    "dompurify": "2.5.7",
     "epubjs": "0.3.93",
     "escape-html": "1.0.3",
     "fast-text-encoding": "1.0.6",


### PR DESCRIPTION
**Changes**
dompurify v3 removed legacy browser support. v2 is still receiving security updates so we should use it instead of an outdated version of v3.

**Issues**
Fixes known CVEs
Closes https://github.com/jellyfin/jellyfin-web/pull/6077
Closes https://github.com/jellyfin/jellyfin-web/pull/6076