### PR TITLE
Fix: Add minimum value 0 for SyncPlay Settings SpeedToSync input

### DIFF
--- a/src/plugins/syncPlay/ui/settings/editor.html
+++ b/src/plugins/syncPlay/ui/settings/editor.html
@@ -34,12 +34,12 @@
             </div>
             <div class="inputContainer inputContainer-withDescription">
                 <input type="number" is="emby-input" id="txtMaxDelaySpeedToSync" pattern="[0-9]*"
-                    label="${LabelSyncPlaySettingsMaxDelaySpeedToSync}" />
+                    label="${LabelSyncPlaySettingsMaxDelaySpeedToSync}" min="0"/>
                 <div class="fieldDescription">${LabelSyncPlaySettingsMaxDelaySpeedToSyncHelp}</div>
             </div>
             <div class="inputContainer inputContainer-withDescription">
                 <input type="number" is="emby-input" id="txtSpeedToSyncDuration" pattern="[0-9]*"
-                    label="${LabelSyncPlaySettingsSpeedToSyncDuration}" />
+                    label="${LabelSyncPlaySettingsSpeedToSyncDuration}" min="0"/>
                 <div class="fieldDescription">${LabelSyncPlaySettingsSpeedToSyncDurationHelp}</div>
             </div>
 
@@ -53,7 +53,7 @@
             </div>
             <div class="inputContainer inputContainer-withDescription">
                 <input type="number" is="emby-input" id="txtMinDelaySkipToSync" pattern="[0-9]*"
-                    label="${LabelSyncPlaySettingsMinDelaySkipToSync}" />
+                    label="${LabelSyncPlaySettingsMinDelaySkipToSync}" min="0"/>
                 <div class="fieldDescription">${LabelSyncPlaySettingsMinDelaySkipToSyncHelp}</div>
             </div>
 
@@ -61,7 +61,7 @@
             <h2 class="sectionTitle">${HeaderSyncPlayTimeSyncSettings}</h2>
             <div class="inputContainer inputContainer-withDescription">
                 <input type="number" is="emby-input" id="txtExtraTimeOffset" pattern="[0-9]*"
-                    label="${LabelSyncPlaySettingsExtraTimeOffset}" />
+                    label="${LabelSyncPlaySettingsExtraTimeOffset}" min="0"/>
                 <div class="fieldDescription">${LabelSyncPlaySettingsExtraTimeOffsetHelp}</div>
             </div>
         </form>


### PR DESCRIPTION
Prevent negative values in SyncPlay Settings inputs

**Changes**
Added `min="0"` attributes to several SyncPlay Settings inputs to prevent negative values:

- SpeedToSync Minimum Delay
- SpeedToSync Duration
- SkipToSync Minimum Delay
- Extra Time Offset

**Issues**
No existing issue; this PR prevents negative values in SyncPlay Settings inputs, which could cause unexpected behavior.