### PR TITLE
Use shadow for trickplay thumbnail text

### DIFF
--- a/src/styles/videoosd.scss
+++ b/src/styles/videoosd.scss
@@ -85,7 +85,7 @@
     bottom: 0;
     left: 0;
     right: 0;
-    background: rgba(0, 0, 0, 0.7);
+    background: none;
     padding: 0.25em 0.5em;
     user-select: none;
 }
@@ -94,10 +94,12 @@
     padding: 0.25em 0;
     margin: 0;
     opacity: 1;
+    color: #fff;
+    text-shadow: 0 0 25px #000, 0 0 6px #000;
 }
 
 .chapterThumbText-dim {
-    opacity: 0.6;
+    opacity: 0.9;
 }
 
 .videoOsdBottom-hidden {


### PR DESCRIPTION
**Changes**
- Use shadow for trickplay thumbnail text, instead of the distracting black container background.

**Issues**
- Fixes #6404

<img src="https://github.com/user-attachments/assets/e05d4307-7b6a-44b4-a4bc-b29058edec7a" width="600">

<img src="https://github.com/user-attachments/assets/cb1241d8-6032-4ad7-870a-54bf42fe4abb" width="300">
<img src="https://github.com/user-attachments/assets/4e3cfa15-372f-49f9-8ff4-dc28b656e680" width="300">

