### PR TITLE
Refactor getDeviceName() for readability

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -93,6 +93,7 @@
 - [Connor Smith](https://github.com/ConnorS1110)
 - [iFraan](https://github.com/iFraan)
 - [Ali](https://github.com/bu3alwa)
+- [K. Kyle Puchkov](https://github.com/kepper104)
 
 ## Emby Contributors
 

--- a/src/components/apphost.js
+++ b/src/components/apphost.js
@@ -8,6 +8,20 @@ import profileBuilder from '../scripts/browserDeviceProfile';
 
 const appName = 'Jellyfin Web';
 
+const BrowserName = {
+    tizen: 'Samsung Smart TV',
+    web0s: 'LG Smart TV',
+    operaTv: 'Opera TV',
+    xboxOne: 'Xbox One',
+    ps4: 'Sony PS4',
+    chrome: 'Chrome',
+    edgeChromium: 'Edge Chromium',
+    edge: 'Edge',
+    firefox: 'Firefox',
+    opera: 'Opera',
+    safari: 'Safari'
+};
+
 function getBaseProfileOptions(item) {
     const disableHlsVideoAudioCodecs = [];
 
@@ -135,25 +149,12 @@ function getDeviceName() {
     if (deviceName) {
         return deviceName;
     }
-    const deviceMappings = {
-        tizen: 'Samsung Smart TV',
-        web0s: 'LG Smart TV',
-        operaTv: 'Opera TV',
-        xboxOne: 'Xbox One',
-        ps4: 'Sony PS4',
-        chrome: 'Chrome',
-        edgeChromium: 'Edge Chromium',
-        edge: 'Edge',
-        firefox: 'Firefox',
-        opera: 'Opera',
-        safari: 'Safari'
-    };
 
     deviceName = 'Web Browser'; // Default device name
 
-    for (const key in deviceMappings) {
+    for (const key in BrowserName) {
         if (browser[key]) {
-            deviceName = deviceMappings[key];
+            deviceName = BrowserName[key];
             break;
         }
     }

--- a/src/components/apphost.js
+++ b/src/components/apphost.js
@@ -135,7 +135,6 @@ function getDeviceName() {
     if (deviceName) {
         return deviceName;
     }
-    
     const deviceMappings = {
         tizen: 'Samsung Smart TV',
         web0s: 'LG Smart TV',
@@ -147,7 +146,7 @@ function getDeviceName() {
         edge: 'Edge',
         firefox: 'Firefox',
         opera: 'Opera',
-        safari: 'Safari',
+        safari: 'Safari'
     };
 
     deviceName = 'Web Browser'; // Default device name
@@ -166,7 +165,6 @@ function getDeviceName() {
     } else if (browser.android) {
         deviceName += ' Android';
     }
-    
     return deviceName;
 }
 

--- a/src/components/apphost.js
+++ b/src/components/apphost.js
@@ -132,42 +132,41 @@ function getDeviceId() {
 }
 
 function getDeviceName() {
-    if (!deviceName) {
-        if (browser.tizen) {
-            deviceName = 'Samsung Smart TV';
-        } else if (browser.web0s) {
-            deviceName = 'LG Smart TV';
-        } else if (browser.operaTv) {
-            deviceName = 'Opera TV';
-        } else if (browser.xboxOne) {
-            deviceName = 'Xbox One';
-        } else if (browser.ps4) {
-            deviceName = 'Sony PS4';
-        } else if (browser.chrome) {
-            deviceName = 'Chrome';
-        } else if (browser.edgeChromium) {
-            deviceName = 'Edge Chromium';
-        } else if (browser.edge) {
-            deviceName = 'Edge';
-        } else if (browser.firefox) {
-            deviceName = 'Firefox';
-        } else if (browser.opera) {
-            deviceName = 'Opera';
-        } else if (browser.safari) {
-            deviceName = 'Safari';
-        } else {
-            deviceName = 'Web Browser';
-        }
+    if (deviceName) {
+        return deviceName;
+    }
+    
+    const deviceMappings = {
+        tizen: 'Samsung Smart TV',
+        web0s: 'LG Smart TV',
+        operaTv: 'Opera TV',
+        xboxOne: 'Xbox One',
+        ps4: 'Sony PS4',
+        chrome: 'Chrome',
+        edgeChromium: 'Edge Chromium',
+        edge: 'Edge',
+        firefox: 'Firefox',
+        opera: 'Opera',
+        safari: 'Safari',
+    };
 
-        if (browser.ipad) {
-            deviceName += ' iPad';
-        } else if (browser.iphone) {
-            deviceName += ' iPhone';
-        } else if (browser.android) {
-            deviceName += ' Android';
+    deviceName = 'Web Browser'; // Default device name
+
+    for (const key in deviceMappings) {
+        if (browser[key]) {
+            deviceName = deviceMappings[key];
+            break;
         }
     }
 
+    if (browser.ipad) {
+        deviceName += ' iPad';
+    } else if (browser.iphone) {
+        deviceName += ' iPhone';
+    } else if (browser.android) {
+        deviceName += ' Android';
+    }
+    
     return deviceName;
 }
 


### PR DESCRIPTION
Refactored a long if-else into a cleaner, easier to extend mapping


**Changes**
- Removed long if-else statement that maps the device type to a string; Added an easily readable and extensible mapping instead.
- Added myself to CONTRIBUTORS.md ;)

**Issues**
No GitHub issue previously associated, found it on [SonarCloud](https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&types=CODE_SMELL&id=jellyfin_jellyfin-web&open=AXepJqSNYTlMEX6vFIG7&tab=code)
