### PR TITLE
Add user setting to control parental rating limit for backdrop images

### DIFF
--- a/src/apps/experimental/features/preferences/hooks/useDisplaySettings.ts
+++ b/src/apps/experimental/features/preferences/hooks/useDisplaySettings.ts
@@ -97,7 +97,8 @@ async function loadDisplaySettings({
         maxDaysForNextUp: settings.maxDaysForNextUp(),
         screensaver: settings.screensaver() || 'none',
         screensaverInterval: settings.backdropScreensaverInterval(),
-        theme: settings.theme()
+        theme: settings.theme(),
+        backdropParentalRatingLimit: Boolean(settings.backdropParentalRatingLimit())
     };
 
     return {
@@ -141,6 +142,7 @@ async function saveDisplaySettings({
     userSettings.screensaver(normalizeValue(newDisplaySettings.screensaver));
     userSettings.backdropScreensaverInterval(newDisplaySettings.screensaverInterval);
     userSettings.theme(newDisplaySettings.theme);
+    userSettings.backdropParentalRatingLimit(newDisplaySettings.backdropParentalRatingLimit);
 
     layoutManager.setLayout(normalizeValue(newDisplaySettings.layout));
 

--- a/src/apps/experimental/features/preferences/types/displaySettingsValues.ts
+++ b/src/apps/experimental/features/preferences/types/displaySettingsValues.ts
@@ -19,4 +19,5 @@ export interface DisplaySettingsValues {
     screensaver: string;
     screensaverInterval: number;
     theme: string;
+    backdropParentalRatingLimit: boolean;
 }

--- a/src/components/displaySettings/displaySettings.js
+++ b/src/components/displaySettings/displaySettings.js
@@ -121,6 +121,7 @@ function loadForm(context, user, userSettings) {
     context.querySelector('#chkFadein').checked = userSettings.enableFastFadein();
     context.querySelector('#chkBlurhash').checked = userSettings.enableBlurhash();
     context.querySelector('#chkBackdrops').checked = userSettings.enableBackdrops();
+    context.querySelector('#chkBackdropParentalRatingLimit').checked = userSettings.backdropParentalRatingLimit();
     context.querySelector('#chkDetailsBanner').checked = userSettings.detailsBanner();
 
     context.querySelector('#chkDisableCustomCss').checked = userSettings.disableCustomCss();
@@ -168,6 +169,7 @@ function saveUser(context, user, userSettingsInstance, apiClient) {
     userSettingsInstance.enableFastFadein(context.querySelector('#chkFadein').checked);
     userSettingsInstance.enableBlurhash(context.querySelector('#chkBlurhash').checked);
     userSettingsInstance.enableBackdrops(context.querySelector('#chkBackdrops').checked);
+    userSettingsInstance.backdropParentalRatingLimit(context.querySelector('#chkBackdropParentalRatingLimit').checked);
     userSettingsInstance.detailsBanner(context.querySelector('#chkDetailsBanner').checked);
 
     userSettingsInstance.disableCustomCss(context.querySelector('#chkDisableCustomCss').checked);

--- a/src/components/displaySettings/displaySettings.template.html
+++ b/src/components/displaySettings/displaySettings.template.html
@@ -247,6 +247,14 @@
         <div class="fieldDescription checkboxFieldDescription">${EnableBackdropsHelp}</div>
     </div>
 
+    <div class="checkboxContainer checkboxContainer-withDescription fldBackdropParentalRatingLimit">
+        <label>
+            <input type="checkbox" is="emby-checkbox" id="chkBackdropParentalRatingLimit" />
+            <span>${BackdropParentalRatingLimit}</span>
+        </label>
+        <div class="fieldDescription checkboxFieldDescription">${BackdropParentalRatingLimitHelp}</div>
+    </div>
+
     <div class="checkboxContainer checkboxContainer-withDescription fldThemeSong">
         <label>
             <input type="checkbox" is="emby-checkbox" id="chkThemeSong" />

--- a/src/scripts/autoBackdrops.js
+++ b/src/scripts/autoBackdrops.js
@@ -31,7 +31,7 @@ function getBackdropItemIds(apiClient, userId, types, parentId) {
         ImageTypes: 'Backdrop',
         ParentId: parentId,
         EnableTotalRecordCount: false,
-        MaxOfficialRating: parentId ? '' : 'PG-13'
+        MaxOfficialRating: userSettings.backdropParentalRatingLimit() ? 'PG-13' : ''
     };
     return apiClient.getItems(apiClient.getCurrentUserId(), options).then(function (result) {
         const images = result.Items.map(function (i) {

--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -465,6 +465,19 @@ export class UserSettings {
     }
 
     /**
+     * Get or set backdrop parental rating limit.
+     * @param {boolean|undefined} [val] - Flag to enable backdrop parental rating limit or undefined.
+     * @return {boolean} Backdrop parental rating limit state.
+     */
+    backdropParentalRatingLimit(val) {
+        if (val !== undefined) {
+            return this.set('backdropParentalRatingLimit', val.toString(), false);
+        }
+
+        return toBoolean(this.get('backdropParentalRatingLimit', true), true);
+    }
+
+    /**
      * Get or set the amount of time it takes to activate the screensaver in seconds. Default 3 minutes.
      * @param {number|undefined} [val] - The amount of time it takes to activate the screensaver in seconds.
      * @return {number} The amount of time it takes to activate the screensaver in seconds.
@@ -705,6 +718,7 @@ export const skin = currentSettings.skin.bind(currentSettings);
 export const theme = currentSettings.theme.bind(currentSettings);
 export const screensaver = currentSettings.screensaver.bind(currentSettings);
 export const backdropScreensaverInterval = currentSettings.backdropScreensaverInterval.bind(currentSettings);
+export const backdropParentalRatingLimit = currentSettings.backdropParentalRatingLimit.bind(currentSettings);
 export const screensaverTime = currentSettings.screensaverTime.bind(currentSettings);
 export const libraryPageSize = currentSettings.libraryPageSize.bind(currentSettings);
 export const maxDaysForNextUp = currentSettings.maxDaysForNextUp.bind(currentSettings);

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -76,6 +76,8 @@
     "Backdrop": "Backdrop",
     "Backdrops": "Backdrops",
     "BackdropScreensaver": "Backdrop Screensaver",
+    "BackdropParentalRatingLimit": "Limit backdrop parental rating",
+    "BackdropParentalRatingLimitHelp": "When enabled, only content rated PG-13 or lower will be used for global backdrops. This helps ensure appropriate background images in family environments.",
     "BackupsPageLoadError": "Failed to load backups page",
     "Banner": "Banner",
     "BirthDateValue": "Born: {0}",

--- a/src/strings/fr-ca.json
+++ b/src/strings/fr-ca.json
@@ -118,6 +118,8 @@
     "Auto": "Auto",
     "Backdrop": "Arrière-plan",
     "Backdrops": "Arrière-plans",
+    "BackdropParentalRatingLimit": "Limiter la classification des arrière-plans",
+    "BackdropParentalRatingLimitHelp": "Lorsque activé, seuls les contenus classés PG-13 ou moins seront utilisés pour les arrière-plans globaux. Cela aide à assurer des images d'arrière-plan appropriées dans les environnements familiaux.",
     "Banner": "Bannière",
     "BirthDateValue": "Né(e) le {0}",
     "BirthLocation": "Lieu de naissance",

--- a/src/strings/fr.json
+++ b/src/strings/fr.json
@@ -36,6 +36,8 @@
     "AspectRatio": "Format d'image",
     "Backdrop": "Arrière-plan",
     "Backdrops": "Arrière-plans",
+    "BackdropParentalRatingLimit": "Limiter la classification des arrière-plans",
+    "BackdropParentalRatingLimitHelp": "Lorsque activé, seuls les contenus classés PG-13 ou moins seront utilisés pour les arrière-plans globaux. Cela aide à assurer des images d'arrière-plan appropriées dans les environnements familiaux.",
     "Banner": "Bannière",
     "BirthDateValue": "Né(e) le {0}",
     "BirthLocation": "Lieu de naissance",


### PR DESCRIPTION
**Changes**
Add a configurable user setting to control parental rating limits for backdrop images. This replaces the previously hardcoded PG-13 limit for global backdrops with a user-controllable option that applies to all backdrop contexts. When enabled (default), only content rated PG-13 or lower will be used for backdrop images, helping ensure appropriate background images in family environments.

**Technical implementation:**
- Added `backdropParentalRatingLimit()` method to `UserSettings` class with default value `true`
- Updated backdrop selection logic in `autoBackdrops.js` to use the user setting instead of hardcoded parent check
- Added UI checkbox in display settings template with descriptive help text
- Extended TypeScript interfaces and experimental settings hooks for the new option
- Added translations for English, French (fr), and French Canadian (fr-ca)

**Key changes:**
- Previously: PG-13 limit only applied to global backdrops (`parentId` empty)
- Now: PG-13 limit applies to all backdrops when user setting is enabled
- Maintains backward compatibility by enabling the setting by default
- Provides users with control over content appropriateness for their environment

**Issues**
Fixes #4077 
