### PR TITLE
use PascalCase for api_key parameter

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -351,13 +351,12 @@ export default tseslint.config(
                     leadingUnderscore: 'allowSingleOrDouble',
                     trailingUnderscore: 'allowSingleOrDouble'
                 },
-                // Ignore numbers, locale strings (en-us), aria/data attributes, CSS selectors,
-                // and api_key parameter
+                // Ignore numbers, locale strings (en-us), aria/data attributes and CSS selectors
                 {
                     selector: [ 'objectLiteralProperty', 'typeProperty' ],
                     format: null,
                     filter: {
-                        regex: '[ &\\-]|^([0-9]+)$|^api_key$',
+                        regex: '[ &\\-]|^([0-9]+)$',
                         match: true
                     }
                 }

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -314,7 +314,7 @@ function getAudioStreamUrl(item, transcodingProfile, directPlayContainers, apiCl
         AudioCodec: transcodingProfile.AudioCodec,
         MaxAudioSampleRate: maxValues.maxAudioSampleRate,
         MaxAudioBitDepth: maxValues.maxAudioBitDepth,
-        api_key: apiClient.accessToken(),
+        ApiKey: apiClient.accessToken(),
         PlaySessionId: startingPlaySession,
         StartTimeTicks: startPosition || 0,
         EnableRedirection: true,
@@ -2826,7 +2826,7 @@ export class PlaybackManager {
                         Static: true,
                         mediaSourceId: mediaSource.Id,
                         deviceId: apiClient.deviceId(),
-                        api_key: apiClient.accessToken()
+                        ApiKey: apiClient.accessToken()
                     };
 
                     if (mediaSource.ETag) {

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1523,7 +1523,7 @@ export default function (view) {
         const offsetY = -(tileOffsetY * trickplayInfo.Height);
 
         const imgSrc = apiClient.getUrl('Videos/' + item.Id + '/Trickplay/' + trickplayInfo.Width + '/' + index + '.jpg', {
-            api_key: apiClient.accessToken(),
+            ApiKey: apiClient.accessToken(),
             MediaSourceId: mediaSourceId
         });
 

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1277,7 +1277,7 @@ export class HtmlVideoPlayer {
             }
         });
         const fallbackFontList = apiClient.getUrl('/FallbackFont/Fonts', {
-            api_key: apiClient.accessToken()
+            ApiKey: apiClient.accessToken()
         });
         const htmlVideoPlayer = this;
         import('@jellyfin/libass-wasm').then(({ default: SubtitlesOctopus }) => {
@@ -1327,7 +1327,7 @@ export class HtmlVideoPlayer {
                     apiClient.getJSON(fallbackFontList).then((fontFiles = []) => {
                         fontFiles.forEach(font => {
                             const fontUrl = apiClient.getUrl(`/FallbackFont/Fonts/${encodeURIComponent(font.Name)}`, {
-                                api_key: apiClient.accessToken()
+                                ApiKey: apiClient.accessToken()
                             });
                             availableFonts.push(fontUrl);
                         });


### PR DESCRIPTION
This change works with existing server but without it web will break with future server releases. See https://gist.github.com/nielsvanvelzen/ea047d9028f676185832e51ffaf12a6f

**Changes**
- use PascalCase for api_key parameter
  - `api_key` ---> `ApiKey`

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
