### PR TITLE
Stop multi select on ESC key press

### DIFF
--- a/src/scripts/keyboardNavigation.js
+++ b/src/scripts/keyboardNavigation.js
@@ -7,6 +7,7 @@ import browser from './browser';
 import inputManager from './inputManager';
 import layoutManager from '../components/layoutManager';
 import appSettings from './settings/appSettings';
+import { stopMultiSelect } from '../components/multiSelect/multiSelect';
 
 /**
  * Key name mapping.
@@ -178,6 +179,7 @@ export function enable() {
                 break;
 
             case 'Escape':
+                stopMultiSelect();
                 if (layoutManager.tv) {
                     inputManager.handleCommand('back');
                 } else {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
Pressing the ESC key on the keyboard will exit multi select mode  

**Issues**
N/A

***Personal note***

A tip for anyone who finds themselves in accidently activated multi-select mode:  
Make sure not to hold down the mouse button for more than one second when interacting with the horizontal scroll items.
