### PR TITLE
Add support for plugin revisions with bad timestamps

### DIFF
--- a/src/apps/dashboard/features/plugins/components/PluginRevisions.tsx
+++ b/src/apps/dashboard/features/plugins/components/PluginRevisions.tsx
@@ -9,7 +9,7 @@ import Stack from '@mui/material/Stack/Stack';
 import React, { type FC } from 'react';
 
 import MarkdownBox from 'components/MarkdownBox';
-import { parseISO8601Date, toLocaleString } from 'scripts/datetime';
+import { getDisplayDateTime } from 'scripts/datetime';
 import globalize from 'lib/globalize';
 
 import type { PluginDetails } from '../types/PluginDetails';
@@ -32,7 +32,7 @@ const PluginRevisions: FC<PluginRevisionsProps> = ({
                 {version.version}
                 {version.timestamp && (<>
                     &nbsp;&mdash;&nbsp;
-                    {toLocaleString(parseISO8601Date(version.timestamp))}
+                    {getDisplayDateTime(version.timestamp)}
                 </>)}
             </AccordionSummary>
             <AccordionDetails>

--- a/src/scripts/datetime.js
+++ b/src/scripts/datetime.js
@@ -203,12 +203,28 @@ export function toLocaleTimeString(date, options) {
     return date.toLocaleTimeString();
 }
 
+export function getDisplayDateTime(date) {
+    if (!date) {
+        throw new Error('date cannot be null');
+    }
+
+    if (typeof date === 'string') {
+        try {
+            date = parseISO8601Date(date, true);
+        } catch (err) {
+            return date;
+        }
+    }
+
+    return toLocaleString(date);
+}
+
 export function getDisplayTime(date) {
     if (!date) {
         throw new Error('date cannot be null');
     }
 
-    if ((typeof date).toString().toLowerCase() === 'string') {
+    if (typeof date === 'string') {
         try {
             date = parseISO8601Date(date, true);
         } catch (err) {


### PR DESCRIPTION
**Changes**
Adds handling for plugin timestamps in an unsupported format

**Issues**
N/A (reported in matrix)