### PR TITLE
Fix imagedownloader Uncaught (in promise)  when no changes are done

### DIFF
--- a/src/components/imageeditor/imageeditor.js
+++ b/src/components/imageeditor/imageeditor.js
@@ -264,7 +264,9 @@ function showImageDownloader(page, imageType) {
         ).then(function () {
             hasChanges = true;
             reload(page);
-        });
+        }).catch(function () {
+        console.debug('No changes were made.');
+        });;
     });
 }
 

--- a/src/components/imageeditor/imageeditor.js
+++ b/src/components/imageeditor/imageeditor.js
@@ -265,7 +265,7 @@ function showImageDownloader(page, imageType) {
             hasChanges = true;
             reload(page);
         }).catch(function () {
-            console.debug('No changes were made.');
+            // image downloader closed
         });;
     });
 }

--- a/src/components/imageeditor/imageeditor.js
+++ b/src/components/imageeditor/imageeditor.js
@@ -266,7 +266,7 @@ function showImageDownloader(page, imageType) {
             reload(page);
         }).catch(function () {
             // image downloader closed
-        });;
+        });
     });
 }
 

--- a/src/components/imageeditor/imageeditor.js
+++ b/src/components/imageeditor/imageeditor.js
@@ -265,7 +265,7 @@ function showImageDownloader(page, imageType) {
             hasChanges = true;
             reload(page);
         }).catch(function () {
-        console.debug('No changes were made.');
+            console.debug('No changes were made.');
         });;
     });
 }


### PR DESCRIPTION


Fix Uncaught (in promise) in image downloader when no changes are made

**Changes:**
- Add catch to `showImageDownloader` in `imageeditor.js`.


I am not sure this is the right fix.
Another option would be to drop the following in [imageDownloader.js:370](https://github.com/jellyfin/jellyfin-web/blob/24f699efa51b186e87b0f4a9d958bb97df41249c/src/components/imageDownloader/imageDownloader.js#L370):
  ```javascript
  else {
      currentReject();
  }
  ```

If you have any thoughts or suggestions on the best way to handle this, I'd really appreciate input.