### PR TITLE
Skip prevented keyboard events

### DIFF
--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1246,12 +1246,14 @@ export default function (view) {
                 case 'ArrowLeft':
                 case 'ArrowRight':
                     if (!e.shiftKey) {
+                        e.preventDefault();
                         showOsd(nowPlayingPositionSlider);
                         nowPlayingPositionSlider.dispatchEvent(new KeyboardEvent(e.type, e));
                     }
                     return;
                 case 'Enter':
                     if (e.target.tagName !== 'BUTTON') {
+                        e.preventDefault();
                         playbackManager.playPause(currentPlayer);
                         showOsd(btnPlayPause);
                     }

--- a/src/scripts/keyboardNavigation.js
+++ b/src/scripts/keyboardNavigation.js
@@ -125,6 +125,8 @@ export function isInteractiveElement(element) {
 export function enable() {
     const hasMediaSession = 'mediaSession' in navigator;
     window.addEventListener('keydown', function (e) {
+        if (e.defaultPrevented) return;
+
         // Skip modified keys
         if (e.ctrlKey || e.altKey || e.metaKey || e.shiftKey) return;
 


### PR DESCRIPTION
**Changes**
- Prevent default actions for hotkeys when OSD is hidden.
- Skip prevented keyboard events.

**Issues**
This doesn't fix https://github.com/jellyfin/jellyfin-tizen/issues/331#issuecomment-2625913829, but we should skip the prevented keyboard event anyway.
