### PR TITLE
Fix bug in JMP flex alignment

### DIFF
--- a/src/apps/experimental/components/library/ItemsView.tsx
+++ b/src/apps/experimental/components/library/ItemsView.tsx
@@ -300,7 +300,7 @@ const ItemsView: FC<ItemsViewProps> = ({
                             xs: 1,
                             sm: 0
                         },
-                        justifyContent: 'end'
+                        justifyContent: 'flex-end'
                     }}
                 >
                     {!isPending && (


### PR DESCRIPTION
**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
JMP seems to not support `end` and was avoided/ replaced so far with `flex-end`

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
