### PR TITLE
Fix Edge WebView 2 being detected as old Edge.

### DIFF
--- a/src/elements/emby-scroller/Scroller.tsx
+++ b/src/elements/emby-scroller/Scroller.tsx
@@ -178,6 +178,7 @@ const Scroller: FC<PropsWithChildren<ScrollerProps>> = ({
             allowNativeScroll: !enableScrollButtons,
             forceHideScrollbars: enableScrollButtons,
             // In edge, with the native scroll, the content jumps around when hovering over the buttons
+            // @ts-expect-error browser doesn't explicitly declare browser.edge, so fails type checking
             requireAnimation: enableScrollButtons && browser.edge
         };
 

--- a/src/scripts/browser.js
+++ b/src/scripts/browser.js
@@ -309,10 +309,6 @@ if (browser.web0s) {
     browser.orsay = userAgent.toLowerCase().indexOf('smarthub') !== -1;
 }
 
-if (browser.edgeUwp) {
-    browser.edge = true;
-}
-
 browser.tv = isTv();
 browser.operaTv = browser.tv && userAgent.toLowerCase().indexOf('opr/') !== -1;
 


### PR DESCRIPTION
**Changes**
From my previous edit to browser.js in https://github.com/jellyfin/jellyfin-web/pull/6993 it currently detects Edge WebView 2 as both Edge Chromium and Old Edge. This PR removes the redundant and explicit setting of browser.edge in browser.js.
