### PR TITLE
Fix filter name collisions

### DIFF
--- a/src/components/filterdialog/filterdialog.js
+++ b/src/components/filterdialog/filterdialog.js
@@ -351,7 +351,10 @@ class FilterDialog {
                 const filterName = chkGenreFilter.getAttribute('data-filter');
                 let filters = query.Genres || '';
                 const delimiter = '|';
-                filters = (delimiter + filters).replace(delimiter + filterName, '').substring(1);
+                filters = filters
+                    .split(delimiter)
+                    .filter((f) => f !== filterName)
+                    .join(delimiter);;
                 if (chkGenreFilter.checked) {
                     filters = filters ? (filters + delimiter + filterName) : filterName;
                 }
@@ -365,7 +368,10 @@ class FilterDialog {
                 const filterName = chkTagFilter.getAttribute('data-filter');
                 let filters = query.Tags || '';
                 const delimiter = '|';
-                filters = (delimiter + filters).replace(delimiter + filterName, '').substring(1);
+                filters = filters
+                    .split(delimiter)
+                    .filter((f) => f !== filterName)
+                    .join(delimiter);;
                 if (chkTagFilter.checked) {
                     filters = filters ? (filters + delimiter + filterName) : filterName;
                 }
@@ -379,7 +385,10 @@ class FilterDialog {
                 const filterName = chkYearFilter.getAttribute('data-filter');
                 let filters = query.Years || '';
                 const delimiter = ',';
-                filters = (delimiter + filters).replace(delimiter + filterName, '').substring(1);
+                filters = filters
+                    .split(delimiter)
+                    .filter((f) => f !== filterName)
+                    .join(delimiter);;
                 if (chkYearFilter.checked) {
                     filters = filters ? (filters + delimiter + filterName) : filterName;
                 }
@@ -393,7 +402,10 @@ class FilterDialog {
                 const filterName = chkOfficialRatingFilter.getAttribute('data-filter');
                 let filters = query.OfficialRatings || '';
                 const delimiter = '|';
-                filters = (delimiter + filters).replace(delimiter + filterName, '').substring(1);
+                filters = filters
+                    .split(delimiter)
+                    .filter((f) => f !== filterName)
+                    .join(delimiter);
                 if (chkOfficialRatingFilter.checked) {
                     filters = filters ? (filters + delimiter + filterName) : filterName;
                 }


### PR DESCRIPTION
fix: filter with delimiter generation closes #6702

**Changes**
for filters with delimiter current implementation uses string.replace function to remove duplicate filter if added. but if i add a filter that is prefix of existing filter then the prefix for item is getting removed and creates a filter that does not represent previous filters

example as in #6702
FSK-12 and AL are preapplied filters, user now tryes to add A
```javascript
("FSK-12|AL").replace("|A")
```
will run resulting in "FSK-12L" after filtering existing
then after addition it will become "FSK-12L|A"

this PR replaces the logic for above by converting the existing filter to Array and removing the checked / unchecked / selected Filter.

![Screenshot From 2025-04-06 04-35-02](https://github.com/user-attachments/assets/905bb257-1bf2-4fec-a75d-a5a4ac988b2a)



**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #6702 
