### PR TITLE
Fix drawer label for the dashboard metadata page

### DIFF
--- a/src/apps/dashboard/components/drawer/sections/ServerDrawerSection.tsx
+++ b/src/apps/dashboard/components/drawer/sections/ServerDrawerSection.tsx
@@ -91,7 +91,7 @@ const ServerDrawerSection = () => {
                         <ListItemText inset primary={globalize.translate('Display')} />
                     </ListItemLink>
                     <ListItemLink to='/dashboard/libraries/metadata' sx={{ pl: 4 }}>
-                        <ListItemText inset primary={globalize.translate('MetadataManager')} />
+                        <ListItemText inset primary={globalize.translate('LabelMetadata')} />
                     </ListItemLink>
                     <ListItemLink to='/dashboard/libraries/nfo' sx={{ pl: 4 }}>
                         <ListItemText inset primary={globalize.translate('TabNfoSettings')} />


### PR DESCRIPTION
**Changes**
Fixes a regression from https://github.com/jellyfin/jellyfin-web/pull/6183 for the drawer label in the dashboard for the Playback > Metadata page

**Issues**
N/A