### PR TITLE
Suggest ImageExtractionTimeoutMs changes for Idle priority

### DIFF
--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1780,7 +1780,7 @@
     "PriorityBelowNormal": "Below Normal",
     "PriorityIdle": "Idle",
     "LabelProcessPriority": "Process Priority",
-    "LabelProcessPriorityHelp": "Setting this lower or higher will determine how the CPU prioritizes the ffmpeg trickplay generation process in relation to other processes. If you notice slowdown while generating trickplay images but don't want to fully stop their generation, try lowering this as well as the thread count.",
+    "LabelProcessPriorityHelp": "Setting this lower or higher will determine how the CPU prioritizes the ffmpeg trickplay generation process in relation to other processes. If you notice slowdown while generating trickplay images but don't want to fully stop their generation, try lowering this as well as the thread count. Increasing the 'ImageExtractionTimeoutMs' value above 20,000 may be needed for the 'Idle' priority.",
     "LabelImageInterval": "Image Interval",
     "LabelImageIntervalHelp": "Interval of time (ms) between each new trickplay image.",
     "LabelWidthResolutions": "Width Resolutions",


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->
After seeing repeated logs about `ffmpeg` being started then killed for being unresponsive, I tracked down this configuration setting on GitHub.

So far, my Trickplay generation is much more reliable with a timeout of 30,000 instead. Having a pointer to this configuration setting would have saved me a lot of confusion when my logs filled with the creating/unresponsive cycle.

Even better would be to expose that configuration setting in the UI, unless I missed it somewhere.

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Add text pointing at the timeout configuration value that may need to be increased.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes jellyfin/jellyfin#13116
