### PR TITLE
Add PremiereDate (AirDate) to getDisplayName for episodes

### DIFF
--- a/src/components/itemHelper.js
+++ b/src/components/itemHelper.js
@@ -48,15 +48,15 @@ export function getDisplayName(item, options = {}) {
             number += '-' + displayIndexNumber;
         }
         if (item.PremiereDate) {
-			date = datetime.parseISO8601Date(item.PremiereDate).toLocaleDateString(undefined, {
-                    weekday: 'short',
-					year: "numeric",
-                    month: 'short',
-                    day: 'numeric',
-					timeZone: "UTC"
-                });
-			name = date + nameSeparator + name;
-		}
+            date = datetime.parseISO8601Date(item.PremiereDate).toLocaleDateString(undefined, {
+                weekday: 'short',
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric',
+                timeZone: 'UTC'
+            });
+            name = date + nameSeparator + name;
+        }
         if (number) {
             name = name ? (number + nameSeparator + name) : number;
         }

--- a/src/components/itemHelper.js
+++ b/src/components/itemHelper.js
@@ -5,6 +5,8 @@ import { RecordingStatus } from '@jellyfin/sdk/lib/generated-client/models/recor
 import { MediaType } from '@jellyfin/sdk/lib/generated-client/models/media-type';
 import { getPlaylistsApi } from '@jellyfin/sdk/lib/utils/api/playlists-api';
 
+import datetime from 'scripts/datetime';
+
 import { appHost } from './apphost';
 import globalize from 'lib/globalize';
 import ServerConnections from './ServerConnections';
@@ -34,7 +36,7 @@ export function getDisplayName(item, options = {}) {
 
         let number = displayIndexNumber;
         let nameSeparator = ' - ';
-
+        let date = 0;
         if (options.includeParentInfo !== false) {
             number = 'S' + item.ParentIndexNumber + ':E' + number;
         } else {
@@ -45,7 +47,16 @@ export function getDisplayName(item, options = {}) {
             displayIndexNumber = item.IndexNumberEnd;
             number += '-' + displayIndexNumber;
         }
-
+        if (item.PremiereDate) {
+			date = datetime.parseISO8601Date(item.PremiereDate).toLocaleDateString(undefined, {
+                    weekday: 'short',
+					year: "numeric",
+                    month: 'short',
+                    day: 'numeric',
+					timeZone: "UTC"
+                });
+			name = date + nameSeparator + name;
+		}
         if (number) {
             name = name ? (number + nameSeparator + name) : number;
         }


### PR DESCRIPTION

**Changes**
Adds PremiereDate (AirDate) to Episode getDisplayName (namely used to display playback title) after episode number
![image](https://github.com/user-attachments/assets/60bfd384-60d6-4a33-b750-2b0cc96c5aba)

Might be only me, however I often want to see the AirDate when watching a show.
This PR adds the date in the playback title, includes weekday, day, month, and year.
Not sure if getDisplayName is used anywhere that this change would not make sense.


