### PR TITLE
Fix shuffle button for random individual items 

### DIFF
--- a/src/controllers/list.js
+++ b/src/controllers/list.js
@@ -326,7 +326,7 @@ function getItems(instance, params, item, sortBy, startIndex, limit) {
     const query = {
         StartIndex: startIndex,
         Limit: limit,
-        Fields: "PrimaryImageAspectRatio,SortName,Path,ChildCount,MediaSourceCount",
+        Fields: 'PrimaryImageAspectRatio,SortName,Path,ChildCount,MediaSourceCount',
         ImageTypeLimit: 1,
         ParentId: item.Id,
         SortBy: sortBy
@@ -334,11 +334,11 @@ function getItems(instance, params, item, sortBy, startIndex, limit) {
 
     if (sortBy === 'Random') {
         instance.queryRecursive = true;
-        query.IncludeItemTypes = "Video,Movie,Series,Music";
+        query.IncludeItemTypes = 'Video,Movie,Series,Music';
         query.Recursive = true;
     }
 
-    return apiClient.getItems(apiClient.getCurrentUserId(),modifyQueryWithFilters(instance, query));
+    return apiClient.getItems(apiClient.getCurrentUserId(), modifyQueryWithFilters(instance, query));
 }
 
 function getItem(params) {

--- a/src/controllers/list.js
+++ b/src/controllers/list.js
@@ -323,14 +323,22 @@ function getItems(instance, params, item, sortBy, startIndex, limit) {
         return apiClient.getItems(apiClient.getCurrentUserId(), modifyQueryWithFilters(instance, query));
     }
 
-    return apiClient.getItems(apiClient.getCurrentUserId(), modifyQueryWithFilters(instance, {
+    const query = {
         StartIndex: startIndex,
         Limit: limit,
-        Fields: 'PrimaryImageAspectRatio,SortName,Path,ChildCount,MediaSourceCount',
+        Fields: "PrimaryImageAspectRatio,SortName,Path,ChildCount,MediaSourceCount",
         ImageTypeLimit: 1,
         ParentId: item.Id,
         SortBy: sortBy
-    }));
+    };
+
+    if (sortBy === 'Random') {
+        instance.queryRecursive = true;
+        query.IncludeItemTypes = "Video,Movie,Series,Music";
+        query.Recursive = true;
+    }
+
+    return apiClient.getItems(apiClient.getCurrentUserId(),modifyQueryWithFilters(instance, query));
 }
 
 function getItem(params) {


### PR DESCRIPTION
**Changes**

Modifies the Shuffle button behavior to shuffle individual items instead of entire collections, albums, or series.
Currently, clicking Shuffle randomly selects a folder, collection, album, or series and plays its contents.
With this update, items will be selected randomly, independent of any grouping.

**Issues**

Fixes #6411 