### PR TITLE
Add HDR10 and Dolby Vision support for Vidaa OS

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -231,6 +231,7 @@ function supportsVc1(videoTestElement) {
 
 function supportsHdr10(options) {
     return options.supportsHdr10 ?? (false // eslint-disable-line sonarjs/no-redundant-boolean
+            || browser.vidaa
             || browser.tizen
             || browser.web0s
             || browser.safari && ((browser.iOS && browser.iOSVersion >= 11) || browser.osx)
@@ -1120,7 +1121,7 @@ export default function (options) {
         vp9VideoRangeTypes += '|HDR10';
         av1VideoRangeTypes += '|HDR10';
 
-        if (browser.tizenVersion >= 3) {
+        if (browser.tizenVersion >= 3 || browser.vidaa) {
             hevcVideoRangeTypes += '|DOVIWithHDR10';
         }
     }


### PR DESCRIPTION
This PR brings HDR10 and Dolby Vision playback on Vidaa OS. The video is properly remuxed and the TV recognizes it correctly.

Samples:

![20241018_005726](https://github.com/user-attachments/assets/8f1ee2a2-2de9-4bdc-b2de-ce579c018785)

![20241018_005934](https://github.com/user-attachments/assets/d4258243-7355-4f4b-9c5d-7a8a48fc106c)
