### PR TITLE
Refactor music video section handling for artists

### DIFF
--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -854,7 +854,7 @@ function setInitialCollapsibleState(page, item, apiClient, context, user) {
         page.querySelector('#additionalPartsCollapsible').classList.add('hide');
     }
 
-    if (item.Type == 'MusicAlbum' || item.Type == 'MusicArtist') {
+    if (item.Type == BaseItemKind.MusicAlbum) {
         renderMusicVideos(page, item, user);
     } else {
         page.querySelector('#musicVideosCollapsible').classList.add('hide');
@@ -1764,14 +1764,9 @@ function renderMusicVideos(page, item, user) {
         SortOrder: 'Ascending',
         IncludeItemTypes: 'MusicVideo',
         Recursive: true,
-        Fields: 'PrimaryImageAspectRatio,CanDelete,MediaSourceCount'
+        Fields: 'PrimaryImageAspectRatio,CanDelete,MediaSourceCount',
+        AlbumIds: item.Id
     };
-
-    if (item.Type == 'MusicAlbum') {
-        request.AlbumIds = item.Id;
-    } else {
-        request.ArtistIds = item.Id;
-    }
 
     ServerConnections.getApiClient(item.ServerId).getItems(user.Id, request).then(function (result) {
         if (result.Items.length) {

--- a/src/scripts/itemsByName.js
+++ b/src/scripts/itemsByName.js
@@ -1,3 +1,5 @@
+import { BaseItemKind } from '@jellyfin/sdk/lib/generated-client/models/base-item-kind';
+
 import listView from 'components/listview/listview';
 import cardBuilder from 'components/cardbuilder/cardBuilder';
 import imageLoader from 'components/images/imageLoader';
@@ -326,16 +328,25 @@ function getMoreItemsHref(item, type) {
 }
 
 function addCurrentItemToQuery(query, item) {
-    if (item.Type === 'Person') {
-        query.PersonIds = item.Id;
-    } else if (item.Type === 'Genre') {
-        query.Genres = item.Name;
-    } else if (item.Type === 'MusicGenre') {
-        query.Genres = item.Name;
-    } else if (item.Type === 'Studio') {
-        query.StudioIds = item.Id;
-    } else if (item.Type === 'MusicArtist') {
-        query.AlbumArtistIds = item.Id;
+    switch (item.Type) {
+        case BaseItemKind.Person:
+            query.PersonIds = item.Id;
+            break;
+        case BaseItemKind.Genre:
+            query.Genres = item.Name;
+            break;
+        case BaseItemKind.MusicGenre:
+            query.Genres = item.Name;
+            break;
+        case BaseItemKind.Studio:
+            query.StudioIds = item.Id;
+            break;
+        case BaseItemKind.MusicArtist:
+            if (query.IncludeItemTypes === BaseItemKind.MusicVideo) {
+                query.ArtistIds = item.Id;
+            } else {
+                query.AlbumArtistIds = item.Id;
+            }
     }
 }
 


### PR DESCRIPTION
**Changes**
Refactors the handling of music videos on the artist details screen to not reuse the custom handling for albums. Prevents a duplicate API request that always returns an empty list of music videos.

**Issues**
N/A