### PR TITLE
limit width for cards on ultrawide monitors

### DIFF
--- a/src/components/cardbuilder/card.scss
+++ b/src/components/cardbuilder/card.scss
@@ -784,6 +784,7 @@ button::-moz-focus-inner {
     .overflowSquareCard,
     .overflowPortraitCard {
         width: 9.3vw;
+        max-width: 20em;
     }
 }
 
@@ -791,6 +792,7 @@ button::-moz-focus-inner {
     .overflowBackdropCard,
     .overflowSmallBackdropCard {
         width: 15.6vw;
+        max-width: 30em;
     }
 }
 

--- a/src/styles/librarybrowser.scss
+++ b/src/styles/librarybrowser.scss
@@ -880,6 +880,7 @@
         left: 5%;
         bottom: 1rem;
         max-width: 30vw;
+        max-height: 58em;
         filter: drop-shadow(0 0 0.5rem #000);
 
         @media all and (max-width: 32em) {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
adds a `max-width` for cards that scale based on `vw`, which causes display issues on ultrawide screens. Also adds a `max-height` to the detail card which escapes the banner on ultrawide screens.

**Issues**
fixes https://github.com/jellyfin/jellyfin-web/issues/7051
