### PR TITLE
Set maxMaxBufferLength to avoid bufferAppendError on Chrome 138

### DIFF
--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -453,6 +453,7 @@ export class HtmlVideoPlayer {
                     startPosition: options.playerStartPositionTicks / 10000000,
                     manifestLoadingTimeOut: 20000,
                     maxBufferLength: maxBufferLength,
+                    maxMaxBufferLength: maxBufferLength,
                     videoPreference: { preferHDR: true },
                     xhrSetup(xhr) {
                         xhr.withCredentials = includeCorsCredentials;


### PR DESCRIPTION
https://github.com/video-dev/hls.js/blob/master/docs/API.md#maxmaxbufferlength
> HLS.js tries to buffer up to a maximum number of bytes (60 MB by default) rather than to buffer up to a maximum nb of seconds. this is to mimic the browser behaviour (the buffer eviction algorithm is starting after the browser detects that video buffer size reaches a limit in bytes)

It seems that the default buffer eviction behavior has changed in Chrome 138, so the default maxMaxBufferLength from hls.js don't apply.

**Changes**
- Set maxMaxBufferLength to avoid bufferAppendError on Chrome 138

**Issues**
- When playing certain video over HLS on Chrome/Edge 138, the player may restart from the beginning at a certain point due to it being unable to recover from a bufferAppendError.
```
HLS Error: Type: mediaError Details: bufferAppendError Fatal: true
```
