### PR TITLE
imageLoader: fix upscrolling showing unloaded images

### DIFF
--- a/src/components/images/imageLoader.js
+++ b/src/components/images/imageLoader.js
@@ -82,12 +82,8 @@ export function fillImage(entry) {
         source = entry;
     }
 
-    if (entry.isIntersecting) {
-        if (source) {
-            fillImageElement(target, source);
-        }
-    } else if (!source) {
-        emptyImageElement(target);
+    if (entry.isIntersecting && source) {
+        fillImageElement(target, source);
     }
 }
 


### PR DESCRIPTION
**Changes**
When scrolling upwards images that have been unloaded as they went out of view show as blank boxes. Fix by not unloading images that have already been lazy-loaded.  Tested with Safari and Google Chrome on macOS.

**Issues**
No issue opened.  If you scroll upwards on any long page with images you will see images unload as you scroll up, leaving blank boxes.