### PR TITLE
Update dependency libpgs to v0.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "jquery": "3.7.1",
         "jstree": "3.3.17",
         "libarchive.js": "2.0.2",
-        "libpgs": "0.8.0",
+        "libpgs": "0.8.1",
         "lodash-es": "4.17.21",
         "markdown-it": "14.1.0",
         "material-design-icons-iconfont": "6.7.0",
@@ -15080,9 +15080,9 @@
       }
     },
     "node_modules/libpgs": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/libpgs/-/libpgs-0.8.0.tgz",
-      "integrity": "sha512-YpmcQYP177j08Vd0zEORgtdHsdPLGF8FCL152DgTQg2txLx1ndjgNOJ1n0217ap5rFV8riTugzjM9sqPrT1e5Q==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/libpgs/-/libpgs-0.8.1.tgz",
+      "integrity": "sha512-Z8WCvHRYr37QjU8b2WqiJpCvnoojbYPtoE4FktwdI+m+b1QkNIKqrYQrlPKG1xvYyQWgV1j+16xjFOhun4nBUA==",
       "license": "MIT"
     },
     "node_modules/lie": {
@@ -36347,9 +36347,9 @@
       }
     },
     "libpgs": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/libpgs/-/libpgs-0.8.0.tgz",
-      "integrity": "sha512-YpmcQYP177j08Vd0zEORgtdHsdPLGF8FCL152DgTQg2txLx1ndjgNOJ1n0217ap5rFV8riTugzjM9sqPrT1e5Q=="
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/libpgs/-/libpgs-0.8.1.tgz",
+      "integrity": "sha512-Z8WCvHRYr37QjU8b2WqiJpCvnoojbYPtoE4FktwdI+m+b1QkNIKqrYQrlPKG1xvYyQWgV1j+16xjFOhun4nBUA=="
     },
     "lie": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "jquery": "3.7.1",
     "jstree": "3.3.17",
     "libarchive.js": "2.0.2",
-    "libpgs": "0.8.0",
+    "libpgs": "0.8.1",
     "lodash-es": "4.17.21",
     "markdown-it": "14.1.0",
     "material-design-icons-iconfont": "6.7.0",


### PR DESCRIPTION
Apologies for the second PR on this.

**Changes**
This PR updates the libpgs dependency to fix an issue where subtitles aren't cleared when drawn outside of the subtitle window. The change ensures the exact drawing area is cleared and ignoring the window.

**Issues**
Fixes https://github.com/Arcus92/libpgs-js/issues/18
