### PR TITLE
Fix trickplay/chapter when play from list/shuffle

### DIFF
--- a/src/controllers/list.js
+++ b/src/controllers/list.js
@@ -255,7 +255,7 @@ function getItems(instance, params, item, sortBy, startIndex, limit) {
     if (params.type === 'nextup') {
         return apiClient.getNextUpEpisodes(modifyQueryWithFilters(instance, {
             Limit: limit,
-            Fields: 'PrimaryImageAspectRatio,DateCreated,MediaSourceCount',
+            Fields: 'PrimaryImageAspectRatio,DateCreated,MediaSourceCount,Chapters,Trickplay',
             UserId: apiClient.getCurrentUserId(),
             ImageTypeLimit: 1,
             EnableImageTypes: 'Primary,Backdrop,Thumb',
@@ -278,7 +278,7 @@ function getItems(instance, params, item, sortBy, startIndex, limit) {
         return apiClient[method](apiClient.getCurrentUserId(), modifyQueryWithFilters(instance, {
             StartIndex: startIndex,
             Limit: limit,
-            Fields: 'PrimaryImageAspectRatio,SortName',
+            Fields: 'PrimaryImageAspectRatio,SortName,Chapters,Trickplay',
             ImageTypeLimit: 1,
             IncludeItemTypes: params.type === 'MusicArtist' || params.type === 'Person' ? null : params.type,
             Recursive: true,

--- a/src/controllers/movies/movies.js
+++ b/src/controllers/movies/movies.js
@@ -277,7 +277,7 @@ export default function (view, params, tabContent, options) {
         SortOrder: 'Ascending',
         IncludeItemTypes: 'Movie',
         Recursive: true,
-        Fields: 'PrimaryImageAspectRatio,MediaSourceCount',
+        Fields: 'PrimaryImageAspectRatio,MediaSourceCount,Chapters,Trickplay',
         ImageTypeLimit: 1,
         EnableImageTypes: 'Primary,Backdrop,Banner,Thumb',
         StartIndex: 0,


### PR DESCRIPTION

**Changes**
Fixes trickplay/chapters sometimes not showing in the player when launched from list pages using the "play all" or "shuffle" buttons.
It seems all required fields are not always requested to the server.

#### before:
![image](https://github.com/user-attachments/assets/836c4bf9-668a-4094-b2fc-7ac10ad19fea)

#### after:
![image](https://github.com/user-attachments/assets/de40e4d8-a3e5-4b07-859a-7ac2f050bc2b)

**Issues**
None
