### PR TITLE
Update filter icons

### DIFF
--- a/src/controllers/list.html
+++ b/src/controllers/list.html
@@ -34,13 +34,13 @@
                 <span class="material-icons btnSortIcon arrow_upward" aria-hidden="true"></span>
             </button>
             <button is="paper-icon-button-light" class="btnSort hide listIconButton-autohide" title="${Sort}">
-                <span class="material-icons sort" aria-hidden="true"></span>
+                <span class="material-icons sort_by_alpha" aria-hidden="true"></span>
             </button>
             <button is="emby-button" class="btnFilter button-flat listTextButton-autohide">
                 <span>${Filter}</span>
             </button>
             <button is="paper-icon-button-light" class="btnFilter listIconButton-autohide" data-ripple="false" style="overflow:visible;" title="${Filter}">
-                <span class="material-icons filter_list" aria-hidden="true"></span>
+                <span class="material-icons filter_alt" aria-hidden="true"></span>
             </button>
             <button is="emby-button" class="btnViewSettings button-flat listTextButton-autohide" title="${ButtonMore}">
                 <span class="material-icons more_vert" aria-hidden="true"></span>

--- a/src/controllers/livetv.html
+++ b/src/controllers/livetv.html
@@ -62,7 +62,7 @@
             <div class="flex align-items-center justify-content-center flex-wrap-wrap padded-top padded-left padded-right padded-bottom focuscontainer-x">
                 <div class="paging"></div>
                 <div class="btnFilter-wrapper">
-                    <button is="paper-icon-button-light" class="btnFilter sectionTitleButton" title="${Filter}"><span class="material-icons filter_list" aria-hidden="true"></span></button>
+                    <button is="paper-icon-button-light" class="btnFilter sectionTitleButton" title="${Filter}"><span class="material-icons filter_alt" aria-hidden="true"></span></button>
                 </div>
             </div>
             <div is="emby-itemscontainer" id="items" class="itemsContainer vertical-wrap padded-left padded-right"></div>

--- a/src/controllers/movies/movies.html
+++ b/src/controllers/movies/movies.html
@@ -7,7 +7,7 @@
             <button is="paper-icon-button-light" class="btnSelectView autoSize" title="${ButtonSelectView}"><span class="material-icons view_comfy" aria-hidden="true"></span></button>
             <button is="paper-icon-button-light" class="btnSort autoSize" title="${Sort}"><span class="material-icons sort_by_alpha" aria-hidden="true"></span></button>
             <div class="btnFilter-wrapper">
-                <button is="paper-icon-button-light" class="btnFilter autoSize" title="${Filter}"><span class="material-icons filter_list" aria-hidden="true"></span></button>
+                <button is="paper-icon-button-light" class="btnFilter autoSize" title="${Filter}"><span class="material-icons filter_alt" aria-hidden="true"></span></button>
             </div>
         </div>
 

--- a/src/controllers/music/music.html
+++ b/src/controllers/music/music.html
@@ -16,7 +16,7 @@
             <button is="paper-icon-button-light" class="btnSelectView autoSize" title="${ButtonSelectView}"><span class="material-icons view_comfy" aria-hidden="true"></span></button>
             <button is="paper-icon-button-light" class="btnSort autoSize" title="${Sort}"><span class="material-icons sort_by_alpha" aria-hidden="true"></span></button>
             <div class="btnFilter-wrapper">
-                <button is="paper-icon-button-light" class="btnFilter autoSize" title="${Filter}"><span class="material-icons filter_list" aria-hidden="true"></span></button>
+                <button is="paper-icon-button-light" class="btnFilter autoSize" title="${Filter}"><span class="material-icons filter_alt" aria-hidden="true"></span></button>
             </div>
         </div>
 
@@ -60,7 +60,7 @@
             <div class="paging"></div>
             <button is="paper-icon-button-light" class="btnSelectView autoSize" title="${ButtonSelectView}"><span class="material-icons view_comfy" aria-hidden="true"></span></button>
             <div class="btnFilter-wrapper">
-                <button is="paper-icon-button-light" class="btnFilter autoSize" title="${Filter}"><span class="material-icons filter_list" aria-hidden="true"></span></button>
+                <button is="paper-icon-button-light" class="btnFilter autoSize" title="${Filter}"><span class="material-icons filter_alt" aria-hidden="true"></span></button>
             </div>
         </div>
 
