### PR TITLE
Add log viewer to dashboard

### DIFF
--- a/src/apps/dashboard/features/logs/api/useServerLog.ts
+++ b/src/apps/dashboard/features/logs/api/useServerLog.ts
@@ -1,0 +1,35 @@
+import { Api } from '@jellyfin/sdk';
+import { getSystemApi } from '@jellyfin/sdk/lib/utils/api/system-api';
+import { useQuery } from '@tanstack/react-query';
+import { useApi } from 'hooks/useApi';
+import type { AxiosRequestConfig } from 'axios';
+
+const fetchServerLog = async (
+    api?: Api,
+    name?: string,
+    options?: AxiosRequestConfig
+) => {
+    if (!api) {
+        console.error('[useServerLog] No API instance available');
+        return;
+    }
+
+    if (!name) {
+        console.error('[useServerLog] Name is required');
+        return;
+    }
+
+    const response = await getSystemApi(api).getLogFile({ name }, options);
+
+    // FIXME: TypeScript SDK thinks it is returning a File but in reality it is a string
+    return response.data as never as string;
+};
+export const useServerLog = (name: string) => {
+    const { api } = useApi();
+
+    return useQuery({
+        queryKey: ['ServerLog', name],
+        queryFn: ({ signal }) => fetchServerLog(api, name, { signal }),
+        enabled: !!api
+    });
+};

