### PR TITLE
Fix item details page not filling desktop screen

### DIFF
--- a/src/styles/librarybrowser.scss
+++ b/src/styles/librarybrowser.scss
@@ -581,10 +581,10 @@
             height: 30vh;
         }
     }
-}
 
-.layout-tv .itemBackdrop {
-    display: none;
+    .layout-tv & {
+        display: none;
+    }
 }
 
 .detailPageContent {
@@ -845,10 +845,14 @@
 
 .detailPageSecondaryContainer {
     padding-top: 1.25em;
-}
 
-.layout-mobile .detailPageSecondaryContainer {
-    padding-top: 1em;
+    .layout-desktop & {
+        flex-grow: 1;
+    }
+
+    .layout-mobile & {
+        padding-top: 1em;
+    }
 }
 
 .detailImageContainer .card {
@@ -1168,6 +1172,12 @@ div.itemDetailGalleryLink.defaultCardBackground {
 .detailPageWrapperContainer {
     border-spacing: 0;
     border-collapse: collapse;
+
+    .layout-desktop & {
+        display: flex;
+        flex-direction: column;
+        min-height: 60vh;
+    }
 }
 
 .mediaInfoContent .btnCopy .material-icons {


### PR DESCRIPTION
**Changes**
* Fixes an issue where the item details page might not fill the bottom of the screen

| Before | After |
|---|---|
| ![Screenshot 2025-04-15 at 14-36-10 Jellyfin](https://github.com/user-attachments/assets/ed69cbce-478d-4fde-a2b9-2b71d987d2ea) | ![Screenshot 2025-04-15 at 14-36-00 Jellyfin Edge](https://github.com/user-attachments/assets/cad0886b-1385-4e05-a98a-838d5405f09a) |


**Issues**
N/A