### PR TITLE
Fix app bar visibility on item details page

### DIFF
--- a/src/apps/experimental/AppOverrides.scss
+++ b/src/apps/experimental/AppOverrides.scss
@@ -27,7 +27,18 @@ $mui-bp-xl: 1536px;
     padding-top: 3.25rem !important;
 }
 
-// Fix backdrop position on mobile item details page
-.layout-mobile .itemBackdrop {
-    margin-top: 0 !important;
+.layout-mobile {
+    .itemBackdrop {
+        // Fix backdrop position on mobile item details page
+        margin-top: 0 !important;
+
+        // Add a subtle gradient over the backdrop to ensure the app bar buttons are visible
+        &::before {
+            display: block;
+            content: "";
+            height: 100%;
+            width: 100%;
+            background: linear-gradient(180deg, rgba(32, 32, 32, 0.6) 0%, rgba(32, 32, 32, 0.2) 4rem, rgba(0, 0, 0, 0) 50%);
+        }
+    }
 }

--- a/src/themes/defaults.ts
+++ b/src/themes/defaults.ts
@@ -1,4 +1,5 @@
 import type { ColorSystemOptions, ThemeOptions } from '@mui/material/styles';
+import type {} from '@mui/material/themeCssVarsAugmentation';
 
 const LIST_ICON_WIDTH = 36;
 
@@ -52,6 +53,13 @@ export const DEFAULT_THEME_OPTIONS: ThemeOptions = {
                     // NOTE: This seems like a bug. Block content does not fill the container width.
                     flexGrow: 1
                 }
+            }
+        },
+        MuiAppBar: {
+            styleOverrides: {
+                colorTransparent: ({ theme }) => ({
+                    color: theme.vars.palette.text.primary
+                })
             }
         },
         MuiButton: {


### PR DESCRIPTION
**Changes**
Fixes the visibility of items in the app bar in the experimental layout when there is a light backdrop on the item details page.

| Before | After |
|---|---|
| ![IMG_8057](https://github.com/user-attachments/assets/0aaa698c-0bfb-4a88-aa2c-6dc0d726e477) |  ![IMG_8056](https://github.com/user-attachments/assets/0992f0eb-12c9-4f85-8c21-fd881febc872) |

**Issues**
N/A