### PR TITLE
Remove safe area padding on video container

### DIFF
--- a/src/plugins/htmlVideoPlayer/style.scss
+++ b/src/plugins/htmlVideoPlayer/style.scss
@@ -7,10 +7,6 @@
     display: flex;
     align-items: center;
     background: #000 !important;
-    padding-left: env(safe-area-inset-left);
-    padding-right: env(safe-area-inset-right);
-    padding-top: env(safe-area-inset-top);
-    padding-bottom: env(safe-area-inset-bottom);
 }
 
 .videoPlayerContainer-onTop {

--- a/src/plugins/youtubePlayer/style.scss
+++ b/src/plugins/youtubePlayer/style.scss
@@ -7,10 +7,6 @@
     right: 0;
     display: flex;
     align-items: center;
-    padding-left: env(safe-area-inset-left);
-    padding-right: env(safe-area-inset-right);
-    padding-top: env(safe-area-inset-top);
-    padding-bottom: env(safe-area-inset-bottom);
 }
 
 .youtubePlayerContainer.onTop {


### PR DESCRIPTION
**Changes**
Removes the safe area padding from the video container. The controls still have the correct padding, but this allows the video to cover the entire screen.

**Before**
![IMG_7346](https://github.com/user-attachments/assets/50b01825-d0b3-4551-b730-d0ab1225bd76)

**After**
![IMG_7344](https://github.com/user-attachments/assets/7a4bc696-87f4-46f0-b4f6-7fe5f95445d4)

**Issues**
Related to https://github.com/jellyfin/jellyfin-expo/issues/377