### PR TITLE
Add HEVC level 6.2 (186) device capability check

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -1079,6 +1079,13 @@ export default function (options) {
         hevcProfiles = 'main|main 10';
     }
 
+    // hevc main10 level 6.2
+    if (videoTestElement.canPlayType('video/mp4; codecs="hvc1.2.4.L186"').replace(/no/, '')
+            || videoTestElement.canPlayType('video/mp4; codecs="hev1.2.4.L186"').replace(/no/, '')) {
+        maxHevcLevel = 186;
+        hevcProfiles = 'main|main 10';
+    }
+
     let maxAv1Level = 15; // level 5.3
     const av1Profiles = 'main'; // av1 main covers 4:2:0 8 & 10 bits
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
Add HEVC level 6.2 (186) device capability check in `browserDeviceProfile.js`.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Currently jellyfin-web tests device capabilities up to HEVC level 6.1. The author of #5586 mentioned that "6.2" is an "incorrect" level, but at least according to my research, 6.2 is a defined level in the standard itself (https://www.loc.gov/preservation/digital/formats/fdd/fdd000530.shtml):

> As of Version 7, Table A.8 of the HEVC specification lists the following general levels: 1, 2, 2.1, 3, 3.1, 4, 4.1, 5, 5.1, 5.2, 6, 6.1, and 6.2.

Also, I encontered a HEVC video file recently that failed to do direct playing in the browser, due to its encoding level of 6.2.
