### PR TITLE
Changed the erroneous spelling of the OK button in localizations.

### DIFF
--- a/src/strings/cs.json
+++ b/src/strings/cs.json
@@ -1025,7 +1025,7 @@
     "Browse": "Procházet",
     "BurnSubtitlesHelp": "Zda má server vypálit titulky do obrazu. Tato funkce má velký negativní vliv na výkon. Chcete-li vypálit grafické formáty titulků (VobSub, PGS, SUB, IDX, atd.) a některé titulky ASS nebo SSA, vyberte možnost Automaticky.",
     "ButtonInfo": "Info",
-    "ButtonOk": "Ok",
+    "ButtonOk": "OK",,
     "ButtonScanAllLibraries": "Skenovat všechny knihovny",
     "ButtonStart": "Start",
     "ChangingMetadataImageSettingsNewContent": "Změny nastavení metadat nebo stahování médií se budou týkat pouze nového obsahu přidaného do vaší knihovny. Chcete-li aplikovat změny na existující položky, musíte je aktualizovat ručně.",

--- a/src/strings/da.json
+++ b/src/strings/da.json
@@ -948,7 +948,7 @@
     "BoxRear": "Boks (bagside)",
     "BurnSubtitlesHelp": "Afgør om serveren skal indbrænde undertekster. Undlader du dette, så vil ydelsen forbedres. Vælg Automatisk for at brænde billedbaserede formater (VobSub, PGS, SUB, IDX) og bestemte ASS- eller SSA-undertekster.",
     "ButtonInfo": "Information",
-    "ButtonOk": "Ok",
+    "ButtonOk": "OK",,
     "ButtonPause": "Pause",
     "ButtonSend": "Send",
     "ButtonStart": "Start",

--- a/src/strings/de.json
+++ b/src/strings/de.json
@@ -1096,7 +1096,7 @@
     "Auto": "Auto",
     "Banner": "Banner",
     "Blacklist": "Sperrliste",
-    "ButtonOk": "Ok",
+    "ButtonOk": "OK",,
     "ButtonPause": "Pause",
     "ButtonStart": "Start",
     "ButtonTrailer": "Trailer",

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -117,7 +117,7 @@
     "ButtonManualLogin": "Manual Login",
     "ButtonMore": "More",
     "ButtonNextTrack": "Next track",
-    "ButtonOk": "Ok",
+    "ButtonOk": "OK",,
     "ButtonParentalControl": "Parental control",
     "ButtonPause": "Pause",
     "ButtonPlayer": "Player",

--- a/src/strings/et.json
+++ b/src/strings/et.json
@@ -569,7 +569,7 @@
     "ButtonPause": "Paus",
     "ButtonParentalControl": "Lapselukk",
     "ButtonOpen": "Ava",
-    "ButtonOk": "Ok",
+    "ButtonOk": "OK",,
     "ButtonNextTrack": "Järgmine rada",
     "ButtonNetwork": "Võrk",
     "ButtonMore": "Veel",

--- a/src/strings/fi.json
+++ b/src/strings/fi.json
@@ -107,7 +107,7 @@
     "ButtonMore": "Lisää",
     "ButtonNetwork": "Verkko",
     "ButtonNextTrack": "Seuraava raita",
-    "ButtonOk": "Ok",
+    "ButtonOk": "OK",,
     "ButtonOpen": "Avaa",
     "BurnSubtitlesHelp": "Määritä polttaako palvelin tekstitykset suoraan videoon. Tämä kasvattaa palvelimen kuormitusta merkittävästi. 'Automaattinen' polttaa kuva- (mm. VobSub, PGS ja SUB/IDX) ja tietyt tekstipohjaiset (ASS/SSA) tekstitykset.",
     "ButtonParentalControl": "Lapsilukko",

--- a/src/strings/fil.json
+++ b/src/strings/fil.json
@@ -1543,7 +1543,7 @@
     "ButtonPlayer": "Pampatugtug",
     "ButtonPause": "I-pause",
     "ButtonOpen": "Buksan",
-    "ButtonOk": "Ok",
+    "ButtonOk": "OK",,
     "ButtonNextTrack": "Susunod na track",
     "ButtonNetwork": "Network",
     "ButtonMore": "Higit pa",

--- a/src/strings/gl.json
+++ b/src/strings/gl.json
@@ -180,7 +180,7 @@
     "ButtonBack": "Atrás",
     "ButtonOpen": "Abrir",
     "ButtonMore": "Máis",
-    "ButtonOk": "Ok",
+    "ButtonOk": "OK",,
     "ButtonResume": "Retomar",
     "ButtonGotIt": "Entendo",
     "ButtonSignIn": "Acceder",

--- a/src/strings/hu.json
+++ b/src/strings/hu.json
@@ -477,7 +477,7 @@
     "ButtonFullscreen": "Teljes képernyő",
     "ButtonInfo": "Információ",
     "ButtonNetwork": "Hálózat",
-    "ButtonOk": "Ok",
+    "ButtonOk": "OK",,
     "ButtonRevoke": "Visszavonás",
     "ButtonSelectView": "Válasszon nézetet",
     "ButtonStart": "Indítás",

