### PR TITLE
Disable renovate lockfile maintenance

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,9 @@
     "github>jellyfin/.github//renovate-presets/nodejs",
     ":dependencyDashboard"
   ],
+  "lockFileMaintenance": {
+    "enabled": false
+  },
   "packageRules": [
     {
       "matchPackageNames": [ "@jellyfin/sdk" ],


### PR DESCRIPTION
**Changes**
This is perpetually broken and the PR cannot be closed, so it's just an annoyance imo https://github.com/jellyfin/jellyfin-web/pull/6504

**Issues**
N/A