### PR TITLE
Fix skip button not displaying correctly with OSD

### DIFF
--- a/src/components/playback/skipsegment.ts
+++ b/src/components/playback/skipsegment.ts
@@ -188,7 +188,7 @@ class SkipSegment extends PlaybackSubscriber {
     onPlaybackStop() {
         this.currentSegment = null;
         this.hideSkipButton();
-        if (!this.playbackManager.getCurrentPlayer()) {
+        if (!this.playbackManager.getNextItem()) {
             Events.off(document, EventType.SHOW_VIDEO_OSD, this.onOsdChanged);
         }
     }

--- a/src/components/playback/skipsegment.ts
+++ b/src/components/playback/skipsegment.ts
@@ -188,7 +188,9 @@ class SkipSegment extends PlaybackSubscriber {
     onPlaybackStop() {
         this.currentSegment = null;
         this.hideSkipButton();
-        Events.off(document, EventType.SHOW_VIDEO_OSD, this.onOsdChanged);
+        if (!this.playbackManager.getCurrentPlayer()) {
+            Events.off(document, EventType.SHOW_VIDEO_OSD, this.onOsdChanged);
+        }
     }
 }
 

--- a/src/components/playback/skipsegment.ts
+++ b/src/components/playback/skipsegment.ts
@@ -1,6 +1,7 @@
 import { PlaybackManager } from './playbackmanager';
 import { TICKS_PER_MILLISECOND, TICKS_PER_SECOND } from 'constants/time';
 import type { MediaSegmentDto } from '@jellyfin/sdk/lib/generated-client/models/media-segment-dto';
+import type { PlaybackStopInfo } from 'types/playbackStopInfo';
 import { PlaybackSubscriber } from 'apps/stable/features/playback/utils/playbackSubscriber';
 import { isInSegment } from 'apps/stable/features/playback/utils/mediaSegments';
 import Events, { type Event } from 'utils/events';
@@ -186,10 +187,10 @@ class SkipSegment extends PlaybackSubscriber {
         }
     }
 
-    onPlaybackStop() {
+    onPlaybackStop(_e: Event, playbackStopInfo: PlaybackStopInfo) {
         this.currentSegment = null;
         this.hideSkipButton();
-        if (!this.playbackManager.getNextItem()) {
+        if (!playbackStopInfo.nextItem) {
             Events.off(document, EventType.SHOW_VIDEO_OSD, this.onOsdChanged);
         }
     }


### PR DESCRIPTION
Resolves an issue where the skip button for media segments fails to appear on the OSD after the first episode in a playlist.  The problem was caused by removing the OSD event listener on playback stop.
