### PR TITLE
Fix favorite button not updating properly

### DIFF
--- a/src/elements/emby-ratingbutton/emby-ratingbutton.js
+++ b/src/elements/emby-ratingbutton/emby-ratingbutton.js
@@ -3,6 +3,7 @@ import globalize from '../../lib/globalize';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
 import Events from '../../utils/events.ts';
 import EmbyButtonPrototype from '../emby-button/emby-button';
+import { playbackManager } from '../../components/playback/playbackmanager';
 
 function addNotificationEvent(instance, name, handler) {
     const localHandler = handler.bind(instance);
@@ -39,7 +40,20 @@ function onClick() {
     }
 
     showPicker(button, apiClient, id, likes, isFavorite).then(function (userData) {
-        setState(button, userData.Likes, userData.IsFavorite);
+        // This hackish, but once all elements are migrated to React components
+        // button state will be able to be handled by React.
+        const buttons = document.querySelectorAll(`button[is="emby-ratingbutton"][data-id="${id}"]`);
+        buttons.forEach((btn) => {
+            setState(btn, userData.Likes, userData.IsFavorite);
+        });
+
+        playbackManager.getPlaylist().then(function(items) {
+            items.forEach(function(e) {
+                if (e.Id == id) {
+                    e.UserData.IsFavorite = userData.IsFavorite;
+                }
+            });
+        });
     });
 }
 

--- a/src/elements/emby-ratingbutton/emby-ratingbutton.js
+++ b/src/elements/emby-ratingbutton/emby-ratingbutton.js
@@ -42,14 +42,14 @@ function onClick() {
     showPicker(button, apiClient, id, likes, isFavorite).then(function (userData) {
         // This hackish, but once all elements are migrated to React components
         // button state will be able to be handled by React.
-        const buttons = document.querySelectorAll(`button[is="emby-ratingbutton"][data-id="${id}"]`);
+        const buttons = document.querySelectorAll(`button[is="emby-ratingbutton"][data-id="${CSS.escape(id)}"]`);
         buttons.forEach((btn) => {
             setState(btn, userData.Likes, userData.IsFavorite);
         });
 
         playbackManager.getPlaylist().then(function(items) {
             items.forEach(function(e) {
-                if (e.Id == id) {
+                if (e.Id === id && e.UserData) {
                     e.UserData.IsFavorite = userData.IsFavorite;
                 }
             });


### PR DESCRIPTION
**Changes**
Some parts of songs aren't React components yet (please correct me if I'm wrong). When the favorite button on a track is clicked, it fails to update in other list views.
The changes were:

- Update all button which have `is=emby-ratingbutton` and the `data-id` of the item being toggled as favorite
- Update the item inside the playlist manager's queue

I think this is a quick fix for now while the React rewrite is still pending.  Because I think this will introduce better state management across the app.

Feedback is appreciated, as I'm still getting familiar with Jellyfin. Thanks!

**Issues**
Fixes #6386

Screen capture after patch:
https://github.com/user-attachments/assets/dd619d54-896e-44c7-b168-382a54658b40

