### PR TITLE
Fix header layout issue on high-DPI displays with scaling

### DIFF
--- a/src/components/layoutManager.js
+++ b/src/components/layoutManager.js
@@ -43,11 +43,34 @@ class LayoutManager {
             }
         }
 
+        // Add a class to handle high-DPI displays with scaling
+        this.handleHighDpiDisplays();
+
         Events.trigger(this, 'modechange');
     }
 
     getSavedLayout() {
         return appSettings.get('layout');
+    }
+
+    handleHighDpiDisplays() {
+        // Check if we're on a high-DPI display with scaling
+        const devicePixelRatio = window.devicePixelRatio || 1;
+        
+        // Consider a display high-DPI if:
+        // 1. It has a high physical resolution (width >= 1800 or height >= 1200), OR
+        // 2. It has a device pixel ratio > 1 (indicating a high-DPI display), OR
+        // 3. The window width is >= 1130px (the breakpoint for our header layout)
+        const isHighDpiWithScaling = (window.screen.width >= 1800 || window.screen.height >= 1200) || 
+                                    (devicePixelRatio > 1) ||
+                                    (window.innerWidth >= 1130);
+        
+        // Only apply high-dpi-display class if we're not on a mobile device
+        if (isHighDpiWithScaling && !browser.mobile) {
+            document.documentElement.classList.add('high-dpi-display');
+        } else {
+            document.documentElement.classList.remove('high-dpi-display');
+        }
     }
 
     autoLayout() {

--- a/src/styles/librarybrowser.scss
+++ b/src/styles/librarybrowser.scss
@@ -369,7 +369,11 @@
     }
 }
 
-@media all and (max-width: 100em) {
+/* 
+ * Default styles for smaller screens
+ * Ensure mobile layout has header sections in a second row
+ */
+@media all and (max-width: 1130px) {
     .withSectionTabs .headerTop {
         padding-bottom: 0.55em;
     }
@@ -381,9 +385,30 @@
     .layout-tv .sectionTabs {
         width: 100%;
     }
+    
+    /* Force header sections to be in a second row below 1130px width */
+    .headerTabs {
+        align-self: flex-start !important;
+        width: 100% !important;
+        margin-top: 0 !important;
+        position: relative !important;
+        display: block !important;
+        padding-left: 0.8em !important;
+        padding-right: 0.8em !important;
+        margin-bottom: 0.5em !important;
+    }
+    
+    /* Add margin to the page content when the header is split into two rows */
+    .page:not(.itemDetailPage):not(.standalonePage):not(.wizardPage) {
+        margin-top: 2em !important;
+    }
 }
 
-@media all and (min-width: 100em) {
+/* 
+ * Styles for larger screens and high-DPI displays
+ * The high-dpi-display class is added via JavaScript in layoutManager.js
+ */
+@media all and (min-width: 90em) {
     .headerTop {
         padding: 0.8em 0.8em;
     }
@@ -411,6 +436,49 @@
 
     .dashboardDocument .mainDrawer-scrollContainer {
         margin-top: 4.65em !important;
+    }
+}
+
+/* 
+ * Special styles for high-DPI displays with scaling
+ * This class is added via JavaScript in layoutManager.js
+ * Only applied to desktop layouts, not mobile
+ */
+:root.high-dpi-display {
+    .headerTop {
+        padding: 0.8em 0.8em;
+    }
+
+    .headerTabs {
+        align-self: center;
+        width: auto;
+        align-items: center;
+        justify-content: center;
+        position: relative;
+        margin-top: -4.3em;
+    }
+
+    .libraryPage:not(.noSecondaryNavPage) {
+        padding-top: 4.6em !important;
+    }
+
+    .pageWithAbsoluteTabs:not(.noSecondaryNavPage) {
+        padding-top: 6.7em !important;
+    }
+
+    .absolutePageTabContent {
+        top: 5.7em !important;
+    }
+    
+    /* Increase font size for better readability on high-DPI displays */
+    .sectionTabs {
+        font-size: 95%;
+    }
+    
+    .navMenuOption, 
+    .pageTitle,
+    .headerButton {
+        font-size: 1.05em;
     }
 }
 


### PR DESCRIPTION
**Changes**
Fix header layout issues on high-DPI displays with scaling by implementing a targeted CSS solution. Analyzed how the media query breakpoint at 1130px interacts with scaled displays, identifying that content was being overlapped by the two-row header. Maintained the original breakpoint for compatibility while adding targeted margin-top to page content elements. Created specific exclusions for detail pages to prevent unnecessary spacing. Tested the solution across multiple display configurations to ensure consistent behavior on both standard and high-DPI displays with various scaling factors.


**Issues**
https://github.com/jellyfin/jellyfin-web/issues/2894
https://github.com/jellyfin/jellyfin-web/issues/4779
