### PR TITLE
Add eslint rules for large imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -128,7 +128,35 @@ export default tseslint.config(
             '@stylistic/quotes': ['error', 'single', { 'avoidEscape': true, 'allowTemplateLiterals': false }],
             '@stylistic/semi': 'error',
             '@stylistic/space-before-blocks': 'error',
-            '@stylistic/space-infix-ops': 'error'
+            '@stylistic/space-infix-ops': 'error',
+
+            '@typescript-eslint/no-restricted-imports': [
+                'error',
+                {
+                    paths: [
+                        {
+                            name: '@jellyfin/sdk/lib/generated-client',
+                            message: 'Use direct file imports for tree-shaking',
+                            allowTypeImports: true
+                        },
+                        {
+                            name: '@jellyfin/sdk/lib/generated-client/api',
+                            message: 'Use direct file imports for tree-shaking',
+                            allowTypeImports: true
+                        },
+                        {
+                            name: '@jellyfin/sdk/lib/generated-client/models',
+                            message: 'Use direct file imports for tree-shaking',
+                            allowTypeImports: true
+                        },
+                        {
+                            name: '@mui/material',
+                            message: 'Use direct file imports for tree-shaking',
+                            allowTypeImports: true
+                        }
+                    ]
+                }
+            ]
         }
     },
 

--- a/src/apps/dashboard/components/UserAvatarButton.tsx
+++ b/src/apps/dashboard/components/UserAvatarButton.tsx
@@ -1,6 +1,6 @@
 import type { UserDto } from '@jellyfin/sdk/lib/generated-client/models/user-dto';
 import type { SxProps, Theme } from '@mui/material';
-import IconButton from '@mui/material/IconButton/IconButton';
+import IconButton from '@mui/material/IconButton';
 import React, { type FC } from 'react';
 import { Link } from 'react-router-dom';
 

--- a/src/apps/dashboard/components/toolbar/HelpButton.tsx
+++ b/src/apps/dashboard/components/toolbar/HelpButton.tsx
@@ -1,5 +1,5 @@
 import HelpOutline from '@mui/icons-material/HelpOutline';
-import IconButton from '@mui/material/IconButton/IconButton';
+import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip/Tooltip';
 import React from 'react';
 import { Route, Routes } from 'react-router-dom';

--- a/src/apps/dashboard/features/activity/components/ActionsCell.tsx
+++ b/src/apps/dashboard/features/activity/components/ActionsCell.tsx
@@ -1,4 +1,4 @@
-import IconButton from '@mui/material/IconButton/IconButton';
+import IconButton from '@mui/material/IconButton';
 import PermMedia from '@mui/icons-material/PermMedia';
 import React, { type FC } from 'react';
 import { Link } from 'react-router-dom';

--- a/src/apps/dashboard/features/keys/api/useRevokeKey.ts
+++ b/src/apps/dashboard/features/keys/api/useRevokeKey.ts
@@ -1,4 +1,4 @@
-import { ApiKeyApiRevokeKeyRequest } from '@jellyfin/sdk/lib/generated-client';
+import type { ApiKeyApiRevokeKeyRequest } from '@jellyfin/sdk/lib/generated-client';
 import { getApiKeyApi } from '@jellyfin/sdk/lib/utils/api/api-key-api';
 import { useMutation } from '@tanstack/react-query';
 import { useApi } from 'hooks/useApi';

--- a/src/apps/dashboard/features/plugins/components/PluginRevisions.tsx
+++ b/src/apps/dashboard/features/plugins/components/PluginRevisions.tsx
@@ -1,3 +1,4 @@
+import type { VersionInfo } from '@jellyfin/sdk/lib/generated-client';
 import Download from '@mui/icons-material/Download';
 import DownloadDone from '@mui/icons-material/DownloadDone';
 import ExpandMore from '@mui/icons-material/ExpandMore';
@@ -13,7 +14,6 @@ import { getDisplayDateTime } from 'scripts/datetime';
 import globalize from 'lib/globalize';
 
 import type { PluginDetails } from '../types/PluginDetails';
