### PR TITLE
Add renovate PR priority for SDK and hls.js

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,12 +9,17 @@
       "matchPackageNames": [ "@jellyfin/sdk" ],
       "followTag": "unstable",
       "minimumReleaseAge": null,
+      "prPriority": 5,
       "schedule": [ "after 7:00 am" ]
     },
     {
-      "matchPackageNames": ["dompurify"],
-      "matchUpdateTypes": ["major"],
+      "matchPackageNames": [ "dompurify" ],
+      "matchUpdateTypes": [ "major" ],
       "enabled": false
+    },
+    {
+      "matchPackageNames": [ "hls.js" ],
+      "prPriority": 5
     }
   ]
 }


### PR DESCRIPTION
**Changes**
Sets the PR priority for renovate updates for the SDK and hls.js as these are likely our most important dependencies

**Issues**
N/A