--- a/src/strings/it.json
+++ b/src/strings/it.json
@@ -1113,7 +1113,7 @@
     "Blacklist": "Lista Nera",
     "Box": "Scatola",
     "ButtonInfo": "Info",
-    "ButtonOk": "Ok",
+    "ButtonOk": "OK",,
     "ButtonStop": "Ferma",
     "ButtonTrailer": "Trailer",
     "ChangingMetadataImageSettingsNewContent": "I cambiamenti alle impostazioni dei download dei metadati verranno applicati solamente ai nuovi contenuti aggiunti alla libreria. Per applicare i cambiamenti ai titoli già esistenti devi ricaricare i metadati manualmente.",

--- a/src/strings/ms.json
+++ b/src/strings/ms.json
@@ -108,7 +108,7 @@
     "Photos": "Gambar-gambar",
     "ButtonParentalControl": "Kawalan penjaga",
     "ButtonOpen": "Buka",
-    "ButtonOk": "Ok",
+    "ButtonOk": "OK",,
     "ButtonPreviousTrack": "Trek sebelumnya",
     "ButtonPause": "Henti Sejenak",
     "ButtonPlayer": "Pemain",

--- a/src/strings/nl.json
+++ b/src/strings/nl.json
@@ -1091,7 +1091,7 @@
     "Blacklist": "Blokkeerlijst",
     "Box": "Hoes",
     "ButtonInfo": "Info",
-    "ButtonOk": "Ok",
+    "ButtonOk": "OK",,
     "ButtonStart": "Starten",
     "ButtonStop": "Stoppen",
     "ButtonTrailer": "Trailer",

--- a/src/strings/pl.json
+++ b/src/strings/pl.json
@@ -1164,7 +1164,7 @@
     "XmlTvSportsCategoriesHelp": "Programy z tymi kategoriami, będą wyświetlane jako sportowe. Oddziel je używając '|'.",
     "Yes": "Tak",
     "Yesterday": "Wczoraj",
-    "ButtonOk": "Ok",
+    "ButtonOk": "OK",,
     "ButtonStart": "Start",
     "FormatValue": "Format: {0}",
     "LabelAuthProvider": "Dostawca uwierzytelniania",

--- a/src/strings/ro.json
+++ b/src/strings/ro.json
@@ -240,7 +240,7 @@
     "ButtonMore": "Mai mult",
     "ButtonNetwork": "Rețea",
     "ButtonNextTrack": "Următoarea cale",
-    "ButtonOk": "Ok",
+    "ButtonOk": "OK",,
     "ButtonOpen": "Deschide",
     "ButtonParentalControl": "Control parental",
     "ButtonPause": "Pauză",

--- a/src/strings/sk.json
+++ b/src/strings/sk.json
@@ -728,7 +728,7 @@
     "Alerts": "Upozornenia",
     "AllowOnTheFlySubtitleExtraction": "Povoliť extrahovanie titulkov za behu",
     "ButtonInfo": "Info",
-    "ButtonOk": "Ok",
+    "ButtonOk": "OK",,
     "ButtonStart": "Štart",
     "ButtonStop": "Zastaviť",
     "ChannelNameOnly": "Iba kanál {0}",

--- a/src/strings/sl-si.json
+++ b/src/strings/sl-si.json
@@ -125,7 +125,7 @@
     "ButtonMore": "Več",
     "ButtonNetwork": "Omrežje",
     "ButtonNextTrack": "Naslednja skladba",
-    "ButtonOk": "Ok",
+    "ButtonOk": "OK",,
     "ButtonOpen": "Odpri",
     "ButtonParentalControl": "Starševski nadzor",
     "ButtonPause": "Premor",

--- a/src/strings/sq.json
+++ b/src/strings/sq.json
@@ -109,7 +109,7 @@
     "ButtonPause": "Ndal",
     "ButtonParentalControl": "Kontrollimet Prindërore",
     "ButtonOpen": "Hap",
-    "ButtonOk": "Ok",
+    "ButtonOk": "OK",,
     "ButtonNextTrack": "Kënga tjetër",
     "ButtonNetwork": "Rrjeti",
     "ButtonMore": "Më shumë",

--- a/src/strings/sv.json
+++ b/src/strings/sv.json
@@ -57,7 +57,7 @@
     "ButtonEditOtherUserPreferences": "Ändra den här användarens profil, bild och personliga inställningar.",
     "ButtonForgotPassword": "Glömt Lösenord",
     "ButtonFullscreen": "Fullskärm",
-    "ButtonGotIt": "Ok",
+    "ButtonGotIt": "OK",
     "ButtonLibraryAccess": "Biblioteksåtkomst",
     "ButtonManualLogin": "Manuell inloggning",
     "ButtonMore": "Mer",


### PR DESCRIPTION
**Changes**
The "OK" button that appears everywhere is wrongly spelt. "Ok" is not a possible spelling. While the origins of the word OK are disputed, [the most frequently accepted one](While the origins of the word are disputed, the most frequently accepted i) is a comedic abbreviation for "oll korrect" from early-mid-nineteenth century America. That makes "OK" a possible spelling and the spelling most often requires from style books.  "Okay", which is phonetic, is also acceptable. "Ok" is not a possible spelling. It's basically a misspelled "ock" sound. It makes Jellyfin look amateurish.

**Issues**
I resolved the wrong spelling of the "OK" button.