### PR TITLE
Resumes playback after reload during playback (#559)

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -3255,6 +3255,10 @@ export class PlaybackManager {
                 playerData.secondarySubtitleStreamIndex = null;
             }
 
+            if (streamInfo?.item?.Id) {
+                sessionStorage.setItem('lastPlayedItemId', streamInfo.item.Id);
+            }
+
             self._playNextAfterEnded = true;
             const isFirstItem = playOptions.isFirstItem;
             const fullscreen = playOptions.fullscreen;

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1620,6 +1620,37 @@ export default function (view) {
         }
     }
 
+    function isPageReloaded() {
+        // Detects if the current page load was a result of a reload.
+        if (typeof performance !== 'undefined' && typeof performance.getEntriesByType === 'function') {
+            const navEntries = performance.getEntriesByType('navigation');
+            if (navEntries.length > 0 && navEntries[0].name.includes('/video')) {
+                return navEntries[0].type === 'reload';
+            }
+        }
+        return false;
+    }
+
+    async function resumePlayback() {
+        // Resume playback based on item id
+        const lastPlayedItemId = sessionStorage.getItem('lastPlayedItemId');
+        const apiClient = ServerConnections.currentApiClient();
+        const serverId = apiClient.serverId();
+        const lastPlayedItemTicks = (await (apiClient.getItem(apiClient.getCurrentUserId(), lastPlayedItemId))).UserData.PlaybackPositionTicks || 0;
+
+        await playbackManager.play({
+            ids: [lastPlayedItemId],
+            serverId: serverId,
+            startPositionTicks: lastPlayedItemTicks
+        }).then(() => {
+            // Remove specified class so playback controls will show
+            const dlg = document.querySelector('.videoPlayerContainer');
+            if (dlg) {
+                dlg.classList.remove('videoPlayerContainer-onTop');
+            }
+        });
+    }
+
     shell.enableFullscreen();
 
     let currentPlayer;
@@ -1669,8 +1700,12 @@ export default function (view) {
         headerElement.classList.add('osdHeader');
         setBackdropTransparency(TRANSPARENCY_LEVEL.Full);
     });
-    view.addEventListener('viewshow', function () {
+    view.addEventListener('viewshow', async function () {
         try {
+            const reloaded = isPageReloaded();
+            if (reloaded) {
+                await resumePlayback();
+            }
             Events.on(playbackManager, 'playerchange', onPlayerChange);
             bindToPlayer(playbackManager.getCurrentPlayer());
             /* eslint-disable-next-line compat/compat */


### PR DESCRIPTION
**Changes**
I modified the following files to fix the bug from issue 559:
- `src/controllers/playback/video/index.js`
- `src/components/playback/playbackmanager.js`

The `playbackmanager` saves the item id in session storage once playback has begun.

If a reload is performed during playback, the item id is retrieved from session storage. Then the last saved position ticks are retrieved using the `apiClient`.  If there are no saved position ticks for that item id, the playback position defaults to zero ticks. Finally, the video is resumed using the `playbackmanager`.

**Current:**
The current functionality is that when a user reloads the page during playback, the user goes back to `/home`

**Now:**
After my changes, the user will resume the last saved playback position on the video after a reload during playback.


https://github.com/user-attachments/assets/ce88b889-83e8-4a51-9744-07bdfdd38392



**Issues**
Fixes #559
