### PR TITLE
Increase restore check interval to 45s

### DIFF
--- a/src/apps/dashboard/routes/backups/index.tsx
+++ b/src/apps/dashboard/routes/backups/index.tsx
@@ -102,7 +102,7 @@ export const Component = () => {
                     }).catch(() => {
                         // Server is still down
                     });
-            }, 5000);
+            }, 45000);
 
             return () => {
                 clearInterval(serverCheckInterval);


### PR DESCRIPTION
UI may falsely report restoration process as complete too early

**Changes**
Increase server check interval from **5s** -> **45s**

**Issues**
Fixes https://github.com/jellyfin/jellyfin-web/issues/7232