### PR TITLE
Make filtering local to each device

### DIFF
--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -23,7 +23,9 @@ const filterSettingsPostfix = '-filter';
 const allowedFilterSettings = [
     'Filters', 'HasSubtitles', 'HasTrailer', 'HasSpecialFeature',
     'HasThemeSong', 'HasThemeVideo', 'Genres', 'OfficialRatings',
-    'Tags', 'VideoTypes', 'IsHD', 'Is4K', 'Is3D', 'Years'
+    'Tags', 'VideoTypes', 'IsSD', 'IsHD', 'Is4K', 'Is3D',
+    'IsFavorite', 'IsMissing', 'IsUnaired', 'ParentIndexNumber',
+    'SeriesStatus', 'Years'
 ];
 
 function filterQuerySettings(query, allowedItems) {

--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -536,7 +536,10 @@ export class UserSettings {
      * @param {Object} query - Query.
      */
     saveQuerySettings(key, query) {
-        return this.set(key, JSON.stringify(query));
+        const newQuery = { ...query };
+        delete newQuery.NameStartsWith;
+        delete newQuery.NameLessThan;
+        return this.set(key, JSON.stringify(newQuery));
     }
 
     /**

--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -538,9 +538,21 @@ export class UserSettings {
      * @param {Object} query - Query.
      */
     saveQuerySettings(key, query) {
-        const newQuery = { ...query };
-        delete newQuery.NameStartsWith;
-        delete newQuery.NameLessThan;
+        const allowedFields = [
+            'SortBy', 'SortOrder', 'Filters', 'HasSubtitles',
+            'HasTrailer', 'HasSpecialFeature', 'HasThemeSong',
+            'HasThemeVideo', 'Genres', 'OfficialRatings',
+            'Tags', 'VideoTypes', 'IsHD', 'Is4K', 'Is3D',
+            'Years'
+        ];
+
+        const newQuery = Object.keys(query)
+            .filter(field => allowedFields.includes(field))
+            .reduce((acc, field) => {
+                acc[field] = query[field];
+                return acc;
+            }, {});
+
         return this.set(key, JSON.stringify(newQuery));
     }
 

--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -524,6 +524,8 @@ export class UserSettings {
         let values = this.get(key);
         if (values) {
             values = JSON.parse(values);
+            delete values.NameStartsWith;
+            delete values.NameLessThan;
             return Object.assign(query, values);
         }
 


### PR DESCRIPTION
Supersedes https://github.com/jellyfin/jellyfin-web/pull/6264

This makes 'filtering' local to each device while keeping sorting settings stored on the server. Additionally, this fixes the issue with storing query options which don't make sense to save (current page, letter filter, etc)

Due to a key change, this will reset any saved filtering settings but will keep sorting intact.

**Changes**
- Keep filtering local to each device, while only storing sorting settings on the server.
- Make it so that we only save filtering and sort options.
- Filter out any unneeded configuration options saved from previous versions.

**Issues**
Fixes https://github.com/jellyfin/jellyfin-web/issues/6263
Fixes https://github.com/jellyfin/jellyfin-web/issues/6268
https://github.com/jellyfin/jellyfin-web/pull/6264#issuecomment-2443685093