-import { VersionInfo } from '@jellyfin/sdk/lib/generated-client';
 
 interface PluginRevisionsProps {
     pluginDetails?: PluginDetails,

--- a/src/apps/dashboard/routes/devices/index.tsx
+++ b/src/apps/dashboard/routes/devices/index.tsx
@@ -3,7 +3,7 @@ import Delete from '@mui/icons-material/Delete';
 import Edit from '@mui/icons-material/Edit';
 import Box from '@mui/material/Box/Box';
 import Button from '@mui/material/Button/Button';
-import IconButton from '@mui/material/IconButton/IconButton';
+import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip/Tooltip';
 import parseISO from 'date-fns/parseISO';
 import { type MRT_ColumnDef, useMaterialReactTable } from 'material-react-table';

--- a/src/apps/experimental/components/library/GridListViewButton.tsx
+++ b/src/apps/experimental/components/library/GridListViewButton.tsx
@@ -1,7 +1,9 @@
 import React, { FC, useCallback } from 'react';
-import { ButtonGroup, IconButton } from '@mui/material';
+import ButtonGroup from '@mui/material/ButtonGroup/ButtonGroup';
+import IconButton from '@mui/material/IconButton';
 import ViewModuleIcon from '@mui/icons-material/ViewModule';
 import ViewListIcon from '@mui/icons-material/ViewList';
+
 import globalize from 'lib/globalize';
 import { LibraryViewSettings, ViewMode } from 'types/library';
 import { LibraryTab } from 'types/libraryTab';

--- a/src/apps/experimental/components/library/ItemsView.tsx
+++ b/src/apps/experimental/components/library/ItemsView.tsx
@@ -1,6 +1,6 @@
 import type { BaseItemKind } from '@jellyfin/sdk/lib/generated-client/models/base-item-kind';
 import { CollectionType } from '@jellyfin/sdk/lib/generated-client/models/collection-type';
-import { ImageType } from '@jellyfin/sdk/lib/generated-client';
+import { ImageType } from '@jellyfin/sdk/lib/generated-client/models/image-type';
 import { ItemSortBy } from '@jellyfin/sdk/lib/generated-client/models/item-sort-by';
 import React, { type FC, useCallback } from 'react';
 import Box from '@mui/material/Box';

--- a/src/apps/experimental/components/library/NewCollectionButton.tsx
+++ b/src/apps/experimental/components/library/NewCollectionButton.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useCallback } from 'react';
-import { IconButton } from '@mui/material';
+import IconButton from '@mui/material/IconButton';
 import AddIcon from '@mui/icons-material/Add';
 import globalize from 'lib/globalize';
 

--- a/src/apps/experimental/components/library/PlayAllButton.tsx
+++ b/src/apps/experimental/components/library/PlayAllButton.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useCallback } from 'react';
-import { IconButton } from '@mui/material';
+import IconButton from '@mui/material/IconButton';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 
 import { playbackManager } from 'components/playback/playbackmanager';

--- a/src/apps/experimental/components/library/QueueButton.tsx
+++ b/src/apps/experimental/components/library/QueueButton.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useCallback } from 'react';
-import { IconButton } from '@mui/material';
+import IconButton from '@mui/material/IconButton';
 import QueueIcon from '@mui/icons-material/Queue';
 
 import { playbackManager } from 'components/playback/playbackmanager';

--- a/src/apps/experimental/components/library/ShuffleButton.tsx
+++ b/src/apps/experimental/components/library/ShuffleButton.tsx
@@ -1,6 +1,6 @@
 import { ItemSortBy } from '@jellyfin/sdk/lib/generated-client/models/item-sort-by';
 import React, { FC, useCallback } from 'react';
-import { IconButton } from '@mui/material';
+import IconButton from '@mui/material/IconButton';
 import ShuffleIcon from '@mui/icons-material/Shuffle';
 
 import { playbackManager } from 'components/playback/playbackmanager';

--- a/src/apps/experimental/components/library/SortButton.tsx
+++ b/src/apps/experimental/components/library/SortButton.tsx
@@ -1,3 +1,5 @@
+import { ItemSortBy } from '@jellyfin/sdk/lib/generated-client/models/item-sort-by';
+import { SortOrder } from '@jellyfin/sdk/lib/generated-client/models/sort-order';
 import React, { FC, useCallback } from 'react';
 import IconButton from '@mui/material/IconButton';
 import MenuItem from '@mui/material/MenuItem';
