### PR TITLE
Catch the exception when the user has no access to the epgs

### DIFF
--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -1631,6 +1631,10 @@ function renderSeriesSchedule(page, item) {
         imageLoader.lazyChildren(scheduleTab);
 
         loading.hide();
+    }).catch(function (resp) {
+        if(resp.status === 403) {
+            page.querySelector('#seriesScheduleSection').classList.add('hide');
+        }
     });
 }
 


### PR DESCRIPTION
Catch exception when the user has no access to tv epgs

**Changes**
When the server returns 403, the client will do as there is 0 items in response

**Issues**
Fixes #6977 
