### PR TITLE
Update playback position on progress update

### DIFF
--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -1333,6 +1333,7 @@ function updateUserData(card, userData) {
             innerCardFooter.appendChild(itemProgressBar);
         }
 
+        card.setAttribute('data-positionticks', userData.PlaybackPositionTicks);
         itemProgressBar.innerHTML = progressHtml;
     } else {
         itemProgressBar = card.querySelector('.itemProgressBar');


### PR DESCRIPTION
When playing through an external player and stopping, the progress bar indicator will update to reflect but re-playing the media will still restart at the initial playback position.

**Changes**
Update the `data-positionticks` attribute when user data updates

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
