### PR TITLE
Fix lyrics styling

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -93,6 +93,7 @@
 - [Connor Smith](https://github.com/ConnorS1110)
 - [iFraan](https://github.com/iFraan)
 - [Ali](https://github.com/bu3alwa)
+- [Alexis Queen](https://github.com/lxqueen)
 
 ## Emby Contributors
 

--- a/src/styles/lyrics.scss
+++ b/src/styles/lyrics.scss
@@ -1,5 +1,5 @@
 .lyricPage {
-    padding-top: 4.2em !important;
+    padding-top: 6rem !important;
     display: flex;
     justify-content: center;
 }
@@ -7,6 +7,7 @@
 .dynamicLyricsContainer {
     display: flex;
     flex-direction: column;
+    max-width: 50rem;
 }
 
 .lyricsLine {

--- a/src/styles/lyrics.scss
+++ b/src/styles/lyrics.scss
@@ -26,6 +26,12 @@
             font-size: 2rem;
         }
     }
+
+    &:empty {
+        padding: 0;
+        height: 0.75em;
+        pointer-events: none;
+    }
 }
 
 .futureLyric {

--- a/src/styles/lyrics.scss
+++ b/src/styles/lyrics.scss
@@ -29,7 +29,7 @@
 }
 
 .futureLyric {
-    opacity: 0.3;
+    opacity: 0.45;
 }
 
 .pastLyric {

--- a/src/styles/lyrics.scss
+++ b/src/styles/lyrics.scss
@@ -13,10 +13,16 @@
 .lyricsLine {
     display: inline-block;
     width: fit-content;
-    margin: 0.1em;
-    font-size: 30px;
+    padding: 0 2rem;
+    font-size: 1.5rem;
+    line-height: 2;
     color: inherit;
-    min-height: 2em;
+
+    .layout-desktop & {
+        @media (min-width: 50em) {
+            font-size: 2rem;
+        }
+    }
 }
 
 .futureLyric {

--- a/src/styles/lyrics.scss
+++ b/src/styles/lyrics.scss
@@ -17,6 +17,9 @@
     font-size: 1.5rem;
     line-height: 2;
     color: inherit;
+    transition-property: color, text-shadow, opacity;
+    transition-duration: 200ms;
+    transition-timing-function: ease-in-out;
 
     .layout-desktop & {
         @media (min-width: 50em) {
@@ -35,4 +38,9 @@
 
 .dynamicLyric {
     cursor: pointer;
+
+    &:hover {
+        opacity: 1;
+        text-shadow: 0 0 0.25em rgba(white, 0.25);
+    }
 }


### PR DESCRIPTION
The styling for the lyrics page needed a tiny bit of TLC for a nicer cross-device experience.

### Changes
- Lyrics container now has extra top padding and max-width
- Lyrics font size and bounding box now scales better on mobile & TV
  - Switched to `rem`
  - Shrunk slightly on non-large-desktop screens
  - Added horizontal padding for mobile
- Added slight glow on dynamic lyric hover, with fast transition
- Increased future lyric opacity slightly
- Empty lyric lines (used as gap between sections in some LRC files) now have a small forced height to separate said sections

### Comparison
|     | Before | After |
|:---:|:------:|:-----:|
| Desktop | ![desktop-before](https://github.com/user-attachments/assets/5776607a-9d7c-4e40-a417-ed7ebafe73d2) | ![desktop-after-hovered](https://github.com/user-attachments/assets/3a12110c-fef4-4886-ad92-f82fb0f94700) |
| Mobile | ![iphonese-before](https://github.com/user-attachments/assets/4a38a14b-8c7a-4484-8d70-30e96442aad4) | ![iphonese-after](https://github.com/user-attachments/assets/6659b879-b781-403f-8f09-cd690367ef45) |
| TV\* | ![tv-before](https://github.com/user-attachments/assets/6afff686-f31a-442f-9377-be6f2c748bf3) | ![tv-after](https://github.com/user-attachments/assets/67d9302c-a3e7-4217-a570-33115d2dae75) |


*\* Don't worry about the serif font on TV, I was alternating by user agent rather than going into settings every time.*