### PR TITLE
Fix: clarify interval units in dummy chapter help text

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -99,6 +99,7 @@
 - [Derek Huber](https://github.com/Derek4aty1)
 - [StableCrimson](https://github.com/StableCrimson)
 - [diegoeche](https://github.com/diegoeche)
+- [Free O'Toole](https://github.com/freeotoole)
 
 ## Emby Contributors
 

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -694,7 +694,7 @@
     "LabelDropShadow": "Drop shadow",
     "LabelDropSubtitleHere": "Drop subtitle here, or click to browse.",
     "LabelDummyChapterDuration": "Interval",
-    "LabelDummyChapterDurationHelp": "The interval between dummy chapters. Set to 0 to disable dummy chapter generation. Changing this will have no effect on existing dummy chapters.",
+    "LabelDummyChapterDurationHelp": "The interval between dummy chapters in seconds. Set to 0 to disable dummy chapter generation. Changing this will have no effect on existing dummy chapters.",
     "LabelChapterImageResolution": "Resolution",
     "LabelChapterImageResolutionHelp": "The resolution of the extracted chapter images. Changing this will have no effect on existing dummy chapters.",
     "LabelDynamicExternalId": "{0} Id",


### PR DESCRIPTION
This PR clarifies the interval between dummy chapters is seconds

**Changes**
Add "in seconds" to `LabelDummyChapterDurationHelp` in strings/en-us.json

**Issues**
Fixes #5555
Closes #6158
