### PR TITLE
Hide cast button if menu is empty

### DIFF
--- a/src/scripts/libraryMenu.js
+++ b/src/scripts/libraryMenu.js
@@ -163,7 +163,9 @@ function updateUserInHeader(user) {
             headerSearchButton.classList.remove('hide');
         }
 
-        if (!layoutManager.tv) {
+        const isChromecastPluginLoaded = !!pluginManager.plugins.find(plugin => plugin.id === 'chromecast');
+
+        if (!layoutManager.tv && isChromecastPluginLoaded) {
             headerCastButton.classList.remove('hide');
         }
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
This PR hides the chromecast button if chromecast is not supported instead of opening an empty menu where it says that it is not supported.

**Before**
<img width="686" height="1030" alt="Bildschirmfoto 2025-08-05 um 13 59 04" src="https://github.com/user-attachments/assets/5697dff6-d21e-412d-9093-81e1b1082f52" />

<img width="686" height="1030" alt="Bildschirmfoto 2025-08-05 um 13 59 05" src="https://github.com/user-attachments/assets/5160fec7-79a1-41b2-b38b-786d09daf22f" />



**After**
<img width="686" height="1030" alt="Bildschirmfoto 2025-08-05 um 13 59 15" src="https://github.com/user-attachments/assets/4ef93238-0436-4fea-a79f-501dd6fe4a9c" />
