### PR TITLE
Add warning for page size setting

### DIFF
--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -780,7 +780,7 @@
     "LabelLanNetworks": "LAN networks",
     "LabelLevel": "Level",
     "LabelLibraryPageSize": "Library page size",
-    "LabelLibraryPageSizeHelp": "Set the amount of items to show on a library page. Set to 0 in order to disable paging.",
+    "LabelLibraryPageSizeHelp": "Set the amount of items to show on a library page. Setting a value of 0 will disable pagination. Please note that setting this to 0 or any value greater than 100 may lead to bugs and reduced performance.",
     "LabelMaxDaysForNextUp": "Max days in 'Next Up'",
     "LabelMaxDaysForNextUpHelp": "Set the maximum amount of days a show should stay in the 'Next Up' list without watching it.",
     "LabelMaxVideoResolution": "Maximum Allowed Video Transcoding Resolution",


### PR DESCRIPTION
**Changes**
Adds a warning that changing the library page size to a value greater than 100 or disabled (0) can cause bugs and poor performance.

**Issues**
N/A