### PR TITLE
Fix "More From" section to show all albums by album artist

### DIFF
--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -1194,7 +1194,7 @@ function renderMoreFromArtist(view, item, apiClient) {
         if (item.Type === 'MusicArtist') {
             query.ContributingArtistIds = item.Id;
         } else {
-            query.AlbumArtistIds = item.AlbumArtists.map(artist => artist.Id);
+            query.AlbumArtistIds = item.AlbumArtists.map(artist => artist.Id).join(',');
         }
 
         apiClient.getItems(apiClient.getCurrentUserId(), query).then(function (result) {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
With the contributing artist query fix ([#14991](https://github.com/jellyfin/jellyfin/pull/14991)) on the server, we need to update the condition for the "More from" section.

Before: "More from" only showed albums where they were a contributing artist 
<img width="976" height="749" alt="1" src="https://github.com/user-attachments/assets/1fda8b1b-f045-4027-a2dd-96d9d9aebc54" />


After: "More from" shows all albums where they are the main album artist
<img width="1024" height="767" alt="2" src="https://github.com/user-attachments/assets/08d62f8b-22ae-454d-b508-f45d2da8b6e1" />

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # --> N/A
