### PR TITLE
Cleanup eslint warnings

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -98,7 +98,7 @@ export default tseslint.config(
 
             'sonarjs/fixme-tag': 'warn',
             'sonarjs/todo-tag': 'off',
-            'sonarjs/deprecation': 'warn',
+            'sonarjs/deprecation': 'off',
             'sonarjs/no-alphabetical-sort': 'warn',
             'sonarjs/no-inverted-boolean-check': 'error',
             'sonarjs/no-selector-parameter': 'off',
@@ -329,6 +329,7 @@ export default tseslint.config(
                     }
                 }
             ],
+            '@typescript-eslint/no-deprecated': 'warn',
             '@typescript-eslint/no-floating-promises': 'error',
             '@typescript-eslint/prefer-string-starts-ends-with': 'error'
         }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -367,7 +367,6 @@ export default tseslint.config(
         rules: {
             '@typescript-eslint/no-floating-promises': 'off',
             '@typescript-eslint/no-this-alias': 'off',
-            '@typescript-eslint/no-unused-vars': 'warn',
 
             'sonarjs/public-static-readonly': 'off',
 

--- a/src/components/ServerConnections.js
+++ b/src/components/ServerConnections.js
@@ -1,5 +1,5 @@
 // NOTE: This is used for jsdoc return type
-// eslint-disable-next-line no-unused-vars
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { Api } from '@jellyfin/sdk';
 import { MINIMUM_VERSION } from '@jellyfin/sdk/lib/versions';
 import { ConnectionManager, Credentials, ApiClient } from 'jellyfin-apiclient';
@@ -18,7 +18,6 @@ const normalizeImageOptions = options => {
 };
 
 const getMaxBandwidth = () => {
-    /* eslint-disable compat/compat */
     if (navigator.connection) {
         let max = navigator.connection.downlinkMax;
         if (max && max > 0 && max < Number.POSITIVE_INFINITY) {
@@ -28,7 +27,6 @@ const getMaxBandwidth = () => {
             return parseInt(max, 10);
         }
     }
-    /* eslint-enable compat/compat */
 
     return null;
 };

--- a/src/components/apphost.js
+++ b/src/components/apphost.js
@@ -452,7 +452,7 @@ let isHidden = false;
 let hidden;
 let visibilityChange;
 
-if (typeof document.hidden !== 'undefined') { /* eslint-disable-line compat/compat */
+if (typeof document.hidden !== 'undefined') {
     hidden = 'hidden';
     visibilityChange = 'visibilitychange';
 } else if (typeof document.webkitHidden !== 'undefined') {
@@ -461,7 +461,6 @@ if (typeof document.hidden !== 'undefined') { /* eslint-disable-line compat/comp
 }
 
 document.addEventListener(visibilityChange, function () {
-    /* eslint-disable-next-line compat/compat */
     if (document[hidden]) {
         onAppHidden();
     } else {

--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -484,7 +484,7 @@ function getAirTimeText(item, showAirDateTime, showAirEndTime) {
                 airTimeText += ' - ' + datetime.getDisplayTime(date);
             }
         } catch (e) {
-            console.error('error parsing date: ' + item.StartDate);
+            console.error('error parsing date: ' + item.StartDate, e);
         }
     }
 
@@ -617,7 +617,7 @@ function getCardFooterText(item, apiClient, options, footerClass, progressHtml, 
                         datetime.parseISO8601Date(item.PremiereDate),
                         { weekday: 'long', month: 'long', day: 'numeric' }
                     ));
-                } catch (err) {
+                } catch {
                     lines.push('');
                 }
             } else {

--- a/src/components/cardbuilder/cardBuilderUtils.test.ts
+++ b/src/components/cardbuilder/cardBuilderUtils.test.ts
@@ -678,6 +678,7 @@ describe('getDefaultBackgroundClass', () => {
     });
 
     test('randomization string provided', () => {
+        // eslint-disable-next-line sonarjs/pseudo-random
         const generateRandomString = (stringLength: number): string => (Math.random() + 1).toString(36).substring(stringLength);
 
         for (let i = 0; i < 100; i++) {

--- a/src/components/filterdialog/filterdialog.js
+++ b/src/components/filterdialog/filterdialog.js
@@ -14,6 +14,7 @@ function merge(resultItems, queryItems, delimiter) {
     if (!queryItems) {
         return resultItems;
     }
+    // eslint-disable-next-line sonarjs/no-alphabetical-sort
     return union(resultItems, queryItems.split(delimiter)).sort();
 }
 

--- a/src/components/guide/guide.js
+++ b/src/components/guide/guide.js
@@ -358,7 +358,7 @@ function Guide(options) {
         if ((typeof date).toString().toLowerCase() === 'string') {
             try {
                 date = datetime.parseISO8601Date(date, { toLocal: true });
-            } catch (err) {
+            } catch {
                 return date;
             }
         }
@@ -392,7 +392,7 @@ function Guide(options) {
             try {
                 program.StartDateLocal = datetime.parseISO8601Date(program.StartDate, { toLocal: true });
             } catch (err) {
-                console.error('error parsing timestamp for start date');
+                console.error('error parsing timestamp for start date', err);
             }
         }
 
@@ -400,7 +400,7 @@ function Guide(options) {
             try {
                 program.EndDateLocal = datetime.parseISO8601Date(program.EndDate, { toLocal: true });
             } catch (err) {
-                console.error('error parsing timestamp for end date');
+                console.error('error parsing timestamp for end date', err);
             }
         }
 

--- a/src/components/imageUploader/imageUploader.js
+++ b/src/components/imageUploader/imageUploader.js
@@ -77,6 +77,7 @@ function setFiles(page, files) {
     reader.readAsDataURL(file);
 }
 
+// eslint-disable-next-line sonarjs/no-invariant-returns
 function onSubmit(e) {
     const file = currentFile;
 

--- a/src/components/images/imageLoader.js
+++ b/src/components/images/imageLoader.js
@@ -2,7 +2,7 @@ import Worker from './blurhash.worker.ts'; // eslint-disable-line import/default
 import * as lazyLoader from '../lazyLoader/lazyLoaderIntersectionObserver';
 import * as userSettings from '../../scripts/settings/userSettings';
 import './style.scss';
-// eslint-disable-next-line compat/compat
+
 const worker = new Worker();
 const targetDic = {};
 worker.addEventListener(

--- a/src/components/listview/List/Lists.tsx
+++ b/src/components/listview/List/Lists.tsx
@@ -25,7 +25,6 @@ const Lists: FC<ListsProps> = ({ items = [], listOptions = {} }) => {
     const renderListItem = (item: ItemDto, index: number) => {
         return (
             <List
-                // eslint-disable-next-line react/no-array-index-key
                 key={`${item.Id}-${index}`}
                 index={index}
                 item={item}

--- a/src/components/mediaLibraryEditor/mediaLibraryEditor.js
+++ b/src/components/mediaLibraryEditor/mediaLibraryEditor.js
@@ -23,6 +23,7 @@ import toast from '../toast/toast';
 import confirm from '../confirm/confirm';
 import template from './mediaLibraryEditor.template.html';
 
+// eslint-disable-next-line sonarjs/no-invariant-returns
 function onEditLibrary() {
     if (isCreating) {
         return false;

--- a/src/components/mediainfo/mediainfo.js
+++ b/src/components/mediainfo/mediainfo.js
@@ -60,7 +60,7 @@ function getProgramInfoHtml(item, options) {
 
             miscInfo.push(text);
         } catch (e) {
-            console.error('error parsing date:', item.StartDate);
+            console.error('error parsing date:', item.StartDate, e);
         }
     }
 
@@ -140,7 +140,7 @@ export function getMediaInfoHtml(item, options = {}) {
             text = datetime.toLocaleDateString(date);
             miscInfo.push(text);
         } catch (e) {
-            console.error('error parsing date:', item.PremiereDate);
+            console.error('error parsing date:', item.PremiereDate, e);
         }
     }
 
@@ -170,7 +170,7 @@ export function getMediaInfoHtml(item, options = {}) {
                 miscInfo.push(text);
             }
         } catch (e) {
-            console.error('error parsing date:', item.StartDate);
+            console.error('error parsing date:', item.StartDate, e);
         }
     }
 
@@ -188,7 +188,7 @@ export function getMediaInfoHtml(item, options = {}) {
                         text += ` - ${endYear}`;
                     }
                 } catch (e) {
-                    console.error('error parsing date:', item.EndDate);
+                    console.error('error parsing date:', item.EndDate, e);
                 }
             }
 
@@ -238,7 +238,7 @@ export function getMediaInfoHtml(item, options = {}) {
                 text = globalize.translate('OriginalAirDateValue', datetime.toLocaleDateString(date));
                 miscInfo.push(text);
             } catch (e) {
-                console.error('error parsing date:', program.PremiereDate);
+                console.error('error parsing date:', program.PremiereDate, e);
             }
         } else if (program.ProductionYear && options.year !== false ) {
             miscInfo.push(program.ProductionYear);
@@ -255,7 +255,7 @@ export function getMediaInfoHtml(item, options = {}) {
                 text = datetime.toLocaleString(datetime.parseISO8601Date(item.PremiereDate).getFullYear(), { useGrouping: false });
                 miscInfo.push(text);
             } catch (e) {
-                console.error('error parsing date:', item.PremiereDate);
+                console.error('error parsing date:', item.PremiereDate, e);
             }
         }
     }

--- a/src/components/metadataEditor/metadataEditor.js
+++ b/src/components/metadataEditor/metadataEditor.js
@@ -821,7 +821,7 @@ function fillItemInfo(context, item, parentalRatingOptions) {
             date = datetime.parseISO8601Date(item.DateCreated, true);
 
             context.querySelector('#txtDateAdded').value = date.toISOString().slice(0, 10);
-        } catch (e) {
+        } catch {
             context.querySelector('#txtDateAdded').value = '';
         }
     } else {
@@ -833,7 +833,7 @@ function fillItemInfo(context, item, parentalRatingOptions) {
             date = datetime.parseISO8601Date(item.PremiereDate, true);
 
             context.querySelector('#txtPremiereDate').value = date.toISOString().slice(0, 10);
-        } catch (e) {
+        } catch {
             context.querySelector('#txtPremiereDate').value = '';
         }
     } else {
@@ -845,7 +845,7 @@ function fillItemInfo(context, item, parentalRatingOptions) {
             date = datetime.parseISO8601Date(item.EndDate, true);
 
             context.querySelector('#txtEndDate').value = date.toISOString().slice(0, 10);
-        } catch (e) {
+        } catch {
             context.querySelector('#txtEndDate').value = '';
         }
     } else {

--- a/src/components/notifications/notifications.js
+++ b/src/components/notifications/notifications.js
@@ -13,7 +13,6 @@ function onOneDocumentClick() {
 
     // don't request notification permissions if they're already granted or denied
     if (window.Notification && window.Notification.permission === 'default') {
-        /* eslint-disable-next-line compat/compat */
         Notification.requestPermission();
     }
 }

--- a/src/components/playback/playbackorientation.js
+++ b/src/components/playback/playbackorientation.js
@@ -17,7 +17,6 @@ Events.on(playbackManager, 'playbackstart', function (e, player) {
     const isLocalVideo = player.isLocalPlayer && !player.isExternalPlayer && playbackManager.isPlayingVideo(player);
 
     if (isLocalVideo && layoutManager.mobile) {
-        /* eslint-disable-next-line compat/compat */
         const lockOrientation = window.screen.lockOrientation || window.screen.mozLockOrientation || window.screen.msLockOrientation || (window.screen.orientation?.lock);
 
         if (lockOrientation) {
@@ -38,7 +37,6 @@ Events.on(playbackManager, 'playbackstart', function (e, player) {
 
 Events.on(playbackManager, 'playbackstop', function (e, playbackStopInfo) {
     if (orientationLocked && !playbackStopInfo.nextMediaType) {
-        /* eslint-disable-next-line compat/compat */
         const unlockOrientation = window.screen.unlockOrientation || window.screen.mozUnlockOrientation || window.screen.msUnlockOrientation || (window.screen.orientation?.unlock);
 
         if (unlockOrientation) {

--- a/src/controllers/lyrics.js
+++ b/src/controllers/lyrics.js
@@ -265,7 +265,7 @@ export default function (view) {
         document.addEventListener('keydown', onKeyDown);
         try {
             onLoad();
-        } catch (e) {
+        } catch {
             appRouter.goHome();
         }
     });

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1352,7 +1352,7 @@ export default function (view) {
             case 'GamepadDPadLeft':
             case 'GamepadLeftThumbstickLeft':
                 // Ignores gamepad events that are always triggered, even when not focused.
-                if (document.hasFocus()) { /* eslint-disable-line compat/compat */
+                if (document.hasFocus()) {
                     playbackManager.rewind(currentPlayer);
                     showOsd(btnRewind);
                 }
@@ -1361,7 +1361,7 @@ export default function (view) {
             case 'GamepadDPadRight':
             case 'GamepadLeftThumbstickRight':
                 // Ignores gamepad events that are always triggered, even when not focused.
-                if (document.hasFocus()) { /* eslint-disable-line compat/compat */
+                if (document.hasFocus()) {
                     playbackManager.fastForward(currentPlayer);
                     showOsd(btnFastForward);
                 }

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -713,7 +713,7 @@ export default function (view) {
                         }, state);
                     }
                 } catch (e) {
-                    console.error('error parsing date: ' + program.EndDate);
+                    console.error('error parsing date: ' + program.EndDate, e);
                 }
             }
         }
@@ -1712,7 +1712,7 @@ export default function (view) {
             if (browser.firefox || browser.edge) {
                 dom.addEventListener(document, 'click', onClickCapture, { capture: true });
             }
-        } catch (e) {
+        } catch {
             setBackdropTransparency(TRANSPARENCY_LEVEL.None); // reset state set in viewbeforeshow
             appRouter.goHome();
         }

--- a/src/controllers/shows/tvupcoming.js
+++ b/src/controllers/shows/tvupcoming.js
@@ -61,7 +61,7 @@ function renderUpcoming(elem, items) {
                     day: 'numeric'
                 });
             } catch (err) {
-                console.error('error parsing timestamp for upcoming tv shows');
+                console.error('error parsing timestamp for upcoming tv shows', err);
             }
         }
 

--- a/src/lib/globalize/index.js
+++ b/src/lib/globalize/index.js
@@ -79,7 +79,7 @@ export function updateCurrentCulture() {
     let culture;
     try {
         culture = userSettings.language();
-    } catch (err) {
+    } catch {
         console.error('no language set in user settings');
     }
     culture = culture || getDefaultLanguage();
@@ -92,7 +92,7 @@ export function updateCurrentCulture() {
     let dateTimeCulture;
     try {
         dateTimeCulture = userSettings.dateTimeLocale();
-    } catch (err) {
+    } catch {
         console.error('no date format set in user settings');
     }
 

--- a/src/lib/legacy/domParserTextHtml.js
+++ b/src/lib/legacy/domParserTextHtml.js
@@ -22,7 +22,7 @@
             // text/html parsing is natively supported
             return;
         }
-    } catch (ex) { /* noop */ }
+    } catch { /* noop */ }
 
     DOMParserPrototype.parseFromString = function (markup, type) {
         if (/^\s*text\/html\s*(?:;|$)/i.test(type)) {

--- a/src/lib/legacy/keyboardEvent.js
+++ b/src/lib/legacy/keyboardEvent.js
@@ -8,7 +8,7 @@
 
     try {
         new window.KeyboardEvent('event', { bubbles: true, cancelable: true });
-    } catch (e) {
+    } catch {
         // We can't use `KeyboardEvent` in old WebKit because `initKeyboardEvent`
         // doesn't seem to populate some properties (`keyCode`, `which`) that
         // are read-only.

--- a/src/lib/legacy/patchHeaders.js
+++ b/src/lib/legacy/patchHeaders.js
@@ -13,7 +13,7 @@
     if (window.Headers) {
         try {
             new window.Headers(undefined);
-        } catch (_) {
+        } catch {
             console.debug('patch \'Headers\' to accept \'undefined\'');
 
             const _Headers = window.Headers;

--- a/src/plugins/chromecastPlayer/plugin.js
+++ b/src/plugins/chromecastPlayer/plugin.js
@@ -1109,7 +1109,8 @@ class ChromecastPlayer {
         return this.getPlayerStateInternal()?.NowPlayingItem?.IndexNumber;
     }
 
-    clearQueue(currentTime) { // eslint-disable-line no-unused-vars
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    clearQueue(currentTime) {
         // not supported yet
     }
 }

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1512,7 +1512,7 @@ export class HtmlVideoPlayer {
                     trackElement.removeCue(trackElement.cues[0]);
                 }
             } catch (e) {
-                console.error('error removing cue from textTrack');
+                console.error('error removing cue from textTrack', e);
             }
 
             trackElement.mode = 'disabled';

--- a/src/plugins/syncPlay/core/PlaybackCore.js
+++ b/src/plugins/syncPlay/core/PlaybackCore.js
@@ -221,6 +221,7 @@ class PlaybackCore {
                             // Account for player imperfections, we got half a second of tollerance we can play with
                             // (the server tollerates a range of values when client reports that is ready).
                             const rangeWidth = 100; // In milliseconds.
+                            // eslint-disable-next-line sonarjs/pseudo-random
                             const randomOffsetTicks = Math.round((Math.random() - 0.5) * rangeWidth) * Helper.TicksPerMillisecond;
                             this.scheduleSeek(command.When, command.PositionTicks + randomOffsetTicks);
                             console.debug('SyncPlay applyCommand: adding random offset to force seek:', randomOffsetTicks, command);

--- a/src/plugins/syncPlay/core/players/GenericPlayer.js
+++ b/src/plugins/syncPlay/core/players/GenericPlayer.js
@@ -158,7 +158,7 @@ class GenericPlayer {
      * Sets the playback rate, if supported.
      * @param {number} value The playback rate.
      */
-    // eslint-disable-next-line no-unused-vars
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     setPlaybackRate(value) {
         // Do nothing.
     }
@@ -197,7 +197,7 @@ class GenericPlayer {
      * Seeks the player to the specified position.
      * @param {number} positionTicks The new position.
      */
-    // eslint-disable-next-line no-unused-vars
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     localSeek(positionTicks) {
         // Override
     }
@@ -213,7 +213,7 @@ class GenericPlayer {
      * Sends a command to the player.
      * @param {Object} command The command.
      */
-    // eslint-disable-next-line no-unused-vars
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     localSendCommand(command) {
         // Override
     }
@@ -222,7 +222,7 @@ class GenericPlayer {
      * Starts playback.
      * @param {Object} options Playback data.
      */
-    // eslint-disable-next-line no-unused-vars
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     localPlay(options) {
         // Override
     }
@@ -231,7 +231,7 @@ class GenericPlayer {
      * Sets playing item from playlist.
      * @param {string} playlistItemId The item to play.
      */
-    // eslint-disable-next-line no-unused-vars
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     localSetCurrentPlaylistItem(playlistItemId) {
         // Override
     }
@@ -240,7 +240,7 @@ class GenericPlayer {
      * Removes items from playlist.
      * @param {Array} playlistItemIds The items to remove.
      */
-    // eslint-disable-next-line no-unused-vars
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     localRemoveFromPlaylist(playlistItemIds) {
         // Override
     }
@@ -250,7 +250,7 @@ class GenericPlayer {
      * @param {string} playlistItemId The item to move.
      * @param {number} newIndex The new position.
      */
-    // eslint-disable-next-line no-unused-vars
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     localMovePlaylistItem(playlistItemId, newIndex) {
         // Override
     }
@@ -259,7 +259,7 @@ class GenericPlayer {
      * Queues in the playlist.
      * @param {Object} options Queue data.
      */
-    // eslint-disable-next-line no-unused-vars
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     localQueue(options) {
         // Override
     }
@@ -268,7 +268,7 @@ class GenericPlayer {
      * Queues after the playing item in the playlist.
      * @param {Object} options Queue data.
      */
-    // eslint-disable-next-line no-unused-vars
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     localQueueNext(options) {
         // Override
     }
@@ -291,7 +291,7 @@ class GenericPlayer {
      * Sets repeat mode.
      * @param {string} value The repeat mode.
      */
-    // eslint-disable-next-line no-unused-vars
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     localSetRepeatMode(value) {
         // Override
     }
@@ -300,7 +300,7 @@ class GenericPlayer {
      * Sets shuffle mode.
      * @param {string} value The shuffle mode.
      */
-    // eslint-disable-next-line no-unused-vars
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     localSetQueueShuffleMode(value) {
         // Override
     }

--- a/src/scripts/datetime.js
+++ b/src/scripts/datetime.js
@@ -211,7 +211,7 @@ export function getDisplayDateTime(date) {
     if (typeof date === 'string') {
         try {
             date = parseISO8601Date(date, true);
-        } catch (err) {
+        } catch {
             return date;
         }
     }
@@ -227,7 +227,7 @@ export function getDisplayTime(date) {
     if (typeof date === 'string') {
         try {
             date = parseISO8601Date(date, true);
-        } catch (err) {
+        } catch {
             return date;
         }
     }

--- a/src/scripts/gamepadtokey.js
+++ b/src/scripts/gamepadtokey.js
@@ -178,7 +178,7 @@ function resetThrottle(key) {
 const isElectron = navigator.userAgent.toLowerCase().indexOf('electron') !== -1;
 function allowInput() {
     // This would be nice but always seems to return true with electron
-    if (!isElectron && document.hidden) { /* eslint-disable-line compat/compat */
+    if (!isElectron && document.hidden) {
         return false;
     }
 
@@ -356,7 +356,6 @@ function isGamepadConnected() {
 }
 
 function onFocusOrGamepadAttach() {
-    /* eslint-disable-next-line compat/compat */
     if (isGamepadConnected() && document.hasFocus()) {
         console.log('Gamepad connected! Starting input loop');
         startInputLoop();
@@ -364,7 +363,6 @@ function onFocusOrGamepadAttach() {
 }
 
 function onFocusOrGamepadDetach() {
-    /* eslint-disable-next-line compat/compat */
     if (!isGamepadConnected() || !document.hasFocus()) {
         console.log('Gamepad disconnected! No other gamepads are connected, stopping input loop');
         stopInputLoop();

--- a/src/scripts/keyboardNavigation.js
+++ b/src/scripts/keyboardNavigation.js
@@ -64,7 +64,7 @@ let hasFieldKey = false;
 try {
     hasFieldKey = 'key' in new KeyboardEvent('keydown');
 } catch (e) {
-    console.error("error checking 'key' field");
+    console.error("error checking 'key' field", e);
 }
 
 if (!hasFieldKey) {

--- a/src/scripts/keyboardNavigation.js
+++ b/src/scripts/keyboardNavigation.js
@@ -239,7 +239,7 @@ function attachGamepadScript() {
 }
 
 // No need to check for gamepads manually at load time, the eventhandler will be fired for that
-if (navigator.getGamepads && appSettings.enableGamepad()) { /* eslint-disable-line compat/compat */
+if (navigator.getGamepads && appSettings.enableGamepad()) {
     window.addEventListener('gamepadconnected', attachGamepadScript);
 }
 

--- a/src/scripts/screensavermanager.js
+++ b/src/scripts/screensavermanager.js
@@ -31,7 +31,7 @@ function getScreensaverPlugin(isLoggedIn) {
     let option;
     try {
         option = userSettings.get('screensaver', false);
-    } catch (err) {
+    } catch {
         option = isLoggedIn ? 'backdropscreensaver' : 'logoscreensaver';
     }
 

--- a/src/utils/dashboard.js
+++ b/src/utils/dashboard.js
@@ -61,7 +61,7 @@ export async function serverAddress() {
                 let config;
                 try {
                     config = await resp.json();
-                } catch (err) {
+                } catch {
                     return;
                 }
 

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -9,6 +9,7 @@ function toLocaleStringSupportsOptions() {
  * @returns {number} Randomly generated number.
  */
 export function randomInt(min: number, max: number): number {
+    // eslint-disable-next-line sonarjs/pseudo-random
     return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 


### PR DESCRIPTION
**Changes**
* Use the `@typescript-eslint/no-deprecated` eslint rule instead of `sonarjs/deprecation` as it catches more issues and provides better warning messages
* Fix all autofixable eslint warnings
* Manually fixed/ignored warnings for:
  * Unused vars (and enabled the rule for legacy js)
  * Pseudorandom number generator
  * Alphabetical sort
  * Invariant returns

**Issues**
N/A