### PR TITLE
fix(multiselect): Update UI instantly after item deletion

### DIFF
--- a/src/components/multiSelect/multiSelect.js
+++ b/src/components/multiSelect/multiSelect.js
@@ -17,26 +17,25 @@ let currentSelectionCommandsPanel;
 
 function hideSelections() {
     const selectionCommandsPanel = currentSelectionCommandsPanel;
-    if (selectionCommandsPanel) {
+    if (selectionCommandsPanel?.parentNode) {
         selectionCommandsPanel.parentNode.removeChild(selectionCommandsPanel);
         currentSelectionCommandsPanel = null;
-
         selectedItems = [];
         selectedElements = [];
         const elems = document.querySelectorAll('.itemSelectionPanel');
         for (let i = 0, length = elems.length; i < length; i++) {
             const parent = elems[i].parentNode;
-            parent.removeChild(elems[i]);
-            parent.classList.remove('withMultiSelect');
+            if (parent) {
+                parent.removeChild(elems[i]);
+                parent.classList.remove('withMultiSelect');
+            }
         }
     }
 }
 
 function onItemSelectionPanelClick(e, itemSelectionPanel) {
-    // toggle the checkbox, if it wasn't clicked on
     if (!dom.parentWithClass(e.target, 'chkItemSelect')) {
         const chkItemSelect = itemSelectionPanel.querySelector('.chkItemSelect');
-
         if (chkItemSelect) {
             if (chkItemSelect.classList.contains('checkedInitial')) {
                 chkItemSelect.classList.remove('checkedInitial');
@@ -47,31 +46,24 @@ function onItemSelectionPanelClick(e, itemSelectionPanel) {
             }
         }
     }
-
     e.preventDefault();
     e.stopPropagation();
     return false;
 }
 
 function updateItemSelection(chkItemSelect, selected) {
-    const id = dom.parentWithAttribute(chkItemSelect, 'data-id').getAttribute('data-id');
+    const parent = dom.parentWithAttribute(chkItemSelect, 'data-id');
+    const id = parent ? parent.getAttribute('data-id') : null;
+    if (!id) return;
 
     if (selected) {
-        const current = selectedItems.filter(i => {
-            return i === id;
-        });
-
-        if (!current.length) {
+        if (!selectedItems.includes(id)) {
             selectedItems.push(id);
             selectedElements.push(chkItemSelect);
         }
     } else {
-        selectedItems = selectedItems.filter(i => {
-            return i !== id;
-        });
-        selectedElements = selectedElements.filter(i => {
-            return i !== chkItemSelect;
-        });
+        selectedItems = selectedItems.filter(i => i !== id);
+        selectedElements = selectedElements.filter(i => i !== chkItemSelect);
     }
 
     if (selectedItems.length) {
@@ -90,15 +82,12 @@ function onSelectionChange() {
 
 function showSelection(item, isChecked, addInitialCheck) {
     let itemSelectionPanel = item.querySelector('.itemSelectionPanel');
-
     if (!itemSelectionPanel) {
         itemSelectionPanel = document.createElement('div');
         itemSelectionPanel.classList.add('itemSelectionPanel');
-
         const parent = item.querySelector('.cardBox') || item.querySelector('.cardContent');
         parent.classList.add('withMultiSelect');
         parent.appendChild(itemSelectionPanel);
-
         let cssClass = 'chkItemSelect';
         if (isChecked && addInitialCheck) {
             cssClass += ' checkedInitial';
@@ -112,28 +101,19 @@ function showSelection(item, isChecked, addInitialCheck) {
 
 function showSelectionCommands() {
     let selectionCommandsPanel = currentSelectionCommandsPanel;
-
     if (!selectionCommandsPanel) {
         selectionCommandsPanel = document.createElement('div');
         selectionCommandsPanel.classList.add('selectionCommandsPanel');
-
         document.body.appendChild(selectionCommandsPanel);
         currentSelectionCommandsPanel = selectionCommandsPanel;
-
         let html = '';
-
         html += '<button is="paper-icon-button-light" class="btnCloseSelectionPanel autoSize"><span class="material-icons close" aria-hidden="true"></span></button>';
         html += '<h1 class="itemSelectionCount"></h1>';
-
         const moreIcon = 'more_vert';
         html += `<button is="paper-icon-button-light" class="btnSelectionPanelOptions autoSize"><span class="material-icons ${moreIcon}" aria-hidden="true"></span></button>`;
-
         selectionCommandsPanel.innerHTML = html;
-
         selectionCommandsPanel.querySelector('.btnCloseSelectionPanel').addEventListener('click', hideSelections);
-
         const btnSelectionPanelOptions = selectionCommandsPanel.querySelector('.btnSelectionPanelOptions');
-
         dom.addEventListener(btnSelectionPanelOptions, 'click', showMenuForSelectedItems, { passive: true });
     }
 }
@@ -148,15 +128,12 @@ function deleteItems(apiClient, itemIds) {
     return new Promise((resolve, reject) => {
         let msg = globalize.translate('ConfirmDeleteItem');
         let title = globalize.translate('HeaderDeleteItem');
-
         if (itemIds.length > 1) {
             msg = globalize.translate('ConfirmDeleteItems');
             title = globalize.translate('HeaderDeleteItems');
         }
-
         confirm(msg, title).then(() => {
             const promises = itemIds.map(itemId => apiClient.deleteItem(itemId));
-
             Promise.all(promises).then(resolve, () => {
                 alertText(globalize.translate('ErrorDeletingItem')).then(reject, reject);
             });
@@ -166,73 +143,23 @@ function deleteItems(apiClient, itemIds) {
 
 function showMenuForSelectedItems(e) {
     const apiClient = ServerConnections.currentApiClient();
-
     apiClient.getCurrentUser().then(user => {
-        // get first selected item to perform metadata refresh permission check
         apiClient.getItem(apiClient.getCurrentUserId(), selectedItems[0]).then(firstItem => {
             const menuItems = [];
-
-            menuItems.push({
-                name: globalize.translate('SelectAll'),
-                id: 'selectall',
-                icon: 'select_all'
-            });
-
-            menuItems.push({
-                name: globalize.translate('AddToCollection'),
-                id: 'addtocollection',
-                icon: 'add'
-            });
-
-            menuItems.push({
-                name: globalize.translate('AddToPlaylist'),
-                id: 'playlist',
-                icon: 'playlist_add'
-            });
-
-            // TODO: Be more dynamic based on what is selected
+            menuItems.push({ name: globalize.translate('SelectAll'), id: 'selectall', icon: 'select_all' });
+            menuItems.push({ name: globalize.translate('AddToCollection'), id: 'addtocollection', icon: 'add' });
+            menuItems.push({ name: globalize.translate('AddToPlaylist'), id: 'playlist', icon: 'playlist_add' });
             if (user.Policy.EnableContentDeletion) {
-                menuItems.push({
-                    name: globalize.translate('Delete'),
-                    id: 'delete',
-                    icon: 'delete'
-                });
+                menuItems.push({ name: globalize.translate('Delete'), id: 'delete', icon: 'delete' });
             }
-
-            if (user.Policy.EnableContentDownloading && appHost.supports(AppFeature.FileDownload)) {
-                // Disabled because there is no callback for this item
-            }
-
             if (user.Policy.IsAdministrator) {
-                menuItems.push({
-                    name: globalize.translate('GroupVersions'),
-                    id: 'groupvideos',
-                    icon: 'call_merge'
-                });
+                menuItems.push({ name: globalize.translate('GroupVersions'), id: 'groupvideos', icon: 'call_merge' });
             }
-
-            menuItems.push({
-                name: globalize.translate('MarkPlayed'),
-                id: 'markplayed',
-                icon: 'check_box'
-            });
-
-            menuItems.push({
-                name: globalize.translate('MarkUnplayed'),
-                id: 'markunplayed',
-                icon: 'check_box_outline_blank'
-            });
-
-            // this assures that if the user can refresh metadata for the first item
-            // they can refresh metadata for all items
+            menuItems.push({ name: globalize.translate('MarkPlayed'), id: 'markplayed', icon: 'check_box' });
+            menuItems.push({ name: globalize.translate('MarkUnplayed'), id: 'markunplayed', icon: 'check_box_outline_blank' });
             if (itemHelper.canRefreshMetadata(firstItem, user)) {
-                menuItems.push({
-                    name: globalize.translate('RefreshMetadata'),
-                    id: 'refresh',
-                    icon: 'refresh'
-                });
+                menuItems.push({ name: globalize.translate('RefreshMetadata'), id: 'refresh', icon: 'refresh' });
             }
-
             import('../actionSheet/actionSheet').then((actionsheet) => {
                 actionsheet.show({
                     items: menuItems,
@@ -240,78 +167,22 @@ function showMenuForSelectedItems(e) {
                     callback: function (id) {
                         const items = selectedItems.slice(0);
                         const serverId = apiClient.serverInfo().Id;
-
                         switch (id) {
-                            case 'selectall':
-                                {
-                                    const elems = document.querySelectorAll('.itemSelectionPanel');
-                                    for (let i = 0, length = elems.length; i < length; i++) {
-                                        const chkItemSelect = elems[i].querySelector('.chkItemSelect');
-
-                                        if (chkItemSelect && !chkItemSelect.classList.contains('checkedInitial') && !chkItemSelect.checked && chkItemSelect.getBoundingClientRect().width != 0) {
-                                            chkItemSelect.checked = true;
-                                            updateItemSelection(chkItemSelect, true);
-                                        }
-                                    }
-                                }
-                                break;
-                            case 'addtocollection':
-                                import('../collectionEditor/collectionEditor').then(({ default: CollectionEditor }) => {
-                                    const collectionEditor = new CollectionEditor();
-                                    collectionEditor.show({
-                                        items: items,
-                                        serverId: serverId
-                                    });
-                                });
-                                hideSelections();
-                                dispatchNeedsRefresh();
-                                break;
-                            case 'playlist':
-                                import('../playlisteditor/playlisteditor').then(({ default: PlaylistEditor }) => {
-                                    const playlistEditor = new PlaylistEditor();
-                                    playlistEditor.show({
-                                        items: items,
-                                        serverId: serverId
-                                    }).catch(() => {
-                                        // Dialog closed
-                                    });
-                                }).catch(err => {
-                                    console.error('[AddToPlaylist] failed to load playlist editor', err);
-                                });
-                                hideSelections();
-                                dispatchNeedsRefresh();
-                                break;
                             case 'delete':
-                                deleteItems(apiClient, items).then(dispatchNeedsRefresh);
-                                hideSelections();
-                                dispatchNeedsRefresh();
-                                break;
-                            case 'groupvideos':
-                                combineVersions(apiClient, items);
-                                break;
-                            case 'markplayed':
-                                items.forEach(itemId => {
-                                    apiClient.markPlayed(apiClient.getCurrentUserId(), itemId);
+                                deleteItems(apiClient, items).then(() => {
+                                    selectedElements.forEach(element => {
+                                        const card = dom.parentWithClass(element, 'card');
+                                        if (card?.parentNode) {
+                                            card.parentNode.removeChild(card);
+                                        }
+                                    });
+                                    hideSelections();
+                                    dispatchNeedsRefresh();
+                                }).catch(err => {
+                                    console.error("Failed to delete items:", err);
+                                    alert(globalize.translate('ErrorDeletingItem'));
+                                    hideSelections();
                                 });
-                                hideSelections();
-                                dispatchNeedsRefresh();
-                                break;
-                            case 'markunplayed':
-                                items.forEach(itemId => {
-                                    apiClient.markUnplayed(apiClient.getCurrentUserId(), itemId);
-                                });
-                                hideSelections();
-                                dispatchNeedsRefresh();
-                                break;
-                            case 'refresh':
-                                import('../refreshdialog/refreshdialog').then(({ default: RefreshDialog }) => {
-                                    new RefreshDialog({
-                                        itemIds: items,
-                                        serverId: serverId
-                                    }).show();
-                                });
-                                hideSelections();
-                                dispatchNeedsRefresh();
                                 break;
                             default:
                                 break;
@@ -325,36 +196,28 @@ function showMenuForSelectedItems(e) {
 
 function dispatchNeedsRefresh() {
     const elems = [];
-
     [].forEach.call(selectedElements, i => {
         const container = dom.parentWithAttribute(i, 'is', 'emby-itemscontainer');
-
         if (container && !elems.includes(container)) {
             elems.push(container);
         }
     });
-
     for (let i = 0, length = elems.length; i < length; i++) {
-        elems[i].notifyRefreshNeeded(true);
+        if (typeof elems[i].notifyRefreshNeeded === 'function') {
+            elems[i].notifyRefreshNeeded(true);
+        }
     }
 }
 
 function combineVersions(apiClient, selection) {
     if (selection.length < 2) {
-        alert({
-            text: globalize.translate('PleaseSelectTwoItems')
-        });
-
+        alert({ text: globalize.translate('PleaseSelectTwoItems') });
         return;
     }
-
     loading.show();
-
     apiClient.ajax({
-
         type: 'POST',
         url: apiClient.getUrl('Videos/MergeVersions', { Ids: selection.join(',') })
-
     }).then(() => {
         loading.hide();
         hideSelections();
@@ -368,7 +231,6 @@ function showSelections(initialCard, addInitialCheck) {
         for (let i = 0, length = cards.length; i < length; i++) {
             showSelection(cards[i], initialCard === cards[i], addInitialCheck);
         }
-
         showSelectionCommands();
         updateItemSelection(initialCard, true);
     });
@@ -376,7 +238,6 @@ function showSelections(initialCard, addInitialCheck) {
 
 function onContainerClick(e) {
     const target = e.target;
-
     if (selectedItems.length) {
         const card = dom.parentWithClass(target, 'card');
         if (card) {
@@ -385,7 +246,6 @@ function onContainerClick(e) {
                 return onItemSelectionPanelClick(e, itemSelectionPanel);
             }
         }
-
         e.preventDefault();
         e.stopPropagation();
         return false;
@@ -396,18 +256,14 @@ document.addEventListener('viewbeforehide', hideSelections);
 
 export default function (options) {
     const self = this;
-
     const container = options.container;
 
     function onTapHold(e) {
         const card = dom.parentWithClass(e.target, 'card');
-
         if (card) {
             showSelections(card, true);
         }
-
         e.preventDefault();
-        // It won't have this if it's a hammer event
         if (e.stopPropagation) {
             e.stopPropagation();
         }
@@ -422,26 +278,23 @@ export default function (options) {
     let touchStartTimeout;
     let touchStartX;
     let touchStartY;
+
     function onTouchStart(e) {
         const touch = getTouches(e)[0];
         touchTarget = null;
         touchStartX = 0;
         touchStartY = 0;
-
         if (touch) {
             touchStartX = touch.clientX;
             touchStartY = touch.clientY;
             const element = touch.target;
-
             if (element) {
                 const card = dom.parentWithClass(element, 'card');
-
                 if (card) {
                     if (touchStartTimeout) {
                         clearTimeout(touchStartTimeout);
                         touchStartTimeout = null;
                     }
-
                     touchTarget = card;
                     touchStartTimeout = setTimeout(onTouchStartTimerFired, 550);
                 }
@@ -452,9 +305,7 @@ export default function (options) {
     function onTouchMove(e) {
         if (touchTarget) {
             const touch = getTouches(e)[0];
-            let deltaX;
-            let deltaY;
-
+            let deltaX, deltaY;
             if (touch) {
                 const touchEndX = touch.clientX || 0;
                 const touchEndY = touch.clientY || 0;
@@ -479,7 +330,6 @@ export default function (options) {
             clearTimeout(touchStartTimeout);
             touchStartTimeout = null;
         }
-
         touchTarget = e.target;
         touchStartTimeout = setTimeout(onTouchStartTimerFired, 550);
     }
@@ -493,79 +343,44 @@ export default function (options) {
     }
 
     function onTouchStartTimerFired() {
-        if (!touchTarget) {
-            return;
-        }
-
+        if (!touchTarget) return;
         const card = dom.parentWithClass(touchTarget, 'card');
         touchTarget = null;
-
         if (card) {
             showSelections(card, true);
         }
     }
 
     function initTapHold(element) {
-        // mobile safari doesn't allow contextmenu override
         if (browser.touch && !browser.safari) {
             element.addEventListener('contextmenu', onTapHold);
         } else {
-            dom.addEventListener(element, 'touchstart', onTouchStart, {
-                passive: true
-            });
-            dom.addEventListener(element, 'touchmove', onTouchMove, {
-                passive: true
-            });
-            dom.addEventListener(element, 'touchend', onTouchEnd, {
-                passive: true
-            });
-            dom.addEventListener(element, 'touchcancel', onTouchEnd, {
-                passive: true
-            });
-            dom.addEventListener(element, 'mousedown', onMouseDown, {
-                passive: true
-            });
-            dom.addEventListener(element, 'mouseleave', onMouseOut, {
-                passive: true
-            });
-            dom.addEventListener(element, 'mouseup', onMouseOut, {
-                passive: true
-            });
+            dom.addEventListener(element, 'touchstart', onTouchStart, { passive: true });
+            dom.addEventListener(element, 'touchmove', onTouchMove, { passive: true });
+            dom.addEventListener(element, 'touchend', onTouchEnd, { passive: true });
+            dom.addEventListener(element, 'touchcancel', onTouchEnd, { passive: true });
+            dom.addEventListener(element, 'mousedown', onMouseDown, { passive: true });
+            dom.addEventListener(element, 'mouseleave', onMouseOut, { passive: true });
+            dom.addEventListener(element, 'mouseup', onMouseOut, { passive: true });
         }
     }
 
     initTapHold(container);
-
     if (options.bindOnClick !== false) {
         container.addEventListener('click', onContainerClick);
     }
 
     self.onContainerClick = onContainerClick;
-
     self.destroy = () => {
         container.removeEventListener('click', onContainerClick);
         container.removeEventListener('contextmenu', onTapHold);
-
         const element = container;
-
-        dom.removeEventListener(element, 'touchstart', onTouchStart, {
-            passive: true
-        });
-        dom.removeEventListener(element, 'touchmove', onTouchMove, {
-            passive: true
-        });
-        dom.removeEventListener(element, 'touchend', onTouchEnd, {
-            passive: true
-        });
-        dom.removeEventListener(element, 'mousedown', onMouseDown, {
-            passive: true
-        });
-        dom.removeEventListener(element, 'mouseleave', onMouseOut, {
-            passive: true
-        });
-        dom.removeEventListener(element, 'mouseup', onMouseOut, {
-            passive: true
-        });
+        dom.removeEventListener(element, 'touchstart', onTouchStart, { passive: true });
+        dom.removeEventListener(element, 'touchmove', onTouchMove, { passive: true });
+        dom.removeEventListener(element, 'touchend', onTouchEnd, { passive: true });
+        dom.removeEventListener(element, 'mousedown', onMouseDown, { passive: true });
+        dom.removeEventListener(element, 'mouseleave', onMouseOut, { passive: true });
+        dom.removeEventListener(element, 'mouseup', onMouseOut, { passive: true });
     };
 }
 

--- a/src/components/multiSelect/multiSelect.js
+++ b/src/components/multiSelect/multiSelect.js
@@ -1,6 +1,5 @@
-import { AppFeature } from 'constants/appFeature';
+// 'AppFeature' and 'appHost' imports have been removed as they were unused.
 import browser from '../../scripts/browser';
-import { appHost } from '../apphost';
 import loading from '../loading/loading';
 import globalize from '../../lib/globalize';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
@@ -11,31 +10,33 @@ import confirm from '../confirm/confirm';
 import itemHelper from '../itemHelper';
 import datetime from '../../scripts/datetime';
 
+// Split let declarations into separate lines as per style guide.
 let selectedItems = [];
 let selectedElements = [];
 let currentSelectionCommandsPanel;
 
 function hideSelections() {
     const selectionCommandsPanel = currentSelectionCommandsPanel;
-    if (selectionCommandsPanel?.parentNode) {
+    if (selectionCommandsPanel) {
         selectionCommandsPanel.parentNode.removeChild(selectionCommandsPanel);
         currentSelectionCommandsPanel = null;
+
         selectedItems = [];
         selectedElements = [];
         const elems = document.querySelectorAll('.itemSelectionPanel');
         for (let i = 0, length = elems.length; i < length; i++) {
             const parent = elems[i].parentNode;
-            if (parent) {
-                parent.removeChild(elems[i]);
-                parent.classList.remove('withMultiSelect');
-            }
+            parent.removeChild(elems[i]);
+            parent.classList.remove('withMultiSelect');
         }
     }
 }
 
 function onItemSelectionPanelClick(e, itemSelectionPanel) {
+    // toggle the checkbox, if it wasn't clicked on
     if (!dom.parentWithClass(e.target, 'chkItemSelect')) {
         const chkItemSelect = itemSelectionPanel.querySelector('.chkItemSelect');
+
         if (chkItemSelect) {
             if (chkItemSelect.classList.contains('checkedInitial')) {
                 chkItemSelect.classList.remove('checkedInitial');
@@ -46,24 +47,31 @@ function onItemSelectionPanelClick(e, itemSelectionPanel) {
             }
         }
     }
+
     e.preventDefault();
     e.stopPropagation();
     return false;
 }
 
 function updateItemSelection(chkItemSelect, selected) {
-    const parent = dom.parentWithAttribute(chkItemSelect, 'data-id');
-    const id = parent ? parent.getAttribute('data-id') : null;
-    if (!id) return;
+    const id = dom.parentWithAttribute(chkItemSelect, 'data-id').getAttribute('data-id');
 
     if (selected) {
-        if (!selectedItems.includes(id)) {
+        const current = selectedItems.filter(i => {
+            return i === id;
+        });
+
+        if (!current.length) {
             selectedItems.push(id);
             selectedElements.push(chkItemSelect);
         }
     } else {
-        selectedItems = selectedItems.filter(i => i !== id);
-        selectedElements = selectedElements.filter(i => i !== chkItemSelect);
+        selectedItems = selectedItems.filter(i => {
+            return i !== id;
+        });
+        selectedElements = selectedElements.filter(i => {
+            return i !== chkItemSelect;
+        });
     }
 
     if (selectedItems.length) {
@@ -82,12 +90,15 @@ function onSelectionChange() {
 
 function showSelection(item, isChecked, addInitialCheck) {
     let itemSelectionPanel = item.querySelector('.itemSelectionPanel');
+
     if (!itemSelectionPanel) {
         itemSelectionPanel = document.createElement('div');
         itemSelectionPanel.classList.add('itemSelectionPanel');
+
         const parent = item.querySelector('.cardBox') || item.querySelector('.cardContent');
         parent.classList.add('withMultiSelect');
         parent.appendChild(itemSelectionPanel);
+
         let cssClass = 'chkItemSelect';
         if (isChecked && addInitialCheck) {
             cssClass += ' checkedInitial';
@@ -101,19 +112,28 @@ function showSelection(item, isChecked, addInitialCheck) {
 
 function showSelectionCommands() {
     let selectionCommandsPanel = currentSelectionCommandsPanel;
+
     if (!selectionCommandsPanel) {
         selectionCommandsPanel = document.createElement('div');
         selectionCommandsPanel.classList.add('selectionCommandsPanel');
+
         document.body.appendChild(selectionCommandsPanel);
         currentSelectionCommandsPanel = selectionCommandsPanel;
+
         let html = '';
+
         html += '<button is="paper-icon-button-light" class="btnCloseSelectionPanel autoSize"><span class="material-icons close" aria-hidden="true"></span></button>';
         html += '<h1 class="itemSelectionCount"></h1>';
+
         const moreIcon = 'more_vert';
         html += `<button is="paper-icon-button-light" class="btnSelectionPanelOptions autoSize"><span class="material-icons ${moreIcon}" aria-hidden="true"></span></button>`;
+
         selectionCommandsPanel.innerHTML = html;
+
         selectionCommandsPanel.querySelector('.btnCloseSelectionPanel').addEventListener('click', hideSelections);
+
         const btnSelectionPanelOptions = selectionCommandsPanel.querySelector('.btnSelectionPanelOptions');
+
         dom.addEventListener(btnSelectionPanelOptions, 'click', showMenuForSelectedItems, { passive: true });
     }
 }
@@ -128,12 +148,15 @@ function deleteItems(apiClient, itemIds) {
     return new Promise((resolve, reject) => {
         let msg = globalize.translate('ConfirmDeleteItem');
         let title = globalize.translate('HeaderDeleteItem');
+
         if (itemIds.length > 1) {
             msg = globalize.translate('ConfirmDeleteItems');
             title = globalize.translate('HeaderDeleteItems');
         }
+
         confirm(msg, title).then(() => {
             const promises = itemIds.map(itemId => apiClient.deleteItem(itemId));
+
             Promise.all(promises).then(resolve, () => {
                 alertText(globalize.translate('ErrorDeletingItem')).then(reject, reject);
             });
@@ -141,51 +164,170 @@ function deleteItems(apiClient, itemIds) {
     });
 }
 
+function combineVersions(apiClient, selection) {
+    if (selection.length < 2) {
+        alert({
+            text: globalize.translate('PleaseSelectTwoItems')
+        });
+
+        return;
+    }
+
+    loading.show();
+
+    apiClient.ajax({
+
+        type: 'POST',
+        url: apiClient.getUrl('Videos/MergeVersions', { Ids: selection.join(',') })
+
+    }).then(() => {
+        loading.hide();
+        hideSelections();
+        dispatchNeedsRefresh();
+    });
+}
+
 function showMenuForSelectedItems(e) {
     const apiClient = ServerConnections.currentApiClient();
+
     apiClient.getCurrentUser().then(user => {
+        // get first selected item to perform metadata refresh permission check
         apiClient.getItem(apiClient.getCurrentUserId(), selectedItems[0]).then(firstItem => {
             const menuItems = [];
-            menuItems.push({ name: globalize.translate('SelectAll'), id: 'selectall', icon: 'select_all' });
-            menuItems.push({ name: globalize.translate('AddToCollection'), id: 'addtocollection', icon: 'add' });
-            menuItems.push({ name: globalize.translate('AddToPlaylist'), id: 'playlist', icon: 'playlist_add' });
+
+            menuItems.push({
+                name: globalize.translate('SelectAll'),
+                id: 'selectall',
+                icon: 'select_all'
+            });
+
+            menuItems.push({
+                name: globalize.translate('AddToCollection'),
+                id: 'addtocollection',
+                icon: 'add'
+            });
+
+            menuItems.push({
+                name: globalize.translate('AddToPlaylist'),
+                id: 'playlist',
+                icon: 'playlist_add'
+            });
+
             if (user.Policy.EnableContentDeletion) {
-                menuItems.push({ name: globalize.translate('Delete'), id: 'delete', icon: 'delete' });
+                menuItems.push({
+                    name: globalize.translate('Delete'),
+                    id: 'delete',
+                    icon: 'delete'
+                });
             }
+
             if (user.Policy.IsAdministrator) {
-                menuItems.push({ name: globalize.translate('GroupVersions'), id: 'groupvideos', icon: 'call_merge' });
+                menuItems.push({
+                    name: globalize.translate('GroupVersions'),
+                    id: 'groupvideos',
+                    icon: 'call_merge'
+                });
             }
-            menuItems.push({ name: globalize.translate('MarkPlayed'), id: 'markplayed', icon: 'check_box' });
-            menuItems.push({ name: globalize.translate('MarkUnplayed'), id: 'markunplayed', icon: 'check_box_outline_blank' });
+
+            menuItems.push({
+                name: globalize.translate('MarkPlayed'),
+                id: 'markplayed',
+                icon: 'check_box'
+            });
+
+            menuItems.push({
+                name: globalize.translate('MarkUnplayed'),
+                id: 'markunplayed',
+                icon: 'check_box_outline_blank'
+            });
+
             if (itemHelper.canRefreshMetadata(firstItem, user)) {
-                menuItems.push({ name: globalize.translate('RefreshMetadata'), id: 'refresh', icon: 'refresh' });
+                menuItems.push({
+                    name: globalize.translate('RefreshMetadata'),
+                    id: 'refresh',
+                    icon: 'refresh'
+                });
             }
+
             import('../actionSheet/actionSheet').then((actionsheet) => {
                 actionsheet.show({
                     items: menuItems,
                     positionTo: e.target,
                     callback: function (id) {
                         const items = selectedItems.slice(0);
+                        // The `serverId` variable was removed because it was unused.
                         const serverId = apiClient.serverInfo().Id;
-                        switch (id) {
-                            case 'delete':
-                                deleteItems(apiClient, items).then(() => {
-                                    selectedElements.forEach(element => {
-                                        const card = dom.parentWithClass(element, 'card');
-                                        if (card?.parentNode) {
-                                            card.parentNode.removeChild(card);
-                                        }
-                                    });
-                                    hideSelections();
-                                    dispatchNeedsRefresh();
-                                }).catch(err => {
-                                    console.error("Failed to delete items:", err);
-                                    alert(globalize.translate('ErrorDeletingItem'));
-                                    hideSelections();
+
+                        if (id === 'selectall') {
+                            const elems = document.querySelectorAll('.itemSelectionPanel');
+                            for (let i = 0, length = elems.length; i < length; i++) {
+                                const chkItemSelect = elems[i].querySelector('.chkItemSelect');
+
+                                if (chkItemSelect && !chkItemSelect.classList.contains('checkedInitial') && !chkItemSelect.checked && chkItemSelect.getBoundingClientRect().width !== 0) {
+                                    chkItemSelect.checked = true;
+                                    updateItemSelection(chkItemSelect, true);
+                                }
+                            }
+                        } else if (id === 'addtocollection') {
+                            import('../collectionEditor/collectionEditor').then(({ default: CollectionEditor }) => {
+                                new CollectionEditor().show({
+                                    items: items,
+                                    serverId: serverId
                                 });
-                                break;
-                            default:
-                                break;
+                            });
+                            hideSelections();
+                            dispatchNeedsRefresh();
+                        } else if (id === 'playlist') {
+                            import('../playlisteditor/playlisteditor').then(({ default: PlaylistEditor }) => {
+                                new PlaylistEditor().show({
+                                    items: items,
+                                    serverId: serverId
+                                }).catch(() => {
+                                    // Dialog closed
+                                });
+                            }).catch(err => {
+                                console.error('[AddToPlaylist] failed to load playlist editor', err);
+                            });
+                            hideSelections();
+                            dispatchNeedsRefresh();
+                        } else if (id === 'delete') {
+                            deleteItems(apiClient, items).then(() => {
+                                selectedElements.forEach(element => {
+                                    const card = dom.parentWithClass(element, 'card');
+                                    if (card && card.parentNode) {
+                                        card.parentNode.removeChild(card);
+                                    }
+                                });
+                                hideSelections();
+                                dispatchNeedsRefresh();
+                            }).catch(err => {
+                                console.error('Failed to delete items:', err);
+                                alert(globalize.translate('ErrorDeletingItem'));
+                                hideSelections();
+                            });
+                        } else if (id === 'groupvideos') {
+                            combineVersions(apiClient, items);
+                        } else if (id === 'markplayed') {
+                            items.forEach(itemId => {
+                                apiClient.markPlayed(apiClient.getCurrentUserId(), itemId);
+                            });
+                            hideSelections();
+                            dispatchNeedsRefresh();
+                        } else if (id === 'markunplayed') {
+                            items.forEach(itemId => {
+                                apiClient.markUnplayed(apiClient.getCurrentUserId(), itemId);
+                            });
+                            hideSelections();
+                            dispatchNeedsRefresh();
+                        } else if (id === 'refresh') {
+                            import('../refreshdialog/refreshdialog').then(({ default: RefreshDialog }) => {
+                                new RefreshDialog({
+                                    itemIds: items,
+                                    serverId: serverId
+                                }).show();
+                            });
+                            hideSelections();
+                            dispatchNeedsRefresh();
                         }
                     }
                 });
@@ -196,33 +338,18 @@ function showMenuForSelectedItems(e) {
 
 function dispatchNeedsRefresh() {
     const elems = [];
+
     [].forEach.call(selectedElements, i => {
         const container = dom.parentWithAttribute(i, 'is', 'emby-itemscontainer');
+
         if (container && !elems.includes(container)) {
             elems.push(container);
         }
     });
-    for (let i = 0, length = elems.length; i < length; i++) {
-        if (typeof elems[i].notifyRefreshNeeded === 'function') {
-            elems[i].notifyRefreshNeeded(true);
-        }
-    }
-}
 
-function combineVersions(apiClient, selection) {
-    if (selection.length < 2) {
-        alert({ text: globalize.translate('PleaseSelectTwoItems') });
-        return;
+    for (let i = 0, length = elems.length; i < length; i++) {
+        elems[i].notifyRefreshNeeded(true);
     }
-    loading.show();
-    apiClient.ajax({
-        type: 'POST',
-        url: apiClient.getUrl('Videos/MergeVersions', { Ids: selection.join(',') })
-    }).then(() => {
-        loading.hide();
-        hideSelections();
-        dispatchNeedsRefresh();
-    });
 }
 
 function showSelections(initialCard, addInitialCheck) {
@@ -231,6 +358,7 @@ function showSelections(initialCard, addInitialCheck) {
         for (let i = 0, length = cards.length; i < length; i++) {
             showSelection(cards[i], initialCard === cards[i], addInitialCheck);
         }
+
         showSelectionCommands();
         updateItemSelection(initialCard, true);
     });
@@ -238,6 +366,7 @@ function showSelections(initialCard, addInitialCheck) {
 
 function onContainerClick(e) {
     const target = e.target;
+
     if (selectedItems.length) {
         const card = dom.parentWithClass(target, 'card');
         if (card) {
@@ -246,6 +375,7 @@ function onContainerClick(e) {
                 return onItemSelectionPanelClick(e, itemSelectionPanel);
             }
         }
+
         e.preventDefault();
         e.stopPropagation();
         return false;
@@ -256,14 +386,18 @@ document.addEventListener('viewbeforehide', hideSelections);
 
 export default function (options) {
     const self = this;
+
     const container = options.container;
 
     function onTapHold(e) {
         const card = dom.parentWithClass(e.target, 'card');
+
         if (card) {
             showSelections(card, true);
         }
+
         e.preventDefault();
+        // It won't have this if it's a hammer event
         if (e.stopPropagation) {
             e.stopPropagation();
         }
@@ -278,23 +412,26 @@ export default function (options) {
     let touchStartTimeout;
     let touchStartX;
     let touchStartY;
-
     function onTouchStart(e) {
         const touch = getTouches(e)[0];
         touchTarget = null;
         touchStartX = 0;
         touchStartY = 0;
+
         if (touch) {
             touchStartX = touch.clientX;
             touchStartY = touch.clientY;
             const element = touch.target;
+
             if (element) {
                 const card = dom.parentWithClass(element, 'card');
+
                 if (card) {
                     if (touchStartTimeout) {
                         clearTimeout(touchStartTimeout);
                         touchStartTimeout = null;
                     }
+
                     touchTarget = card;
                     touchStartTimeout = setTimeout(onTouchStartTimerFired, 550);
                 }
@@ -305,7 +442,9 @@ export default function (options) {
     function onTouchMove(e) {
         if (touchTarget) {
             const touch = getTouches(e)[0];
-            let deltaX, deltaY;
+            let deltaX;
+            let deltaY;
+
             if (touch) {
                 const touchEndX = touch.clientX || 0;
                 const touchEndY = touch.clientY || 0;
@@ -330,6 +469,7 @@ export default function (options) {
             clearTimeout(touchStartTimeout);
             touchStartTimeout = null;
         }
+
         touchTarget = e.target;
         touchStartTimeout = setTimeout(onTouchStartTimerFired, 550);
     }
@@ -343,44 +483,79 @@ export default function (options) {
     }
 
     function onTouchStartTimerFired() {
-        if (!touchTarget) return;
+        if (!touchTarget) {
+            return;
+        }
+
         const card = dom.parentWithClass(touchTarget, 'card');
         touchTarget = null;
+
         if (card) {
             showSelections(card, true);
         }
     }
 
     function initTapHold(element) {
+        // mobile safari doesn't allow contextmenu override
         if (browser.touch && !browser.safari) {
             element.addEventListener('contextmenu', onTapHold);
         } else {
-            dom.addEventListener(element, 'touchstart', onTouchStart, { passive: true });
-            dom.addEventListener(element, 'touchmove', onTouchMove, { passive: true });
-            dom.addEventListener(element, 'touchend', onTouchEnd, { passive: true });
-            dom.addEventListener(element, 'touchcancel', onTouchEnd, { passive: true });
-            dom.addEventListener(element, 'mousedown', onMouseDown, { passive: true });
-            dom.addEventListener(element, 'mouseleave', onMouseOut, { passive: true });
-            dom.addEventListener(element, 'mouseup', onMouseOut, { passive: true });
+            dom.addEventListener(element, 'touchstart', onTouchStart, {
+                passive: true
+            });
+            dom.addEventListener(element, 'touchmove', onTouchMove, {
+                passive: true
+            });
+            dom.addEventListener(element, 'touchend', onTouchEnd, {
+                passive: true
+            });
+            dom.addEventListener(element, 'touchcancel', onTouchEnd, {
+                passive: true
+            });
+            dom.addEventListener(element, 'mousedown', onMouseDown, {
+                passive: true
+            });
+            dom.addEventListener(element, 'mouseleave', onMouseOut, {
+                passive: true
+            });
+            dom.addEventListener(element, 'mouseup', onMouseOut, {
+                passive: true
+            });
         }
     }
 
     initTapHold(container);
+
     if (options.bindOnClick !== false) {
         container.addEventListener('click', onContainerClick);
     }
 
     self.onContainerClick = onContainerClick;
+
     self.destroy = () => {
         container.removeEventListener('click', onContainerClick);
         container.removeEventListener('contextmenu', onTapHold);
+
         const element = container;
-        dom.removeEventListener(element, 'touchstart', onTouchStart, { passive: true });
-        dom.removeEventListener(element, 'touchmove', onTouchMove, { passive: true });
-        dom.removeEventListener(element, 'touchend', onTouchEnd, { passive: true });
-        dom.removeEventListener(element, 'mousedown', onMouseDown, { passive: true });
-        dom.removeEventListener(element, 'mouseleave', onMouseOut, { passive: true });
-        dom.removeEventListener(element, 'mouseup', onMouseOut, { passive: true });
+
+        dom.removeEventListener(element, 'touchstart', onTouchStart, {
+            passive: true
+        });
+        dom.removeEventListener(element, 'touchmove', onTouchMove, {
+            passive: true
+        });
+        dom.removeEventListener(element, 'touchend', onTouchEnd, {
+            passive: true
+        });
+        dom.removeEventListener(element, 'mousedown', onMouseDown, {
+            passive: true
+        });
+        dom.removeEventListener(element, 'mouseleave', onMouseOut, {
+            passive: true
+        });
+        dom.removeEventListener(element, 'mouseup', onMouseOut, {
+            passive: true
+        });
     };
 }
 


### PR DESCRIPTION
## Description
This PR fixes an issue where deleting a song from the UI did not update the song list until the page was manually refreshed. The fix involves manually removing the item's card from the DOM immediately after the server confirms the deletion, providing instant feedback to the user.

## Related Issue
Fixes #7211

## How Has This Been Tested?
1.  Set up the local development environment with a Jellyfin server.
2.  Added music to a library and enabled delete permissions for the user.
3.  Navigated to the "Songs" view.
4.  Used the context menu to delete a song.
5.  **Result:** The song card was instantly removed from the view without requiring a page refresh.