### PR TITLE
Use reference framerate as sampling rate (target FPS) for SubtitlesOctopus

### DIFF
--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1305,7 +1305,7 @@ export class HtmlVideoPlayer {
                 dropAllAnimations: false,
                 libassMemoryLimit: 40,
                 libassGlyphLimit: 40,
-                targetFps: videoStream?.AverageFrameRate || videoStream?.RealFrameRate || 24,
+                targetFps: videoStream?.ReferenceFrameRate || videoStream?.RealFrameRate || 24,
                 prescaleFactor: 0.8,
                 prescaleHeightLimit: 1080,
                 maxRenderHeight: 2160,

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -119,6 +119,12 @@ function requireHlsPlayer(callback) {
     });
 }
 
+function getMediaStreamVideoTracks(mediaSource) {
+    return mediaSource.MediaStreams.filter(function (s) {
+        return s.Type === 'Video';
+    });
+}
+
 function getMediaStreamAudioTracks(mediaSource) {
     return mediaSource.MediaStreams.filter(function (s) {
         return s.Type === 'Audio';
@@ -1274,6 +1280,9 @@ export class HtmlVideoPlayer {
         });
         const htmlVideoPlayer = this;
         import('@jellyfin/libass-wasm').then(({ default: SubtitlesOctopus }) => {
+            const mediaSource = this._currentPlayOptions.mediaSource;
+            const videoStream = getMediaStreamVideoTracks(mediaSource)[0];
+
             const options = {
                 video: videoElement,
                 subUrl: getTextTrackUrl(track, item),
@@ -1296,7 +1305,7 @@ export class HtmlVideoPlayer {
                 dropAllAnimations: false,
                 libassMemoryLimit: 40,
                 libassGlyphLimit: 40,
-                targetFps: 24,
+                targetFps: videoStream?.AverageFrameRate || videoStream?.RealFrameRate || 24,
                 prescaleFactor: 0.8,
                 prescaleHeightLimit: 1080,
                 maxRenderHeight: 2160,


### PR DESCRIPTION
**Changes**
Use reference framerate as sampling rate (target FPS) for SubtitlesOctopus.

**Issues**
#6461
But I'm not sure it can maintain the rate when _"even if there should be movement on every frame"_ on 60fps.