@@ -13,8 +15,6 @@ import SortByAlphaIcon from '@mui/icons-material/SortByAlpha';
 import globalize from 'lib/globalize';
 import { LibraryViewSettings } from 'types/library';
 import { LibraryTab } from 'types/libraryTab';
-import { ItemSortBy } from '@jellyfin/sdk/lib/generated-client/models/item-sort-by';
-import { SortOrder } from '@jellyfin/sdk/lib/generated-client';
 
 type SortOption = {
     label: string;

--- a/src/apps/experimental/components/library/ViewSettingsButton.tsx
+++ b/src/apps/experimental/components/library/ViewSettingsButton.tsx
@@ -1,4 +1,4 @@
-import { ImageType } from '@jellyfin/sdk/lib/generated-client';
+import { ImageType } from '@jellyfin/sdk/lib/generated-client/models/image-type';
 import React, { FC, useCallback } from 'react';
 
 import IconButton from '@mui/material/IconButton';

--- a/src/apps/experimental/components/library/filter/FilterButton.tsx
+++ b/src/apps/experimental/components/library/filter/FilterButton.tsx
@@ -9,8 +9,8 @@ import MuiAccordionDetails from '@mui/material/AccordionDetails';
 import MuiAccordionSummary, {
     AccordionSummaryProps
 } from '@mui/material/AccordionSummary';
+import Badge from '@mui/material/Badge';
 import IconButton from '@mui/material/IconButton';
-import { Badge } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
 

--- a/src/apps/experimental/components/library/filter/FiltersSeriesStatus.tsx
+++ b/src/apps/experimental/components/library/filter/FiltersSeriesStatus.tsx
@@ -1,10 +1,11 @@
+import { SeriesStatus } from '@jellyfin/sdk/lib/generated-client/models/series-status';
 import React, { FC, useCallback } from 'react';
 import FormGroup from '@mui/material/FormGroup';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Checkbox from '@mui/material/Checkbox';
+
 import globalize from 'lib/globalize';
 import { LibraryViewSettings } from 'types/library';
-import { SeriesStatus } from '@jellyfin/sdk/lib/generated-client';
 
 const statusFiltersOptions = [
     { label: 'Continuing', value: SeriesStatus.Continuing },

--- a/src/apps/experimental/components/library/filter/FiltersStatus.tsx
+++ b/src/apps/experimental/components/library/filter/FiltersStatus.tsx
@@ -1,10 +1,11 @@
+import { ItemFilter } from '@jellyfin/sdk/lib/generated-client/models/item-filter';
 import React, { FC, useCallback } from 'react';
 import FormGroup from '@mui/material/FormGroup';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Checkbox from '@mui/material/Checkbox';
+
 import globalize from 'lib/globalize';
 import { LibraryViewSettings } from 'types/library';
-import { ItemFilter } from '@jellyfin/sdk/lib/generated-client';
 import { LibraryTab } from 'types/libraryTab';
 
 const statusFiltersOptions = [

--- a/src/apps/experimental/components/library/filter/FiltersVideoTypes.tsx
+++ b/src/apps/experimental/components/library/filter/FiltersVideoTypes.tsx
@@ -1,9 +1,10 @@
+import { VideoType } from '@jellyfin/sdk/lib/generated-client/models/video-type';
 import React, { FC, useCallback } from 'react';
 import FormGroup from '@mui/material/FormGroup';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Checkbox from '@mui/material/Checkbox';
+
 import { LibraryViewSettings, VideoBasicFilter } from 'types/library';
-import { VideoType } from '@jellyfin/sdk/lib/generated-client';
 
 const videoBasicFilterOptions = [
     { label: 'SD', value: VideoBasicFilter.IsSD },

--- a/src/apps/experimental/features/details/components/buttons/CancelSeriesTimerButton.tsx
+++ b/src/apps/experimental/features/details/components/buttons/CancelSeriesTimerButton.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { IconButton } from '@mui/material';
+import IconButton from '@mui/material/IconButton';
 import DeleteIcon from '@mui/icons-material/Delete';
 
 import { useCancelSeriesTimer } from 'hooks/api/liveTvHooks';

--- a/src/apps/experimental/features/details/components/buttons/CancelTimerButton.tsx
+++ b/src/apps/experimental/features/details/components/buttons/CancelTimerButton.tsx
@@ -1,7 +1,8 @@
 import React, { FC, useCallback } from 'react';
-import { IconButton } from '@mui/material';
+import IconButton from '@mui/material/IconButton';
 import StopIcon from '@mui/icons-material/Stop';
 import { useQueryClient } from '@tanstack/react-query';
+
 import { useCancelTimer } from 'hooks/api/liveTvHooks';
 import globalize from 'lib/globalize';
 import loading from 'components/loading/loading';

--- a/src/apps/experimental/features/details/components/buttons/DownloadButton.tsx
+++ b/src/apps/experimental/features/details/components/buttons/DownloadButton.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useCallback } from 'react';
-import { IconButton } from '@mui/material';
+import IconButton from '@mui/material/IconButton';
 import FileDownloadIcon from '@mui/icons-material/FileDownload';
+
 import { useGetDownload } from 'hooks/api/libraryHooks';
 import globalize from 'lib/globalize';
 import { download } from 'scripts/fileDownloader';

--- a/src/apps/experimental/features/details/components/buttons/InstantMixButton.tsx
+++ b/src/apps/experimental/features/details/components/buttons/InstantMixButton.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useCallback } from 'react';
-import { IconButton } from '@mui/material';
+import IconButton from '@mui/material/IconButton';
 import ExploreIcon from '@mui/icons-material/Explore';
+
 import { playbackManager } from 'components/playback/playbackmanager';
 import globalize from 'lib/globalize';
 import type { ItemDto } from 'types/base/models/item-dto';

--- a/src/apps/experimental/features/details/components/buttons/MoreCommandsButton.tsx
+++ b/src/apps/experimental/features/details/components/buttons/MoreCommandsButton.tsx
@@ -1,7 +1,8 @@
 import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
-import { IconButton } from '@mui/material';
+import IconButton from '@mui/material/IconButton';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import { useQueryClient } from '@tanstack/react-query';
+
 import { useApi } from 'hooks/useApi';
 import { useGetItemByType } from '../../hooks/api/useGetItemByType';
 import globalize from 'lib/globalize';

--- a/src/apps/experimental/features/details/components/buttons/PlayOrResumeButton.tsx
+++ b/src/apps/experimental/features/details/components/buttons/PlayOrResumeButton.tsx
@@ -1,8 +1,9 @@
 import React, { FC, useCallback, useMemo } from 'react';
-import { IconButton } from '@mui/material';
+import IconButton from '@mui/material/IconButton';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import ReplayIcon from '@mui/icons-material/Replay';
 import { useQueryClient } from '@tanstack/react-query';
+
 import { useApi } from 'hooks/useApi';
 import { getChannelQuery } from 'hooks/api/liveTvHooks/useGetChannel';
 import globalize from 'lib/globalize';

--- a/src/apps/experimental/features/details/components/buttons/PlayTrailerButton.tsx
+++ b/src/apps/experimental/features/details/components/buttons/PlayTrailerButton.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useCallback } from 'react';
-import { IconButton } from '@mui/material';
+import IconButton from '@mui/material/IconButton';
 import TheatersIcon from '@mui/icons-material/Theaters';
+
 import { playbackManager } from 'components/playback/playbackmanager';
 import globalize from 'lib/globalize';
 import type { ItemDto } from 'types/base/models/item-dto';

--- a/src/apps/experimental/features/details/components/buttons/ShuffleButton.tsx
+++ b/src/apps/experimental/features/details/components/buttons/ShuffleButton.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useCallback } from 'react';
-import { IconButton } from '@mui/material';
+import IconButton from '@mui/material/IconButton';
 import ShuffleIcon from '@mui/icons-material/Shuffle';
 
 import { playbackManager } from 'components/playback/playbackmanager';

