### PR TITLE
Revert scroller overflow change for tv layout

### DIFF
--- a/src/lib/scroller/index.js
+++ b/src/lib/scroller/index.js
@@ -765,6 +765,10 @@ const scrollerFactory = function (frame, options) {
                 }
             }
         } else {
+            if (layoutManager.tv) {
+                frame.style.overflow = 'hidden';
+            }
+
             slideeElement.style['will-change'] = 'transform';
             slideeElement.style.transition = 'transform ' + o.speed + 'ms ease-out';
 

--- a/src/styles/librarybrowser.scss
+++ b/src/styles/librarybrowser.scss
@@ -841,7 +841,6 @@
 
 .detailPageSecondaryContainer {
     padding-top: 1.25em;
-    overflow: hidden;
 
     .layout-desktop & {
         flex-grow: 1;


### PR DESCRIPTION
**Changes**
Quick fix to restore the overflow behavior in the TV layout. A better fix should be investigated since this also adds back the cutoff images at the edge of the screen on TVs.

**Issues**
Fixes https://github.com/jellyfin/jellyfin-web/issues/7239