### PR TITLE
Fix restart and shutdown buttons

### DIFF
--- a/src/apps/dashboard/controllers/dashboard.html
+++ b/src/apps/dashboard/controllers/dashboard.html
@@ -23,10 +23,10 @@
                         <button is="emby-button" type="button" class="raised btnRefresh">
                             <span>${ButtonScanAllLibraries}</span>
                         </button>
-                        <button is="emby-button" type="button" id="btnRestartServer" class="raised" onclick="DashboardPage.restart(this);">
+                        <button is="emby-button" type="button" id="btnRestartServer" class="raised">
                             <span>${Restart}</span>
                         </button>
-                        <button is="emby-button" type="button" id="btnShutdown" class="raised" onclick="DashboardPage.shutdown(this);">
+                        <button is="emby-button" type="button" id="btnShutdown" class="raised">
                             <span>${ButtonShutdown}</span>
                         </button>
                     </div>

--- a/src/apps/dashboard/controllers/dashboard.js
+++ b/src/apps/dashboard/controllers/dashboard.js
@@ -714,30 +714,34 @@ const DashboardPage = {
             pollForInfo(page, ApiClient);
         });
     },
-    restart: function (btn) {
+    restart: function (event) {
         confirm({
             title: globalize.translate('Restart'),
             text: globalize.translate('MessageConfirmRestart'),
             confirmText: globalize.translate('Restart'),
             primary: 'delete'
-        }).then(function () {
-            const page = dom.parentWithClass(btn, 'page');
+        }).then(() => {
+            const page = dom.parentWithClass(event.target, 'page');
             page.querySelector('#btnRestartServer').disabled = true;
             page.querySelector('#btnShutdown').disabled = true;
             ApiClient.restartServer();
+        }).catch(() => {
+            // Confirm dialog closed
         });
     },
-    shutdown: function (btn) {
+    shutdown: function (event) {
         confirm({
             title: globalize.translate('ButtonShutdown'),
             text: globalize.translate('MessageConfirmShutdown'),
             confirmText: globalize.translate('ButtonShutdown'),
             primary: 'delete'
-        }).then(function () {
-            const page = dom.parentWithClass(btn, 'page');
+        }).then(() => {
+            const page = dom.parentWithClass(event.target, 'page');
             page.querySelector('#btnRestartServer').disabled = true;
             page.querySelector('#btnShutdown').disabled = true;
             ApiClient.shutdownServer();
+        }).catch(() => {
+            // Confirm dialog closed
         });
     }
 };
@@ -817,7 +821,11 @@ export default function (view) {
             taskKey: 'RefreshLibrary',
             button: page.querySelector('.btnRefresh')
         });
+
+        page.querySelector('#btnRestartServer').addEventListener('click', DashboardPage.restart);
+        page.querySelector('#btnShutdown').addEventListener('click', DashboardPage.shutdown);
     });
+
     view.addEventListener('viewbeforehide', function () {
         const apiClient = ApiClient;
         const page = this;
@@ -839,6 +847,9 @@ export default function (view) {
             taskKey: 'RefreshLibrary',
             button: page.querySelector('.btnRefresh')
         });
+
+        page.querySelector('#btnRestartServer').removeEventListener('click', DashboardPage.restart);
+        page.querySelector('#btnShutdown').removeEventListener('click', DashboardPage.shutdown);
     });
     view.addEventListener('viewdestroy', function () {
         const page = this;


### PR DESCRIPTION
**Changes**
Fixes a small regression from #6523. The shutdown and restart buttons were using `onclick` attributes in the page template to call the `DashboardPage` global.

**Issues**
Fixes #6532 