### PR TITLE
Hardcode vidaa hevc playback is unsupported

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -11,7 +11,7 @@ function canPlayHevc(videoTestElement, options) {
         return true;
     }
 
-    if (browser.ps4) {
+    if (browser.ps4 || browser.vidaa) {
         return false;
     }
 


### PR DESCRIPTION
Hardcode vidaa lack of support for hevc

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

See https://forum.jellyfin.org/t-setting-up-jellyfin-on-a-hisense-vidaa-os-tv for more context on why this is desirable.
