### PR TITLE
Add Proxy polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "material-react-table": "3.2.1",
         "native-promise-only": "0.8.1",
         "pdfjs-dist": "3.11.174",
+        "proxy-polyfill": "0.3.2",
         "react": "18.3.1",
         "react-blurhash": "0.3.0",
         "react-dom": "18.3.1",
@@ -18711,6 +18712,12 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "peer": true
+    },
+    "node_modules/proxy-polyfill": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/proxy-polyfill/-/proxy-polyfill-0.3.2.tgz",
+      "integrity": "sha512-ENKSXOMCewnQTOyqrQXxEjIhzT6dy572mtehiItbDoIUF5Sv5UkmRUc8kowg2MFvr232Uo8rwRpNg3V5kgTKbA==",
+      "license": "Apache-2.0"
     },
     "node_modules/pump": {
       "version": "3.0.2",
@@ -37664,6 +37671,11 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "peer": true
+    },
+    "proxy-polyfill": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/proxy-polyfill/-/proxy-polyfill-0.3.2.tgz",
+      "integrity": "sha512-ENKSXOMCewnQTOyqrQXxEjIhzT6dy572mtehiItbDoIUF5Sv5UkmRUc8kowg2MFvr232Uo8rwRpNg3V5kgTKbA=="
     },
     "pump": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "material-react-table": "3.2.1",
     "native-promise-only": "0.8.1",
     "pdfjs-dist": "3.11.174",
+    "proxy-polyfill": "0.3.2",
     "react": "18.3.1",
     "react-blurhash": "0.3.0",
     "react-dom": "18.3.1",

--- a/src/lib/legacy/index.ts
+++ b/src/lib/legacy/index.ts
@@ -8,6 +8,7 @@ import 'classlist.js';
 import 'whatwg-fetch';
 import 'abortcontroller-polyfill'; // requires fetch
 import 'resize-observer-polyfill';
+import 'proxy-polyfill';
 
 import './domParserTextHtml';
 import './elementAppendPrepend';

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -229,6 +229,7 @@ const config = {
                     path.resolve(__dirname, 'node_modules/markdown-it'),
                     path.resolve(__dirname, 'node_modules/material-react-table'),
                     path.resolve(__dirname, 'node_modules/mdurl'),
+                    path.resolve(__dirname, 'node_modules/proxy-polyfill'),
                     path.resolve(__dirname, 'node_modules/punycode'),
                     path.resolve(__dirname, 'node_modules/react-blurhash'),
                     path.resolve(__dirname, 'node_modules/react-lazy-load-image-component'),


### PR DESCRIPTION
https://github.com/jellyfin/jellyfin-web/pull/6787 broke old browsers (webOS 1.2) because tanstack-query started using `Proxy`.

**Changes**
Add Proxy polyfill.

**Issues**
N/A
