### PR TITLE
Improve Album Sort on Songs Tab

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -96,6 +96,7 @@
 - [K. Kyle Puchkov](https://github.com/kepper104)
 - [ItsAllAboutTheCode](https://github.com/ItsAllAboutTheCode)
 - [Jxiced](https://github.com/Jxiced)
+- [Derek Huber](https://github.com/Derek4aty1)
 
 ## Emby Contributors
 

--- a/src/controllers/music/songs.js
+++ b/src/controllers/music/songs.js
@@ -169,7 +169,7 @@ export default function (view, params, tabContent) {
                     id: 'Name'
                 }, {
                     name: globalize.translate('Album'),
-                    id: 'Album,SortName'
+                    id: 'Album,AlbumArtist,SortName'
                 }, {
                     name: globalize.translate('AlbumArtist'),
                     id: 'AlbumArtist,Album,SortName'


### PR DESCRIPTION
**Changes**
* Adds a secondary sorting of Album Artist to the Album sort in the Songs tab

It is rare for the average person to have albums with the same name across different artists, but it is possible. Using "Greatest Hits" as an example, with the current logic, albums songs from Fleetwood Mac's "Greatest Hits" album could be intertwined with The Bangles' "Greatest Hits" album. This PR adds a secondary sort on Album Artist such that this won't happen. The example I used is directly from the issue linked below, where you can see it visually. I reproduced on my end, which prompted me to fix it.

**Issues**
Fixes jellyfin/jellyfin#5733
