### PR TITLE
Implement horizontal scroll seeking in video player

### DIFF
--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -19,6 +19,7 @@ import globalize from '../../../lib/globalize';
 import { appHost } from '../../../components/apphost';
 import layoutManager from '../../../components/layoutManager';
 import * as userSettings from '../../../scripts/settings/userSettings';
+import appSettings from '../../../scripts/settings/appSettings';
 import keyboardnavigation from '../../../scripts/keyboardNavigation';
 import '../../../styles/scrollstyles.scss';
 import '../../../elements/emby-slider/emby-slider';
@@ -1443,6 +1444,14 @@ export default function (view) {
         }
         if (e.deltaY > 0) {
             playbackManager.volumeDown(currentPlayer);
+        }
+        if (appSettings.enableHorizontalScroll()) {
+            if (e.deltaX < 0) {
+                playbackManager.rewind(currentPlayer);
+            }
+            if (e.deltaX > 0) {
+                playbackManager.fastForward(currentPlayer);
+            }
         }
     }
 

--- a/src/controllers/user/controls/index.html
+++ b/src/controllers/user/controls/index.html
@@ -21,6 +21,14 @@
                         <span>${EnableSmoothScroll}</span>
                     </label>
                 </div>
+
+                <div class="checkboxContainer checkboxContainer-withDescription">
+                    <label>
+                        <input type="checkbox" is="emby-checkbox" class="chkEnableHorizontalScroll" />
+                        <span>${LabelEnableHorizontalScroll}</span>
+                    </label>
+                    <div class="fieldDescription checkboxFieldDescription">${EnableHorizontalScrollHelp}</div>
+                </div>
             </div>
 
             <button is="emby-button" type="submit" class="raised button-submit block btnSave hide">

--- a/src/controllers/user/controls/index.js
+++ b/src/controllers/user/controls/index.js
@@ -9,6 +9,7 @@ export default function (view) {
     function submit(e) {
         appSettings.enableGamepad(view.querySelector('.chkEnableGamepad').checked);
         appSettings.enableSmoothScroll(view.querySelector('.chkSmoothScroll').checked);
+        appSettings.enableHorizontalScroll(view.querySelector('.chkEnableHorizontalScroll').checked);
 
         toast(globalize.translate('SettingsSaved'));
 
@@ -25,6 +26,7 @@ export default function (view) {
 
         view.querySelector('.chkEnableGamepad').checked = appSettings.enableGamepad();
         view.querySelector('.chkSmoothScroll').checked = appSettings.enableSmoothScroll();
+        view.querySelector('.chkEnableHorizontalScroll').checked = appSettings.enableHorizontalScroll();
 
         view.querySelector('form').addEventListener('submit', submit);
         view.querySelector('.btnSave').classList.remove('hide');

--- a/src/scripts/settings/appSettings.js
+++ b/src/scripts/settings/appSettings.js
@@ -45,6 +45,19 @@ class AppSettings {
         return toBoolean(this.get('enableSmoothScroll'), !!browser.tizen);
     }
 
+    /**
+     * Get or set 'Enable horizontal scroll' state.
+     * @param {boolean|undefined} val - Flag to enable 'Enable horizontal scroll' or undefined.
+     * @return {boolean} 'Enable horizontal scroll' state.
+     */
+    enableHorizontalScroll(val) {
+        if (val !== undefined) {
+            this.set('enableHorizontalScroll', val.toString());
+        }
+
+        return toBoolean(this.get('enableHorizontalScroll'), false);
+    }
+
     enableSystemExternalPlayers(val) {
         if (val !== undefined) {
             this.set('enableSystemExternalPlayers', val.toString());

--- a/src/strings/en-gb.json
+++ b/src/strings/en-gb.json
@@ -1331,6 +1331,8 @@
     "DirectPlayHelp": "The source file is entirely compatible with this client and the session is receiving the file without modifications.",
     "EnableGamepadHelp": "Listen for input from any connected controllers. (Requires: 'TV' Display Mode)",
     "LabelEnableGamepad": "Enable Gamepad",
+    "EnableHorizontalScrollHelp": "Allow mouse wheel horizontal axis to seek forward/backward during video playback.",
+    "LabelEnableHorizontalScroll": "Enable Horizontal Scrolling",
     "Controls": "Controls",
     "TextSent": "Text sent.",
     "MessageSent": "Message sent.",


### PR DESCRIPTION
**Changes**
Implements horizontal scroll seeking in the video player, allowing to navigate through the video by scrolling left or right. Scrolling left rewinds, while scrolling right fast-forwards.
This feature will be disabled by default, with an option to enable it in the controls menu.

**Issues**
N/A
