### PR TITLE
Fix navigation for emby-select element

### DIFF
--- a/src/elements/emby-select/emby-select.js
+++ b/src/elements/emby-select/emby-select.js
@@ -79,23 +79,9 @@ function onMouseDown(e) {
 }
 
 function onKeyDown(e) {
-    switch (e.keyCode) {
-        case 13:
-            if (!enableNativeMenu()) {
-                e.preventDefault();
-                showActionSheet(this);
-            }
-            return;
-        case 37:
-        case 38:
-        case 39:
-        case 40:
-            if (layoutManager.tv) {
-                e.preventDefault();
-            }
-            return;
-        default:
-            break;
+    if (e.keyCode === 13 && !enableNativeMenu()) {
+        e.preventDefault();
+        showActionSheet(this);
     }
 }
 


### PR DESCRIPTION
**Changes**
Don't prevent default action for arrow keys in `emby-select` - they will be prevented by keyboard navigation.

**Issues**
Regression #6496
If we prevent default action, keyboard navigation won't work.
Fixes #6512

Maybe someone has other thoughts on the `keydown` event handling?