### PR TITLE
Fix focus loss on popups in Samsung Tizen 8 Smart TVs

### DIFF
--- a/src/components/alert.js
+++ b/src/components/alert.js
@@ -6,7 +6,8 @@ import globalize from '../lib/globalize';
 export default async function (text, title) {
     // Modals seem to be blocked on Web OS and Tizen 2.x
     const canUseNativeAlert = !!(
-        !browser.web0s
+        !(browser.tizenVersion && browser.tizenVersion >= 8)
+        && !browser.web0s
         && !(browser.tizenVersion && browser.tizenVersion < 3)
         && browser.tv
         && window.alert

--- a/src/components/alert.js
+++ b/src/components/alert.js
@@ -6,9 +6,8 @@ import globalize from '../lib/globalize';
 export default async function (text, title) {
     // Modals seem to be blocked on Web OS and Tizen 2.x
     const canUseNativeAlert = !!(
-        !(browser.tizenVersion && browser.tizenVersion >= 8)
-        && !browser.web0s
-        && !(browser.tizenVersion && browser.tizenVersion < 3)
+        !browser.web0s
+        && !(browser.tizenVersion && (browser.tizenVersion < 3 || browser.tizenVersion >= 8))
         && browser.tv
         && window.alert
     );

--- a/src/components/confirm/confirm.js
+++ b/src/components/confirm/confirm.js
@@ -7,6 +7,7 @@ function useNativeConfirm() {
     // webOS seems to block modals
     // Tizen 2.x seems to block modals
     return !browser.web0s
+        && !(browser.tizenVersion && browser.tizenVersion >= 8)
         && !(browser.tizenVersion && browser.tizenVersion < 3)
         && browser.tv
         && window.confirm;

--- a/src/components/confirm/confirm.js
+++ b/src/components/confirm/confirm.js
@@ -4,9 +4,6 @@ import dialog from '../dialog/dialog';
 import globalize from '../../lib/globalize';
 
 function useNativeConfirm() {
-    if (browser.tizenVersion && browser.tizenVersion >= 8) {
-        return false;
-    }
     // webOS seems to block modals
     // Tizen 2.x seems to block modals
     return !browser.web0s

--- a/src/components/confirm/confirm.js
+++ b/src/components/confirm/confirm.js
@@ -7,8 +7,7 @@ function useNativeConfirm() {
     // webOS seems to block modals
     // Tizen 2.x seems to block modals
     return !browser.web0s
-        && !(browser.tizenVersion && browser.tizenVersion >= 8)
-        && !(browser.tizenVersion && browser.tizenVersion < 3)
+        && !(browser.tizenVersion && (browser.tizenVersion < 3 || browser.tizenVersion >= 8))
         && browser.tv
         && window.confirm;
 }


### PR DESCRIPTION
The web client loses focus when a popup is displayed on Samsung Smart TVs with Tizen 8 (OneUI/Tizen 8). This issue only occurs on the TV itself and not on the Tizen emulator.
Fixes the issue https://github.com/jellyfin/jellyfin-tizen/issues/311


**Changes**  
This PR updates `confirm.js` to ensure that the native `window.confirm` is not used on Samsung Smart TVs with Tizen 8 (OneUI). Instead, it uses a custom confirmation dialog to prevent focus-related issues specific to this platform.  

**Issues**  
Fixes https://github.com/jellyfin/jellyfin-tizen/issues/311  