### PR TITLE
Fix missing space in pt-BR translation

### DIFF
--- a/src/strings/pt-br.json
+++ b/src/strings/pt-br.json
@@ -1895,7 +1895,7 @@
     "Penciller": "Lápis",
     "LabelSelectPreferredTranscodeVideoCodec": "Codec de vídeo transcodificado preferido",
     "SelectPreferredTranscodeVideoCodecHelp": "Seleccione o codec de vídeo preferido para transcodificar. Se o codec preferido não for suportado, o servidor irá usar o melhor codec disponível a seguir.",
-    "HeaderNextItemPlayingInValue": "Próximo{0} Tocando em {1}",
+    "HeaderNextItemPlayingInValue": "Próximo {0} Tocando em {1}",
     "LibraryInvalidItemIdError": "A biblioteca está em um estado inválido e não pode ser editada. Você possivelmente está encontrando um bug: o caminho no banco de dados não é o caminho correto no sistema de arquivos.",
     "Reset": "Resetar",
     "PasswordMissingSaveError": "A nova senha não pode ser em branco.",


### PR DESCRIPTION
Add a missing space between words in the HeaderNextItemPlayingInValue string in the Portuguese (pt-BR) translation.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
Added a missing space in the HeaderNextItemPlayingInValue string in the Portuguese (pt-BR) translation file. This ensures proper spacing between words, improving the readability of the message displayed to users.

**Issues**
N/A (This is a minor fix without an associated issue.)


