### PR TITLE
Add targetABI to plugin repo page

### DIFF
--- a/src/apps/dashboard/features/plugins/components/PluginDetailsTable.tsx
+++ b/src/apps/dashboard/features/plugins/components/PluginDetailsTable.tsx
@@ -86,6 +86,18 @@ const PluginDetailsTable: FC<PluginDetailsTableProps> = ({
                         }
                     </TableCell>
                 </TableRow>
+                <TableRow>
+                    <TableCell variant='head'>
+                        {globalize.translate('TargetABI')}
+                    </TableCell>
+                    <TableCell>
+                        {
+                            (isRepositoryLoading && <Skeleton />)
+                            || pluginDetails?.version?.targetAbi
+                            || globalize.translate('Unknown')
+                        }
+                    </TableCell>
+                </TableRow>
             </TableBody>
         </Table>
     </TableContainer>


### PR DESCRIPTION
**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Add the targetABI. Especially useful for Unstable/master and if the plugin is updated or not. Fast check for reproting reporting something, build/patch something or maybe deactivate it.
