### PR TITLE
Fix unavailable server handling

### DIFF
--- a/src/components/ConnectionErrorPage.tsx
+++ b/src/components/ConnectionErrorPage.tsx
@@ -1,6 +1,8 @@
 import React, { FC, useEffect, useState } from 'react';
 
+import { appHost } from 'components/apphost';
 import Page from 'components/Page';
+import LinkButton from 'elements/emby-button/LinkButton';
 import globalize from 'lib/globalize';
 import { ConnectionState } from 'lib/jellyfin-apiclient';
 
@@ -13,14 +15,22 @@ const ConnectionErrorPage: FC<ConnectionErrorPageProps> = ({
 }) => {
     const [ title, setTitle ] = useState<string>();
     const [ htmlMessage, setHtmlMessage ] = useState<string>();
+    const [ message, setMessage ] = useState<string>();
 
     useEffect(() => {
-        if (state === ConnectionState.ServerUpdateNeeded) {
-            setTitle(globalize.translate('HeaderUpdateRequired'));
-            setHtmlMessage(globalize.translate(
-                'ServerUpdateNeeded',
-                '<a href="https://jellyfin.org/downloads/server/">jellyfin.org/downloads/server</a>'
-            ));
+        switch (state) {
+            case ConnectionState.ServerUpdateNeeded:
+                setTitle(globalize.translate('HeaderUpdateRequired'));
+                setHtmlMessage(globalize.translate(
+                    'ServerUpdateNeeded',
+                    '<a href="https://jellyfin.org/downloads/server/">jellyfin.org/downloads/server</a>'
+                ));
+                setMessage(undefined);
+                return;
+            case ConnectionState.Unavailable:
+                setTitle(globalize.translate('HeaderServerUnavailable'));
+                setHtmlMessage(undefined);
+                setMessage(globalize.translate('MessageUnableToConnectToServer'));
         }
     }, [ state ]);
 
@@ -36,6 +46,17 @@ const ConnectionErrorPage: FC<ConnectionErrorPageProps> = ({
                 <h1>{title}</h1>
                 {htmlMessage && (
                     <p dangerouslySetInnerHTML={{ __html: htmlMessage }} />
+                )}
+                {message && (
+                    <p>{message}</p>
+                )}
+                {appHost.supports('multiserver') && (
+                    <LinkButton
+                        className='raised'
+                        href='/selectserver'
+                    >
+                        {globalize.translate('ButtonChangeServer')}
+                    </LinkButton>
                 )}
             </div>
         </Page>

--- a/src/components/ConnectionRequired.tsx
+++ b/src/components/ConnectionRequired.tsx
@@ -184,7 +184,7 @@ const ConnectionRequired: FunctionComponent<ConnectionRequiredProps> = ({
             console.debug('[ConnectionRequired] connection state', firstConnection?.State);
             ServerConnections.firstConnection = true;
 
-            if (firstConnection?.State === ConnectionState.ServerUpdateNeeded) {
+            if ([ ConnectionState.ServerUpdateNeeded, ConnectionState.Unavailable ].includes(firstConnection?.State)) {
                 setErrorState(firstConnection.State);
             } else if (level === AccessLevel.Wizard) {
                 handleWizard(firstConnection)

--- a/src/lib/jellyfin-apiclient/connectionManager.js
+++ b/src/lib/jellyfin-apiclient/connectionManager.js
@@ -423,10 +423,6 @@ export default class ConnectionManager {
             // See if we have any saved credentials and can auto sign in
             if (firstServer) {
                 return self.connectToServer(firstServer, options).then((result) => {
-                    if (result.State === ConnectionState.Unavailable) {
-                        result.State = ConnectionState.ServerSelection;
-                    }
-
                     console.log('resolving connectToServers with result.State: ' + result.State);
                     return result;
                 });

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -515,6 +515,7 @@
     "HeaderSeriesOptions": "Series Options",
     "HeaderSeriesStatus": "Series Status",
     "HeaderServerAddressSettings": "Server Address Settings",
+    "HeaderServerUnavailable": "Server Unavailable",
     "HeaderSetupLibrary": "Set up your media libraries",
     "HeaderSortBy": "Sort By",
     "HeaderSortOrder": "Sort Order",


### PR DESCRIPTION
**Changes**
* Adds error messaging when trying to connect to an unavailable server instead of always redirecting to the select server page

**Issues**
Related to https://github.com/jellyfin/jellyfin-web/issues/5407#issuecomment-2672880732
