### PR TITLE
Scale the lyrics page responsively

### DIFF
--- a/src/styles/lyrics.scss
+++ b/src/styles/lyrics.scss
@@ -1,5 +1,7 @@
 .lyricPage {
     padding-top: 4.2em !important;
+    padding-left: 0.5em !important;
+    padding-right: 0.5em !important;
     display: flex;
     justify-content: center;
 }
@@ -13,9 +15,12 @@
     display: inline-block;
     width: fit-content;
     margin: 0.1em;
-    font-size: 30px;
+    font-size: 1.5em;
     color: inherit;
     min-height: 2em;
+
+    transition-property: opacity;
+    transition-duration: 150ms;
 }
 
 .futureLyric {


### PR DESCRIPTION
**Changes**
- Changes the lyrics text size from 30px to 1.5em. Looks proportionate on all devices.
- Adds a small breathing room of 0.5em around the lyrics container to ensure
the text does not touch the screen edges on smaller devices.
- Smoothly transition the opacity of each `lyricsLine`.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
