### PR TITLE
Don't send unsupported commands to Cast receiver

### DIFF
--- a/src/plugins/chromecastPlayer/plugin.js
+++ b/src/plugins/chromecastPlayer/plugin.js
@@ -678,11 +678,7 @@ class ChromecastPlayer {
                 'SetAudioStreamIndex',
                 'SetSubtitleStreamIndex',
                 'DisplayContent',
-                'SetRepeatMode',
-                'SetShuffleQueue',
-                'EndSession',
-                'PlayMediaSource',
-                'PlayTrailers'
+                'SetRepeatMode'
             ]
         };
     }
@@ -890,13 +886,7 @@ class ChromecastPlayer {
     }
 
     playTrailers(item) {
-        this._castPlayer.sendMessage({
-            options: {
-                ItemId: item.Id,
-                ServerId: item.ServerId
-            },
-            command: 'PlayTrailers'
-        });
+        console.warn('[chromecastPlayer] Playing trailers is not supported.');
     }
 
     setRepeatMode(mode) {
@@ -909,12 +899,7 @@ class ChromecastPlayer {
     }
 
     setQueueShuffleMode(value) {
-        this._castPlayer.sendMessage({
-            options: {
-                ShuffleMode: value
-            },
-            command: 'SetShuffleQueue'
-        });
+        console.warn('[chromecastPlayer] Setting shuffle queue mode is not supported.');
     }
 
     toggleMute() {

--- a/src/plugins/chromecastPlayer/plugin.js
+++ b/src/plugins/chromecastPlayer/plugin.js
@@ -885,7 +885,7 @@ class ChromecastPlayer {
         return state.ShuffleMode;
     }
 
-    playTrailers(item) {
+    playTrailers() {
         console.warn('[chromecastPlayer] Playing trailers is not supported.');
     }
 
@@ -898,7 +898,7 @@ class ChromecastPlayer {
         });
     }
 
-    setQueueShuffleMode(value) {
+    setQueueShuffleMode() {
         console.warn('[chromecastPlayer] Setting shuffle queue mode is not supported.');
     }
 


### PR DESCRIPTION
**Changes**
Don't send unsupported commands to Cast receiver.

The following commands are listed as supported in jellyfin-web's plugin.js:
* SetShuffleQueue
* EndSession
* PlayMediaSource
* PlayTrailers

But they are not in the list of currently supported commands in the Cast receiver app: https://github.com/jellyfin/jellyfin-chromecast/blob/22099bfd45cec11d743c3978181d7161aed9e6b4/src/components/commandHandler.ts#L27-L51

**Issues**
No issue raised. This probably doesn't cause any issues currently, just cleaning up some tech debt.