### PR TITLE
Backdrop Screen Saver enhancements

### DIFF
--- a/src/components/slideshow/slideshow.js
+++ b/src/components/slideshow/slideshow.js
@@ -412,7 +412,9 @@ export default function (options) {
         return getSwiperSlideHtmlFromSlide({
             originalImage: getImgUrl(item, currentOptions.user),
             Id: item.Id,
-            ServerId: item.ServerId
+            ServerId: item.ServerId,
+            title: item.Name,
+            description: getSlideDescriptionFromItem(item)
         });
     }
 
@@ -449,6 +451,22 @@ export default function (options) {
         html += '</div>';
 
         return html;
+    }
+
+    /**
+     * Generates the description string of a slide for a slide object.
+     * @param {Object} item - Slide Object used to generate the slide.
+     * @returns Description string
+     */
+    function getSlideDescriptionFromItem(item) {
+        let subtitle = '';
+        let prefix = '';
+        if (item.CommunityRating) {
+            subtitle += '✯ ' + parseFloat(item.CommunityRating).toFixed(1);
+            prefix = '｜';
+        }
+        if (item.ProductionYear) subtitle += prefix + item.ProductionYear;
+        return subtitle;
     }
 
     /**

--- a/src/components/slideshow/style.scss
+++ b/src/components/slideshow/style.scss
@@ -105,15 +105,15 @@
     left: 0;
     right: 0;
     bottom: 10vh;
-    text-align: center;
+    font-size: 3em;
+    text-align: left;
+    text-shadow: 0 0 20px rgba(0, 0, 0, 0.8);
 }
 
 .slideTextInner {
-    margin: 0 auto;
     max-width: 60%;
-    background: rgba(0, 0, 0, 0.8);
     display: inline-block;
-    padding: 0.5em 1em;
+    margin: 0.5em 2em;
     border-radius: 0.25em;
 }
 
@@ -139,4 +139,21 @@
 
 .swiper-zoom-fakeimg-hidden {
     display: none;
+}
+
+@keyframes backgroundScroll {
+    0% {
+        margin-left: 0%;
+    }
+
+    100% {
+        margin-left: 20%;
+    }
+}
+
+.swiper-slide-img {
+    height: 120%;
+    object-fit: cover !important;
+    mask-image: linear-gradient(90deg, transparent 0%, black 50%, transparent 100%);
+    animation: backgroundScroll 20s ease-in-out 1s infinite alternate both running;
 }

--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -461,7 +461,7 @@ export class UserSettings {
             return this.set('backdropScreensaverInterval', val.toString(), false);
         }
 
-        return parseInt(this.get('backdropScreensaverInterval', false), 10) || 5;
+        return parseInt(this.get('backdropScreensaverInterval', false), 10) || 20;
     }
 
     /**


### PR DESCRIPTION
### Backdrop Screensaver enhancements
This PR adds netflix/plex like screensaver backdrop look and feel to jellyfin web. 

#### Changes
1. Make backdrop image **cover the entire screen**
2. Fix title and description text display
   * Description is community rating (if available) and production year (if available)
4. Add animation to backdrop images and improve text layout and rendering
5. Increase default backdropScreensaverInterval **from 5 to 30 seconds**, to better align with animation effects

This MR also resolves the issue #6261 ✅ 

|Before|After|
|---|---|
|![old](https://github.com/user-attachments/assets/1c0edbea-d689-4bae-b6b4-99aa2a310f27)| ![new](https://github.com/user-attachments/assets/816923a5-7a9f-4a9c-b572-87acd3652669)|
|Video: https://github.com/user-attachments/assets/a70f1819-8aa2-45ce-9acb-c71172aee0ea| Video: https://github.com/user-attachments/assets/e1ca12d6-09c6-44c4-b782-39af0f1cc09c|

#### Future Work
We can allow the user to customize the overlay text through the settings.


#### Seeing it in action
To see the changes in action, 
1. Open the preview url from the cloudflare deployment below
2. Once you sign in, go to Profile settings -> Display
3. Change Screensaver from None to Backdrop
4. Let your screen be idle for 180s and voila !!

