### PR TITLE
fix: endless loop when saving metadata people with no type

### DIFF
--- a/src/components/metadataEditor/metadataEditor.js
+++ b/src/components/metadataEditor/metadataEditor.js
@@ -67,6 +67,12 @@ function submitUpdatedItem(form, item) {
         } else {
             afterContentTypeUpdated();
         }
+    })
+    .catch(function (err) {
+        loading.hide();
+        if (err.status == 400)
+            toast("Error, you must specify a type for people");
+
     });
 }
 

--- a/src/components/metadataEditor/personEditor.template.html
+++ b/src/components/metadataEditor/personEditor.template.html
@@ -12,7 +12,7 @@
         </div>
 
         <div class="selectContainer">
-            <select is="emby-select" id="selectPersonType" class="selectPersonType" label="${LabelType}"></select>
+            <select is="emby-select" id="selectPersonType" class="selectPersonType" label="${LabelType}" required></select>
         </div>
 
         <div class="inputContainer fldRole hide">


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Fix infinite loading circle when saving metadata of an item with people with no `type`.

- Now the `type` field is required in the add people form.
- I handled the error with the code `400` that was causing the infinite loading (i added it in case) 

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
#6559
