### PR TITLE
Fix vertical alignment during fetch of media aditional content

### DIFF
--- a/src/styles/videoosd.scss
+++ b/src/styles/videoosd.scss
@@ -174,6 +174,8 @@
 
 .osdMediaStatus {
     margin-left: auto;
+    display: flex;
+    align-items: center;
 }
 
 .osdMediaStatus .animate {

--- a/src/styles/videoosd.scss
+++ b/src/styles/videoosd.scss
@@ -176,7 +176,10 @@
     margin-left: auto;
     display: flex;
     align-items: center;
-    gap: 0.125rem;
+}
+
+.osdMediaStatus span:first-child {
+    margin-right: 0.125rem;
 }
 
 .osdMediaStatus .animate {

--- a/src/styles/videoosd.scss
+++ b/src/styles/videoosd.scss
@@ -176,6 +176,7 @@
     margin-left: auto;
     display: flex;
     align-items: center;
+    gap: 0.125rem;
 }
 
 .osdMediaStatus .animate {


### PR DESCRIPTION
**Changes**  
Adjust the vertical alignment of the loader and label when fetching additional content of a media.

| BEFORE | AFTER |
|--------|-------|
| <img width="223" height="37" alt="image" src="https://github.com/user-attachments/assets/75a9caa0-cbf3-428c-9697-e56cb51f8790" /> | <img width="220" height="27" alt="image" src="https://github.com/user-attachments/assets/943c6768-7aca-4d92-915b-5567d8d34caa" /> |

