### PR TITLE
Update library name validation to trim automatically

### DIFF
--- a/src/components/mediaLibraryCreator/mediaLibraryCreator.js
+++ b/src/components/mediaLibraryCreator/mediaLibraryCreator.js
@@ -42,10 +42,10 @@ function onAddLibrary(e) {
     isCreating = true;
     loading.show();
     const dlg = dom.parentWithClass(this, 'dlg-librarycreator');
-    const name = dlg.querySelector('#txtValue').value;
+    const name = dlg.querySelector('#txtValue').value.trim();
     let type = dlg.querySelector('#selectCollectionType').value;
 
-    if (name.length == 0 || name.trim().length !== name.length) {
+    if (name.length === 0) {
         alert({
             text: globalize.translate('LibraryNameInvalid'),
             type: 'error'

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1015,7 +1015,7 @@
     "LeaveBlankToNotSetAPassword": "You can leave this field blank to set no password.",
     "Letterer": "Letterer",
     "LibraryAccessHelp": "Select the libraries to share with this user. Administrators will be able to edit all folders using the metadata manager.",
-    "LibraryNameInvalid": "Library name cannot be empty or have leading/trailing spaces.",
+    "LibraryNameInvalid": "Library name cannot be empty.",
     "LibraryScanFanoutConcurrency": "Parallel library scan tasks limit",
     "LibraryScanFanoutConcurrencyHelp": "Maximum number of parallel tasks during library scans. Setting this to 0 will choose a limit based on your systems core count. WARNING: Setting this number too high may cause issues with network file systems; if you encounter problems lower this number.",
     "LibraryInvalidItemIdError": "The library is in an invalid state and cannot be edited. You are possibly encountering a bug: the path in the database is not the correct path on the filesystem.",


### PR DESCRIPTION
**Changes**
Similar to https://github.com/jellyfin/jellyfin-web/pull/6528, let's handle trimming library names automatically instead of prompting with an error

**Issues**
N/A
