### PR TITLE
Set maximum npm version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -139,7 +139,7 @@
       },
       "engines": {
         "node": ">=20.0.0",
-        "npm": ">=9.6.4",
+        "npm": ">=9.6.4 <11.0.0",
         "yarn": "YARN NO LONGER USED - use npm instead."
       },
       "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
   },
   "engines": {
     "node": ">=20.0.0",
-    "npm": ">=9.6.4",
+    "npm": ">=9.6.4 <11.0.0",
     "yarn": "YARN NO LONGER USED - use npm instead."
   }
 }


### PR DESCRIPTION
**Changes**
Limits the maximum supported npm version to be 10.x. 

This should fix renovate generating invalid changes to the package lockfile in its PRs per https://github.com/renovatebot/renovate/discussions/37335

**Issues**
N/A