### PR TITLE
fix overlapping text with long artist names in album view.

### DIFF
--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -488,6 +488,42 @@ function renderName(item, container, context) {
     } else {
         container.classList.add('hide');
     }
+    // Adjust card position based on text length
+    adjustCardPositionForTextLength(container);
+}
+
+/**
+ * Adjusts the position of the detail image card when artist names are long.
+ * By default, the card is positioned at -80% from the top in desktop layouts.
+ * However, because of changes in the formatting of the
+ * detailPagePrimaryContainer to support long artist names, the image card
+ * would appear offscreen at some screen sizes. This function detects long
+ * artist names and centers the card vertically instead to prevent overlap.
+ */
+function adjustCardPositionForTextLength(container) {
+    // Only adjust for desktop layout
+    if (!layoutManager.desktop) return;
+
+    const parentName = container.querySelector('.parentName.musicParentName');
+    if (!parentName) return;
+
+    // Find the card within the current page/container
+    const page = container.closest('.page');
+    if (!page) return;
+
+    const card = page.querySelector('.detailImageContainer .card');
+    if (!card) return;
+
+    const lineHeight = Math.ceil(parseFloat(window.getComputedStyle(parentName).lineHeight));
+    const textHeight = parentName.scrollHeight;
+
+    // if the text height is greater than 2.5 lines, center the image card
+    // vertically in the detailPagePrimaryContainer. otherwise, leave the style as is.
+    if (textHeight > lineHeight * 2.5) {
+        card.classList.add('cardCentered');
+    } else {
+        card.classList.remove('cardCentered');
+    }
 }
 
 function setTrailerButtonVisibility(page, item) {

--- a/src/styles/librarybrowser.scss
+++ b/src/styles/librarybrowser.scss
@@ -782,6 +782,7 @@
     align-items: center;
     align-content: center;
     z-index: 2;
+    flex: 1;
 
     .layout-mobile & {
         display: block;
@@ -920,6 +921,11 @@
         .layout-desktop & {
             right: 3.3%;
         }
+    }
+
+    &.cardCentered {
+        top: 50% !important;
+        transform: translateY(-50%) !important;
     }
 }
 


### PR DESCRIPTION


<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
In order to avoid overlapping text, the .detailPagePrimaryContainer selector is set to flex: 1. This forces us to use an alternate method of placing the album art card, to avoid it moving offscreen. The adjustCardPositionForTextLength function detects when text height is greater than 2.5 lines in the artist name field, and adds a css class to the image card which centers it in the detailPagePrimaryContainer vertically (with long artist names this looks better than the way it is offset by default now)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #6740
