### PR TITLE
Replace locally-defined video playback constants

### DIFF
--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -29,9 +29,7 @@ import { setBackdropTransparency, TRANSPARENCY_LEVEL } from '../../../components
 import { pluginManager } from '../../../components/pluginManager';
 import { PluginType } from '../../../types/plugin.ts';
 import { EventType } from 'types/eventType';
-
-const TICKS_PER_MINUTE = 600000000;
-const TICKS_PER_SECOND = 10000000;
+import { TICKS_PER_MINUTE, TICKS_PER_SECOND } from 'constants/time';
 
 function getOpenedDialog() {
     return document.querySelector('.dialogContainer .dialog.opened');


### PR DESCRIPTION
**Changes**
This is a simple PR to replace constants in the video playback controller. The file had locally defined values for `TICKS_PER_SECOND` and `TICKS_PER_MINUTE` instead of using the constants exported from the shared `constants/` directory. Basically just a little linting PR.

**Issues**

