### PR TITLE
Fix tags and schedule edit for parental control

### DIFF
--- a/src/apps/dashboard/routes/users/parentalcontrol.tsx
+++ b/src/apps/dashboard/routes/users/parentalcontrol.tsx
@@ -70,13 +70,6 @@ const UserParentalControl = () => {
     const [ blockedTags, setBlockedTags ] = useState<string[]>([]);
     const libraryMenu = useMemo(async () => ((await import('../../../../scripts/libraryMenu')).default), []);
 
-    // The following are meant to be reset on each render.
-    // These are to prevent multiple callbacks to be added to a single element in one render as useEffect may be executed multiple times in each render.
-    let allowedTagsPopupCallback: (() => void) | null = null;
-    let blockedTagsPopupCallback: (() => void) | null = null;
-    let accessSchedulesPopupCallback: (() => void) | null = null;
-    let formSubmissionCallback: ((e: Event) => void) | null = null;
-
     const element = useRef<HTMLDivElement>(null);
 
     const populateRatings = useCallback((allParentalRatings: ParentalRating[]) => {
@@ -314,9 +307,10 @@ const UserParentalControl = () => {
         };
 
         // The following is still hacky and should migrate to pure react implementation for callbacks in the future
-        if (accessSchedulesPopupCallback) {
-            (page.querySelector('#btnAddSchedule') as HTMLButtonElement).removeEventListener('click', accessSchedulesPopupCallback);
-        }
+        let allowedTagsPopupCallback: (() => void) | null = null;
+        let blockedTagsPopupCallback: (() => void) | null = null;
+        let accessSchedulesPopupCallback: (() => void) | null = null;
+        let formSubmissionCallback: ((e: Event) => void) | null = null;
         accessSchedulesPopupCallback = function () {
             showSchedulePopup({
                 Id: 0,
@@ -327,24 +321,19 @@ const UserParentalControl = () => {
             }, -1);
         };
         (page.querySelector('#btnAddSchedule') as HTMLButtonElement).addEventListener('click', accessSchedulesPopupCallback);
-
-        if (allowedTagsPopupCallback) {
-            (page.querySelector('#btnAddAllowedTag') as HTMLButtonElement).removeEventListener('click', allowedTagsPopupCallback);
-        }
         allowedTagsPopupCallback = showAllowedTagPopup;
         (page.querySelector('#btnAddAllowedTag') as HTMLButtonElement).addEventListener('click', allowedTagsPopupCallback);
-
-        if (blockedTagsPopupCallback) {
-            (page.querySelector('#btnAddBlockedTag') as HTMLButtonElement).removeEventListener('click', blockedTagsPopupCallback);
-        }
         blockedTagsPopupCallback = showBlockedTagPopup;
         (page.querySelector('#btnAddBlockedTag') as HTMLButtonElement).addEventListener('click', blockedTagsPopupCallback);
-
-        if (formSubmissionCallback) {
-            (page.querySelector('.userParentalControlForm') as HTMLFormElement).removeEventListener('submit', formSubmissionCallback);
-        }
         formSubmissionCallback = onSubmit;
         (page.querySelector('.userParentalControlForm') as HTMLFormElement).addEventListener('submit', formSubmissionCallback);
+
+        return () => {
+            (page.querySelector('#btnAddSchedule') as HTMLButtonElement).removeEventListener('click', accessSchedulesPopupCallback);
+            (page.querySelector('#btnAddAllowedTag') as HTMLButtonElement).removeEventListener('click', allowedTagsPopupCallback);
+            (page.querySelector('#btnAddBlockedTag') as HTMLButtonElement).removeEventListener('click', blockedTagsPopupCallback);
+            (page.querySelector('.userParentalControlForm') as HTMLFormElement).removeEventListener('submit', formSubmissionCallback);
+        }
     }, [setAllowedTags, setBlockedTags, loadData, userId]);
 
     const optionMaxParentalRating = () => {

--- a/src/apps/dashboard/routes/users/parentalcontrol.tsx
+++ b/src/apps/dashboard/routes/users/parentalcontrol.tsx
@@ -479,7 +479,7 @@ const UserParentalControl = () => {
                         <div className='accessScheduleList paperList'>
                             {accessSchedules.map((accessSchedule, index) => {
                                 return <AccessScheduleList
-                                    key={accessSchedule.Id}
+                                    key={index}
                                     index={index}
                                     DayOfWeek={accessSchedule.DayOfWeek}
                                     StartHour={accessSchedule.StartHour}

--- a/src/apps/dashboard/routes/users/parentalcontrol.tsx
+++ b/src/apps/dashboard/routes/users/parentalcontrol.tsx
@@ -313,7 +313,7 @@ const UserParentalControl = () => {
             return false;
         };
 
-        // FIXME: The following is still hacky and should migrate to pure react implementation for callbacks in the future
+        // The following is still hacky and should migrate to pure react implementation for callbacks in the future
         if (accessSchedulesPopupCallback) {
             (page.querySelector('#btnAddSchedule') as HTMLButtonElement).removeEventListener('click', accessSchedulesPopupCallback);
         }

--- a/src/apps/dashboard/routes/users/parentalcontrol.tsx
+++ b/src/apps/dashboard/routes/users/parentalcontrol.tsx
@@ -317,18 +317,15 @@ const UserParentalControl = () => {
             }, -1);
         };
         (page.querySelector('#btnAddSchedule') as HTMLButtonElement).addEventListener('click', accessSchedulesPopupCallback);
-        const allowedTagsPopupCallback = showAllowedTagPopup;
-        (page.querySelector('#btnAddAllowedTag') as HTMLButtonElement).addEventListener('click', allowedTagsPopupCallback);
-        const blockedTagsPopupCallback = showBlockedTagPopup;
-        (page.querySelector('#btnAddBlockedTag') as HTMLButtonElement).addEventListener('click', blockedTagsPopupCallback);
-        const formSubmissionCallback = onSubmit;
-        (page.querySelector('.userParentalControlForm') as HTMLFormElement).addEventListener('submit', formSubmissionCallback);
+        (page.querySelector('#btnAddAllowedTag') as HTMLButtonElement).addEventListener('click', showAllowedTagPopup);
+        (page.querySelector('#btnAddBlockedTag') as HTMLButtonElement).addEventListener('click', showBlockedTagPopup);
+        (page.querySelector('.userParentalControlForm') as HTMLFormElement).addEventListener('submit', onSubmit);
 
         return () => {
             (page.querySelector('#btnAddSchedule') as HTMLButtonElement).removeEventListener('click', accessSchedulesPopupCallback);
-            (page.querySelector('#btnAddAllowedTag') as HTMLButtonElement).removeEventListener('click', allowedTagsPopupCallback);
-            (page.querySelector('#btnAddBlockedTag') as HTMLButtonElement).removeEventListener('click', blockedTagsPopupCallback);
-            (page.querySelector('.userParentalControlForm') as HTMLFormElement).removeEventListener('submit', formSubmissionCallback);
+            (page.querySelector('#btnAddAllowedTag') as HTMLButtonElement).removeEventListener('click', showAllowedTagPopup);
+            (page.querySelector('#btnAddBlockedTag') as HTMLButtonElement).removeEventListener('click', showBlockedTagPopup);
+            (page.querySelector('.userParentalControlForm') as HTMLFormElement).removeEventListener('submit', onSubmit);
         };
     }, [setAllowedTags, setBlockedTags, loadData, userId]);
 

--- a/src/apps/dashboard/routes/users/parentalcontrol.tsx
+++ b/src/apps/dashboard/routes/users/parentalcontrol.tsx
@@ -307,11 +307,7 @@ const UserParentalControl = () => {
         };
 
         // The following is still hacky and should migrate to pure react implementation for callbacks in the future
-        let allowedTagsPopupCallback: (() => void) | null = null;
-        let blockedTagsPopupCallback: (() => void) | null = null;
-        let accessSchedulesPopupCallback: (() => void) | null = null;
-        let formSubmissionCallback: ((e: Event) => void) | null = null;
-        accessSchedulesPopupCallback = function () {
+        const accessSchedulesPopupCallback = function () {
             showSchedulePopup({
                 Id: 0,
                 UserId: '',
@@ -321,11 +317,11 @@ const UserParentalControl = () => {
             }, -1);
         };
         (page.querySelector('#btnAddSchedule') as HTMLButtonElement).addEventListener('click', accessSchedulesPopupCallback);
-        allowedTagsPopupCallback = showAllowedTagPopup;
+        const allowedTagsPopupCallback = showAllowedTagPopup;
         (page.querySelector('#btnAddAllowedTag') as HTMLButtonElement).addEventListener('click', allowedTagsPopupCallback);
-        blockedTagsPopupCallback = showBlockedTagPopup;
+        const blockedTagsPopupCallback = showBlockedTagPopup;
         (page.querySelector('#btnAddBlockedTag') as HTMLButtonElement).addEventListener('click', blockedTagsPopupCallback);
-        formSubmissionCallback = onSubmit;
+        const formSubmissionCallback = onSubmit;
         (page.querySelector('.userParentalControlForm') as HTMLFormElement).addEventListener('submit', formSubmissionCallback);
 
         return () => {
@@ -333,7 +329,7 @@ const UserParentalControl = () => {
             (page.querySelector('#btnAddAllowedTag') as HTMLButtonElement).removeEventListener('click', allowedTagsPopupCallback);
             (page.querySelector('#btnAddBlockedTag') as HTMLButtonElement).removeEventListener('click', blockedTagsPopupCallback);
             (page.querySelector('.userParentalControlForm') as HTMLFormElement).removeEventListener('submit', formSubmissionCallback);
-        }
+        };
     }, [setAllowedTags, setBlockedTags, loadData, userId]);
 
     const optionMaxParentalRating = () => {

--- a/src/apps/dashboard/routes/users/parentalcontrol.tsx
+++ b/src/apps/dashboard/routes/users/parentalcontrol.tsx
@@ -187,7 +187,7 @@ const UserParentalControl = () => {
         }
         setAccessSchedules(user.Policy?.AccessSchedules || []);
         loading.hide();
-    }, [setAllowedTags, setBlockedTags, loadUnratedItems, populateRatings]);
+    }, [libraryMenu, setAllowedTags, setBlockedTags, loadUnratedItems, populateRatings]);
 
     const loadData = useCallback(() => {
         if (!userId) {

--- a/src/apps/dashboard/routes/users/parentalcontrol.tsx
+++ b/src/apps/dashboard/routes/users/parentalcontrol.tsx
@@ -479,7 +479,7 @@ const UserParentalControl = () => {
                         <div className='accessScheduleList paperList'>
                             {accessSchedules.map((accessSchedule, index) => {
                                 return <AccessScheduleList
-                                    key={index}
+                                    key={`${accessSchedule.DayOfWeek}${accessSchedule.StartHour}${accessSchedule.EndHour}`}
                                     index={index}
                                     DayOfWeek={accessSchedule.DayOfWeek}
                                     StartHour={accessSchedule.StartHour}

--- a/src/components/dashboard/users/AccessScheduleList.tsx
+++ b/src/components/dashboard/users/AccessScheduleList.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useCallback } from 'react';
 import datetime from '../../../scripts/datetime';
 import globalize from '../../../lib/globalize';
 import IconButtonElement from '../../../elements/IconButtonElement';
@@ -8,6 +8,7 @@ type AccessScheduleListProps = {
     DayOfWeek?: string;
     StartHour?: number ;
     EndHour?: number;
+    removeScheduleCallback?: (index: number) => void;
 };
 
 function getDisplayTime(hours = 0) {
@@ -21,7 +22,10 @@ function getDisplayTime(hours = 0) {
     return datetime.getDisplayTime(new Date(2000, 1, 1, hours, minutes, 0, 0));
 }
 
-const AccessScheduleList: FunctionComponent<AccessScheduleListProps> = ({ index, DayOfWeek, StartHour, EndHour }: AccessScheduleListProps) => {
+const AccessScheduleList: FunctionComponent<AccessScheduleListProps> = ({ index, DayOfWeek, StartHour, EndHour, removeScheduleCallback }: AccessScheduleListProps) => {
+    const onClick = useCallback(() => {
+        index !== undefined && removeScheduleCallback !== undefined && removeScheduleCallback(index);
+    }, [index, removeScheduleCallback]);
     return (
         <div
             className='liSchedule listItem'
@@ -43,6 +47,7 @@ const AccessScheduleList: FunctionComponent<AccessScheduleListProps> = ({ index,
                 title='Delete'
                 icon='delete'
                 dataIndex={index}
+                onClick={onClick}
             />
         </div>
     );

--- a/src/components/dashboard/users/TagList.tsx
+++ b/src/components/dashboard/users/TagList.tsx
@@ -1,12 +1,16 @@
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useCallback } from 'react';
 import IconButtonElement from '../../../elements/IconButtonElement';
 
 type IProps = {
     tag?: string,
     tagType?: string;
+    removeTagCallback?: (tag: string) => void;
 };
 
-const TagList: FunctionComponent<IProps> = ({ tag, tagType }: IProps) => {
+const TagList: FunctionComponent<IProps> = ({ tag, tagType, removeTagCallback }: IProps) => {
+    const onClick = useCallback(() => {
+        tag !== undefined && removeTagCallback !== undefined && removeTagCallback(tag);
+    }, [tag, removeTagCallback]);
     return (
         <div className='paperList'>
             <div className='listItem'>
@@ -21,6 +25,7 @@ const TagList: FunctionComponent<IProps> = ({ tag, tagType }: IProps) => {
                     title='Delete'
                     icon='delete'
                     dataTag={tag}
+                    onClick={onClick}
                 />
             </div>
         </div>

--- a/src/elements/IconButtonElement.tsx
+++ b/src/elements/IconButtonElement.tsx
@@ -43,7 +43,7 @@ const IconButtonElement: FunctionComponent<IProps> = ({ is, id, className, title
 
     if (onClick !== undefined) {
         return (
-            <a
+            <button
                 dangerouslySetInnerHTML={button}
                 onClick={onClick}
             />

--- a/src/elements/IconButtonElement.tsx
+++ b/src/elements/IconButtonElement.tsx
@@ -11,6 +11,7 @@ type IProps = {
     dataIndex?: string | number;
     dataTag?: string | number;
     dataProfileid?: string | number;
+    onClick?: () => void;
 };
 
 const createIconButtonElement = ({ is, id, className, title, icon, dataIndex, dataTag, dataProfileid }: IProps) => ({
@@ -28,7 +29,7 @@ const createIconButtonElement = ({ is, id, className, title, icon, dataIndex, da
     </button>`
 });
 
-const IconButtonElement: FunctionComponent<IProps> = ({ is, id, className, title, icon, dataIndex, dataTag, dataProfileid }: IProps) => {
+const IconButtonElement: FunctionComponent<IProps> = ({ is, id, className, title, icon, dataIndex, dataTag, dataProfileid, onClick }: IProps) => {
     return (
         <div
             dangerouslySetInnerHTML={createIconButtonElement({
@@ -41,6 +42,7 @@ const IconButtonElement: FunctionComponent<IProps> = ({ is, id, className, title
                 dataTag: dataTag ? `data-tag="${dataTag}"` : '',
                 dataProfileid: dataProfileid ? `data-profileid="${dataProfileid}"` : ''
             })}
+            onClick={onClick}
         />
     );
 };

--- a/src/elements/IconButtonElement.tsx
+++ b/src/elements/IconButtonElement.tsx
@@ -30,19 +30,29 @@ const createIconButtonElement = ({ is, id, className, title, icon, dataIndex, da
 });
 
 const IconButtonElement: FunctionComponent<IProps> = ({ is, id, className, title, icon, dataIndex, dataTag, dataProfileid, onClick }: IProps) => {
+    const button = createIconButtonElement({
+        is: is,
+        id: id ? `id="${id}"` : '',
+        className: className,
+        title: title ? `title="${globalize.translate(title)}"` : '',
+        icon: icon,
+        dataIndex: (dataIndex || dataIndex === 0) ? `data-index="${dataIndex}"` : '',
+        dataTag: dataTag ? `data-tag="${dataTag}"` : '',
+        dataProfileid: dataProfileid ? `data-profileid="${dataProfileid}"` : ''
+    });
+
+    if (onClick !== undefined) {
+        return (
+            <a
+                dangerouslySetInnerHTML={button}
+                onClick={onClick}
+            />
+        )
+    }
+
     return (
         <div
-            dangerouslySetInnerHTML={createIconButtonElement({
-                is: is,
-                id: id ? `id="${id}"` : '',
-                className: className,
-                title: title ? `title="${globalize.translate(title)}"` : '',
-                icon: icon,
-                dataIndex: (dataIndex || dataIndex === 0) ? `data-index="${dataIndex}"` : '',
-                dataTag: dataTag ? `data-tag="${dataTag}"` : '',
-                dataProfileid: dataProfileid ? `data-profileid="${dataProfileid}"` : ''
-            })}
-            onClick={onClick}
+            dangerouslySetInnerHTML={button}
         />
     );
 };

--- a/src/elements/IconButtonElement.tsx
+++ b/src/elements/IconButtonElement.tsx
@@ -44,6 +44,7 @@ const IconButtonElement: FunctionComponent<IProps> = ({ is, id, className, title
     if (onClick !== undefined) {
         return (
             <button
+                style={{all: 'unset'}}
                 dangerouslySetInnerHTML={button}
                 onClick={onClick}
             />

--- a/src/elements/IconButtonElement.tsx
+++ b/src/elements/IconButtonElement.tsx
@@ -44,11 +44,11 @@ const IconButtonElement: FunctionComponent<IProps> = ({ is, id, className, title
     if (onClick !== undefined) {
         return (
             <button
-                style={{all: 'unset'}}
+                style={{ all: 'unset' }}
                 dangerouslySetInnerHTML={button}
                 onClick={onClick}
             />
-        )
+        );
     }
 
     return (


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

Our callback implementation for the parental control page was quite hacky and fragile. It stopped working properly in the current master branch, likely due to updates in React. This isn't the only instance where we manipulate DOM objects directly instead of using React, so other pages may also be affected, but this one has been reported.

In the parental control page, the popup callback was added twice since `useEffect` was executed twice in each render cycle. Also, the delete tag/schedule button had no callbacks assigned because the DOM object wasn't available when the data loading hook was executing.

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

- Migrate onClick to pure react callback for delete operations.
- Unbind showing popup callbacks when unmounting

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
