### PR TITLE
Don't persist letter filter when querying

### DIFF
--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -536,7 +536,10 @@ export class UserSettings {
      * @param {Object} query - Query.
      */
     saveQuerySettings(key, query) {
-        return this.set(key, JSON.stringify(query));
+        const newQuery = { ...query };
+        delete newQuery.NameStartsWith;
+        delete newQuery.NameLessThan;
+        return this.set(key, JSON.stringify(newQuery));
     }
 
     /**

--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -538,9 +538,21 @@ export class UserSettings {
      * @param {Object} query - Query.
      */
     saveQuerySettings(key, query) {
-        const newQuery = { ...query };
-        delete newQuery.NameStartsWith;
-        delete newQuery.NameLessThan;
+        const allowedFields = [
+            'SortBy', 'SortOrder', 'Filters', 'HasSubtitles',
+            'HasTrailer', 'HasSpecialFeature', 'HasThemeSong',
+            'HasThemeVideo', 'Genres', 'OfficialRatings',
+            'Tags', 'VideoTypes', 'IsHD', 'Is4K', 'Is3D',
+            'Years'
+        ];
+
+        const newQuery = Object.keys(query)
+            .filter(field => allowedFields.includes(field))
+            .reduce((acc, field) => {
+                acc[field] = query[field];
+                return acc;
+            }, {});
+
         return this.set(key, JSON.stringify(newQuery));
     }
 

--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -524,6 +524,8 @@ export class UserSettings {
         let values = this.get(key);
         if (values) {
             values = JSON.parse(values);
+            delete values.NameStartsWith;
+            delete values.NameLessThan;
             return Object.assign(query, values);
         }
 


### PR DESCRIPTION
Currently, the letter filter will only be persisted in some media types if you first select a letter, then use 'sort' or 'filter' (which calls save). In other media types like shows it's saved when items are loaded.

**Changes**
To stay consistent, prevent the letter filter from being saved anywhere.

**Issues**
Fixes https://github.com/jellyfin/jellyfin-web/issues/6263