### PR TITLE
Enable "Network Discovery" section in Networking settings

### DIFF
--- a/src/apps/dashboard/controllers/networking.html
+++ b/src/apps/dashboard/controllers/networking.html
@@ -125,7 +125,7 @@
                     </fieldset>
 
 
-                    <fieldset class='verticalSection verticalSection-extrabottompadding hide'>
+                    <fieldset class='verticalSection verticalSection-extrabottompadding'>
                         <legend><h3>${HeaderAutoDiscovery}</h3></legend>
                         <div class="checkboxContainer checkboxContainer-withDescription">
                             <label>


### PR DESCRIPTION
This PR enables the "Network Discovery" section in the Networking settings of the web interface, such that this setting can be disabled without modifying the `network.xml` file directly.
In a production deplyment I can access this setting by using the browser inspector to remove the `hide` css class, and then (after a jellyfin restart) verify that port 7359 is no longer being listened on (with `ss -lu | grep 7359`), so I am fairly certain that this change would work as expected.

**Changes**
* Remove `hide` property from "Auto Discovery" section

**Issues**
No particular issue, it just feels unnecessary to hide this setting from the web interface when all the code to enable/disable AutoDiscovery on the server is already in place. At least one other user (according to [a comment in jellyfin PR7038](https://github.com/jellyfin/jellyfin/pull/7038#issuecomment-1000539107)) did not like this option not being available in the web interface.
