### PR TITLE
Remove invalid item id usage as media source id

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -2602,16 +2602,11 @@ export class PlaybackManager {
                 });
             }
 
+            let mediaSourceId = playOptions.mediaSourceId;
+
             const apiClient = ServerConnections.getApiClient(item.ServerId);
-            let mediaSourceId;
-
             const isLiveTv = [BaseItemKind.TvChannel, BaseItemKind.LiveTvChannel].includes(item.Type);
-
-            if (!isLiveTv) {
-                mediaSourceId = playOptions.mediaSourceId || item.Id;
-            }
-
-            const getMediaStreams = isLiveTv ? Promise.resolve([]) : apiClient.getItem(apiClient.getCurrentUserId(), mediaSourceId)
+            const getMediaStreams = isLiveTv ? Promise.resolve([]) : apiClient.getItem(apiClient.getCurrentUserId(), mediaSourceId || item.Id)
                 .then(fullItem => {
                     return fullItem.MediaStreams;
                 });
@@ -2644,13 +2639,20 @@ export class PlaybackManager {
                 playOptions.items = null;
 
                 const trackOptions = {};
+                let isIdFallbackNeeded = false;
 
                 autoSetNextTracks(prevSource, mediaStreams, trackOptions, user.Configuration.RememberAudioSelections, user.Configuration.RememberSubtitleSelections);
                 if (trackOptions.DefaultAudioStreamIndex != null) {
                     options.audioStreamIndex = trackOptions.DefaultAudioStreamIndex;
+                    isIdFallbackNeeded = true;
                 }
                 if (trackOptions.DefaultSubtitleStreamIndex != null) {
                     options.subtitleStreamIndex = trackOptions.DefaultSubtitleStreamIndex;
+                    isIdFallbackNeeded = true;
+                }
+
+                if (isIdFallbackNeeded) {
+                    mediaSourceId ||= item.Id;
                 }
 
                 return getPlaybackMediaSource(player, apiClient, deviceProfile, item, mediaSourceId, options).then(async (mediaSource) => {


### PR DESCRIPTION
Looking at the change history, it looks like an accidental ` || item.Id` was introduced in 4c31742cc50c19702f2c1610c2bcfc0d6c4d210b to query for the item, perhaps not realising it is later used in the query later on for server-side filtering. This was partially fixed by c54db604d9426f3b3d46222c9161b88aa210d4da and
ca4763512f4a4e2a73e37600a5dc520f917c2274 for Live TV by not setting this variable in that case.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
Only use the fallback item id in the API call

**Issues**
Fixes #6395
