### PR TITLE
Remove index.html redirects

### DIFF
--- a/src/apps/wizard/controllers/finish/index.js
+++ b/src/apps/wizard/controllers/finish/index.js
@@ -9,7 +9,7 @@ function onFinish() {
         type: 'POST'
     }).then(function () {
         loading.hide();
-        window.location.href = 'index.html';
+        window.location.href = '';
     });
 }
 

--- a/src/controllers/session/resetPassword/index.js
+++ b/src/controllers/session/resetPassword/index.js
@@ -11,7 +11,7 @@ function processForgotPasswordResult(result) {
             message: msg,
             title: globalize.translate('HeaderPasswordReset'),
             callback: function () {
-                window.location.href = 'index.html';
+                window.location.href = '';
             }
         });
         return;


### PR DESCRIPTION
**Changes**
We haven't required explicitly using `index.html` since [10.9.0](https://github.com/jellyfin/jellyfin/pull/9776)

**Issues**
N/A
