### PR TITLE
Use paper background for avatar with user image

### DIFF
--- a/src/components/UserAvatar.tsx
+++ b/src/components/UserAvatar.tsx
@@ -22,7 +22,9 @@ const UserAvatar: FC<UserAvatarProps> = ({ user }) => {
                     undefined
             }
             sx={{
-                bgcolor: theme.palette.primary.dark,
+                bgcolor: api && user.Id && user.PrimaryImageTag ?
+                    theme.palette.background.paper :
+                    theme.palette.primary.dark,
                 color: 'inherit'
             }}
         />


### PR DESCRIPTION
**Changes**
Use the paper background for the avatar component if a user image is set. (This is mainly to improve the appearance on the demo server where the JF logo is used for the user image.)

![Screenshot 2025-03-13 at 12-53-54 Jellyfin](https://github.com/user-attachments/assets/56b70fcd-0799-4a44-ac56-57562892492f)

**Issues**
N/A