### PR TITLE
Update subtitle position styling

### DIFF
--- a/src/components/subtitlesettings/subtitleappearancehelper.js
+++ b/src/components/subtitlesettings/subtitleappearancehelper.js
@@ -103,7 +103,7 @@ function getTextStyles(settings, preview) {
         const lineHeight = 1.35; // FIXME: It is better to read this value from element
         const line = Math.abs(pos * lineHeight);
         if (pos < 0) {
-            list.push({ name: 'margin-bottom', value: `${line}em` });
+            list.push({ name: 'margin-bottom', value: `${line - 1}em` });
             list.push({ name: 'margin-top', value: '' });
         } else {
             list.push({ name: 'margin-bottom', value: '' });

--- a/src/components/subtitlesettings/subtitleappearancehelper.js
+++ b/src/components/subtitlesettings/subtitleappearancehelper.js
@@ -101,13 +101,14 @@ function getTextStyles(settings, preview) {
     if (!preview) {
         const pos = parseInt(settings.verticalPosition, 10);
         const lineHeight = 1.35; // FIXME: It is better to read this value from element
-        const line = Math.abs(pos * lineHeight);
         if (pos < 0) {
-            list.push({ name: 'margin-bottom', value: `${line - 1}em` });
+            const margin = Math.abs(pos + 1) * lineHeight;
+            list.push({ name: 'margin-bottom', value: `${margin}em` });
             list.push({ name: 'margin-top', value: '' });
         } else {
+            const margin = pos * lineHeight;
             list.push({ name: 'margin-bottom', value: '' });
-            list.push({ name: 'margin-top', value: `${line}em` });
+            list.push({ name: 'margin-top', value: `${margin}em` });
         }
     }
 

--- a/src/components/subtitlesettings/subtitleappearancehelper.js
+++ b/src/components/subtitlesettings/subtitleappearancehelper.js
@@ -103,10 +103,10 @@ function getTextStyles(settings, preview) {
         const lineHeight = 1.35; // FIXME: It is better to read this value from element
         const line = Math.abs(pos * lineHeight);
         if (pos < 0) {
-            list.push({ name: 'min-height', value: `${line}em` });
+            list.push({ name: 'margin-bottom', value: `${line}em` });
             list.push({ name: 'margin-top', value: '' });
         } else {
-            list.push({ name: 'min-height', value: '' });
+            list.push({ name: 'margin-bottom', value: '' });
             list.push({ name: 'margin-top', value: `${line}em` });
         }
     }

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1532,10 +1532,16 @@ export class HtmlVideoPlayer {
             // in safari, the cues need to be added before setting the track mode to showing
             for (const trackEvent of data.TrackEvents) {
                 const TrackCue = window.VTTCue || window.TextTrackCue;
-                const cue = new TrackCue(trackEvent.StartPositionTicks / 10000000, trackEvent.EndPositionTicks / 10000000, normalizeTrackEventText(trackEvent.Text, false));
+                const text = normalizeTrackEventText(trackEvent.Text, false);
+                const cue = new TrackCue(trackEvent.StartPositionTicks / 10000000, trackEvent.EndPositionTicks / 10000000, text);
 
                 if (cue.line === 'auto') {
-                    cue.line = cueLine;
+                    if (cueLine < 0) {
+                        const lineCount = (text.match(/\n/g) || []).length;
+                        cue.line = cueLine - lineCount;
+                    } else {
+                        cue.line = cueLine;
+                    }
                 }
 
                 trackElement.addCue(cue);

--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -38,7 +38,7 @@ function filterQuerySettings(query, allowedItems) {
 }
 
 const defaultSubtitleAppearanceSettings = {
-    verticalPosition: -3
+    verticalPosition: -2
 };
 
 const defaultComicsPlayerSettings = {

--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -38,7 +38,7 @@ function filterQuerySettings(query, allowedItems) {
 }
 
 const defaultSubtitleAppearanceSettings = {
-    verticalPosition: -2
+    verticalPosition: -3
 };
 
 const defaultComicsPlayerSettings = {


### PR DESCRIPTION
**Changes**
* Updates the positioning of subtitles when they are bottom aligned to maintain a constant spacing from the bottom of the screen

**Single Line**

| position | current | updated |
|---|---|---|
| -4 | | |
| -3 | line 1 | line 1 |
| -2 | | |
| -1 | | |

**Two Lines**

| position | current | updated |
|---|---|---|
| -4 | | line 1 |
| -3 | line 1 | line 2 |
| -2 | line 2 | |
| -1 | | |

**Four Lines**

| position | current | updated |
|---|---|---|
| -6 | | line 1 |
| -5 | | line 2 |
| -4 | line 1 | line 3 |
| -3 | line 2 | line 4 |
| -2 | line 3 | |
| -1 | line 4 | |

**Issues**
https://features.jellyfin.org/posts/3210/subtitle-position-correction-adjustment-line-1-2