### PR TITLE
Fix unsorted results in Edit Images #7008

### DIFF
--- a/src/components/imageDownloader/imageDownloader.js
+++ b/src/components/imageDownloader/imageDownloader.js
@@ -61,6 +61,16 @@ function reloadBrowsableImages(page, apiClient) {
     }
 
     apiClient.getAvailableRemoteImages(options).then(function (result) {
+        result.Images.sort((a, b) => {
+            // Sort images from the most to the least popular
+            if (a.CommunityRating && b.CommunityRating) {
+                // Lazy eval will make it 0 if needed
+                return (b.VoteCount || 0) - (a.VoteCount || 0);
+            } else {
+                return 0;
+            }
+        });
+
         renderRemoteImages(page, apiClient, result, browsableImageType, options.startIndex, options.limit);
 
         page.querySelector('#selectBrowsableImageType').value = browsableImageType;


### PR DESCRIPTION
Going through the results of the "Edit Images" tool is cumbersome because the results are unsorted by defaults which leads to pages of irrelevant results.

Being able to see the number of votes is a good feature, but it is only halfway implemented if the user has to go through pages of random posters.

**Changes**
- Now sorts the results in descending order automatically

**Issues**
Fixes #7008