### PR TITLE
Prevent Focus Loss When Skip Button is Pressed

### DIFF
--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -354,7 +354,7 @@ export default function (view) {
             toggleSubtitleSync('hide');
 
             // Firefox does not blur by itself
-            if (document.activeElement) {
+            if (osdBottomElement.contains(document.activeElement)) {
                 document.activeElement.blur();
             }
         }
@@ -1252,7 +1252,7 @@ export default function (view) {
 
         switch (key) {
             case 'Enter':
-                showOsd();
+                showOsd(e.target.classList.contains('skip-button') ? btnPlayPause : undefined);
                 break;
             case 'Escape':
             case 'Back':


### PR DESCRIPTION
Addresses the focus-related issue when interacting with the skip button during playback.

1. Ensures that after the skip button is pressed and the OSD is visible, the focus automatically moves to the pause button.
2. Updates the logic to retain focus on the skip button when the OSD hides.
