### PR TITLE
Add "DownloadManagement" app feature for use in NativeShell clients

### DIFF
--- a/src/apps/stable/routes/user/settings/index.tsx
+++ b/src/apps/stable/routes/user/settings/index.tsx
@@ -189,7 +189,7 @@ const UserSettingsPage: FC = () => {
                         {appHost.supports(AppFeature.DownloadManagement) && (
                             <LinkButton
                                 onClick={shell.openDownloadManager}
-                                className='clientSettings listItem-border'
+                                className='downloadManager listItem-border'
                                 style={{
                                     display: 'block',
                                     margin: 0,

--- a/src/apps/stable/routes/user/settings/index.tsx
+++ b/src/apps/stable/routes/user/settings/index.tsx
@@ -186,6 +186,27 @@ const UserSettingsPage: FC = () => {
                             </div>
                         </LinkButton>
 
+                        {appHost.supports(AppFeature.DownloadManagement) && (
+                            <LinkButton
+                                onClick={shell.openDownloadManager}
+                                className='clientSettings listItem-border'
+                                style={{
+                                    display: 'block',
+                                    margin: 0,
+                                    padding: 0
+                                }}
+                            >
+                                <div className='listItem'>
+                                    <span className='material-icons listItemIcon listItemIcon-transparent download' aria-hidden='true' />
+                                    <div className='listItemBody'>
+                                        <div className='listItemBodyText'>
+                                            {globalize.translate('DownloadManager')}
+                                        </div>
+                                    </div>
+                                </div>
+                            </LinkButton>
+                        )}
+
                         {appHost.supports(AppFeature.ClientSettings) && (
                             <LinkButton
                                 onClick={shell.openClientSettings}

--- a/src/components/toolbar/AppUserMenu.tsx
+++ b/src/components/toolbar/AppUserMenu.tsx
@@ -22,6 +22,7 @@ import { useQuickConnectEnabled } from 'hooks/useQuickConnect';
 import globalize from 'lib/globalize';
 import shell from 'scripts/shell';
 import Dashboard from 'utils/dashboard';
+import { Download } from '@mui/icons-material';
 
 export const ID = 'app-user-menu';
 
@@ -37,6 +38,10 @@ const AppUserMenu: FC<AppUserMenuProps> = ({
     const { user } = useApi();
     const { data: isQuickConnectEnabled } = useQuickConnectEnabled();
 
+    const onDownloadManagerClick = useCallback(() => {
+        shell.openDownloadManager();
+        onMenuClose();
+    }, [ onMenuClose ]);
     const onClientSettingsClick = useCallback(() => {
         shell.openClientSettings();
         onMenuClose();
@@ -98,8 +103,25 @@ const AppUserMenu: FC<AppUserMenuProps> = ({
                 </ListItemText>
             </MenuItem>
 
-            {appHost.supports(AppFeature.ClientSettings) && ([
-                <Divider key='client-settings-divider' />,
+            {(appHost.supports(AppFeature.DownloadManagement) || appHost.supports(AppFeature.ClientSettings)) && (
+                <Divider key='app-feature-divider' />
+            )}
+
+            {appHost.supports(AppFeature.DownloadManagement) && (
+                <MenuItem
+                    key='download-manager-button'
+                    onClick={onDownloadManagerClick}
+                >
+                    <ListItemIcon>
+                        <Download />
+                    </ListItemIcon>
+                    <ListItemText>
+                        {globalize.translate('DownloadManager')}
+                    </ListItemText>
+                </MenuItem>
+            )}
+
+            {appHost.supports(AppFeature.ClientSettings) && (
                 <MenuItem
                     key='client-settings-button'
                     onClick={onClientSettingsClick}
@@ -111,7 +133,7 @@ const AppUserMenu: FC<AppUserMenuProps> = ({
                         {globalize.translate('ClientSettings')}
                     </ListItemText>
                 </MenuItem>
-            ])}
+            )}
 
             {/* ADMIN LINKS */}
             {user?.Policy?.IsAdministrator && ([

--- a/src/components/toolbar/AppUserMenu.tsx
+++ b/src/components/toolbar/AppUserMenu.tsx
@@ -105,12 +105,11 @@ const AppUserMenu: FC<AppUserMenuProps> = ({
             </MenuItem>
 
             {(appHost.supports(AppFeature.DownloadManagement) || appHost.supports(AppFeature.ClientSettings)) && (
-                <Divider key='app-feature-divider' />
+                <Divider />
             )}
 
             {appHost.supports(AppFeature.DownloadManagement) && (
                 <MenuItem
-                    key='download-manager-button'
                     onClick={onDownloadManagerClick}
                 >
                     <ListItemIcon>
@@ -124,7 +123,6 @@ const AppUserMenu: FC<AppUserMenuProps> = ({
 
             {appHost.supports(AppFeature.ClientSettings) && (
                 <MenuItem
-                    key='client-settings-button'
                     onClick={onClientSettingsClick}
                 >
                     <ListItemIcon>

--- a/src/components/toolbar/AppUserMenu.tsx
+++ b/src/components/toolbar/AppUserMenu.tsx
@@ -2,6 +2,7 @@ import AccountCircle from '@mui/icons-material/AccountCircle';
 import AppSettingsAlt from '@mui/icons-material/AppSettingsAlt';
 import Close from '@mui/icons-material/Close';
 import DashboardIcon from '@mui/icons-material/Dashboard';
+import Download from '@mui/icons-material/Download';
 import Edit from '@mui/icons-material/Edit';
 import Logout from '@mui/icons-material/Logout';
 import PhonelinkLock from '@mui/icons-material/PhonelinkLock';
@@ -22,7 +23,6 @@ import { useQuickConnectEnabled } from 'hooks/useQuickConnect';
 import globalize from 'lib/globalize';
 import shell from 'scripts/shell';
 import Dashboard from 'utils/dashboard';
-import { Download } from '@mui/icons-material';
 
 export const ID = 'app-user-menu';
 
@@ -42,6 +42,7 @@ const AppUserMenu: FC<AppUserMenuProps> = ({
         shell.openDownloadManager();
         onMenuClose();
     }, [ onMenuClose ]);
+
     const onClientSettingsClick = useCallback(() => {
         shell.openClientSettings();
         onMenuClose();

--- a/src/constants/appFeature.ts
+++ b/src/constants/appFeature.ts
@@ -10,6 +10,8 @@ export enum AppFeature {
     DisplayLanguage = 'displaylanguage',
     /** The app supports configuring the display mode (TV, Desktop, etc.) */
     DisplayMode = 'displaymode',
+    /** The app supports showing a download management interface via a menu entry */
+    DownloadManagement = 'downloadmanagement',
     /** The app can exit via back navigation */
     Exit = 'exit',
     /** The app can be exited via a menu entry */

--- a/src/scripts/shell.js
+++ b/src/scripts/shell.js
@@ -15,6 +15,11 @@ export default {
             window.NativeShell.openClientSettings();
         }
     },
+    openDownloadManager: () => {
+        if (window.NativeShell?.openDownloadManager) {
+            window.NativeShell.openDownloadManager();
+        }
+    },
     openUrl: function(url, target) {
         if (window.NativeShell?.openUrl) {
             window.NativeShell.openUrl(url, target);

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -253,6 +253,7 @@
     "Down": "Down",
     "Download": "Download",
     "DownloadAll": "Download All",
+    "DownloadManager": "Downloads",
     "DownloadsValue": "{0} downloads",
     "DrmChannelsNotImported": "Channels with DRM will not be imported.",
     "DropShadow": "Drop Shadow",


### PR DESCRIPTION
Related: jellyfin/jellyfin-android#1627
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**

Adds a new app feature "downloadmanager". When enabled it adds a button to the experimental layout (profile dropdown menu) and legacy layout (preferences menu) to open the download manager in a nativeshell enabled client using the new "openDownloadManager" function.

This is intended to be used for the upcoming download management support in the mobile Android app.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
