### PR TITLE
Add support for HEVC codec in Hisense Vidaa OS

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -11,7 +11,7 @@ function canPlayHevc(videoTestElement, options) {
         return true;
     }
 
-    if (browser.ps4) {
+    if (browser.ps4 || browser.vidaa) {
         return false;
     }
 


### PR DESCRIPTION
**Changes**
The Jellyfin has a problem playing HEVC videos on Hisense TV with Vidaa OS. That PR is meant to fix this issue. The idea was taken from [Jellyfin forum](https://forum.jellyfin.org/t-setting-up-jellyfin-on-a-hisense-vidaa-os-tv), and it solves the issue. 
