### PR TITLE
Fix Load Spinner when Playback Error Message Closes

### DIFF
--- a/src/components/dialogHelper/dialogHelper.js
+++ b/src/components/dialogHelper/dialogHelper.js
@@ -3,6 +3,7 @@ import browser from '../../scripts/browser';
 import layoutManager from '../layoutManager';
 import inputManager from '../../scripts/inputManager';
 import { toBoolean } from '../../utils/string.ts';
+import { hide } from '../loading/loading.ts';
 import dom from '../../scripts/dom';
 
 import { history } from 'RootAppRouter';
@@ -99,6 +100,8 @@ function DialogHashHandler(dlg, hash, resolve) {
         }
 
         removeBackdrop(dlg);
+        hide();
+
         dlg.classList.remove('opened');
 
         if (removeScrollLockOnClose) {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
Used the hide function from the ../loading/loading.ts file in the dialogHelper file that has operations to close the Playback error mesage modal.

**Issues**
 Fixes #6889
