### PR TITLE
Prevent whitespaces in username during wizard setup

### DIFF
--- a/src/controllers/wizard/user/index.js
+++ b/src/controllers/wizard/user/index.js
@@ -37,7 +37,7 @@ function submit(form) {
         .ajax({
             type: 'POST',
             data: JSON.stringify({
-                Name: form.querySelector('#txtUsername').value,
+                Name: form.querySelector('#txtUsername').value.trim(),
                 Password: form.querySelector('#txtManualPassword').value
             }),
             url: apiClient.getUrl('Startup/User'),


### PR DESCRIPTION
**Changes**
Trim the username on the wizard setup page to remove whitespaces.

**Issues**
This is alongside: [#13604](https://github.com/jellyfin/jellyfin/pull/13604)