--- a/src/apps/experimental/features/details/components/buttons/SplitVersionsButton.tsx
+++ b/src/apps/experimental/features/details/components/buttons/SplitVersionsButton.tsx
@@ -1,7 +1,8 @@
 import React, { FC, useCallback } from 'react';
-import { IconButton } from '@mui/material';
+import IconButton from '@mui/material/IconButton';
 import CallSplitIcon from '@mui/icons-material/CallSplit';
 import { useQueryClient } from '@tanstack/react-query';
+
 import { useDeleteAlternateSources } from 'hooks/api/videosHooks';
 import globalize from 'lib/globalize';
 import confirm from 'components/confirm/confirm';

--- a/src/apps/stable/features/search/api/useSearchSuggestions.ts
+++ b/src/apps/stable/features/search/api/useSearchSuggestions.ts
@@ -1,9 +1,10 @@
 import type { AxiosRequestConfig } from 'axios';
 import type { Api } from '@jellyfin/sdk';
-import { ItemSortBy } from '@jellyfin/sdk/lib/generated-client';
 import { BaseItemKind } from '@jellyfin/sdk/lib/generated-client/models/base-item-kind';
+import { ItemSortBy } from '@jellyfin/sdk/lib/generated-client/models/item-sort-by';
 import { getItemsApi } from '@jellyfin/sdk/lib/utils/api/items-api';
 import { useQuery } from '@tanstack/react-query';
