### PR TITLE
Make DirectoryBrowser and UserSettings available to plugins

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -19,7 +19,6 @@ import { initialize as initializeAutoCast } from 'scripts/autocast';
 import browser from './scripts/browser';
 import keyboardNavigation from './scripts/keyboardNavigation';
 import { getPlugins } from './scripts/settings/webSettings';
-import taskButton from './scripts/taskbutton';
 import { pageClassOn, serverAddress } from './utils/dashboard';
 import Events from './utils/events';
 
@@ -38,6 +37,7 @@ import './scripts/autoThemes';
 import './scripts/mouseManager';
 import './scripts/screensavermanager';
 import './scripts/serverNotifications';
+import './pluginImport';
 
 // Import site styles
 import './styles/site.scss';
@@ -53,10 +53,6 @@ async function init() {
 version: ${__PACKAGE_JSON_VERSION__}
 commit: ${__COMMIT_SHA__}
 build: ${__JF_BUILD_VERSION__}`);
-
-    // Register globals used in plugins
-    window.Events = Events;
-    window.TaskButton = taskButton;
 
     // Register handlers to update header classes
     pageClassOn('viewshow', 'standalonePage', function () {

--- a/src/pluginImport.js
+++ b/src/pluginImport.js
@@ -1,0 +1,61 @@
+import taskButton from 'scripts/taskbutton';
+import Events from 'utils/events';
+
+function pluginImport(path) {
+    // Structuring imports this way allows modules to be lazily imported at
+    // runtime.  We can't directly call `import(path)` because webpack doesn't
+    // know how to handle that.
+    //
+    // This returns a promise, so it is a bit different than the old globals:
+    // ```
+    // // Old
+    // TaskButton({ ... });
+    //
+    // // New
+    // pluginImport("scripts/taskbutton").then(TaskButton => {
+    //     TaskButton.default({ ... });
+    // });
+    // ```
+    switch (path) {
+        case 'components/directorybrowser/directorybrowser':
+            return import('components/directorybrowser/directorybrowser');
+        case 'scripts/settings/userSettings':
+            return import('scripts/settings/userSettings');
+        case 'scripts/taskbutton':
+            return import('scripts/taskbutton');
+        case 'utils/events':
+            return import('utils/events');
+        default:
+            console.warn(`Unable to import plugin ${path}.`);
+            console.warn(
+                'If you are writing a plugin and are trying to import a module '
+                + 'at runtime, it needs to be registered in src/pluginImport.js'
+                + ' in https://github.com/jellyfin/jellyfin-web'
+            );
+            throw new TypeError(`Unable to import plugin ${path}`);
+    }
+}
+
+export default pluginImport;
+window.pluginImport = pluginImport; // So plugins can use it
+
+// Legacy properties for plugin imports that used to be globals
+Object.defineProperty(window, 'Events', {
+    'get': function() {
+        console.warn(
+            '`window.Events` is deprecated.  Use '
+            + '`window.pluginImport(\'utils/events\')` instead.'
+        );
+        return Events;
+    }
+});
+
+Object.defineProperty(window, 'TaskButton', {
+    'get': function() {
+        console.warn(
+            '`window.TaskButton` is deprecated.  Use '
+            + '`window.pluginImport(\'scripts/taskbutton\')` instead.'
+        );
+        return taskButton;
+    }
+});


### PR DESCRIPTION
**Changes**
The DirectoryBrowser and UserSettings modules can now be accessed from plugins to use (e.g. in their configuration pages).
This also sets up a pluginImport() function that can be used for similar needs in the future in a cleaner way that importing everything into globals.  It deprecates the old globals that used to exist for this purpose.