### PR TITLE
Refactor queries to use non-null assert

### DIFF
--- a/src/apps/dashboard/features/activity/api/useLogEntries.ts
+++ b/src/apps/dashboard/features/activity/api/useLogEntries.ts
@@ -7,15 +7,10 @@ import { useQuery } from '@tanstack/react-query';
 import { useApi } from 'hooks/useApi';
 
 const fetchLogEntries = async (
-    api?: Api,
+    api: Api,
     requestParams?: ActivityLogApiGetLogEntriesRequest,
     options?: AxiosRequestConfig
 ) => {
-    if (!api) {
-        console.warn('[fetchLogEntries] No API instance available');
-        return;
-    }
-
     const response = await getActivityLogApi(api).getLogEntries(requestParams, {
         signal: options?.signal
     });
@@ -30,7 +25,7 @@ export const useLogEntries = (
     return useQuery({
         queryKey: ['ActivityLogEntries', requestParams],
         queryFn: ({ signal }) =>
-            fetchLogEntries(api, requestParams, { signal }),
+            fetchLogEntries(api!, requestParams, { signal }),
         enabled: !!api
     });
 };

--- a/src/apps/dashboard/features/branding/api/useBrandingOptions.ts
+++ b/src/apps/dashboard/features/branding/api/useBrandingOptions.ts
@@ -8,14 +8,9 @@ import { useApi } from 'hooks/useApi';
 export const QUERY_KEY = 'BrandingOptions';
 
 const fetchBrandingOptions = async (
-    api?: Api,
+    api: Api,
     options?: AxiosRequestConfig
 ) => {
-    if (!api) {
-        console.error('[fetchBrandingOptions] no Api instance provided');
-        throw new Error('No Api instance provided to fetchBrandingOptions');
-    }
-
     return getBrandingApi(api)
         .getBrandingOptions(options)
         .then(({ data }) => data);
@@ -25,7 +20,7 @@ export const getBrandingOptionsQuery = (
     api?: Api
 ) => queryOptions({
     queryKey: [ QUERY_KEY ],
-    queryFn: ({ signal }) => fetchBrandingOptions(api, { signal }),
+    queryFn: ({ signal }) => fetchBrandingOptions(api!, { signal }),
     enabled: !!api
 });
 

--- a/src/apps/dashboard/features/devices/api/useDeleteDevice.ts
+++ b/src/apps/dashboard/features/devices/api/useDeleteDevice.ts
@@ -11,7 +11,6 @@ export const useDeleteDevice = () => {
 
     return useMutation({
         mutationFn: (params: DevicesApiDeleteDeviceRequest) => (
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             getDevicesApi(api!)
                 .deleteDevice(params)
         ),

--- a/src/apps/dashboard/features/devices/api/useDevices.ts
+++ b/src/apps/dashboard/features/devices/api/useDevices.ts
@@ -9,15 +9,10 @@ import { useApi } from 'hooks/useApi';
 export const QUERY_KEY = 'Devices';
 
 const fetchDevices = async (
-    api?: Api,
+    api: Api,
     requestParams?: DevicesApiGetDevicesRequest,
     options?: AxiosRequestConfig
 ) => {
-    if (!api) {
-        console.warn('[fetchDevices] No API instance available');
-        return;
-    }
-
     const response = await getDevicesApi(api).getDevices(requestParams, {
         signal: options?.signal
     });
@@ -32,7 +27,7 @@ export const useDevices = (
     return useQuery({
         queryKey: [QUERY_KEY, requestParams],
         queryFn: ({ signal }) =>
-            fetchDevices(api, requestParams, { signal }),
+            fetchDevices(api!, requestParams, { signal }),
         enabled: !!api
     });
 };

--- a/src/apps/dashboard/features/devices/api/useUpdateDevice.ts
+++ b/src/apps/dashboard/features/devices/api/useUpdateDevice.ts
@@ -11,7 +11,6 @@ export const useUpdateDevice = () => {
 
     return useMutation({
         mutationFn: (params: DevicesApiUpdateDeviceOptionsRequest) => (
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             getDevicesApi(api!)
                 .updateDeviceOptions(params)
         ),

--- a/src/apps/dashboard/features/keys/api/useApiKeys.ts
+++ b/src/apps/dashboard/features/keys/api/useApiKeys.ts
@@ -1,17 +1,13 @@
 import { Api } from '@jellyfin/sdk';
 import { getApiKeyApi } from '@jellyfin/sdk/lib/utils/api/api-key-api';
 import { useQuery } from '@tanstack/react-query';
+import { AxiosRequestConfig } from 'axios';
 import { useApi } from 'hooks/useApi';
 
 export const QUERY_KEY = 'ApiKeys';
 
-const fetchApiKeys = async (api?: Api) => {
-    if (!api) {
-        console.error('[useApiKeys] Failed to create Api instance');
-        return;
-    }
-
-    const response = await getApiKeyApi(api).getKeys();
+const fetchApiKeys = async (api: Api, options?: AxiosRequestConfig) => {
+    const response = await getApiKeyApi(api).getKeys(options);
 
     return response.data;
 };
@@ -21,7 +17,7 @@ export const useApiKeys = () => {
 
     return useQuery({
         queryKey: [ QUERY_KEY ],
-        queryFn: () => fetchApiKeys(api),
+        queryFn: ({ signal }) => fetchApiKeys(api!, { signal }),
         enabled: !!api
     });
 };

--- a/src/apps/dashboard/features/keys/api/useCreateKey.ts
+++ b/src/apps/dashboard/features/keys/api/useCreateKey.ts
@@ -10,7 +10,6 @@ export const useCreateKey = () => {
 
     return useMutation({
         mutationFn: (params: ApiKeyApiCreateKeyRequest) => (
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             getApiKeyApi(api!)
                 .createKey(params)
         ),

--- a/src/apps/dashboard/features/keys/api/useRevokeKey.ts
+++ b/src/apps/dashboard/features/keys/api/useRevokeKey.ts
@@ -10,7 +10,6 @@ export const useRevokeKey = () => {
 
     return useMutation({
         mutationFn: (params: ApiKeyApiRevokeKeyRequest) => (
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             getApiKeyApi(api!)
                 .revokeKey(params)
         ),

--- a/src/apps/dashboard/features/logs/api/useServerLogs.ts
+++ b/src/apps/dashboard/features/logs/api/useServerLogs.ts
@@ -4,13 +4,8 @@ import { useQuery } from '@tanstack/react-query';
 import { useApi } from 'hooks/useApi';
 import type { AxiosRequestConfig } from 'axios';
 
-const fetchServerLogs = async (api?: Api, options?: AxiosRequestConfig) => {
-    if (!api) {
-        console.error('[useServerLogs] No API instance available');
-        return;
-    }
-
-    const response = await getSystemApi(api).getServerLogs(options);
+const fetchServerLogs = async (api: Api, options?: AxiosRequestConfig) => {
+    const response = await getSystemApi(api!).getServerLogs(options);
 
     return response.data;
 };
@@ -20,7 +15,7 @@ export const useServerLogs = () => {
 
     return useQuery({
         queryKey: [ 'ServerLogs' ],
-        queryFn: ({ signal }) => fetchServerLogs(api, { signal }),
+        queryFn: ({ signal }) => fetchServerLogs(api!, { signal }),
         enabled: !!api
     });
 };

--- a/src/apps/dashboard/features/plugins/api/useConfigurationPages.ts
+++ b/src/apps/dashboard/features/plugins/api/useConfigurationPages.ts
@@ -9,15 +9,10 @@ import { useApi } from 'hooks/useApi';
 import { QueryKey } from './queryKey';
 
 const fetchConfigurationPages = async (
-    api?: Api,
+    api: Api,
     params?: DashboardApiGetConfigurationPagesRequest,
     options?: AxiosRequestConfig
 ) => {
-    if (!api) {
-        console.warn('[fetchConfigurationPages] No API instance available');
-        return [];
-    }
-
     const response = await getDashboardApi(api)
         .getConfigurationPages(params, options);
     return response.data;
@@ -28,7 +23,7 @@ const getConfigurationPagesQuery = (
     params?: DashboardApiGetConfigurationPagesRequest
 ) => queryOptions({
     queryKey: [ QueryKey.ConfigurationPages, params?.enableInMainMenu ],
-    queryFn: ({ signal }) => fetchConfigurationPages(api, params, { signal }),
+    queryFn: ({ signal }) => fetchConfigurationPages(api!, params, { signal }),
     enabled: !!api
 });
 

--- a/src/apps/dashboard/features/plugins/api/useDisablePlugin.ts
+++ b/src/apps/dashboard/features/plugins/api/useDisablePlugin.ts
@@ -11,7 +11,6 @@ export const useDisablePlugin = () => {
     const { api } = useApi();
     return useMutation({
         mutationFn: (params: PluginsApiDisablePluginRequest) => (
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             getPluginsApi(api!)
                 .disablePlugin(params)
         ),

--- a/src/apps/dashboard/features/plugins/api/useEnablePlugin.ts
+++ b/src/apps/dashboard/features/plugins/api/useEnablePlugin.ts
@@ -11,7 +11,6 @@ export const useEnablePlugin = () => {
     const { api } = useApi();
     return useMutation({
         mutationFn: (params: PluginsApiEnablePluginRequest) => (
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             getPluginsApi(api!)
                 .enablePlugin(params)
         ),

--- a/src/apps/dashboard/features/plugins/api/useInstallPackage.ts
+++ b/src/apps/dashboard/features/plugins/api/useInstallPackage.ts
@@ -11,7 +11,6 @@ export const useInstallPackage = () => {
     const { api } = useApi();
     return useMutation({
         mutationFn: (params: PackageApiInstallPackageRequest) => (
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             getPackageApi(api!)
                 .installPackage(params)
         ),

--- a/src/apps/dashboard/features/plugins/api/usePackageInfo.ts
+++ b/src/apps/dashboard/features/plugins/api/usePackageInfo.ts
@@ -9,34 +9,24 @@ import { useApi } from 'hooks/useApi';
 import { QueryKey } from './queryKey';
 
 const fetchPackageInfo = async (
-    api?: Api,
-    params?: PackageApiGetPackageInfoRequest,
+    api: Api,
+    params: PackageApiGetPackageInfoRequest,
     options?: AxiosRequestConfig
 ) => {
-    if (!api) {
-        console.warn('[fetchPackageInfo] No API instance available');
-        return;
-    }
-
-    if (!params) {
-        console.warn('[fetchPackageInfo] Missing request params');
-        return;
-    }
-
     const response = await getPackageApi(api)
         .getPackageInfo(params, options);
     return response.data;
 };
 
 const getPackageInfoQuery = (
-    api?: Api,
+    api: Api | undefined,
     params?: PackageApiGetPackageInfoRequest
 ) => queryOptions({
     // Don't retry since requests for plugins not available in repos fail
     retry: false,
     queryKey: [ QueryKey.PackageInfo, params?.name, params?.assemblyGuid ],
-    queryFn: ({ signal }) => fetchPackageInfo(api, params, { signal }),
-    enabled: !!api && !!params?.name
+    queryFn: ({ signal }) => fetchPackageInfo(api!, params!, { signal }),
+    enabled: !!params && !!api && !!params.name
 });
 
 export const usePackageInfo = (

--- a/src/apps/dashboard/features/plugins/api/usePlugins.ts
+++ b/src/apps/dashboard/features/plugins/api/usePlugins.ts
@@ -8,14 +8,9 @@ import { useApi } from 'hooks/useApi';
 import { QueryKey } from './queryKey';
 
 const fetchPlugins = async (
-    api?: Api,
+    api: Api,
     options?: AxiosRequestConfig
 ) => {
-    if (!api) {
-        console.warn('[fetchPlugins] No API instance available');
-        return [];
-    }
-
     const response = await getPluginsApi(api)
         .getPlugins(options);
     return response.data;
@@ -25,7 +20,7 @@ const getPluginsQuery = (
     api?: Api
 ) => queryOptions({
     queryKey: [ QueryKey.Plugins ],
-    queryFn: ({ signal }) => fetchPlugins(api, { signal }),
+    queryFn: ({ signal }) => fetchPlugins(api!, { signal }),
     enabled: !!api
 });
 

--- a/src/apps/dashboard/features/plugins/api/useUninstallPlugin.ts
+++ b/src/apps/dashboard/features/plugins/api/useUninstallPlugin.ts
@@ -11,7 +11,6 @@ export const useUninstallPlugin = () => {
     const { api } = useApi();
     return useMutation({
         mutationFn: (params: PluginsApiUninstallPluginByVersionRequest) => (
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             getPluginsApi(api!)
                 .uninstallPluginByVersion(params)
         ),

--- a/src/apps/dashboard/features/scheduledtasks/api/useStartTask.ts
+++ b/src/apps/dashboard/features/scheduledtasks/api/useStartTask.ts
@@ -10,7 +10,6 @@ export const useStartTask = () => {
 
     return useMutation({
         mutationFn: (params: ScheduledTasksApiStartTaskRequest) => (
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             getScheduledTasksApi(api!)
                 .startTask(params)
         ),

--- a/src/apps/dashboard/features/scheduledtasks/api/useStopTask.ts
+++ b/src/apps/dashboard/features/scheduledtasks/api/useStopTask.ts
@@ -10,7 +10,6 @@ export const useStopTask = () => {
 
     return useMutation({
         mutationFn: (params: ScheduledTasksApiStartTaskRequest) => (
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             getScheduledTasksApi(api!)
                 .stopTask(params)
         ),

--- a/src/apps/dashboard/features/scheduledtasks/api/useTasks.ts
+++ b/src/apps/dashboard/features/scheduledtasks/api/useTasks.ts
@@ -9,15 +9,10 @@ import { useApi } from 'hooks/useApi';
 export const QUERY_KEY = 'Tasks';
 
 const fetchTasks = async (
-    api?: Api,
+    api: Api,
     params?: ScheduledTasksApiGetTasksRequest,
     options?: AxiosRequestConfig
 ) => {
-    if (!api) {
-        console.warn('[fetchTasks] No API instance available');
-        return;
-    }
-
     const response = await getScheduledTasksApi(api).getTasks(params, options);
 
     return response.data;
@@ -29,7 +24,7 @@ export const useTasks = (params?: ScheduledTasksApiGetTasksRequest) => {
     return useQuery({
         queryKey: [QUERY_KEY],
         queryFn: ({ signal }) =>
-            fetchTasks(api, params, { signal }),
+            fetchTasks(api!, params, { signal }),
         enabled: !!api
     });
 };

--- a/src/components/playback/displayMirrorManager.ts
+++ b/src/components/playback/displayMirrorManager.ts
@@ -17,8 +17,8 @@ async function mirrorIfEnabled(serverId: string, itemId: string) {
             try {
                 const item = await queryClient.fetchQuery(getItemQuery(
                     api,
-                    userId,
-                    itemId));
+                    itemId,
+                    userId));
 
                 playbackManager.displayContent({
                     ItemName: item.Name,

--- a/src/components/router/appRouter.js
+++ b/src/components/router/appRouter.js
@@ -142,7 +142,7 @@ class AppRouter {
             const userId = apiClient.getCurrentUserId();
 
             queryClient
-                .fetchQuery(getItemQuery(api, userId, item))
+                .fetchQuery(getItemQuery(api, item, userId))
                 .then(itemObject => {
                     this.showItem(itemObject, options);
                 })

--- a/src/components/themeMediaPlayer.js
+++ b/src/components/themeMediaPlayer.js
@@ -84,8 +84,9 @@ async function loadThemeMedia(serverId, itemId) {
     try {
         const item = await queryClient.fetchQuery(getItemQuery(
             api,
-            userId,
-            itemId));
+            itemId,
+            userId
+        ));
 
         if (item.CollectionType) {
             stopIfPlaying();

--- a/src/hooks/useItem.ts
+++ b/src/hooks/useItem.ts
@@ -7,26 +7,23 @@ import { useApi } from './useApi';
 import type { ItemDto } from 'types/base/models/item-dto';
 
 const fetchItem = async (
-    api?: Api,
-    userId?: string,
-    itemId?: string,
+    api: Api,
+    itemId: string,
+    userId: string,
     options?: AxiosRequestConfig
 ) => {
-    if (!api) throw new Error('No API instance available');
-    if (!itemId) throw new Error('No item ID provided');
-
     const response = await getUserLibraryApi(api)
         .getItem({ userId, itemId }, options);
     return response.data as ItemDto;
 };
 
 export const getItemQuery = (
-    api?: Api,
-    userId?: string,
-    itemId?: string
+    api: Api | undefined,
+    itemId?: string,
+    userId?: string
 ) => queryOptions({
     queryKey: [ 'User', userId, 'Items', itemId ],
-    queryFn: ({ signal }) => fetchItem(api, userId, itemId, { signal }),
+    queryFn: ({ signal }) => fetchItem(api!, itemId!, userId!, { signal }),
     staleTime: 1000, // 1 second
     enabled: !!api && !!userId && !!itemId
 });
@@ -36,5 +33,5 @@ export const useItem = (
 ) => {
     const apiContext = useApi();
     const { api, user } = apiContext;
-    return useQuery(getItemQuery(api, user?.Id, itemId));
+    return useQuery(getItemQuery(api, itemId, user?.Id));
 };

--- a/src/hooks/useSyncPlayGroups.ts
+++ b/src/hooks/useSyncPlayGroups.ts
@@ -6,14 +6,9 @@ import type { AxiosRequestConfig } from 'axios';
 import { useApi } from './useApi';
 
 const fetchSyncPlayGroups = async (
-    api?: Api,
+    api: Api,
     options?: AxiosRequestConfig
 ) => {
-    if (!api) {
-        console.warn('[fetchSyncPlayGroups] No API instance available');
-        return;
-    }
-
     const response = await getSyncPlayApi(api)
         .syncPlayGetGroups(options);
     return response.data;
@@ -23,7 +18,7 @@ export const useSyncPlayGroups = () => {
     const { api } = useApi();
     return useQuery({
         queryKey: [ 'SyncPlay', 'Groups' ],
-        queryFn: ({ signal }) => fetchSyncPlayGroups(api, { signal }),
+        queryFn: ({ signal }) => fetchSyncPlayGroups(api!, { signal }),
         enabled: !!api
     });
 };

--- a/src/hooks/useSystemInfo.ts
+++ b/src/hooks/useSystemInfo.ts
@@ -6,14 +6,9 @@ import type { AxiosRequestConfig } from 'axios';
 import { useApi } from './useApi';
 
 const fetchSystemInfo = async (
-    api?: Api,
+    api: Api,
     options?: AxiosRequestConfig
 ) => {
-    if (!api) {
-        console.warn('[fetchSystemInfo] No API instance available');
-        return;
-    }
-
     const response = await getSystemApi(api)
         .getSystemInfo(options);
     return response.data;
@@ -23,7 +18,7 @@ export const getSystemInfoQuery = (
     api?: Api
 ) => queryOptions({
     queryKey: [ 'SystemInfo' ],
-    queryFn: ({ signal }) => fetchSystemInfo(api, { signal, headers: { 'Cache-Control': 'no-cache' } }),
+    queryFn: ({ signal }) => fetchSystemInfo(api!, { signal, headers: { 'Cache-Control': 'no-cache' } }),
     // Allow for query reuse in legacy javascript.
     staleTime: 1000, // 1 second
     enabled: !!api

--- a/src/hooks/useUserViews.ts
+++ b/src/hooks/useUserViews.ts
@@ -7,14 +7,11 @@ import type { AxiosRequestConfig } from 'axios';
 import { useApi } from './useApi';
 
 const fetchUserViews = async (
-    api?: Api,
-    userId?: string,
+    api: Api,
+    userId: string,
     params?: UserViewsApiGetUserViewsRequest,
     options?: AxiosRequestConfig
 ) => {
-    if (!api) throw new Error('No API instance available');
-    if (!userId) throw new Error('No User ID provided');
-
     const response = await getUserViewsApi(api)
         .getUserViews({ ...params, userId }, options);
     return response.data;
@@ -26,7 +23,7 @@ export const getUserViewsQuery = (
     params?: UserViewsApiGetUserViewsRequest
 ) => queryOptions({
     queryKey: [ 'User', userId, 'Views', params ],
-    queryFn: ({ signal }) => fetchUserViews(api, userId, params, { signal }),
+    queryFn: ({ signal }) => fetchUserViews(api!, userId!, params, { signal }),
     // On initial page load we request user views 3x. Setting a 1 second stale time
     // allows a single request to be made to resolve all 3.
     staleTime: 1000, // 1 second

--- a/src/hooks/useUsers.ts
+++ b/src/hooks/useUsers.ts
@@ -9,15 +9,10 @@ import { useApi } from './useApi';
 export type UsersRecords = Record<string, UserDto>;
 
 const fetchUsers = async (
-    api?: Api,
+    api: Api,
     requestParams?: UserApiGetUsersRequest,
     options?: AxiosRequestConfig
 ) => {
-    if (!api) {
-        console.warn('[fetchUsers] No API instance available');
-        return;
-    }
-
     const response = await getUserApi(api).getUsers(requestParams, {
         signal: options?.signal
     });
@@ -30,7 +25,7 @@ export const useUsers = (requestParams?: UserApiGetUsersRequest) => {
     return useQuery({
         queryKey: ['Users'],
         queryFn: ({ signal }) =>
-            fetchUsers(api, requestParams, { signal }),
+            fetchUsers(api!, requestParams, { signal }),
         enabled: !!api
     });
 };

--- a/src/utils/container.ts
+++ b/src/utils/container.ts
@@ -33,7 +33,6 @@ export function includesAny(list: string | string[] | null | undefined, search: 
 
     search = search.filter(i => i);
 
-    /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
     if (search.some(s => list!.includes(s))) {
         return !inverseMatch;
     }


### PR DESCRIPTION
**Changes**
Refactors the react queries to use non-null assert for api and other required params in order to remove redundant, impossible to hit checks.

This also has the added benefit of removing an impossible `undefined` from the response data type union after checking for `isPending` and `isError`, which allows us to remove a lot of unnecessary optional chaining expressions which I know dmitry would like.

**Issues**
N/A
