### PR TITLE
Always do tone-mapping for HDR transcoding when software pipeline is used

### DIFF
--- a/src/controllers/dashboard/encodingsettings.html
+++ b/src/controllers/dashboard/encodingsettings.html
@@ -183,7 +183,7 @@
                 </div>
 
                 <div class="tonemappingOptions hide">
-                    <div class="checkboxListContainer checkboxContainer-withDescription">
+                    <div class="checkboxListContainer checkboxContainer-withDescription fldTonemapCheckbox hide">
                         <label>
                             <input type="checkbox" is="emby-checkbox" id="chkTonemapping" />
                             <span>${EnableTonemapping}</span>

--- a/src/controllers/dashboard/encodingsettings.js
+++ b/src/controllers/dashboard/encodingsettings.js
@@ -207,10 +207,15 @@ $(document).on('pageinit', '#encodingSettingsPage', function () {
         }
 
         const isHwaSelected = [ 'amf', 'nvenc', 'qsv', 'vaapi', 'rkmpp', 'videotoolbox' ].includes(this.value);
-        if (this.value === 'none' || isHwaSelected) {
+        if (this.value === 'none') {
             page.querySelector('.tonemappingOptions').classList.remove('hide');
+            page.querySelector('.fldTonemapCheckbox').classList.add('hide');
+        } else if (isHwaSelected) {
+            page.querySelector('.tonemappingOptions').classList.remove('hide');
+            page.querySelector('.fldTonemapCheckbox').classList.remove('hide');
         } else {
             page.querySelector('.tonemappingOptions').classList.add('hide');
+            page.querySelector('.fldTonemapCheckbox').classList.add('hide');
         }
 
         page.querySelector('.tonemappingModeOptions').classList.toggle('hide', !isHwaSelected);


### PR DESCRIPTION
**Changes**
- Enable software tone-mapping by default
  (hide tonemap checkbox for software transcoding)
