### PR TITLE
Add collections as header on collections page

### DIFF
--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -1492,6 +1492,9 @@ function renderChildren(page, item) {
             }, {
                 name: globalize.translate('Books'),
                 type: 'Book'
+            }, {
+                name: globalize.translate('Collections'),
+                type: 'BoxSet'
             }];
             renderCollectionItems(page, item, collectionItemTypes, result.Items);
         }


### PR DESCRIPTION
Currently, when you add a collection to a boxset, it appears under the "Other Items" header. This update introduces a "Collections" header for collections within a collection (inception).

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # --> N/A
