### PR TITLE
Allow to scroll partial images in slider

### DIFF
--- a/src/elements/emby-scrollbuttons/utils.ts
+++ b/src/elements/emby-scrollbuttons/utils.ts
@@ -76,7 +76,7 @@ function scrollToWindow({
     let scrollToPosition: number;
 
     if (direction === ScrollDirection.RIGHT) {
-        const nextItem = items[lastVisibleIndex] ? items[lastVisibleIndex] : items[lastVisibleIndex - 1];
+        const nextItem = items[lastVisibleIndex] || items[lastVisibleIndex - 1];
 
         // This will be the position to anchor the item at `lastVisibleIndex` to the start of the view window.
         const nextItemScrollOffset = lastVisibleIndex * nextItem.offsetWidth;


### PR DESCRIPTION

**Changes/Issue**

If tries to access a non-existing image it will throw an JS error. It will go to the image before, and it will scroll, so image is visible.

**Occurrence**

This will happen if last mage is already partially shown, and it tries to access the next image, but this was already the last one. The icons are still active until last image is fully visible.

