### PR TITLE
add feature to mark item as unplayed

### DIFF
--- a/src/components/itemContextMenu.js
+++ b/src/components/itemContextMenu.js
@@ -196,6 +196,14 @@ export async function getCommands(options) {
         }
     }
 
+    if (item.UserData.PlaybackPositionTicks !== 0) {
+        commands.push({
+            name: globalize.translate('MarkUnplayed'),
+            id: 'markunplayed',
+            icon: 'remove'
+        });
+    }
+
     if (item.CanDelete && options.deleteItem !== false) {
         commands.push({
             name: getDeleteLabel(item.Type),
@@ -556,6 +564,9 @@ function executeCommand(item, id, options) {
                 playbackManager.instantMix(item);
                 getResolveFunction(resolve, id)();
                 break;
+            case 'markunplayed':
+                markUnplayed(apiClient, itemId, options.user.Id).then(getResolveFunction(resolve, id, true), getResolveFunction(resolve, id));
+                break;
             case 'delete':
                 deleteItem(apiClient, item).then(getResolveFunction(resolve, id, true, true, itemId), getResolveFunction(resolve, id));
                 break;
@@ -710,6 +721,10 @@ function editItem(apiClient, item) {
             });
         }
     });
+}
+
+function markUnplayed(apiClient, itemId, userId) {
+    return apiClient.markUnplayed(userId, itemId);
 }
 
 function deleteItem(apiClient, item) {


### PR DESCRIPTION
Based on [this request](https://features.jellyfin.org/posts/517/add-an-option-to-remove-an-item-from-continue-watching):
 An ability to remove item from currently watching, implemented according to my comment:
`
...Anyway, I'm planning to implement this as an option for the context menu: "Mark unplayed" (if you want to remove from continue watching but make it marked as played - just use the check icon)
`
Hope it's good!