### PR TITLE
Add Custom Playback Speed option

### DIFF
--- a/src/components/customplaybackrate/customplaybackrate.js
+++ b/src/components/customplaybackrate/customplaybackrate.js
@@ -1,0 +1,91 @@
+import { playbackManager } from '../playback/playbackmanager';
+import template from './customplaybackrate.template.html';
+import './customplaybackrate.scss';
+
+let player;
+let rateInputField;
+let closeButton;
+let container;
+
+function init(instance) {
+    const parent = document.createElement('div');
+    document.body.appendChild(parent);
+    parent.innerHTML = template;
+
+    rateInputField = parent.querySelector('.customPlaybackRateInput');
+    closeButton = parent.querySelector('.customPlaybackRate-closeButton');
+    container = parent.querySelector('.customPlaybackRateContainer');
+
+    container.classList.add('hide');
+
+    rateInputField.value = '1.0';
+    rateInputField.hasFocus = false;
+
+    rateInputField.addEventListener('click', function () {
+        this.hasFocus = true;
+    });
+
+    rateInputField.addEventListener('keydown', function (event) {
+        if (event.key === 'Enter') {
+            const value = parseFloat(this.value);
+            if (!isNaN(value) && value >= 0.1 && value <= 10) {
+                playbackManager.setPlaybackRate(value, player);
+                CustomPlaybackRate.prototype.toggle('forceToHide');
+            } else {
+                alert('Enter a number between 0.1 and 10');
+            }
+            this.hasFocus = false;
+            event.preventDefault();
+        } else {
+            this.hasFocus = true;
+            if (!event.key.match(/[\d.]|Backspace|ArrowLeft|ArrowRight|Delete/)) {
+                event.preventDefault();
+            }
+        }
+        event.stopPropagation();
+    });
+
+    closeButton.addEventListener('click', function () {
+        const value = parseFloat(rateInputField.value);
+        if (!isNaN(value) && value >= 0.1 && value <= 10) {
+            playbackManager.setPlaybackRate(value, player);
+        } else {
+            alert('Enter a valid number between 0.1 and 10');
+        }
+
+        CustomPlaybackRate.prototype.toggle('forceToHide');
+    });
+
+    instance.element = parent;
+}
+
+class CustomPlaybackRate {
+    constructor(currentPlayer) {
+        player = currentPlayer;
+        init(this);
+    }
+
+    destroy() {
+        CustomPlaybackRate.prototype.toggle('forceToHide');
+        const elem = this.element;
+        if (elem) {
+            elem.parentNode.removeChild(elem);
+            this.element = null;
+        }
+    }
+
+    toggle(action) {
+        if (action && action === 'forceToHide') {
+            container.classList.add('hide');
+            return;
+        }
+
+        const currentRate = playbackManager.getPlaybackRate(player);
+        rateInputField.value = currentRate;
+
+        container.classList.remove('hide');
+        rateInputField.focus();
+    }
+}
+
+export default CustomPlaybackRate;

--- a/src/components/customplaybackrate/customplaybackrate.scss
+++ b/src/components/customplaybackrate/customplaybackrate.scss
@@ -1,0 +1,37 @@
+.customPlaybackRateContainer {
+    width: 20%;
+    min-width: 200px;
+    margin: auto;
+    background: rgba(30, 30, 30, 0.9);
+    padding: 1em;
+    border-radius: 0.5em;
+    text-align: center;
+    position: fixed;
+    top: 30%;
+    left: 40%;
+    color: white;
+}
+
+.customPlaybackRateInput {
+    width: 60%;
+    font-size: 1.5em;
+    text-align: center;
+}
+
+.customPlaybackRate-closeButton {
+    position: absolute;
+    top: 5px;
+    right: 5px;
+    background: none;
+    border: none;
+    color: white;
+    cursor: pointer;
+}
+
+.customPlaybackRateInstructions {
+    text-align: center;
+    margin-top: 10px;
+    margin-bottom: 12px;
+    font-size: 16px;
+    color: #fff;
+}

--- a/src/components/customplaybackrate/customplaybackrate.template.html
+++ b/src/components/customplaybackrate/customplaybackrate.template.html
@@ -1,0 +1,11 @@
+<div class="customPlaybackRate">
+    <div class="customPlaybackRateContainer">
+        <button type="button" is="paper-icon-button-light" class="customPlaybackRate-closeButton">
+            <span class="material-icons close" aria-hidden="true"></span>
+        </button>
+        <div class="customPlaybackRateInstructions">
+            Enter a playback rate between 0.1 and 10:
+        </div>
+        <input type="text" class="customPlaybackRateInput" value="1.0" />
+    </div>
+</div>

--- a/src/components/playback/playersettingsmenu.js
+++ b/src/components/playback/playersettingsmenu.js
@@ -149,25 +149,42 @@ function showAspectRatioMenu(player, btn) {
     });
 }
 