--- a/src/apps/dashboard/features/logs/api/useServerLog.ts
+++ b/src/apps/dashboard/features/logs/api/useServerLog.ts
@@ -5,20 +5,14 @@ import { useApi } from 'hooks/useApi';
 import type { AxiosRequestConfig } from 'axios';
 
 const fetchServerLog = async (
-    api?: Api,
-    name?: string,
+    api: Api | undefined,
+    name: string,
     options?: AxiosRequestConfig
 ) => {
     if (!api) {
         console.error('[useServerLog] No API instance available');
         return;
     }
-
-    if (!name) {
-        console.error('[useServerLog] Name is required');
-        return;
-    }
-
     const response = await getSystemApi(api).getLogFile({ name }, options);
 
     // FIXME: TypeScript SDK thinks it is returning a File but in reality it is a string

--- a/src/apps/dashboard/features/logs/api/useServerLog.ts
+++ b/src/apps/dashboard/features/logs/api/useServerLog.ts
@@ -5,7 +5,7 @@ import { useApi } from 'hooks/useApi';
 import type { AxiosRequestConfig } from 'axios';
 
 const fetchServerLog = async (
-    api: Api | undefined,
+    api: Api,
     name: string,
     options?: AxiosRequestConfig
 ) => {
@@ -23,7 +23,7 @@ export const useServerLog = (name: string) => {
 
     return useQuery({
         queryKey: ['ServerLog', name],
-        queryFn: ({ signal }) => fetchServerLog(api, name, { signal }),
+        queryFn: ({ signal }) => fetchServerLog(api!, name, { signal }),
         enabled: !!api
     });
 };

--- a/src/apps/dashboard/features/logs/api/useServerLog.ts
+++ b/src/apps/dashboard/features/logs/api/useServerLog.ts
@@ -9,10 +9,6 @@ const fetchServerLog = async (
     name: string,
     options?: AxiosRequestConfig
 ) => {
-    if (!api) {
-        console.error('[useServerLog] No API instance available');
-        return;
-    }
     const response = await getSystemApi(api).getLogFile({ name }, options);
 
     // FIXME: TypeScript SDK thinks it is returning a File but in reality it is a string

--- a/src/apps/dashboard/features/logs/components/LogItemList.tsx
+++ b/src/apps/dashboard/features/logs/components/LogItemList.tsx
@@ -2,28 +2,15 @@ import React, { FunctionComponent } from 'react';
 import type { LogFile } from '@jellyfin/sdk/lib/generated-client/models/log-file';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
-import ListItemButton from '@mui/material/ListItemButton';
 import ListItemText from '@mui/material/ListItemText';
-import OpenInNewIcon from '@mui/icons-material/OpenInNew';
-import { useApi } from 'hooks/useApi';
 import datetime from 'scripts/datetime';
+import ListItemLink from 'components/ListItemLink';
 
 type LogItemProps = {
     logs: LogFile[];
 };
 
 const LogItemList: FunctionComponent<LogItemProps> = ({ logs }: LogItemProps) => {
-    const { api } = useApi();
-
-    const getLogFileUrl = (logFile: LogFile) => {
-        if (!api) return '';
-
-        return api.getUri('/System/Logs/Log', {
-            name: logFile.Name,
-            api_key: api.accessToken
-        });
-    };
-
     const getDate = (logFile: LogFile) => {
         const date = datetime.parseISO8601Date(logFile.DateModified, true);
         return datetime.toLocaleDateString(date) + ' ' + datetime.getDisplayTime(date);
@@ -34,15 +21,14 @@ const LogItemList: FunctionComponent<LogItemProps> = ({ logs }: LogItemProps) =>
             {logs.map(log => {
                 return (
                     <ListItem key={log.Name} disablePadding>
-                        <ListItemButton href={getLogFileUrl(log)} target='_blank'>
+                        <ListItemLink to={`/dashboard/logs/${log.Name}`}>
                             <ListItemText
                                 primary={log.Name}
                                 primaryTypographyProps={{ variant: 'h3' }}
                                 secondary={getDate(log)}
                                 secondaryTypographyProps={{ variant: 'body1' }}
                             />
-                            <OpenInNewIcon />
-                        </ListItemButton>
+                        </ListItemLink>
                     </ListItem>
                 );
             })}

--- a/src/apps/dashboard/routes/_asyncRoutes.ts
+++ b/src/apps/dashboard/routes/_asyncRoutes.ts
@@ -7,6 +7,7 @@ export const ASYNC_ADMIN_ROUTES: AsyncRoute[] = [
     { path: 'devices', type: AppType.Dashboard },
     { path: 'keys', type: AppType.Dashboard },
     { path: 'logs', type: AppType.Dashboard },
+    { path: 'logs/:file', page: 'logs/file', type: AppType.Dashboard },
     { path: 'playback/resume', type: AppType.Dashboard },
     { path: 'playback/streaming', type: AppType.Dashboard },
     { path: 'playback/trickplay', type: AppType.Dashboard },

--- a/src/apps/dashboard/routes/logs/file.tsx
+++ b/src/apps/dashboard/routes/logs/file.tsx
@@ -66,7 +66,7 @@ export const Component = () => {
                                     size='small'
                                     onClick={retry}
                                 >
-                                    Retry
+                                    {globalize.translate('Retry')}
                                 </Button>
                             }
                         >

--- a/src/apps/dashboard/routes/logs/file.tsx
+++ b/src/apps/dashboard/routes/logs/file.tsx
@@ -15,6 +15,7 @@ import {
 } from '@mui/material';
 import { ContentCopy, FileDownload } from '@mui/icons-material';
 import globalize from 'lib/globalize';
+import toast from 'components/toast/toast';
 
 export const Component = () => {
     const { file: fileName } = useParams();
@@ -30,6 +31,7 @@ export const Component = () => {
     const copyToClipboard = useCallback(async () => {
         if ('clipboard' in navigator && log) {
             await navigator.clipboard.writeText(log);
+            toast({ text: globalize.translate('CopyLogSuccess') });
         }
     }, [log]);
 

--- a/src/apps/dashboard/routes/logs/file.tsx
+++ b/src/apps/dashboard/routes/logs/file.tsx
@@ -7,13 +7,13 @@ import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import ButtonGroup from '@mui/material/ButtonGroup';
-import Card from '@mui/material/Card';
-import CardContent from '@mui/material/CardContent';
 import Container from '@mui/material/Container';
+import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import { ContentCopy, FileDownload } from '@mui/icons-material';
 import globalize from 'lib/globalize';
 import toast from 'components/toast/toast';
+import { copy } from 'scripts/clipboard';
 
 export const Component = () => {
     const { file: fileName } = useParams();
@@ -27,8 +27,8 @@ export const Component = () => {
     const retry = useCallback(() => refetch(), [refetch]);
 
     const copyToClipboard = useCallback(async () => {
-        if ('clipboard' in navigator && log) {
-            await navigator.clipboard.writeText(log);
+        if (log) {
+            await copy(log);
             toast({ text: globalize.translate('CopyLogSuccess') });
         }
     }, [log]);
@@ -94,13 +94,11 @@ export const Component = () => {
                                 </Button>
                             </ButtonGroup>
 
-                            <Card sx={{ mt: 2 }}>
-                                <CardContent>
-                                    <code>
-                                        <pre style={{ margin: 0 }}>{log}</pre>
-                                    </code>
-                                </CardContent>
-                            </Card>
+                            <Paper sx={{ mt: 2 }}>
+                                <code>
+                                    <pre style={{ overflow:'auto', margin: 0, padding: '16px' }}>{log}</pre>
+                                </code>
+                            </Paper>
                         </>
                     )}
                 </Box>

--- a/src/apps/dashboard/routes/logs/file.tsx
+++ b/src/apps/dashboard/routes/logs/file.tsx
@@ -3,16 +3,14 @@ import Page from 'components/Page';
 import React, { useCallback } from 'react';
 import { useParams } from 'react-router-dom';
 import { useServerLog } from 'apps/dashboard/features/logs/api/useServerLog';
-import {
-    Alert,
-    Box,
-    Button,
-    ButtonGroup,
-    Card,
-    CardContent,
-    Container,
-    Typography
-} from '@mui/material';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import ButtonGroup from '@mui/material/ButtonGroup';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
 import { ContentCopy, FileDownload } from '@mui/icons-material';
 import globalize from 'lib/globalize';
 import toast from 'components/toast/toast';

--- a/src/apps/dashboard/routes/logs/file.tsx
+++ b/src/apps/dashboard/routes/logs/file.tsx
@@ -80,7 +80,6 @@ export const Component = () => {
                         <>
                             <ButtonGroup variant='contained' sx={{ mt: 2 }}>
                                 <Button
-                                    disabled={!('clipboard' in navigator)}
                                     startIcon={<ContentCopy />}
                                     onClick={copyToClipboard}
                                 >

--- a/src/apps/dashboard/routes/logs/file.tsx
+++ b/src/apps/dashboard/routes/logs/file.tsx
@@ -1,0 +1,112 @@
+import Loading from 'components/loading/LoadingComponent';
+import Page from 'components/Page';
+import React, { useCallback } from 'react';
+import { useParams } from 'react-router-dom';
+import { useServerLog } from 'apps/dashboard/features/logs/api/useServerLog';
+import {
+    Alert,
+    Box,
+    Button,
+    ButtonGroup,
+    Card,
+    CardContent,
+    Container,
+    Typography
+} from '@mui/material';
+import { ContentCopy, FileDownload } from '@mui/icons-material';
+import globalize from 'lib/globalize';
+
+export const Component = () => {
+    const { file: fileName } = useParams();
+    const {
+        isError: error,
+        isPending: loading,
+        data: log,
+        refetch
+    } = useServerLog(fileName ?? '');
+
+    const retry = useCallback(() => refetch(), [refetch]);
+
+    const copyToClipboard = useCallback(async () => {
+        if ('clipboard' in navigator && log) {
+            await navigator.clipboard.writeText(log);
+        }
+    }, [log]);
+
+    const downloadFile = useCallback(() => {
+        if ('URL' in globalThis && log && fileName) {
+            const blob = new Blob([log], { type: 'text/plain' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = fileName;
+            a.click();
+            URL.revokeObjectURL(url);
+        }
+    }, [log, fileName]);
+
+    return (
+        <Page
+            id='logPage'
+            title={fileName}
+            className='mainAnimatedPage type-interior'
+        >
+            <Container className='content-primary'>
+                <Box>
+                    <Typography variant='h1'>{fileName}</Typography>
+
+                    {error && (
+                        <Alert
+                            key='error'
+                            severity='error'
+                            sx={{ mt: 2 }}
+                            action={
+                                <Button
+                                    color='inherit'
+                                    size='small'
+                                    onClick={retry}
+                                >
+                                    Retry
+                                </Button>
+                            }
+                        >
+                            {globalize.translate('LogLoadFailure')}
+                        </Alert>
+                    )}
+
+                    {loading && <Loading />}
+
+                    {!error && !loading && (
+                        <>
+                            <ButtonGroup variant='contained' sx={{ mt: 2 }}>
+                                <Button
+                                    disabled={!('clipboard' in navigator)}
+                                    startIcon={<ContentCopy />}
+                                    onClick={copyToClipboard}
+                                >
+                                    {globalize.translate('Copy')}
+                                </Button>
+                                <Button
+                                    startIcon={<FileDownload />}
+                                    onClick={downloadFile}
+                                >
+                                    {globalize.translate('Download')}
+                                </Button>
+                            </ButtonGroup>
+
+                            <Card sx={{ mt: 2 }}>
+                                <CardContent>
+                                    <code>
+                                        <pre style={{ margin: 0 }}>{log}</pre>
+                                    </code>
+                                </CardContent>
+                            </Card>
+                        </>
+                    )}
+                </Box>
+            </Container>
+        </Page>
+    );
+};
+
+Component.displayName = 'LogPage';

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -188,6 +188,7 @@
     "CopyFailed": "Could not copy",
     "CopyStreamURL": "Copy Stream URL",
     "CopyStreamURLSuccess": "URL copied successfully.",
+    "CopyLogSuccess": "Log contents copied successfully.",
     "CoverArtist": "Cover artist",
     "Creator": "Creator",
     "CriticRating": "Critics rating",

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1808,5 +1808,6 @@
     "OptionExtractTrickplayImage": "Enable trickplay image extraction",
     "ExtractTrickplayImagesHelp": "Trickplay images are similar to chapter images, except they span the entire length of the content and are used to show a preview when scrubbing through videos.",
     "LabelExtractTrickplayDuringLibraryScan": "Extract trickplay images during the library scan",
-    "LabelExtractTrickplayDuringLibraryScanHelp": "Generate trickplay images when videos are imported during the library scan. Otherwise, they will be extracted during the trickplay images scheduled task. If generation is set to non-blocking this will not affect the time a library scan takes to complete."
+    "LabelExtractTrickplayDuringLibraryScanHelp": "Generate trickplay images when videos are imported during the library scan. Otherwise, they will be extracted during the trickplay images scheduled task. If generation is set to non-blocking this will not affect the time a library scan takes to complete.",
+    "LogLoadFailure": "Failed to load the log file. It may still be actively written to."
 }

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1445,6 +1445,7 @@
     "ReplaceAllMetadata": "Replace all metadata",
     "ReplaceExistingImages": "Replace existing images",
     "ReplaceTrickplayImages": "Replace existing trickplay images",
+    "Retry": "Retry",
     "Reset": "Reset",
     "ResetPassword": "Reset Password",
     "ResolutionMatchSource": "Match Source",


### PR DESCRIPTION
Add a new page to view logs in the dashboard instead of opening a new tab with the API key in the URL. I kept it simple as I'm sure there's enough React rules I've broken already!

**Changes**
- Add new dashboard page to view a log file
- Open log viewer from dashboard logs list

**Screenshots**

![Screenshot 2025-02-22 at 22-26-56 upload_Jellyfin Android TV_0 0 0-dev 1_20250221200030_7064061cfa16413693e752c01a2f2545 log](https://github.com/user-attachments/assets/59b494a4-9e48-4dab-806c-c8fd47ecc1cc)

![Screenshot 2025-02-22 at 22-26-39 log_20250222 log](https://github.com/user-attachments/assets/687d2bd9-41c9-440d-9219-add16bc0a2db)

**Planned**

If someone else is willing to do it: be my guest, otherwise I'd like to add frontmatter parsing in a future PR. Some clients (ATV) add YAML frontmatter with some information about the log file which can be used for displaying the log in various ways:
  - Client link
    The `client`, `client_version` and `client_repository` fields in the frontmatter can be used to display basic client info & a button to the GH issues
  - Markdown preview
    When the `format` field in the fronmatter is set to `markdown` we should render the log as markdown (copy still copies raw file, download will set media type to markdown)

Additionally, it might be useful to add a "live reload" feature where the log file is refetched every few seconds. This would be useful for watching the server logs of the current day or an active ffmpeg transcode.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
