### PR TITLE
Mark item played when starting next episode through upNextDialog

### DIFF
--- a/src/components/upnextdialog/upnextdialog.js
+++ b/src/components/upnextdialog/upnextdialog.js
@@ -109,6 +109,11 @@ async function onStartNowClick() {
 
         await this.hide();
 
+        const currentItem = playbackManager.currentItem(player);
+        if (itemHelper.canMarkPlayed(currentItem)) {
+            const apiClient = ServerConnections.getApiClient(currentItem);
+            apiClient.markPlayed(apiClient.getCurrentUserId(), currentItem.Id, new Date());
+        }
         playbackManager.nextTrack(player);
     }
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Explicitly marks episodes as watched when starting next episode through `upNextDialog`. 
This fixes a problem where for episodes with relatively long outros that fall outside the `Maximum resume percentage` will remain in the `continue watching` section while only the outro credits remain.

**Issues**
<!-- Tag any issues that this PR solves here. ex. Fixes # -->
Fixes #7039


**Notes**

Changes have been tested locally and appear to work. This is however my first contribution to this code-base and this solution may not be the best option to solve this particular issue. 