### PR TITLE
Fix TV dpad focus issues if the body of the page is the focused element.

### DIFF
--- a/src/components/focusManager.js
+++ b/src/components/focusManager.js
@@ -239,7 +239,7 @@ function nav(activeElement, direction, container, focusableElements) {
 
     container = container || (activeElement ? getFocusContainer(activeElement, direction) : getDefaultScope());
 
-    if (!activeElement) {
+    if (!activeElement || activeElement == document.body) {
         autoFocus(container, true, false);
         return;
     }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
Currently if a page is focused, but not specific elements, then arrow keys or a TV remote cannot not select anything.
With this PR when the arrow keys are pressed, if the page is focused but no elements, then it autofocuses the page.
This not only fixes the current pages that are unable to be navigated by any TV remote, but should also stop future pages from becoming unnavigable too.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #7097 
