### PR TITLE
Fix styling for wide device icons

### DIFF
--- a/src/controllers/dashboard/devices/devices.js
+++ b/src/controllers/dashboard/devices/devices.js
@@ -99,7 +99,7 @@ function load(page, devices) {
         const iconUrl = imageHelper.getDeviceIcon(device);
 
         if (iconUrl) {
-            deviceHtml += '<div class="cardImage" style="background-image:url(\'' + iconUrl + "');background-size: auto 64%;background-position:center center;\">";
+            deviceHtml += '<div class="cardImage" style="background-image:url(\'' + iconUrl + "');background-size:contain;background-position:center center;background-origin:content-box;padding:1em;\">";
             deviceHtml += '</div>';
         } else {
             deviceHtml += '<span class="cardImageIcon material-icons tablet_android" aria-hidden="true"></span>';


### PR DESCRIPTION
**Changes**
Fixes wide device icons being cutoff on the sides. This affected the webOS icon added in https://github.com/jellyfin/jellyfin-web/pull/6281 in particular.

**Issues**
N/A