### PR TITLE
remove black bar from trickplay images fixes #6404

### DIFF
--- a/src/styles/videoosd.scss
+++ b/src/styles/videoosd.scss
@@ -85,7 +85,7 @@
     bottom: 0;
     left: 0;
     right: 0;
-    background: rgba(0, 0, 0, 0.7);
+    background: none;
     padding: 0.25em 0.5em;
     user-select: none;
 }


### PR DESCRIPTION
Enhancement : Remove black bar from trickplay images fixes #6404 

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
in this Pr we are chaning the container chapterThumbTextContainer to not show any background for trickplay text. so that black bar that covers signifiacant amount of the image can be removed


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
fixes #6404 

![Screenshot From 2025-02-23 19-44-36](https://github.com/user-attachments/assets/9dfbad96-d59a-423c-84f6-5291df095d78)

