### PR TITLE
Show scroller content that overflows

### DIFF
--- a/src/lib/scroller/index.js
+++ b/src/lib/scroller/index.js
@@ -758,7 +758,6 @@ const scrollerFactory = function (frame, options) {
                 }
             }
         } else {
-            frame.style.overflow = 'hidden';
             slideeElement.style['will-change'] = 'transform';
             slideeElement.style.transition = 'transform ' + o.speed + 'ms ease-out';
 

--- a/src/styles/librarybrowser.scss
+++ b/src/styles/librarybrowser.scss
@@ -845,6 +845,7 @@
 
 .detailPageSecondaryContainer {
     padding-top: 1.25em;
+    overflow: hidden;
 
     .layout-desktop & {
         flex-grow: 1;


### PR DESCRIPTION
**Changes**
Allows scroller content that overflows the container to still be visible allowing for an "edge to edge" experience.

<img width="1382" height="578" alt="Screenshot 2025-10-08 at 12-42-17 Jellyfin Edge" src="https://github.com/user-attachments/assets/dd2cf2f9-84b7-41a8-8fc3-fe72f75d3380" />

**Issues**
N/A