### PR TITLE
feat: Enable Missing Indicator for Movies

### DIFF
--- a/src/components/indicators/indicators.js
+++ b/src/components/indicators/indicators.js
@@ -150,7 +150,7 @@ export function getTypeIndicator(item) {
 }
 
 export function getMissingIndicator(item) {
-    if (item.Type === 'Episode' && item.LocationType === 'Virtual') {
+    if ((item.Type === 'Episode' || item.Type === 'Movie') && item.LocationType === 'Virtual') {
         if (item.PremiereDate) {
             try {
                 const premiereDate = datetime.parseISO8601Date(item.PremiereDate).getTime();

--- a/src/components/indicators/useIndicator.tsx
+++ b/src/components/indicators/useIndicator.tsx
@@ -81,7 +81,7 @@ const useIndicator = (item: ItemDto) => {
 
     const getMissingIndicator = () => {
         if (
-            item.Type === ItemKind.Episode
+            (item.Type === ItemKind.Episode || item.Type === ItemKind.Movie)
             && item.LocationType === LocationType.Virtual
         ) {
             if (item.PremiereDate) {


### PR DESCRIPTION
**Changes**
Enables the the "Missing" Indicator (currently used for Virtual Episodes) for Virtual Movies too.

This is particularly useful since I wish to contribute to the internal Tmdb plugin, allowing users to display missing movies in their collections.

The jellyfin core counterpart PR is https://github.com/jellyfin/jellyfin/pull/14237

