### PR TITLE
Show Skip Button When 'Next Video Info Overlay' is Disabled

### DIFF
--- a/src/components/playback/skipsegment.ts
+++ b/src/components/playback/skipsegment.ts
@@ -127,7 +127,8 @@ class SkipSegment extends PlaybackSubscriber {
     onPromptSkip(e: Event, segment: MediaSegmentDto) {
         if (this.player && segment.EndTicks != null
             && segment.EndTicks >= this.playbackManager.currentItem(this.player).RunTimeTicks
-            && this.playbackManager.getNextItem() && userSettings.enableNextVideoInfoOverlay()
+            && this.playbackManager.getNextItem()
+            && userSettings.enableNextVideoInfoOverlay()
         ) {
             // Don't display button when UpNextDialog is expected.
             return;

--- a/src/components/playback/skipsegment.ts
+++ b/src/components/playback/skipsegment.ts
@@ -8,6 +8,7 @@ import { EventType } from 'types/eventType';
 import './skipbutton.scss';
 import dom from 'scripts/dom';
 import globalize from 'lib/globalize';
+import * as userSettings from '../../scripts/settings/userSettings';
 
 interface ShowOptions {
     animate?: boolean;
@@ -126,7 +127,7 @@ class SkipSegment extends PlaybackSubscriber {
     onPromptSkip(e: Event, segment: MediaSegmentDto) {
         if (this.player && segment.EndTicks != null
             && segment.EndTicks >= this.playbackManager.currentItem(this.player).RunTimeTicks
-            && this.playbackManager.getNextItem()
+            && this.playbackManager.getNextItem() && userSettings.enableNextVideoInfoOverlay()
         ) {
             // Don't display button when UpNextDialog is expected.
             return;

--- a/src/components/playback/skipsegment.ts
+++ b/src/components/playback/skipsegment.ts
@@ -3,12 +3,12 @@ import { TICKS_PER_MILLISECOND, TICKS_PER_SECOND } from 'constants/time';
 import type { MediaSegmentDto } from '@jellyfin/sdk/lib/generated-client/models/media-segment-dto';
 import { PlaybackSubscriber } from 'apps/stable/features/playback/utils/playbackSubscriber';
 import { isInSegment } from 'apps/stable/features/playback/utils/mediaSegments';
-import Events, { type Event } from '../../utils/events';
+import Events, { type Event } from 'utils/events';
 import { EventType } from 'types/eventType';
 import './skipbutton.scss';
 import dom from 'scripts/dom';
 import globalize from 'lib/globalize';
-import * as userSettings from '../../scripts/settings/userSettings';
+import * as userSettings from 'scripts/settings/userSettings';
 
 interface ShowOptions {
     animate?: boolean;

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -636,7 +636,7 @@ export default function (view) {
         const player = this;
         if (mediaSegment && player && mediaSegment.EndTicks != null
             && mediaSegment.EndTicks >= playbackManager.duration(player)
-            && playbackManager.getNextItem()
+            && playbackManager.getNextItem() && userSettings.enableNextVideoInfoOverlay()
         ) {
             showComingUpNext(player);
         }

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -636,7 +636,8 @@ export default function (view) {
         const player = this;
         if (mediaSegment && player && mediaSegment.EndTicks != null
             && mediaSegment.EndTicks >= playbackManager.duration(player)
-            && playbackManager.getNextItem() && userSettings.enableNextVideoInfoOverlay()
+            && playbackManager.getNextItem()
+            && userSettings.enableNextVideoInfoOverlay()
         ) {
             showComingUpNext(player);
         }

--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -173,7 +173,7 @@ export class UserSettings {
 
     /**
      * Get or set 'Next Video Info Overlay' state.
-     * @param {boolean|undefined} val - Flag to enable 'Next Video Info Overlay' or undefined.
+     * @param {boolean|undefined} [val] - Flag to enable 'Next Video Info Overlay' or undefined.
      * @return {boolean} 'Next Video Info Overlay' state.
      */
     enableNextVideoInfoOverlay(val) {


### PR DESCRIPTION
Adjusts the behavior of the skip button based on the 'Next Video Info Overlay' setting. When the overlay option is enabled, the up-next info box is displayed as expected. However, if the setting is disabled, the regular segment skip button will be shown instead, allowing for a more consistent experience based on user preference.