### PR TITLE
Fix "Select All" for Search Results with more than 49 Items in a Row

### DIFF
--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -1224,12 +1224,7 @@ export function buildCards(items, options) {
     if (html) {
         if (options.itemsContainer.cardBuilderHtml !== html) {
             options.itemsContainer.innerHTML = html;
-
-            if (items.length < 50) {
-                options.itemsContainer.cardBuilderHtml = html;
-            } else {
-                options.itemsContainer.cardBuilderHtml = null;
-            }
+            options.itemsContainer.cardBuilderHtml = html;
         }
 
         imageLoader.lazyChildren(options.itemsContainer);

--- a/src/components/multiSelect/multiSelect.js
+++ b/src/components/multiSelect/multiSelect.js
@@ -222,7 +222,7 @@ function showMenuForSelectedItems(e) {
                 icon: 'check_box_outline_blank'
             });
 
-            // this assues that if the user can refresh metadata for the first item
+            // this assures that if the user can refresh metadata for the first item
             // they can refresh metadata for all items
             if (itemHelper.canRefreshMetadata(firstItem, user)) {
                 menuItems.push({


### PR DESCRIPTION
**Changes**
Fix select all for search results rows with over 49 items.

**Issues**
Fixes #6309
