### PR TITLE
Fix image loading skeleton

### DIFF
--- a/src/apps/dashboard/routes/plugins/plugin.tsx
+++ b/src/apps/dashboard/routes/plugins/plugin.tsx
@@ -64,13 +64,13 @@ const PluginPage: FC = () => {
     const {
         data: configurationPages,
         isError: isConfigurationPagesError,
-        isLoading: isConfigurationPagesLoading
+        isPending: isConfigurationPagesLoading
     } = useConfigurationPages();
 
     const {
         data: packageInfo,
         isError: isPackageInfoError,
-        isLoading: isPackageInfoLoading
+        isPending: isPackageInfoLoading
     } = usePackageInfo(pluginName ? {
         name: pluginName,
         assemblyGuid: pluginId
@@ -78,8 +78,8 @@ const PluginPage: FC = () => {
 
     const {
         data: plugins,
-        isLoading: isPluginsLoading,
-        isError: isPluginsError
+        isError: isPluginsError,
+        isPending: isPluginsLoading
     } = usePlugins();
 
     const isLoading =

--- a/src/components/Image.tsx
+++ b/src/components/Image.tsx
@@ -2,8 +2,9 @@ import type { SvgIconComponent } from '@mui/icons-material';
 import ImageNotSupported from '@mui/icons-material/ImageNotSupported';
 import Box from '@mui/material/Box/Box';
 import Paper from '@mui/material/Paper/Paper';
-import Skeleton from '@mui/material/Skeleton/Skeleton';
 import React, { type FC } from 'react';
+
+import { LoadingSkeleton } from './LoadingSkeleton';
 
 interface ImageProps {
     isLoading: boolean
@@ -30,36 +31,36 @@ const Image: FC<ImageProps> = ({
             overflow: 'hidden'
         }}
     >
-        {isLoading && (
-            <Skeleton
-                variant='rectangular'
-                width='100%'
-                height='100%'
-            />
-        )}
-        {url ? (
-            <img
-                src={url}
-                alt={alt}
-                width='100%'
-            />
-        ) : (
-            <Box
-                sx={{
-                    height: '100%',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center'
-                }}
-            >
-                <FallbackIcon
-                    sx={{
-                        height: '25%',
-                        width: 'auto'
-                    }}
+        <LoadingSkeleton
+            isLoading={isLoading}
+            variant='rectangular'
+            width='100%'
+            height='100%'
+        >
+            {url ? (
+                <img
+                    src={url}
+                    alt={alt}
+                    width='100%'
                 />
-            </Box>
-        )}
+            ) : (
+                <Box
+                    sx={{
+                        height: '100%',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center'
+                    }}
+                >
+                    <FallbackIcon
+                        sx={{
+                            height: '25%',
+                            width: 'auto'
+                        }}
+                    />
+                </Box>
+            )}
+        </LoadingSkeleton>
     </Paper>
 );
 

--- a/src/components/LoadingSkeleton.tsx
+++ b/src/components/LoadingSkeleton.tsx
@@ -1,0 +1,18 @@
+import Skeleton, { type SkeletonProps } from '@mui/material/Skeleton/Skeleton';
+import React, { FC } from 'react';
+
+interface LoadingSkeletonProps extends SkeletonProps {
+    isLoading: boolean
+}
+
+export const LoadingSkeleton: FC<LoadingSkeletonProps> = ({
+    children,
+    isLoading,
+    ...props
+}) => (
+    isLoading ? (
+        <Skeleton {...props} />
+    ) : (
+        children
+    )
+);


### PR DESCRIPTION
**Changes**
* Creates a new `LoadingSkeleton` component that will render either a `Skeleton` or the children it is passed based on the loading state
* Uses the `LoadingSkeleton` for plugin images to fix a logic error that caused the `Skeleton` and fallback icon to be displayed simultaneously 
![Screen Shot 2025-07-01 at 16 23 52-fullpage](https://github.com/user-attachments/assets/9a987297-8de6-4698-b194-1c8617e04689)
* Drive by: Use `isPending` instead of `isLoading` in the plugin details route

**Issues**
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new LoadingSkeleton component for improved loading state handling.

* **Refactor**
  * Updated the Image component to use the new LoadingSkeleton for more streamlined loading visuals.
  * Replaced loading state property names in plugin-related hooks for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->