### PR TITLE
Fix async route page refresh not loading header

### DIFF
--- a/src/components/ConnectionRequired.tsx
+++ b/src/components/ConnectionRequired.tsx
@@ -150,21 +150,25 @@ const ConnectionRequired: FunctionComponent<ConnectionRequiredProps> = ({
     useEffect(() => {
         // Check connection status on initial page load
         const apiClient = ServerConnections.currentApiClient();
-        const firstConnection = ServerConnections.firstConnection;
-        console.debug('[ConnectionRequired] connection state', firstConnection?.State);
-        ServerConnections.firstConnection = null;
+        const connection = Promise.resolve(ServerConnections.firstConnection ? null : ServerConnections.connect());
+        connection.then(firstConnection => {
+            console.debug('[ConnectionRequired] connection state', firstConnection?.State);
+            ServerConnections.firstConnection = true;
 
-        if (firstConnection && firstConnection.State !== ConnectionState.SignedIn && !apiClient?.isLoggedIn()) {
-            handleIncompleteWizard(firstConnection)
-                .catch(err => {
-                    console.error('[ConnectionRequired] could not start wizard', err);
-                });
-        } else {
-            validateUserAccess()
-                .catch(err => {
-                    console.error('[ConnectionRequired] could not validate user access', err);
-                });
-        }
+            if (firstConnection && firstConnection.State !== ConnectionState.SignedIn && !apiClient?.isLoggedIn()) {
+                handleIncompleteWizard(firstConnection)
+                    .catch(err => {
+                        console.error('[ConnectionRequired] could not start wizard', err);
+                    });
+            } else {
+                validateUserAccess()
+                    .catch(err => {
+                        console.error('[ConnectionRequired] could not validate user access', err);
+                    });
+            }
+        }).catch(err => {
+            console.error('[ConnectionRequired] failed to connect', err);
+        });
     }, [handleIncompleteWizard, validateUserAccess]);
 
     if (isLoading) {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -110,9 +110,6 @@ build: ${__JF_BUILD_VERSION__}`);
         Events.on(apiClient, 'requestfail', appRouter.onRequestFail);
     });
 
-    // Connect to server
-    ServerConnections.firstConnection = await ServerConnections.connect();
-
     // Render the app
     await renderApp();
 


### PR DESCRIPTION
Refreshing some async route pages (search, userprofile, and quickconnect) may cause the header not to load. Regression from https://github.com/jellyfin/jellyfin-web/pull/6150

**Changes**
Move first connect to run in `ConnectionRequired`

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
