### PR TITLE
Adding ability to select Cuda device in the UI

### DIFF
--- a/src/apps/dashboard/routes/playback/transcoding.tsx
+++ b/src/apps/dashboard/routes/playback/transcoding.tsx
@@ -299,19 +299,37 @@ export const Component = () => {
                             )}
 
                             {hardwareAccelType === 'nvenc' && (
-                                <FormControl>
-                                    <FormControlLabel
-                                        label={globalize.translate('EnableEnhancedNvdecDecoder')}
-                                        control={
-                                            <Checkbox
-                                                name='EnableEnhancedNvdecDecoder'
-                                                checked={config.EnableEnhancedNvdecDecoder}
-                                                onChange={onCheckboxChange}
-                                            />
-                                        }
+                                <>
+                                    <FormControl>
+                                        <FormControlLabel
+                                            label={globalize.translate('EnableEnhancedNvdecDecoder')}
+                                            control={
+                                                <Checkbox
+                                                    name='EnableEnhancedNvdecDecoder'
+                                                    checked={config.EnableEnhancedNvdecDecoder}
+                                                    onChange={onCheckboxChange}
+                                                />
+                                            }
+                                        />
+                                        <FormHelperText>{globalize.translate('EnableEnhancedNvdecDecoderHelp')}</FormHelperText>
+                                    </FormControl>
+
+                                    <TextField
+                                        name='CudaDevice'
+                                        value={config.CudaDevice}
+                                        onChange={onConfigChange}
+                                        label={globalize.translate('LabelCudaDevice')}
+                                        helperText={globalize.translate('LabelCudaDeviceHelp')}
+                                        type='number'
+                                        slotProps={{
+                                            htmlInput: {
+                                                min: 0,
+                                                max: 9,
+                                                step: 1
+                                            }
+                                        }}
                                     />
-                                    <FormHelperText>{globalize.translate('EnableEnhancedNvdecDecoderHelp')}</FormHelperText>
-                                </FormControl>
+                                </>
                             )}
 
                             {hardwareAccelType === 'qsv' && (

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -661,6 +661,8 @@
     "LabelCreateHttpPortMap": "Enable automatic port mapping for HTTP traffic as well as HTTPS.",
     "LabelCreateHttpPortMapHelp": "Permit automatic port mapping to create a rule for HTTP traffic in addition to HTTPS traffic.",
     "LabelCriticRating": "Critics rating",
+    "LabelCudaDevice": "Cuda Device Index",
+    "LabelCudaDeviceHelp": "Specify the Cuda device index for ffmpeg argument '-init_hw_device cuda=cu:<deviceIndex>'. Default is 0.",
     "LabelCurrentPassword": "Current password",
     "LabelCurrentStatus": "Current status",
     "LabelCustomCertificatePath": "Custom SSL certificate path",


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->
Adding UI control to transcode setting config change.
Server PR: https://github.com/jellyfin/jellyfin/pull/14977

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
- Added number text field in the nvenc transcoding settings to pass `config.CudaDevice`
