### PR TITLE
Prevent unwanted navigation history changes during horizontal scroll for trackpads

### DIFF
--- a/src/lib/scroller/index.js
+++ b/src/lib/scroller/index.js
@@ -599,6 +599,13 @@ const scrollerFactory = function (frame, options) {
         let delta = normalizeWheelDelta(event);
 
         if (transform) {
+            if (o.horizontal && event.deltaX !== 0 &&
+                (event.deltaY >= -5 && event.deltaY <= 5) &&
+                (pos.dest + o.scrollBy * delta > 0) &&
+                (pos.dest + o.scrollBy * delta < pos.end)
+            ) {
+                event.preventDefault();
+            }
             self.slideBy(o.scrollBy * delta);
         } else {
             if (isSmoothScrollSupported) {
@@ -794,7 +801,7 @@ const scrollerFactory = function (frame, options) {
             if (o.mouseWheel) {
                 // Scrolling navigation
                 dom.addEventListener(scrollSource, wheelEvent, scrollHandler, {
-                    passive: true
+                    passive: false
                 });
             }
         } else if (o.horizontal && o.mouseWheel) {


### PR DESCRIPTION
**Summary:**
This PR introduces a `preventDefault` mechanism to prevent unintended backward/forward navigation in the browser history when performing a two-finger horizontal scroll gesture on a trackpad.

**Details:**
Previously, horizontal trackpad scrolling could inadvertently trigger navigation history changes, especially during aggressive or boundary-hitting scroll movements. This change specifically restricts history navigation by evaluating the scroll start, end, and the intensity of the scroll movement.

**Visual Reference:**
Please refer to the accompanying GIF for a demonstration of the fix.

Before:
![annoying-behavior](https://github.com/user-attachments/assets/46d79a67-a393-4896-8e1d-41da0bd769bb)

After:
![behavior-fixed](https://github.com/user-attachments/assets/75e5ce1c-87c8-4fb2-966d-a199547572f2)
