### PR TITLE
Enter FullScreen before playback, passing video info to enable DoVi support on Xbox 

### DIFF
--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -25,7 +25,6 @@ import '../../../elements/emby-slider/emby-slider';
 import '../../../elements/emby-button/paper-icon-button-light';
 import '../../../elements/emby-ratingbutton/emby-ratingbutton';
 import '../../../styles/videoosd.scss';
-import shell from '../../../scripts/shell';
 import SubtitleSync from '../../../components/subtitlesync/subtitlesync';
 import { appRouter } from '../../../components/router/appRouter';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
@@ -1594,8 +1593,6 @@ export default function (view) {
     let playPauseClickTimeout;
     function onViewHideStopPlayback() {
         if (playbackManager.isPlayingVideo()) {
-            shell.disableFullscreen();
-
             clearTimeout(playPauseClickTimeout);
             const player = currentPlayer;
             view.removeEventListener('viewbeforehide', onViewHideStopPlayback);
@@ -1619,8 +1616,6 @@ export default function (view) {
             player.setPlaybackRate(playbackRateSpeed);
         }
     }
-
-    shell.enableFullscreen();
 
     let currentPlayer;
     let comingUpNextDisplayed;

--- a/src/scripts/shell.js
+++ b/src/scripts/shell.js
@@ -1,8 +1,11 @@
 // TODO: This seems like a good candidate for deprecation
 export default {
-    enableFullscreen: function() {
+    /**
+     * Ask the NativeShell to enter fullscreen & switch resolution if possible
+     */
+    enableFullscreen: function (videoInfo) {
         if (window.NativeShell?.enableFullscreen) {
-            window.NativeShell.enableFullscreen();
+            window.NativeShell.enableFullscreen(videoInfo);
         }
     },
     disableFullscreen: function() {


### PR DESCRIPTION
**Changes**

In order for DoVi videos to play on Xbox, the client must switch the resolution to DolbyVisionLowLatency. Currently `enableFullscreen()` is called after the video begins playing but the Xbox expects the display to be in DoVi mode before. This PR moves `enableFullscreen()` & `disableFullscreen()` to playbackmanager.js. This PR also extends the `window.NativeShell.enableFullscreen()` to take in video information so that NativeShell can switch the display resolution, hdr mode. This also allow a client to attempt to match the display to the resolution & refresh rate.

Note: The Xbox is an always `full screen` device, but I have used `enableFullscreen()` to switch the resolution to match the video (typically 24hz) and then `disableFullscreen()` to switch it back to the default mode (typically 60hz)

The changes can be tested on Xbox One/Series by compiling `jellyfin-uwp` using my fork https://github.com/jellyfin/jellyfin-uwp/pull/46 . https://github.com/jellyfin/jellyfin-web/pull/5669 is also required.

Note: This PR is based on https://github.com/jellyfin/jellyfin-web/pull/5628 with conflicts resolved

![image](https://github.com/jellyfin/jellyfin-web/assets/1393949/e43d1f04-267b-47b4-adb0-0bcf8edb43cd)


**Testing:**
I have tested `jellyfin-web` on
- Xbox Series X (The 1080p & 4K profile 5 video from https://developer.dolby.com/tools-media/sample-media/video-streams/dolby-vision-streams plays.)
- Windows 11 (to check enableFullScreen/disableFullScreen works but I don't have a HDR capable monitor so playback doesn't work)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
