### PR TITLE
Add double-tap to fast-forward and rewind in video player

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -101,6 +101,7 @@
 - [diegoeche](https://github.com/diegoeche)
 - [Free O'Toole](https://github.com/freeotoole)
 - [TheBosZ](https://github.com/thebosz)
+- [Shoham Peller](https://github.com/spellr)
 
 ## Emby Contributors
 

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1839,7 +1839,28 @@ export default function (view) {
 
     dom.addEventListener(view, 'dblclick', (e) => {
         if (e.target !== view) return;
-        playbackManager.toggleFullscreen(currentPlayer);
+
+        if (layoutManager.mobile) {
+            // Get the click position relative to the video container width
+            const rect = view.getBoundingClientRect();
+            const clickX = e.clientX - rect.left;
+            const containerWidth = rect.width;
+
+            // If clicked on the left third of the screen, seek backward
+            // If clicked on the right third of the screen, seek forward
+            // Middle third toggles full screen
+            if (clickX < containerWidth / 3) {
+                playbackManager.rewind(currentPlayer);
+                showOsd(btnRewind);
+            } else if (clickX > (containerWidth * 2 / 3)) {
+                playbackManager.fastForward(currentPlayer);
+                showOsd(btnFastForward);
+            } else {
+                playbackManager.toggleFullscreen(currentPlayer);
+            }
+        } else {
+            playbackManager.toggleFullscreen(currentPlayer);
+        }
     });
 
     view.querySelector('.buttonMute').addEventListener('click', function () {


### PR DESCRIPTION
This PR implements the double-tap to fast-forward or rewind feature as requested in [Feature Request #131](https://features.jellyfin.org/posts/131/double-tap-to-fast-forward-or-rewind).

In mobile, adds support for double-tapping on the left/right areas of the video player to seek backward/forward by 10 seconds.
Doesn't effect non-mobile devices, where this gesture doesn't feel natural. This behavior is consistent with other players. e.g. YouTube, VLC.

**Issues**
[Feature Request #131](https://features.jellyfin.org/posts/131/double-tap-to-fast-forward-or-rewind)