### PR TITLE
Fix active device cards from getting too large/overflowing on some resolutions

### DIFF
--- a/src/styles/dashboard.scss
+++ b/src/styles/dashboard.scss
@@ -268,7 +268,7 @@ div[data-role=controlgroup] a.ui-btn-active {
 }
 
 .activeSession {
-    min-width: 20rem;
+    min-width: 10rem;
     width: 100% !important;
 }
 


### PR DESCRIPTION
**Changes**
I noticed on my 125% scaled 1080p monitor that some of the **Active Device** cards were over flowing into the right hand side of the screen. 

**Before** 
![fix1](https://github.com/user-attachments/assets/f42c2eaf-86f5-408e-995e-3e8a5763f5f0)

**After**
![fix2](https://github.com/user-attachments/assets/be8f58db-f5d0-4218-babc-555b691a8246)

I was looking for a more elegant solution, but `dashboardSection` is used in multiple places on the dashboard. This should suffice and still work great. 
