### PR TITLE
Add overview text to episode cards in "Next Up" and "More from" 

### DIFF
--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -573,6 +573,10 @@ function getCardFooterText(item, apiClient, options, footerClass, progressHtml, 
     }
 
     if (showOtherText) {
+        if (options.showOverview && item.Overview) {
+            lines.push(escapeHtml(item.Overview));
+        }
+
         if (options.showParentTitle && parentTitleUnderneath) {
             if (flags.isOuterFooter && item.AlbumArtists?.length) {
                 item.AlbumArtists[0].Type = 'MusicArtist';

--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -776,7 +776,7 @@ function renderNextUp(page, item, user) {
     ServerConnections.getApiClient(item.ServerId).getNextUpEpisodes({
         SeriesId: item.Id,
         UserId: user.Id,
-        Fields: 'MediaSourceCount'
+        Fields: 'MediaSourceCount,Overview'
     }).then(function (result) {
         if (result.Items.length) {
             section.classList.remove('hide');
@@ -788,6 +788,7 @@ function renderNextUp(page, item, user) {
             items: result.Items,
             shape: 'overflowBackdrop',
             showTitle: true,
+            showOverview: true,
             displayAsSpecial: item.Type == 'Season' && item.IndexNumber,
             overlayText: false,
             centerText: true,
@@ -1141,7 +1142,7 @@ function renderMoreFromSeason(view, item, apiClient) {
         apiClient.getEpisodes(item.SeriesId, {
             SeasonId: item.SeasonId,
             UserId: userId,
-            Fields: 'ItemCounts,PrimaryImageAspectRatio,CanDelete,MediaSourceCount'
+            Fields: 'ItemCounts,PrimaryImageAspectRatio,CanDelete,MediaSourceCount,Overview'
         }).then(function (result) {
             if (result.Items.length < 2) {
                 section.classList.add('hide');
@@ -1158,6 +1159,7 @@ function renderMoreFromSeason(view, item, apiClient) {
                 sectionTitleTagName: 'h2',
                 scalable: true,
                 showTitle: true,
+                showOverview: true,
                 overlayText: false,
                 centerText: true,
                 includeParentInfoInTitle: false,

--- a/src/types/cardOptions.ts
+++ b/src/types/cardOptions.ts
@@ -62,6 +62,7 @@ export interface CardOptions {
     showCurrentProgram?: boolean;
     showCurrentProgramTime?: boolean;
     showItemCounts?: boolean;
+    showOverview?: boolean;
     showPersonRoleOrType?: boolean;
     showProgressBar?: boolean;
     showPremiereDate?: boolean;


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
Adds the `Overview` text for each episode to their cards in the "Next Up" and "More from" sections. 

This is to avoid the interaction cost of navigating back out to the main episode list to figure out which episode is which if you aren't familiar with the titles.

Examples:

<details>
<summary>Next up</summary>

<img width="368" height="284" alt="image" src="https://github.com/user-attachments/assets/64523b64-fe05-4715-adba-f4f67d39e393" />

</details>


<details>
<summary>More from</summary>

<img width="885" height="275" alt="image" src="https://github.com/user-attachments/assets/327717f9-def0-4193-b6b0-e107bba0f020" />

</details>

Please let me know if I should look into adding a display setting to toggle this. I also wasn't quite sure if/where I should put any test cases, so any guidance would be great!

**Issues**
N/A
