### PR TITLE
Fix music playback order for artists and albums

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -1843,7 +1843,7 @@ export class PlaybackManager {
                         ArtistIds: firstItem.Id,
                         Filters: 'IsNotFolder',
                         Recursive: true,
-                        SortBy: options.shuffle ? 'Random' : 'SortName',
+                        SortBy: options.shuffle ? 'Random' : 'Album,ParentIndexNumber,IndexNumber,SortName',
                         MediaTypes: 'Audio'
                     }, queryOptions));
                 case 'PhotoAlbum':
@@ -1924,7 +1924,11 @@ export class PlaybackManager {
                 if (options.shuffle) {
                     sortBy = 'Random';
                 } else if (firstItem.Type !== 'BoxSet') {
-                    sortBy = 'SortName';
+                    if (firstItem.CollectionType === 'music' || firstItem.MediaType === 'Audio') {
+                        sortBy = 'Album,ParentIndexNumber,IndexNumber,SortName';
+                    } else {
+                        sortBy = 'SortName';
+                    }
                 }
 
                 return getItemsForPlayback(serverId, mergePlaybackQueries({


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
Updated the playback query for MusicArtist and music folders to sort tracks by: 
`Album, ParentIndexNumber, IndexNumber, SortName`

**Behavior Before and After**
Music → Artists → Select an artist → Press the play button

	Old behavior:
    Played all tracks using a sort order, which mixed tracks from different albums.
    
	New behavior:
    Plays all tracks grouped by album, preserving the album order and track sequence.

Music → Albums → Press the play button

	Old behavior:
    Played all tracks using a sort order, which mixed tracks from different albums.
	
	New behavior:
    Plays all tracks grouped by album, preserving the album order and track sequence.

**Issues**
Fixes #6887

