### PR TITLE
Fixed audio change playback on Firefox

### DIFF
--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1850,8 +1850,8 @@ export default function (view) {
         playbackManager.setVolume(e.target.value, currentPlayer);
     });
 
-        // Firefox vol slider
-    if (browser.firefox) {
+    // Firefox vol slider
+    if (browser.firefox)  {
         let isDragging = false;
         const updateVolumeFromMousePosition = (e) => {
             const slider = nowPlayingVolumeSlider;
@@ -1861,7 +1861,6 @@ export default function (view) {
             if (globalize.getIsElementRTL(slider)) {
                 fraction = (rect.right - e.clientX) / rect.width;
             }
-        
             fraction = Math.min(Math.max(fraction, 0), 1);
 
             const min = parseFloat(slider.min) || 0;
@@ -1871,8 +1870,7 @@ export default function (view) {
             slider.value = volume;
             playbackManager.setVolume(volume, currentPlayer);
         };
-        
-        nowPlayingVolumeSlider.addEventListener('mousedown', (e) => {
+        nowPlayingVolumeSlider.addEventListener('mo<!-- Describe your changes here in 1-5 sentences. -->usedown', (e) => {
             isDragging = true;
             updateVolumeFromMousePosition(e);
         });
@@ -1888,13 +1886,11 @@ export default function (view) {
                 updateVolumeFromMousePosition(e);
             }
         });
-        
         if (window.PointerEvent) {
             nowPlayingVolumeSlider.addEventListener('pointerdown', (e) => {
                 isDragging = true;
                 updateVolumeFromMousePosition(e);
             });
-            
             document.addEventListener('pointerup', () => {
                 if (isDragging) {
                     isDragging = false;

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1850,6 +1850,65 @@ export default function (view) {
         playbackManager.setVolume(e.target.value, currentPlayer);
     });
 
+        // Firefox vol slider
+    if (browser.firefox) {
+        let isDragging = false;
+        const updateVolumeFromMousePosition = (e) => {
+            const slider = nowPlayingVolumeSlider;
+            const rect = slider.getBoundingClientRect();
+            if (rect.width === 0) return;
+            let fraction = (e.clientX - rect.left) / rect.width;
+            if (globalize.getIsElementRTL(slider)) {
+                fraction = (rect.right - e.clientX) / rect.width;
+            }
+        
+            fraction = Math.min(Math.max(fraction, 0), 1);
+
+            const min = parseFloat(slider.min) || 0;
+            const max = parseFloat(slider.max) || 100;
+            const volume = Math.round(min + fraction * (max - min));
+
+            slider.value = volume;
+            playbackManager.setVolume(volume, currentPlayer);
+        };
+        
+        nowPlayingVolumeSlider.addEventListener('mousedown', (e) => {
+            isDragging = true;
+            updateVolumeFromMousePosition(e);
+        });
+        
+        document.addEventListener('mouseup', () => {
+            if (isDragging) {
+                isDragging = false;
+            }
+        });
+        
+        document.addEventListener('mousemove', (e) => {
+            if (isDragging) {
+                updateVolumeFromMousePosition(e);
+            }
+        });
+        
+        if (window.PointerEvent) {
+            nowPlayingVolumeSlider.addEventListener('pointerdown', (e) => {
+                isDragging = true;
+                updateVolumeFromMousePosition(e);
+            });
+            
+            document.addEventListener('pointerup', () => {
+                if (isDragging) {
+                    isDragging = false;
+                }
+            });
+            
+            document.addEventListener('pointermove', (e) => {
+                if (isDragging) {
+                    updateVolumeFromMousePosition(e);
+                }
+            });
+        }
+    }
+    
     nowPlayingPositionSlider.addEventListener('change', function () {
         const player = currentPlayer;
 


### PR DESCRIPTION
**Changes**
- Custom drag handling - mouse & pointer event listeners to  smooth volume slider dragging in Firefox  HTML range slider behavior is limited
- Real-time volume updates - Calculates volume levels in real-time as the user drags, provide immediate audio feedback without waiting for mouse release
- Precise position mapping - I took the mouse coordinate in Screen to be  mouse coordinates to accurate volume percentages (0-100) based on the slider's dimensions and min/max values 
**Issues**
[<!-- Tag any issues that this PR solves here.
ex. Fixes # -->](https://github.com/jellyfin/jellyfin-web/issues/7107)
