### PR TITLE
Move strict mode to page component

### DIFF
--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -1,4 +1,4 @@
-import React, { type FC, type PropsWithChildren, type HTMLAttributes, useEffect, useRef } from 'react';
+import React, { type FC, type PropsWithChildren, type HTMLAttributes, useEffect, useRef, StrictMode } from 'react';
 
 import viewManager from './viewManager/viewManager';
 
@@ -57,18 +57,20 @@ const Page: FC<PropsWithChildren<PageProps & HTMLAttributes<HTMLDivElement>>> = 
     }, [ element, isNowPlayingBarEnabled, isThemeMediaSupported ]);
 
     return (
-        <div
-            ref={element}
-            id={id}
-            data-role='page'
-            className={`page ${className}`}
-            data-title={title}
-            data-backbutton={isBackButtonEnabled}
-            data-menubutton={isMenuButtonEnabled}
-            data-backdroptype={backDropType}
-        >
-            {children}
-        </div>
+        <StrictMode>
+            <div
+                ref={element}
+                id={id}
+                data-role='page'
+                className={`page ${className}`}
+                data-title={title}
+                data-backbutton={isBackButtonEnabled}
+                data-menubutton={isMenuButtonEnabled}
+                data-backdroptype={backDropType}
+            >
+                {children}
+            </div>
+        </StrictMode>
     );
 };
 

--- a/src/components/router/AsyncRoute.tsx
+++ b/src/components/router/AsyncRoute.tsx
@@ -1,4 +1,3 @@
-import React, { StrictMode } from 'react';
 import type { RouteObject } from 'react-router-dom';
 
 export enum AsyncRouteType {
@@ -19,7 +18,7 @@ export interface AsyncRoute {
     type?: AsyncRouteType
 }
 
-const importPage = (page: string, type: AsyncRouteType) => {
+const importRoute = (page: string, type: AsyncRouteType) => {
     switch (type) {
         case AsyncRouteType.Dashboard:
             return import(/* webpackChunkName: "[request]" */ `../../apps/dashboard/routes/${page}`);
@@ -38,14 +37,16 @@ export const toAsyncPageRoute = ({
     return {
         path,
         lazy: async () => {
-            const { default: Page } = await importPage(page ?? path, type);
-            return {
-                element: (
-                    <StrictMode>
-                        <Page />
-                    </StrictMode>
-                )
-            };
+            const { default: route } = await importRoute(page ?? path, type);
+
+            // If route is not a RouteObject, use it as the Component
+            if (!route.Component) {
+                return {
+                    Component: route
+                };
+            }
+
+            return route;
         }
     };
 };


### PR DESCRIPTION
**Changes**
* Moves `StrictMode` to the `Page` component instead of the `toAsyncPageRoute` function
* Adds support for routes returning `RouteObject`s directly (similar to the examples in the [official documentation for lazy](https://reactrouter.com/en/main/route/lazy))

**Issues**
N/A