### PR TITLE
Restore manifest.json output filename

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -125,6 +125,9 @@ const config = {
         ),
         chunkFilename: '[name].[contenthash].chunk.js',
         assetModuleFilename: pathData => {
+            if (pathData.filename === 'manifest.json') {
+                return '[base]';
+            }
             if (pathData.filename.startsWith('assets/') || pathData.filename.startsWith('themes/')) {
                 return '[path][base][query]';
             }


### PR DESCRIPTION
**Changes**
Restores the `manifest.json` filename in the build output since it is referenced by the webOS app

**Issues**
Fixes #6755
