### PR TITLE
Immediately update UI to reflect media deletion

### DIFF
--- a/src/components/itemContextMenu.js
+++ b/src/components/itemContextMenu.js
@@ -557,7 +557,18 @@ function executeCommand(item, id, options) {
                 getResolveFunction(resolve, id)();
                 break;
             case 'delete':
-                deleteItem(apiClient, item).then(getResolveFunction(resolve, id, true, true, itemId), getResolveFunction(resolve, id));
+                deleteItem(apiClient, item).then(() => {
+                    const itemElement = document.querySelector(`[data-id="${itemId}"]`);
+                    if (itemElement) {
+                        const listItem = itemElement.closest('li, div.listItem');
+                        if (listItem) {
+                            listItem.parentNode.removeChild(listItem);
+                        } else {
+                            itemElement.parentNode.removeChild(itemElement);
+                        }
+                    }
+                    getResolveFunction(resolve, id, true, true, itemId)();
+                }, getResolveFunction(resolve, id));
                 break;
             case 'share':
                 navigator.share({


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Currently, when deleting a media item using the context menu, the request seemingly completes, but no changes to the UI are made until the user refreshes the page, and finds that the media is now gone.  I have added a few lines that will immediately remove the deleted media from the list in the UI after the delete API call succeeds.

This change reflects this feature request found [here](https://features.jellyfin.org/posts/169/refresh-page-after-deleting-a-media-element), and is also a fix I have wanted for a little while as well.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
N/A
