### PR TITLE
Enforce ESLint as default formatter in VSCode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
+  "[json][typescript][typescriptreact][javascript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
   },


### PR DESCRIPTION
My user settings have prettier configured as default formatter. This caused a lot of problems when I tried to work on jellyfin-web, as it uses ESLint as formatter. Adding the setting to the project settings to use ESLint fixes that.

**Changes**
- Enforce ESLint as default formatter in VSCode settings

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