+
 import { useApi } from 'hooks/useApi';
 
 const fetchGetItems = async (

--- a/src/components/common/Media.tsx
+++ b/src/components/common/Media.tsx
@@ -1,5 +1,7 @@
-import { BaseItemKind, ImageType } from '@jellyfin/sdk/lib/generated-client';
+import { BaseItemKind } from '@jellyfin/sdk/lib/generated-client/models/base-item-kind';
+import { ImageType } from '@jellyfin/sdk/lib/generated-client/models/image-type';
 import React, { type FC } from 'react';
+
 import Image from './Image';
 import DefaultIconText from './DefaultIconText';
 import type { ItemDto } from 'types/base/models/item-dto';

--- a/src/components/listview/List/ListViewUserDataButtons.tsx
+++ b/src/components/listview/List/ListViewUserDataButtons.tsx
@@ -1,5 +1,6 @@
 import React, { type FC } from 'react';
-import { Box } from '@mui/material';
+import Box from '@mui/material/Box';
+
 import itemHelper from '../../itemHelper';
 import PlayedButton from 'elements/emby-playstatebutton/PlayedButton';
 import FavoriteButton from 'elements/emby-ratingbutton/FavoriteButton';

--- a/src/components/listview/List/listHelper.ts
+++ b/src/components/listview/List/listHelper.ts
@@ -1,8 +1,9 @@
 import { Api } from '@jellyfin/sdk';
-import { BaseItemKind, ImageType } from '@jellyfin/sdk/lib/generated-client';
+import { BaseItemKind } from '@jellyfin/sdk/lib/generated-client/models/base-item-kind';
+import { ImageType } from '@jellyfin/sdk/lib/generated-client/models/image-type';
 import { getImageApi } from '@jellyfin/sdk/lib/utils/api/image-api';
-import globalize from 'lib/globalize';
 
+import globalize from 'lib/globalize';
 import type { ItemDto } from 'types/base/models/item-dto';
 import type { ListOptions } from 'types/listOptions';
 

--- a/src/components/metadataEditor/personEditor.js
+++ b/src/components/metadataEditor/personEditor.js
@@ -1,8 +1,8 @@
+import { PersonKind } from '@jellyfin/sdk/lib/generated-client/models/person-kind';
 
 import dialogHelper from '../dialogHelper/dialogHelper';
 import layoutManager from '../layoutManager';
 import globalize from '../../lib/globalize';
-import { PersonKind } from '@jellyfin/sdk/lib/generated-client';
 import '../../elements/emby-button/paper-icon-button-light';
 import '../../elements/emby-input/emby-input';
 import '../../elements/emby-select/emby-select';

--- a/src/components/themeMediaPlayer.js
+++ b/src/components/themeMediaPlayer.js
@@ -1,3 +1,4 @@
+import { ItemSortBy } from '@jellyfin/sdk/lib/generated-client/models/item-sort-by';
 import { MediaType } from '@jellyfin/sdk/lib/generated-client/models/media-type';
 import { getLibraryApi } from '@jellyfin/sdk/lib/utils/api/library-api';
 
@@ -10,7 +11,6 @@ import { queryClient } from 'utils/query/queryClient';
 
 import { playbackManager } from './playback/playbackmanager';
 import ServerConnections from './ServerConnections';
-import { ItemSortBy } from '@jellyfin/sdk/lib/generated-client';
 
 let currentOwnerId;
 let currentThemeIds = [];

--- a/src/elements/emby-itemscontainer/ItemsContainer.tsx
+++ b/src/elements/emby-itemscontainer/ItemsContainer.tsx
@@ -1,13 +1,12 @@
-import {
-    MediaType,
-    type LibraryUpdateInfo
-} from '@jellyfin/sdk/lib/generated-client';
+import type { LibraryUpdateInfo } from '@jellyfin/sdk/lib/generated-client/models/library-update-info';
+import { MediaType } from '@jellyfin/sdk/lib/generated-client/models/media-type';
 import { ApiClient } from 'jellyfin-apiclient';
 import React, { type FC, type PropsWithChildren, useCallback, useEffect, useRef } from 'react';
 import classNames from 'classnames';
 import Box from '@mui/material/Box';
 import Sortable from 'sortablejs';
 import { useQueryClient } from '@tanstack/react-query';
+
 import { usePlaylistsMoveItemMutation } from 'hooks/useFetchItems';
 import Events, { type Event } from 'utils/events';
 import serverNotifications from 'scripts/serverNotifications';

--- a/src/elements/emby-playstatebutton/PlayedButton.tsx
+++ b/src/elements/emby-playstatebutton/PlayedButton.tsx
@@ -1,9 +1,10 @@
 import { BaseItemKind } from '@jellyfin/sdk/lib/generated-client/models/base-item-kind';
 import { useQueryClient } from '@tanstack/react-query';
 import React, { type FC, useCallback } from 'react';
+import IconButton from '@mui/material/IconButton';
 import CheckIcon from '@mui/icons-material/Check';
-import { IconButton } from '@mui/material';
 import classNames from 'classnames';
+
 import globalize from 'lib/globalize';
 import { useTogglePlayedMutation } from 'hooks/useFetchItems';
 

--- a/src/elements/emby-ratingbutton/FavoriteButton.tsx
+++ b/src/elements/emby-ratingbutton/FavoriteButton.tsx
@@ -1,7 +1,8 @@
 import React, { type FC, useCallback } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
+import IconButton from '@mui/material/IconButton';
 import FavoriteIcon from '@mui/icons-material/Favorite';
-import { IconButton } from '@mui/material';
+
 import classNames from 'classnames';
 import { useToggleFavoriteMutation } from 'hooks/useFetchItems';
 import globalize from 'lib/globalize';

--- a/src/themes/UserThemeProvider.tsx
+++ b/src/themes/UserThemeProvider.tsx
@@ -1,4 +1,4 @@
-import { ThemeProvider } from '@mui/material';
+import { ThemeProvider } from '@mui/material/styles';
 import React, { type FC, type PropsWithChildren, useState, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 

--- a/src/types/sections.ts
+++ b/src/types/sections.ts
@@ -1,5 +1,7 @@
-import { BaseItemKind, SortOrder } from '@jellyfin/sdk/lib/generated-client';
-import { ItemSortBy } from '@jellyfin/sdk/lib/generated-client/models/item-sort-by';
+import type { BaseItemKind } from '@jellyfin/sdk/lib/generated-client/models/base-item-kind';
+import type { ItemSortBy } from '@jellyfin/sdk/lib/generated-client/models/item-sort-by';
+import type { SortOrder } from '@jellyfin/sdk/lib/generated-client/models/sort-order';
+
 import { CardOptions } from './cardOptions';
 import { SectionsView } from './libraryTabContent';
 


### PR DESCRIPTION
**Changes**
* Adds eslint rules to prevent bulk import of large libraries. Specifically the SDK and MUI should use direct file imports to help with tree-shaking for smaller bundle sizes. We have been manually suggesting this as part of reviews, but clearly missed some. :sweat_smile: 

**Issues**
N/A
