### PR TITLE
Prevent dialog backdrop from displaying above dialog content

### DIFF
--- a/src/components/dialogHelper/dialoghelper.scss
+++ b/src/components/dialogHelper/dialoghelper.scss
@@ -148,7 +148,7 @@
     left: 0 !important;
     right: 0 !important;
     margin: 0 !important;
-    z-index: 999999 !important;
+    z-index: 999998 !important;
     transition: opacity ease-out 0.2s;
     will-change: opacity;
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->
The source of the issue seems to be that the dialog backdrop (in some cases) is placed after the dialog content in the DOM. Since they both have the same z-index the backdrop will appear above the content. It seems `Node.insertBefore` used [here](https://github.com/jellyfin/jellyfin-web/blob/e9e56af09279ba8b84bdcc87814d8e3788b79c38/src/components/dialogHelper/dialogHelper.js#L204) not always inserts before the content. Therefore I suppose this is more of a workaround than a fix.

Submitting using the enter key compared to the button on the page made no difference for me. However when I used a breakpoint it did seem to work every time, suggesting maybe the node has not been inserted in time.

**Changes**
Changes z-index of backdrop to be one less than that of the dialog content (999998 compared to 999999)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #7171 
