### PR TITLE
Fix displaying secondary subtitles on Tizen 5

### DIFF
--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1355,7 +1355,8 @@ export class HtmlVideoPlayer {
             return true;
         }
 
-        if (browser.web0s) {
+        // Tizen 5 doesn't support displaying secondary subtitles
+        if (browser.tizenVersion >= 5 || browser.web0s) {
             return true;
         }
 


### PR DESCRIPTION
**Changes**
Use custom subtitles element on Tizen 5+.
_It would be nice to test if Tizen 5.5+ natively supports secondary subtitles so we can narrow down the use of the custom subtitles element._

**Issues**
Fixes https://github.com/jellyfin/jellyfin-tizen/issues/300