@@ -78,7 +78,7 @@
             <div class="paging"></div>
             <button is="paper-icon-button-light" class="btnSelectView autoSize" title="${ButtonSelectView}"><span class="material-icons view_comfy" aria-hidden="true"></span></button>
             <div class="btnFilter-wrapper">
-                <button is="paper-icon-button-light" class="btnFilter autoSize" title="${Filter}"><span class="material-icons filter_list" aria-hidden="true"></span></button>
+                <button is="paper-icon-button-light" class="btnFilter autoSize" title="${Filter}"><span class="material-icons filter_alt" aria-hidden="true"></span></button>
             </div>
         </div>
 
@@ -101,7 +101,7 @@
             <button is="paper-icon-button-light" class="btnShuffle autoSize" title="${Shuffle}"><span class="material-icons shuffle" aria-hidden="true"></span></button>
             <button is="paper-icon-button-light" class="btnSort autoSize" title="${Sort}"><span class="material-icons sort_by_alpha" aria-hidden="true"></span></button>
             <div class="btnFilter-wrapper">
-                <button is="paper-icon-button-light" class="btnFilter autoSize" title="${Filter}"><span class="material-icons filter_list" aria-hidden="true"></span></button>
+                <button is="paper-icon-button-light" class="btnFilter autoSize" title="${Filter}"><span class="material-icons filter_alt" aria-hidden="true"></span></button>
             </div>
         </div>
 

--- a/src/controllers/shows/tvrecommended.html
+++ b/src/controllers/shows/tvrecommended.html
@@ -6,7 +6,7 @@
             <button is="paper-icon-button-light" class="btnSelectView autoSize" title="${ButtonSelectView}"><span class="material-icons view_comfy" aria-hidden="true"></span></button>
             <button is="paper-icon-button-light" class="btnSort autoSize" title="${Sort}"><span class="material-icons sort_by_alpha" aria-hidden="true"></span></button>
             <div class="btnFilter-wrapper">
-                <button is="paper-icon-button-light" class="btnFilter autoSize" title="${Filter}"><span class="material-icons filter_list" aria-hidden="true"></span></button>
+                <button is="paper-icon-button-light" class="btnFilter autoSize" title="${Filter}"><span class="material-icons filter_alt" aria-hidden="true"></span></button>
             </div>
         </div>
 
@@ -62,7 +62,7 @@
             <button is="paper-icon-button-light" class="btnSelectView autoSize" title="${ButtonSelectView}"><span class="material-icons view_comfy" aria-hidden="true"></span></button>
             <button is="paper-icon-button-light" class="btnSort autoSize" title="${Sort}"><span class="material-icons sort_by_alpha" aria-hidden="true"></span></button>
             <div class="btnFilter-wrapper">
-                <button is="paper-icon-button-light" class="btnFilter autoSize" title="${Filter}"><span class="material-icons filter_list" aria-hidden="true"></span></button>
+                <button is="paper-icon-button-light" class="btnFilter autoSize" title="${Filter}"><span class="material-icons filter_alt" aria-hidden="true"></span></button>
             </div>
         </div>
         <div is="emby-itemscontainer" class="itemsContainer vertical-wrap padded-left padded-right">

--- a/src/scripts/libraryBrowser.js
+++ b/src/scripts/libraryBrowser.js
@@ -70,7 +70,7 @@ export function getQueryPagingHtml (options) {
         }
 
         if (options.filterButton) {
-            html += '<button is="paper-icon-button-light" class="btnFilter autoSize" title="' + globalize.translate('Filter') + '"><span class="material-icons filter_list" aria-hidden="true"></span></button>';
+            html += '<button is="paper-icon-button-light" class="btnFilter autoSize" title="' + globalize.translate('Filter') + '"><span class="material-icons filter_alt" aria-hidden="true"></span></button>';
         }
 
         html += '</div>';


### PR DESCRIPTION
**Changes**
* Updates the filter icons to use `filter_alt` instead of `filter_list`
* Fixes the list view using a different icon for sorting

| Before | After |
|---|---|
| ![Screenshot 2025-04-16 at 14-31-16 Music Videos](https://github.com/user-attachments/assets/19735c50-837c-4037-a1c1-ed2504840ae6) | ![Screenshot 2025-04-16 at 14-30-40 Music Videos](https://github.com/user-attachments/assets/94601eff-1846-4509-9656-74a72e1b702f) |

**Issues**
N/A