### PR TITLE
Use playback manager to set default audio stream index

### DIFF
--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -962,7 +962,7 @@ export class HtmlVideoPlayer {
         this.setCurrentTrackElement(this.#subtitleTrackIndexToSetOnPlaying);
 
         if (this.#audioTrackIndexToSetOnPlaying != null && this.canSetAudioStreamIndex()) {
-            this.setAudioStreamIndex(this.#audioTrackIndexToSetOnPlaying);
+            playbackManager.setAudioStreamIndex(this.#audioTrackIndexToSetOnPlaying);
         }
 
         if (this.#secondarySubtitleTrackIndexToSetOnPlaying != null && this.#secondarySubtitleTrackIndexToSetOnPlaying >= 0) {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

Use the method directly on the player might select a stream that is not playable and/or cause some inconsistencies on GUI. (Like track 1 is selected on the OSD but actually playing track 2). 

If we are doing more 10.10 releases we might want to backport this.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
