### PR TITLE
Fix metadata dialog backdrop click to exit

### DIFF
--- a/src/components/dialogHelper/dialogHelper.js
+++ b/src/components/dialogHelper/dialogHelper.js
@@ -43,7 +43,7 @@ function tryRemoveElement(elem) {
     }
 }
 
-function DialogHashHandler(dlg, hash, resolve, dlgOptions) {
+function DialogHashHandler(dlg, hash, resolve) {
     const self = this;
     self.originalUrl = window.location.href;
     const activeElement = document.activeElement;
@@ -158,7 +158,7 @@ function DialogHashHandler(dlg, hash, resolve, dlgOptions) {
 
     dlg.classList.remove('hide');
 
-    addBackdropOverlay(dlg, dlgOptions);
+    addBackdropOverlay(dlg);
 
     dlg.classList.add('opened');
     dlg.dispatchEvent(new CustomEvent('open', {
@@ -193,7 +193,7 @@ function DialogHashHandler(dlg, hash, resolve, dlgOptions) {
     }
 }
 
-function addBackdropOverlay(dlg, dlgOptions = {}) {
+function addBackdropOverlay(dlg) {
     const backdrop = document.createElement('div');
     backdrop.classList.add('dialogBackdrop');
 
@@ -205,33 +205,35 @@ function addBackdropOverlay(dlg, dlgOptions = {}) {
     void backdrop.offsetWidth;
     backdrop.classList.add('dialogBackdropOpened');
 
-    if (!dlgOptions.preventCloseOnClick) {
-        dom.addEventListener((dlg.dialogContainer || backdrop), 'click', e => {
-            if (e.target === dlg.dialogContainer) {
-                close(dlg);
-            }
-        }, {
-            passive: true
-        });
-    }
+    let clickedElement;
 
-    if (!dlgOptions.preventCloseOnRightClick) {
-        dom.addEventListener((dlg.dialogContainer || backdrop), 'contextmenu', e => {
-            if (e.target === dlg.dialogContainer) {
-                // Close the application dialog menu
-                close(dlg);
-                // Prevent the default browser context menu from appearing
-                e.preventDefault();
-            }
-        });
-    }
+    dom.addEventListener((dlg.dialogContainer || backdrop), 'mousedown', e => {
+        clickedElement = e.target;
+    });
+
+    dom.addEventListener((dlg.dialogContainer || backdrop), 'click', e => {
+        if (e.target === dlg.dialogContainer && e.target == clickedElement) {
+            close(dlg);
+        }
+    }, {
+        passive: true
+    });
+
+    dom.addEventListener((dlg.dialogContainer || backdrop), 'contextmenu', e => {
+        if (e.target === dlg.dialogContainer) {
+            // Close the application dialog menu
+            close(dlg);
+            // Prevent the default browser context menu from appearing
+            e.preventDefault();
+        }
+    });
 }
 
 function isHistoryEnabled(dlg) {
     return dlg.getAttribute('data-history') === 'true';
 }
 
-export function open(dlg, dlgOptions) {
+export function open(dlg) {
     if (globalOnOpenCallback) {
         globalOnOpenCallback(dlg);
     }
@@ -248,7 +250,7 @@ export function open(dlg, dlgOptions) {
     document.body.appendChild(dialogContainer);
 
     return new Promise((resolve) => {
-        new DialogHashHandler(dlg, `dlg${new Date().getTime()}`, resolve, dlgOptions);
+        new DialogHashHandler(dlg, `dlg${new Date().getTime()}`, resolve);
     });
 }
 

--- a/src/components/metadataEditor/metadataEditor.js
+++ b/src/components/metadataEditor/metadataEditor.js
@@ -1099,10 +1099,7 @@ function show(itemId, serverId, resolve) {
         centerFocus(dlg.querySelector('.formDialogContent'), false, true);
     }
 
-    dialogHelper.open(dlg, {
-        preventCloseOnClick : true,
-        preventCloseOnRightClick : true
-    });
+    dialogHelper.open(dlg);
 
     dlg.addEventListener('close', function () {
         if (layoutManager.tv) {


### PR DESCRIPTION
**Changes**
- Fixes not being able to click the backdrop of the metadata dialog to exit
- Fixes dragging mouse from inner dialog to outside causing it to close (Firefox)

**Issues**
Fixes https://github.com/jellyfin/jellyfin-web/issues/5723
