### PR TITLE
Prevent opus more than 2 channels being remuxed on Safari

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -1057,7 +1057,6 @@ export default function (options) {
 
             const opusTranscodingProfile = { ...transcodingProfile };
             opusTranscodingProfile.AudioCodec = 'opus';
-            opusTranscodingProfile.MaxAudioChannels = '2';
             opusTranscodingProfile.ApplyConditions = [
                 ...opusTranscodingProfile.ApplyConditions || [],
                 ...opusConditions

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -1028,6 +1028,49 @@ export default function (options) {
         profile.TranscodingProfiles.push(...flacTranscodingProfiles);
     }
 
+    if (safariSupportsOpus) {
+        const opusConditions = [
+            // Safari doesn't support opus with more than 2 channels
+            {
+                Condition: 'LessThanEqual',
+                Property: 'AudioChannels',
+                Value: '2',
+                IsRequired: false
+            }
+        ];
+
+        profile.CodecProfiles.push({
+            Type: 'VideoAudio',
+            Codec: 'opus',
+            Conditions: opusConditions
+        });
+
+        const opusTranscodingProfiles = [];
+
+        // Split each video transcoding profile with opus so that the containing opus is only applied to 2 channels audio
+        profile.TranscodingProfiles.forEach(transcodingProfile => {
+            if (transcodingProfile.Type !== 'Video') return;
+
+            const audioCodecs = transcodingProfile.AudioCodec.split(',');
+
+            if (!audioCodecs.includes('opus')) return;
+
+            const opusTranscodingProfile = { ...transcodingProfile };
+            opusTranscodingProfile.AudioCodec = 'opus';
+            opusTranscodingProfile.MaxAudioChannels = '2';
+            opusTranscodingProfile.ApplyConditions = [
+                ...opusTranscodingProfile.ApplyConditions || [],
+                ...opusConditions
+            ];
+
+            opusTranscodingProfiles.push(opusTranscodingProfile);
+
+            transcodingProfile.AudioCodec = audioCodecs.filter(codec => codec != 'opus').join(',');
+        });
+
+        profile.TranscodingProfiles.push(...opusTranscodingProfiles);
+    }
+
     let maxH264Level = 42;
     let h264Profiles = 'high|main|baseline|constrained baseline';
 


### PR DESCRIPTION
Safari only supports stereo Opus, which requires a similar workaround as we are applying on WebOS for FLAC.

This would currently force downmix 5.1 opus to stereo. After jellyfin/jellyfin#13209 landed in server the server will fallback to transcode 5.1 aac when source is 5.1 opus. 

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
