### PR TITLE
Show username validation error messages

### DIFF
--- a/src/apps/dashboard/routes/users/add.tsx
+++ b/src/apps/dashboard/routes/users/add.tsx
@@ -148,9 +148,17 @@ const UserNew = () => {
                 }).catch(err => {
                     console.error('[usernew] failed to update user policy', err);
                 });
-            }, function () {
-                toast(globalize.translate('ErrorDefault'));
-                loading.hide();
+            }, function (error) {
+                try {
+                    console.error('[usernew] failed to create new user', error);
+                    error.text().then((errorMessage: string) => {
+                        toast(errorMessage);
+                        loading.hide();
+                    });
+                } catch {
+                    toast(globalize.translate('ErrorDefault'));
+                    loading.hide();
+                }
             });
         };
 

--- a/src/apps/dashboard/routes/users/add.tsx
+++ b/src/apps/dashboard/routes/users/add.tsx
@@ -205,7 +205,7 @@ const UserNew = () => {
                             type='text'
                             id='txtUsername'
                             label='LabelName'
-                            validator={{ pattern: '^([\\w \\-\'._@+]*)([\\w\\-\'._@+])([\\w \\-\'._@+]*)$', errMessage: 'Username must not be empty and contain only numbers, letters, spaces, or the following symbols -\'._@+' }}
+                            validator={{ pattern: '^([\\w \\-\'._@+]*)([\\w\\-\'._@+])([\\w \\-\'._@+]*)$', errMessage: globalize.translate('MessageInvalidUsernameFormat') }}
                             options={'required'}
                         />
                     </div>

--- a/src/apps/dashboard/routes/users/add.tsx
+++ b/src/apps/dashboard/routes/users/add.tsx
@@ -205,6 +205,7 @@ const UserNew = () => {
                             type='text'
                             id='txtUsername'
                             label='LabelName'
+                            validator={{ pattern: '^([\\w \\-\'._@+]*)([\\w\\-\'._@+])([\\w \\-\'._@+]*)$', errMessage: 'Username must not be empty and contain only numbers, letters, spaces, or the following symbols -\'._@+' }}
                             options={'required'}
                         />
                     </div>

--- a/src/apps/dashboard/routes/users/profile.tsx
+++ b/src/apps/dashboard/routes/users/profile.tsx
@@ -327,6 +327,7 @@ const UserEdit = () => {
                             type='text'
                             id='txtUserName'
                             label='LabelName'
+                            validator={{ pattern: '^([\\w \\-\'._@+]*)([\\w\\-\'._@+])([\\w \\-\'._@+]*)$', errMessage: 'Username must not be empty and contain only numbers, letters, spaces, or the following symbols -\'._@+' }}
                             options={'required'}
                         />
                     </div>

--- a/src/apps/dashboard/routes/users/profile.tsx
+++ b/src/apps/dashboard/routes/users/profile.tsx
@@ -230,7 +230,16 @@ const UserEdit = () => {
             )).then(() => {
                 onSaveComplete();
             }).catch(err => {
-                console.error('[useredit] failed to update user', err);
+                try {
+                    console.error('[useredit] failed to update user', err);
+                    err.text().then((errorMessage: string) => {
+                        toast(errorMessage);
+                        loading.hide();
+                    });
+                } catch {
+                    toast(globalize.translate('ErrorDefault'));
+                    loading.hide();
+                }
             });
         };
 

--- a/src/apps/dashboard/routes/users/profile.tsx
+++ b/src/apps/dashboard/routes/users/profile.tsx
@@ -327,7 +327,7 @@ const UserEdit = () => {
                             type='text'
                             id='txtUserName'
                             label='LabelName'
-                            validator={{ pattern: '^([\\w \\-\'._@+]*)([\\w\\-\'._@+])([\\w \\-\'._@+]*)$', errMessage: 'Username must not be empty and contain only numbers, letters, spaces, or the following symbols -\'._@+' }}
+                            validator={{ pattern: '^([\\w \\-\'._@+]*)([\\w\\-\'._@+])([\\w \\-\'._@+]*)$', errMessage: globalize.translate('MessageInvalidUsernameFormat') }}
                             options={'required'}
                         />
                     </div>

--- a/src/elements/InputElement.tsx
+++ b/src/elements/InputElement.tsx
@@ -2,23 +2,30 @@ import React, { type FC, useCallback, useEffect, useMemo, useRef } from 'react';
 
 import globalize from 'lib/globalize';
 
+import './InputElementInvalidMessage.scss';
+
 interface CreateInputElementParams {
     type?: string
     id?: string
     label?: string
     initialValue?: string
+    validator?: { pattern: string, errMessage: string }
     options?: string
 }
 
-const createInputElement = ({ type, id, label, initialValue, options }: CreateInputElementParams) => ({
+const createInputElement = ({ type, id, label, initialValue, validator, options }: CreateInputElementParams) => ({
     __html: `<input
         is="emby-input"
         type="${type}"
         id="${id}"
         label="${label}"
         value="${initialValue}"
+        ${validator ? 'pattern="' + validator.pattern + '"' : ''}
         ${options}
-    />`
+    />
+    <div class="inputElementInvalidMessage">
+        ${validator?.errMessage || ''}
+    </div>`
 });
 
 type InputElementProps = {
@@ -33,7 +40,9 @@ const InputElement: FC<InputElementProps> = ({
     type,
     id,
     label,
+    validator,
     options = ''
+
 }) => {
     const container = useRef<HTMLDivElement>(null);
 
@@ -44,14 +53,16 @@ const InputElement: FC<InputElementProps> = ({
             id,
             label: globalize.translate(label),
             initialValue,
+            validator,
             options
         })
     // eslint-disable-next-line react-hooks/exhaustive-deps
     ), []);
 
     const onInput = useCallback((e: Event) => {
+        if (validator) (e.target as HTMLElement).parentElement?.querySelector('.inputElementInvalidMessage')?.classList.add('inputReadyForValidation');
         onChange((e.target as HTMLInputElement).value);
-    }, [ onChange ]);
+    }, [ onChange, validator ]);
 
     useEffect(() => {
         const inputElement = container?.current?.querySelector<HTMLInputElement>('input');

--- a/src/elements/InputElementInvalidMessage.scss
+++ b/src/elements/InputElementInvalidMessage.scss
@@ -1,0 +1,8 @@
+.inputElementInvalidMessage {
+    color: red;
+    display: none;
+}
+
+.emby-input:invalid + .inputElementInvalidMessage.inputReadyForValidation {
+    display: block;
+}

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1113,6 +1113,7 @@
     "MessageImageTypeNotSelected": "Please select an image type from the drop-down menu.",
     "MessageInvalidForgotPasswordPin": "An invalid or expired PIN code was entered. Please try again.",
     "MessageInvalidUser": "Invalid username or password. Please try again.",
+    "MessageInvalidUsernameFormat": "Username must not be empty and contain only numbers, letters, spaces, or the following symbols -'._@+",
     "MessageItemsAdded": "Items added.",
     "MessageItemSaved": "Item saved.",
     "MessageLeaveEmptyToInherit": "Leave empty to inherit settings from a parent item or the global default value.",


### PR DESCRIPTION
**Changes**
- Validates the username input field against the same regex used by the backend. The regex was modified to not allow usernames that are all spaces.
- This is done by adding a "validator" attribute to InputElement which has a regex pattern and an error message.
- The error message is only shown when the input is invalid, and after the input has been changed (to prevent immediate error messages before a single character has been entered)
- Styles for the error message are in a new scss file
- Shows errors returned by the api in a toast notification, such as when another user already has that name
- These changes were all made to the forms for creating a new user and editing an existing user
- Hides loading spinner when submitting user profile edits with errors. Previously the spinner would stay until the page was refreshed if the api returned an error

**Issues**
Closes #6384