### PR TITLE
Add CSS variable to override font for easy theming

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -94,6 +94,7 @@
 - [iFraan](https://github.com/iFraan)
 - [Ali](https://github.com/bu3alwa)
 - [K. Kyle Puchkov](https://github.com/kepper104)
+- [JohnyTheCarrot](https://github.com/johnythecarrot)
 
 ## Emby Contributors
 

--- a/src/styles/fonts.noto.scss
+++ b/src/styles/fonts.noto.scss
@@ -1,25 +1,29 @@
 @import "../styles/noto-sans/index.scss";
 
+$font-override-var: --jf-font-override;
+$current-font: --jf-current-font;
+
 html {
-    font-family: "Noto Sans", "Noto Sans HK", "Noto Sans JP", "Noto Sans KR", "Noto Sans SC", "Noto Sans TC", sans-serif;
+    #{$current-font}: var(#{$font-override-var}, "Noto Sans", "Noto Sans HK", "Noto Sans JP", "Noto Sans KR", "Noto Sans SC", "Noto Sans TC"), sans-serif;
+    font-family: var($current-font);
 }
 
 html[lang|="ja"] {
-    font-family: "Noto Sans", "Noto Sans JP", "Noto Sans HK", "Noto Sans KR", "Noto Sans SC", "Noto Sans TC", sans-serif;
+    #{$current-font}: var($font-override-var + "--ja", var($font-override-var, "Noto Sans", "Noto Sans JP", "Noto Sans HK", "Noto Sans KR", "Noto Sans SC", "Noto Sans TC")), sans-serif;
 }
 
 html[lang|="ko"] {
-    font-family: "Noto Sans", "Noto Sans KR", "Noto Sans HK", "Noto Sans JP", "Noto Sans SC", "Noto Sans TC", sans-serif;
+    #{$current-font}: var($font-override-var + "--ko", var($font-override-var, "Noto Sans", "Noto Sans KR", "Noto Sans HK", "Noto Sans JP", "Noto Sans SC", "Noto Sans TC")), sans-serif;
 }
 
 html[lang|="zh-CN"] {
-    font-family: "Noto Sans", "Noto Sans SC", "Noto Sans HK", "Noto Sans JP", "Noto Sans KR", "Noto Sans TC", sans-serif;
+    #{$current-font}: var($font-override-var + "--zh-CN", var($font-override-var, "Noto Sans", "Noto Sans SC", "Noto Sans HK", "Noto Sans JP", "Noto Sans KR", "Noto Sans TC")), sans-serif;
 }
 
 html[lang|="zh-TW"] {
-    font-family: "Noto Sans", "Noto Sans TC", "Noto Sans HK", "Noto Sans JP", "Noto Sans KR", "Noto Sans SC", sans-serif;
+    #{$current-font}: var($font-override-var + "--zh-TW", var($font-override-var, "Noto Sans", "Noto Sans TC", "Noto Sans HK", "Noto Sans JP", "Noto Sans KR", "Noto Sans SC")), sans-serif;
 }
 
 html[lang|="zh-HK"] {
-    font-family: "Noto Sans", "Noto Sans HK", "Noto Sans JP", "Noto Sans KR", "Noto Sans SC", "Noto Sans TC", sans-serif;
+    #{$current-font}: var($font-override-var + "--zh-HK", var($font-override-var, "Noto Sans", "Noto Sans HK", "Noto Sans JP", "Noto Sans KR", "Noto Sans SC", "Noto Sans TC")), sans-serif;
 }

--- a/src/themes/defaults.ts
+++ b/src/themes/defaults.ts
@@ -26,7 +26,7 @@ export const DEFAULT_THEME_OPTIONS: ThemeOptions = {
         }
     },
     typography: {
-        fontFamily: '"Noto Sans", sans-serif',
+        fontFamily: 'var(--jf-current-font)',
         button: {
             textTransform: 'none'
         },


### PR DESCRIPTION
**Changes**
This PR adds a couple CSS variables for the user to override in order to add a custom font.
Why not just overwrite it using a custom `html` rule with a `font-family` property? There are "typography" elements that manually re-specify the font family, and given that those class names seem to be hash based, they would be subject to change as the CSS would change, assuming I'm right.

Added vars to override:
`--jf-font-override`
`--jf-font-override--ja`
`--jf-font-override--ko`
`--jf-font-override--zh-CN`
`--jf-font-override--zh-TW`
`--jf-font-override--zh-HK`
Each of the per-lang overwrites will fall back to `--jf-font-override` if not overridden, and `--jf-font-override` will fall back to Noto Sans if not overriden.

When wanting to use `font-family` anywhere in the code base, one would reference the `--jf-current-font` variable to retrieve the current effective font, overridden or not.
A `jf` prefix has been added to the vars to avoid clashes with user themes.