### PR TITLE
add remember me option at login

### DIFF
--- a/src/controllers/session/login/index.html
+++ b/src/controllers/session/login/index.html
@@ -31,6 +31,12 @@
         <div class="visualLoginForm" style="text-align: center;">
             <h1 style="margin-top:1em;">${HeaderPleaseSignIn}</h1>
             <div id="divUsers" class="itemsContainer vertical-wrap centered"></div>
+            <div class="itemsContainer vertical-wrap centered">
+                <label class="checkboxContainer" style="width: auto;">
+                    <input is="emby-checkbox" type="checkbox" class="chkRememberProfile" checked />
+                    <span>${RememberMe}</span>
+                </label>
+            </div>
         </div>
 
         <div class="readOnlyContent" style="margin: .5em auto 1em;">

--- a/src/controllers/session/login/index.js
+++ b/src/controllers/session/login/index.js
@@ -209,6 +209,7 @@ export default function (view, params) {
     }
 
     function showVisualForm() {
+        view.querySelector('.chkRememberProfile').checked = appSettings.enableAutoLogin();
         view.querySelector('.visualLoginForm').classList.remove('hide');
         view.querySelector('.manualLoginForm').classList.add('hide');
         view.querySelector('.btnManual').classList.remove('hide');
@@ -232,6 +233,7 @@ export default function (view, params) {
                 context.querySelector('#txtManualName').value = '';
                 showManualForm(context, true);
             } else if (haspw == 'false') {
+                appSettings.enableAutoLogin(view.querySelector('.chkRememberProfile').checked);
                 authenticateUserByName(context, getApiClient(), getTargetUrl(), name, '');
             } else {
                 context.querySelector('#txtManualName').value = name;


### PR DESCRIPTION
Add "Remember Me" option to login screen.

**Changes**
This PR adds a new remember me checkbox to the login screen for the visible profiles. The intention here is to make the profile selection page show up every time the app/page is loaded. This is inline with Netflix/Disney style profile selection screens.

By default the checkbox is checked therefore current existing behaviour remains unchanged.
Users who deselect the checkbox will be shown the profile selection screen on every app start or page refresh.

Screenshot with the new checkbox.
![Screenshot from 2025-05-09 18-08-28](https://github.com/user-attachments/assets/fb796271-2156-4dee-83c9-a84dd94d29aa)

I believe this feature is a desirable one as the Android client already provides a similar option and I have found a few Reddit threads talking about this behaviour. However, I understand if this particular implementation is not ideal. If you are not happy with the UX please provide me some feedback/suggestions and I can try implementing a different approach.