### PR TITLE
metadata update function catch case fixes #6559

### DIFF
--- a/src/components/metadataEditor/metadataEditor.js
+++ b/src/components/metadataEditor/metadataEditor.js
@@ -38,35 +38,32 @@ function closeDialog() {
     }
 }
 
-function submitUpdatedItem(form, item) {
-    function afterContentTypeUpdated() {
+async function submitUpdatedItem(form, item) {
+    const afterContentTypeUpdated = () => {
         toast(globalize.translate('MessageItemSaved'));
 
         loading.hide();
         closeDialog();
-    }
-
+    };
     const apiClient = getApiClient();
 
-    apiClient.updateItem(item).then(function () {
-        const newContentType = form.querySelector('#selectContentType').value || '';
+    try {
+        await apiClient.updateItem(item);
+        const newContentType = form.querySelector('#selectContentType')?.value || '';
 
-        if ((metadataEditorInfo.ContentType || '') !== newContentType) {
-            apiClient.ajax({
+        await apiClient.ajax({
+            url: apiClient.getUrl(`Items/${item.Id}/ContentType`, {
+                ContentType: newContentType
+            }),
 
-                url: apiClient.getUrl('Items/' + item.Id + '/ContentType', {
-                    ContentType: newContentType
-                }),
+            type: 'POST'
+        });
 
-                type: 'POST'
-
-            }).then(function () {
-                afterContentTypeUpdated();
-            });
-        } else {
-            afterContentTypeUpdated();
-        }
-    });
+        afterContentTypeUpdated();
+    } catch {
+        toast(globalize.translate('MessageItemSaveFailed'));
+        loading.hide();
+    }
 }
 
 function getSelectedAirDays(form) {

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1123,6 +1123,7 @@
     "MessageInvalidUser": "Invalid username or password. Please try again.",
     "MessageItemsAdded": "Items added.",
     "MessageItemSaved": "Item saved.",
+    "MessageItemSaveFailed": "Failed to save item",
     "MessageLeaveEmptyToInherit": "Leave empty to inherit settings from a parent item or the global default value.",
     "MessageNoItemsAvailable": "No Items are currently available.",
     "MessageNoFavoritesAvailable": "No favorites are currently available.",


### PR DESCRIPTION
Fix: catch block for metadataupdate function to fix infinite loader when update api fails fixes #6559

**Changes**
1. as described in #6559 there is a infinite loader in update metadata when the api fails. This can be avoided by using try catch method. as such the same has been implemented in this PR. 


**Issues**
fixes #6559 


**Proof of testing**
https://youtu.be/3YHXEthmzoY