### PR TITLE
Update dependency libpgs to v0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "jquery": "3.7.1",
         "jstree": "3.3.17",
         "libarchive.js": "2.0.2",
-        "libpgs": "0.6.0",
+        "libpgs": "0.8.0",
         "lodash-es": "4.17.21",
         "markdown-it": "14.1.0",
         "material-design-icons-iconfont": "6.7.0",
@@ -15080,9 +15080,9 @@
       }
     },
     "node_modules/libpgs": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/libpgs/-/libpgs-0.6.0.tgz",
-      "integrity": "sha512-k8ic6VTJTCun8Ump8iAe+tZi3pa1ZhDlq1v4hmZOmYQzSQ44QpZoClMXuSfJ1B91eRWOO6q50rXhyCPuB9dXbg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/libpgs/-/libpgs-0.8.0.tgz",
+      "integrity": "sha512-YpmcQYP177j08Vd0zEORgtdHsdPLGF8FCL152DgTQg2txLx1ndjgNOJ1n0217ap5rFV8riTugzjM9sqPrT1e5Q==",
       "license": "MIT"
     },
     "node_modules/lie": {
@@ -36347,9 +36347,9 @@
       }
     },
     "libpgs": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/libpgs/-/libpgs-0.6.0.tgz",
-      "integrity": "sha512-k8ic6VTJTCun8Ump8iAe+tZi3pa1ZhDlq1v4hmZOmYQzSQ44QpZoClMXuSfJ1B91eRWOO6q50rXhyCPuB9dXbg=="
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/libpgs/-/libpgs-0.8.0.tgz",
+      "integrity": "sha512-YpmcQYP177j08Vd0zEORgtdHsdPLGF8FCL152DgTQg2txLx1ndjgNOJ1n0217ap5rFV8riTugzjM9sqPrT1e5Q=="
     },
     "lie": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "jquery": "3.7.1",
     "jstree": "3.3.17",
     "libarchive.js": "2.0.2",
-    "libpgs": "0.6.0",
+    "libpgs": "0.8.0",
     "lodash-es": "4.17.21",
     "markdown-it": "14.1.0",
     "material-design-icons-iconfont": "6.7.0",

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1339,7 +1339,8 @@ export class HtmlVideoPlayer {
                 video: videoElement,
                 subUrl: getTextTrackUrl(track, item),
                 workerUrl: `${appRouter.baseUrl()}/libraries/libpgs.worker.js`,
-                timeOffset: (this._currentPlayOptions.transcodingOffsetTicks || 0) / 10000000
+                timeOffset: (this._currentPlayOptions.transcodingOffsetTicks || 0) / 10000000,
+                aspectRatio: this._currentAspectRatio === 'auto' ? 'contain' : this._currentAspectRatio
             };
             this.#currentPgsRenderer = new libpgs.PgsRenderer(options);
         });
@@ -2087,6 +2088,14 @@ export class HtmlVideoPlayer {
                 mediaElement.style.removeProperty('object-fit');
             } else {
                 mediaElement.style['object-fit'] = val;
+            }
+        }
+        const pgsRenderer = this.#currentPgsRenderer;
+        if (pgsRenderer) {
+            if (val === 'auto') {
+                pgsRenderer.aspectRatio = 'contain';
+            } else {
+                pgsRenderer.aspectRatio = val;
             }
         }
         this._currentAspectRatio = val;


### PR DESCRIPTION
**Changes**
This PR updates libpgs-js to version v0.8.0:
- Fixed a subtitle position issue (see #6273). The subtitle position now matches the position in FFmpeg.
- Custom video aspect ratios _(stretch, cover)_ are now respected by the subtitle canvas.
- Subtitle cropping is now supported. This is based on the FFmpeg implementation, but I couldn't test it on a real subtitle track yet.

**Issues**
Fixes #6273 
