### PR TITLE
Remove self cast target

### DIFF
--- a/src/apps/experimental/components/AppToolbar/menus/RemotePlayMenu.tsx
+++ b/src/apps/experimental/components/AppToolbar/menus/RemotePlayMenu.tsx
@@ -65,17 +65,20 @@ const RemotePlayMenu: FC<RemotePlayMenuProps> = ({
             open={open}
             onClose={onMenuClose}
         >
-            {!isChromecastPluginLoaded && ([
-                <MenuItem key='cast-unsupported-item' disabled>
+            {!isChromecastPluginLoaded && (
+                <MenuItem disabled>
                     <ListItemIcon>
                         <Warning />
                     </ListItemIcon>
                     <ListItemText>
                         {globalize.translate('GoogleCastUnsupported')}
                     </ListItemText>
-                </MenuItem>,
-                <Divider key='cast-unsupported-divider' />
-            ])}
+                </MenuItem>
+            )}
+
+            {!isChromecastPluginLoaded && playbackTargets.length > 0 && (
+                <Divider />
+            )}
 
             {playbackTargets.map(target => (
                 <MenuItem

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -852,17 +852,8 @@ export class PlaybackManager {
         self.getTargets = function () {
             const promises = players.filter(displayPlayerIndividually).map(getPlayerTargets);
 
-            return Promise.all(promises).then(function (responses) {
-                const targets = [];
-
-                for (const subTargets of responses) {
-                    for (const subTarget of subTargets) {
-                        targets.push(subTarget);
-                    }
-                }
-
-                return targets.sort(sortPlayerTargets);
-            });
+            return Promise.all(promises)
+                .then(responses => responses.flat().sort(sortPlayerTargets));
         };
 
         self.playerHasSecondarySubtitleSupport = function (player = self._currentPlayer) {

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -853,29 +853,15 @@ export class PlaybackManager {
             const promises = players.filter(displayPlayerIndividually).map(getPlayerTargets);
 
             return Promise.all(promises).then(function (responses) {
-                return ServerConnections.currentApiClient().getCurrentUser().then(function (user) {
-                    const targets = [];
+                const targets = [];
 
-                    targets.push({
-                        name: globalize.translate('HeaderMyDevice'),
-                        id: 'localplayer',
-                        playerName: 'localplayer',
-                        playableMediaTypes: ['Audio', 'Video', 'Photo', 'Book'],
-                        isLocalPlayer: true,
-                        supportedCommands: self.getSupportedCommands({
-                            isLocalPlayer: true
-                        }),
-                        user: user
-                    });
-
-                    for (const subTargets of responses) {
-                        for (const subTarget of subTargets) {
-                            targets.push(subTarget);
-                        }
+                for (const subTargets of responses) {
+                    for (const subTarget of subTargets) {
+                        targets.push(subTarget);
                     }
+                }
 
-                    return targets.sort(sortPlayerTargets);
-                });
+                return targets.sort(sortPlayerTargets);
             });
         };
 

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -451,7 +451,6 @@
     "HeaderMetadataSettings": "Metadata Settings",
     "HeaderMoreLikeThis": "More Like This",
     "HeaderMusicQuality": "Music Quality",
-    "HeaderMyDevice": "My Device",
     "HeaderMyMedia": "My Media",
     "HeaderMyMediaSmall": "My Media (small)",
     "HeaderNavigation": "Navigation",


### PR DESCRIPTION
**Changes**
Removes the current device from the list of remote control / "cast" targets... I have never understood why this option exists. When you are connected to a device then the menu changes and has a disconnect button. :man_shrugging: 

**Issues**
N/A