### PR TITLE
Fix unpause and pause references in syncplay video player

### DIFF
--- a/src/plugins/syncPlay/ui/players/HtmlVideoPlayer.js
+++ b/src/plugins/syncPlay/ui/players/HtmlVideoPlayer.js
@@ -96,8 +96,8 @@ class HtmlVideoPlayer extends NoActivePlayer {
 
         Events.off(this.player, 'playbackstart', this._onPlaybackStart);
         Events.off(this.player, 'playbackstop', this._onPlaybackStop);
-        Events.on(this.player, 'unpause', this._onUnpause);
-        Events.on(this.player, 'pause', this._onPause);
+        Events.off(this.player, 'unpause', this._onUnpause);
+        Events.off(this.player, 'pause', this._onPause);
         Events.off(this.player, 'timeupdate', this._onTimeUpdate);
         Events.off(this.player, 'playing', this._onPlaying);
         Events.off(this.player, 'waiting', this._onWaiting);


### PR DESCRIPTION
**Changes**
This PR corrects event cleanup logic by replacing invalid handler references (_onPlayerUnpause / _onPlayerPause) with the correct method names (_onUnpause / _onPause).

Note: you can see the events its binding on here: https://github.com/jellyfin/jellyfin-web/blob/master/src/plugins/syncPlay/ui/players/HtmlVideoPlayer.js#L82
