### PR TITLE
Refactor api keys to use TablePage component

### DIFF
--- a/src/apps/dashboard/components/table/TablePage.tsx
+++ b/src/apps/dashboard/components/table/TablePage.tsx
@@ -1,4 +1,5 @@
 import Box from '@mui/material/Box/Box';
+import Stack from '@mui/material/Stack/Stack';
 import Typography from '@mui/material/Typography/Typography';
 import { type MRT_RowData, type MRT_TableInstance, MaterialReactTable } from 'material-react-table';
 import React from 'react';
@@ -7,6 +8,7 @@ import Page, { type PageProps } from 'components/Page';
 
 interface TablePageProps<T extends MRT_RowData> extends PageProps {
     title: string
+    subtitle?: string
     table: MRT_TableInstance<T>
 }
 
@@ -27,6 +29,7 @@ export const DEFAULT_TABLE_OPTIONS = {
 
 const TablePage = <T extends MRT_RowData>({
     title,
+    subtitle,
     table,
     children,
     ...pageProps
@@ -44,7 +47,8 @@ const TablePage = <T extends MRT_RowData>({
                     height: '100%'
                 }}
             >
-                <Box
+                <Stack
+                    spacing={2}
                     sx={{
                         marginBottom: 1
                     }}
@@ -52,7 +56,12 @@ const TablePage = <T extends MRT_RowData>({
                     <Typography variant='h2'>
                         {title}
                     </Typography>
-                </Box>
+                    {subtitle && (
+                        <Typography>
+                            {subtitle}
+                        </Typography>
+                    )}
+                </Stack>
                 <MaterialReactTable table={table} />
             </Box>
             {children}

--- a/src/apps/dashboard/routes/activity/index.tsx
+++ b/src/apps/dashboard/routes/activity/index.tsx
@@ -61,7 +61,13 @@ export const Component = () => {
         hasUserId: activityView !== ActivityView.All ? activityView === ActivityView.User : undefined
     }), [activityView, pagination.pageIndex, pagination.pageSize]);
 
-    const { data: logEntries, isLoading: isLogEntriesLoading } = useLogEntries(activityParams);
+    const { data, isLoading: isLogEntriesLoading } = useLogEntries(activityParams);
+    const logEntries = useMemo(() => (
+        data?.Items || []
+    ), [ data ]);
+    const rowCount = useMemo(() => (
+        data?.TotalRecordCount || 0
+    ), [ data ]);
 
     const isLoading = isUsersLoading || isLogEntriesLoading;
 
@@ -154,7 +160,7 @@ export const Component = () => {
         ...DEFAULT_TABLE_OPTIONS,
 
         columns,
-        data: logEntries?.Items || [],
+        data: logEntries,
 
         // State
         initialState: {
@@ -168,7 +174,7 @@ export const Component = () => {
         // Server pagination
         manualPagination: true,
         onPaginationChange: setPagination,
-        rowCount: logEntries?.TotalRecordCount || 0,
+        rowCount,
 
         // Custom toolbar contents
         renderTopToolbarCustomActions: () => (

--- a/src/apps/dashboard/routes/activity/index.tsx
+++ b/src/apps/dashboard/routes/activity/index.tsx
@@ -40,7 +40,7 @@ const getUserCell = (users: UsersRecords) => function UserCell({ row }: Activity
     );
 };
 
-const Activity = () => {
+export const Component = () => {
     const [ searchParams, setSearchParams ] = useSearchParams();
 
     const [ activityView, setActivityView ] = useState(
@@ -201,4 +201,4 @@ const Activity = () => {
     );
 };
 
-export default Activity;
+Component.displayName = 'ActivityPage';

--- a/src/apps/dashboard/routes/keys/index.tsx
+++ b/src/apps/dashboard/routes/keys/index.tsx
@@ -1,26 +1,25 @@
-import parseISO from 'date-fns/parseISO';
-
-import DateTimeCell from 'apps/dashboard/components/table/DateTimeCell';
-import Page from 'components/Page';
-import { useApi } from 'hooks/useApi';
-import globalize from 'lib/globalize';
-import React, { useCallback, useMemo } from 'react';
 import type { AuthenticationInfo } from '@jellyfin/sdk/lib/generated-client/models/authentication-info';
-import confirm from 'components/confirm/confirm';
-import { useApiKeys } from 'apps/dashboard/features/keys/api/useApiKeys';
-import { useRevokeKey } from 'apps/dashboard/features/keys/api/useRevokeKey';
-import { useCreateKey } from 'apps/dashboard/features/keys/api/useCreateKey';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
-import Stack from '@mui/material/Stack';
 import Tooltip from '@mui/material/Tooltip';
-import Typography from '@mui/material/Typography';
-import { MaterialReactTable, MRT_ColumnDef, useMaterialReactTable } from 'material-react-table';
-import DeleteIcon from '@mui/icons-material/Delete';
 import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
+import parseISO from 'date-fns/parseISO';
+import { type MRT_ColumnDef, useMaterialReactTable } from 'material-react-table';
+import React, { useCallback, useMemo } from 'react';
 
-const ApiKeys = () => {
+import DateTimeCell from 'apps/dashboard/components/table/DateTimeCell';
+import TablePage from 'apps/dashboard/components/table/TablePage';
+import { useApiKeys } from 'apps/dashboard/features/keys/api/useApiKeys';
+import { useRevokeKey } from 'apps/dashboard/features/keys/api/useRevokeKey';
+import { useCreateKey } from 'apps/dashboard/features/keys/api/useCreateKey';
+import confirm from 'components/confirm/confirm';
+import prompt from 'components/prompt/prompt';
+import { useApi } from 'hooks/useApi';
+import globalize from 'lib/globalize';
+
+export const Component = () => {
     const { api } = useApi();
     const { data: keys, isLoading } = useApiKeys();
     const revokeKey = useRevokeKey();
@@ -119,53 +118,28 @@ const ApiKeys = () => {
     const showNewKeyPopup = useCallback(() => {
         if (!api) return;
 
-        import('../../../../components/prompt/prompt').then(({ default: prompt }) => {
-            prompt({
-                title: globalize.translate('HeaderNewApiKey'),
-                label: globalize.translate('LabelAppName'),
-                description: globalize.translate('LabelAppNameExample')
-            }).then((value) => {
-                createKey.mutate({
-                    app: value
-                });
-            }).catch(() => {
-                // popup closed
+        prompt({
+            title: globalize.translate('HeaderNewApiKey'),
+            label: globalize.translate('LabelAppName'),
+            description: globalize.translate('LabelAppNameExample')
+        }).then((value) => {
+            createKey.mutate({
+                app: value
             });
-        }).catch(err => {
-            console.error('[apikeys] failed to load api key popup', err);
+        }).catch(() => {
+            // popup closed
         });
     }, [api, createKey]);
 
     return (
-        <Page
+        <TablePage
             id='apiKeysPage'
             title={globalize.translate('HeaderApiKeys')}
+            subtitle={globalize.translate('HeaderApiKeysHelp')}
             className='mainAnimatedPage type-interior'
-        >
-            <Box
-                className='content-primary'
-                sx={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    height: '100%'
-                }}
-            >
-                <Box
-                    sx={{
-                        marginBottom: 1
-                    }}
-                >
-                    <Stack spacing={2}>
-                        <Typography variant='h2'>
-                            {globalize.translate('HeaderApiKeys')}
-                        </Typography>
-                        <Typography>{globalize.translate('HeaderApiKeysHelp')}</Typography>
-                    </Stack>
-                </Box>
-                <MaterialReactTable table={table} />
-            </Box>
-        </Page>
+            table={table}
+        />
     );
 };
 
-export default ApiKeys;
+Component.displayName = 'ApiKeysPage';

--- a/src/apps/dashboard/routes/keys/index.tsx
+++ b/src/apps/dashboard/routes/keys/index.tsx
@@ -10,7 +10,7 @@ import { type MRT_ColumnDef, useMaterialReactTable } from 'material-react-table'
 import React, { useCallback, useMemo } from 'react';
 
 import DateTimeCell from 'apps/dashboard/components/table/DateTimeCell';
-import TablePage from 'apps/dashboard/components/table/TablePage';
+import TablePage, { DEFAULT_TABLE_OPTIONS } from 'apps/dashboard/components/table/TablePage';
 import { useApiKeys } from 'apps/dashboard/features/keys/api/useApiKeys';
 import { useRevokeKey } from 'apps/dashboard/features/keys/api/useRevokeKey';
 import { useCreateKey } from 'apps/dashboard/features/keys/api/useCreateKey';
@@ -21,7 +21,10 @@ import globalize from 'lib/globalize';
 
 export const Component = () => {
     const { api } = useApi();
-    const { data: keys, isLoading } = useApiKeys();
+    const { data, isLoading } = useApiKeys();
+    const keys = useMemo(() => (
+        data?.Items || []
+    ), [ data ]);
     const revokeKey = useRevokeKey();
     const createKey = useCreateKey();
 
@@ -47,24 +50,13 @@ export const Component = () => {
     ], []);
 
     const table = useMaterialReactTable({
+        ...DEFAULT_TABLE_OPTIONS,
+
         columns,
-        data: keys?.Items || [],
+        data: keys,
 
         state: {
             isLoading
-        },
-
-        rowCount: keys?.TotalRecordCount || 0,
-
-        enableColumnPinning: true,
-        enableColumnResizing: true,
-
-        enableStickyFooter: true,
-        enableStickyHeader: true,
-        muiTableContainerProps: {
-            sx: {
-                maxHeight: 'calc(100% - 7rem)' // 2 x 3.5rem for header and footer
-            }
         },
 
         // Enable (delete) row actions


### PR DESCRIPTION
**Changes**
Small refactor to update the API keys page to also use the new `<TablePage>` component and a couple miscellaneous driveby cleanup items :upside_down_face: 

**Issues**
N/A