### PR TITLE
Fix catalog plugin page not setting page title

### DIFF
--- a/src/apps/dashboard/routes/plugins/plugin.tsx
+++ b/src/apps/dashboard/routes/plugins/plugin.tsx
@@ -304,6 +304,7 @@ const PluginPage: FC = () => {
     return (
         <Page
             id='addPluginPage'
+            title={pluginDetails?.name || pluginName}
             className='mainAnimatedPage type-interior'
         >
             <Container className='content-primary'>


### PR DESCRIPTION
I'm a React expert now.

**Changes**
Fix catalog plugin page not setting page title, before this PR it would keep the title of the last page (most commonly "Catalog").

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