-function showPlaybackRateMenu(player, btn) {
+function showPlaybackRateMenu(player, options) {
     // each has a name and id
-    const currentId = playbackManager.getPlaybackRate(player);
-    const menuItems = playbackManager.getSupportedPlaybackRates(player).map(i => ({
+    const currentRate = playbackManager.getPlaybackRate(player);
+    const supportedRates = playbackManager.getSupportedPlaybackRates(player);
+
+    const isDefaultRate = supportedRates.some(i => i.id === currentRate);
+
+    const menuItems = supportedRates.map(i => ({
         id: i.id,
         name: i.name,
-        selected: i.id === currentId
+        selected: i.id === currentRate
     }));
+
+    menuItems.push({
+        id: 'custom',
+        name: 'Custom Rate',
+        selected: !isDefaultRate
+    });
 
     return actionsheet.show({
         items: menuItems,
-        positionTo: btn
+        positionTo: options.positionTo
     }).then(function (id) {
-        if (id) {
-            playbackManager.setPlaybackRate(id, player);
+
+        if (!id) return Promise.reject();
+
+        if (id === 'custom') {
+            if (typeof options?.onOption === 'function') {
+                options.onOption('playbackrate');
+            }
+            // custom rate set in modal so we can just return here.
             return Promise.resolve();
         }
 
-        return Promise.reject();
+        playbackManager.setPlaybackRate(id, player);
+        return Promise.resolve();
     });
 }
 
@@ -189,13 +206,15 @@ function showWithUser(options, player, user) {
     }
 
     if (supportedCommands.indexOf('PlaybackRate') !== -1) {
-        const currentPlaybackRateId = playbackManager.getPlaybackRate(player);
-        const currentPlaybackRate = playbackManager.getSupportedPlaybackRates(player).filter(i => i.id === currentPlaybackRateId)[0];
+        const currentRate = playbackManager.getPlaybackRate(player);
+        const supportedRates = playbackManager.getSupportedPlaybackRates(player);
+
+        const matchedRate = supportedRates.find(i => i.id === currentRate); // use rate from table
 
         menuItems.push({
             name: globalize.translate('PlaybackRate'),
             id: 'playbackrate',
-            asideText: currentPlaybackRate ? currentPlaybackRate.name : null
+            asideText: matchedRate ? matchedRate.name : `${parseFloat(currentRate).toFixed(2)}x` //generate text from current set rate
         });
     }
 
@@ -265,7 +284,7 @@ function handleSelectedOption(id, options, player) {
         case 'aspectratio':
             return showAspectRatioMenu(player, options.positionTo);
         case 'playbackrate':
-            return showPlaybackRateMenu(player, options.positionTo);
+            return showPlaybackRateMenu(player, options);
         case 'repeatmode':
             return showRepeatModeMenu(player, options.positionTo);
         case 'stats':

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -21,6 +21,7 @@ import '../../../elements/emby-ratingbutton/emby-ratingbutton';
 import '../../../styles/videoosd.scss';
 import shell from '../../../scripts/shell';
 import SubtitleSync from '../../../components/subtitlesync/subtitlesync';
+import CustomPlaybackRate from '../../../components/customplaybackrate/customplaybackrate';
 import { appRouter } from '../../../components/router/appRouter';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
 import LibraryMenu from '../../../scripts/libraryMenu';
@@ -989,6 +990,11 @@ export default function (view) {
                 playbackManager.enableShowingSubtitleOffset(player);
                 toggleSubtitleSync();
             }
+        } else if (selectedOption === 'playbackrate') {
+            const player = currentPlayer;
+            if (player) {
+                toggleCustomPlaybackRate();
+            }
         }
     }
 
@@ -1185,6 +1191,16 @@ export default function (view) {
             subtitleSyncOverlay.toggle(action);
         } else if (player) {
             subtitleSyncOverlay = new SubtitleSync(player);
+        }
+    }
+
+    function toggleCustomPlaybackRate(action) {
+        const player = currentPlayer;
+        if (customPlaybackRateOverlay) {
+            customPlaybackRateOverlay.toggle(action);
+        } else if (player) {
+            customPlaybackRateOverlay = new CustomPlaybackRate(player);
+            customPlaybackRateOverlay.toggle(action);
         }
     }
 
@@ -1638,6 +1654,7 @@ export default function (view) {
     let programEndDateMs = 0;
     let playbackStartTimeTicks = 0;
     let subtitleSyncOverlay;
+    let customPlaybackRateOverlay;
     let trickplayResolution = null;
     const nowPlayingVolumeSlider = view.querySelector('.osdVolumeSlider');
     const nowPlayingVolumeSliderContainer = view.querySelector('.osdVolumeSliderContainer');


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
Added the ability to enter a custom playback speed during playback. This uses the existing SetPlaybackRate function and adds a new component which displays a modal over the playing video that allows the user to enter a custom value. I made the limit 0.1 to 10 as arbitrary limits, but they could be changed.

My reasoning for implementing this is to allow more granular playback speed control without requiring an ever expanding list of specific playback speeds. 

![custom_rate button_selected](https://github.com/user-attachments/assets/ab60f6dd-f3e5-46ba-8e03-f08cae567011)
![custom_speed_shown](https://github.com/user-attachments/assets/17ef5b16-3eb1-4484-9530-223683757406)
![modal](https://github.com/user-attachments/assets/f90456d1-07cd-4bb6-b396-237f3b87ea44)

**Issues**
No ticket, but I did open a feature request on the jellyfin.org site. https://features.jellyfin.org/posts/3277/custom-playback-speeds
