### PR TITLE
Fix wizard reference to dashboard library controller

### DIFF
--- a/src/apps/experimental/routes/legacyRoutes/public.ts
+++ b/src/apps/experimental/routes/legacyRoutes/public.ts
@@ -53,7 +53,7 @@ export const LEGACY_PUBLIC_ROUTES: LegacyRoute[] = [
     {
         path: 'wizardlibrary.html',
         pageProps: {
-            controller: 'dashboard/library',
+            controller: 'wizard/library',
             view: 'wizard/library.html'
         }
     },

--- a/src/apps/stable/routes/legacyRoutes/public.ts
+++ b/src/apps/stable/routes/legacyRoutes/public.ts
@@ -53,7 +53,7 @@ export const LEGACY_PUBLIC_ROUTES: LegacyRoute[] = [
     {
         path: 'wizardlibrary.html',
         pageProps: {
-            controller: 'dashboard/library',
+            controller: 'wizard/library',
             view: 'wizard/library.html'
         }
     },

--- a/src/controllers/wizard/library.js
+++ b/src/controllers/wizard/library.js
@@ -7,7 +7,7 @@ import dom from 'scripts/dom';
 import imageHelper from 'utils/image';
 import 'components/cardbuilder/card.scss';
 import 'elements/emby-itemrefreshindicator/emby-itemrefreshindicator';
-import { pageClassOn, pageIdOn } from 'utils/dashboard';
+import Dashboard, { pageClassOn, pageIdOn } from 'utils/dashboard';
 import confirm from 'components/confirm/confirm';
 import { getDefaultBackgroundClass } from 'components/cardbuilder/cardBuilderUtils';
 
@@ -258,7 +258,7 @@ function getVirtualFolderHtml(page, virtualFolder, index) {
     let html = '';
 
     const elementId = virtualFolder.elementId ? `id="${virtualFolder.elementId}" ` : '';
-    html += '<div ' + elementId + 'class="card backdropCard scalableCard backdropCard-scalable" data-index="' + index + '" data-id="' + virtualFolder.ItemId + '">';
+    html += '<div ' + elementId + 'class="card backdropCard scalableCard backdropCard-scalable" style="min-width:33.3%;" data-index="' + index + '" data-id="' + virtualFolder.ItemId + '">';
 
     html += '<div class="cardBox visualCardBox">';
     html += '<div class="cardScalable visualCardBox-cardScalable">';
@@ -359,6 +359,11 @@ function getVirtualFolderHtml(page, virtualFolder, index) {
     return html;
 }
 
+window.WizardLibraryPage = {
+    next: function () {
+        Dashboard.navigate('wizardsettings.html');
+    }
+};
 pageClassOn('pageshow', 'mediaLibraryPage', function () {
     reloadLibrary(this);
 });


### PR DESCRIPTION
**Changes**
Fixes a regression caused by https://github.com/jellyfin/jellyfin-web/pull/6474... who knew the setup wizard was sharing a controller with the dashboard? :man_facepalming: 

While it's not ideal to duplicate the controller, the dashboard page will likely be rewritten soon :tm: in React+MUI, so jumping through hoops to avoid duplication is probably not worthwhile. 

**Issues**
Fixes #6587 
