### PR TITLE
Move Chapters,Trickplay fields to shuffle query only for Movie

### DIFF
--- a/src/controllers/movies/movies.js
+++ b/src/controllers/movies/movies.js
@@ -33,7 +33,7 @@ export default function (view, params, tabContent, options) {
     function shuffle() {
         isLoading = true;
         loading.show();
-        const newQuery = { ...query, SortBy: 'Random', StartIndex: 0, Limit: 300 };
+        const newQuery = { ...query, SortBy: 'Random', StartIndex: 0, Limit: 300, Fields: 'PrimaryImageAspectRatio,MediaSourceCount,Chapters,Trickplay' };
         return ApiClient.getItems(ApiClient.getCurrentUserId(), newQuery).then(({ Items }) => {
             playbackManager.play({
                 items: Items,
@@ -277,7 +277,7 @@ export default function (view, params, tabContent, options) {
         SortOrder: 'Ascending',
         IncludeItemTypes: 'Movie',
         Recursive: true,
-        Fields: 'PrimaryImageAspectRatio,MediaSourceCount,Chapters,Trickplay',
+        Fields: 'PrimaryImageAspectRatio,MediaSourceCount',
         ImageTypeLimit: 1,
         EnableImageTypes: 'Primary,Backdrop,Banner,Thumb',
         StartIndex: 0,


### PR DESCRIPTION

**Changes**
Optimize query performance by removing Chapters,Trickplay fields from the main library query and adding them only to the shuffle functionality query. This reduces the amount of data fetched during regular browsing while maintaining full functionality for shuffle playback, which specifically needs these fields for proper media handling.

**Issues**
Improves performance for library browsing by reducing unnecessary field loading.

Currently:
![image](https://github.com/user-attachments/assets/00148e5d-7606-4de9-b1b3-78d66074b14e)

Now:
![image](https://github.com/user-attachments/assets/8e9b4654-1e32-41a8-9074-59e18c6adc9c)

