### PR TITLE
Fixed issue where waiting event is not being called correctly

### DIFF
--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1066,7 +1066,7 @@ export class HtmlVideoPlayer {
 
     onWaiting = () => {
         Events.trigger(this, 'waiting');
-    }
+    };
 
     /**
      * @private


### PR DESCRIPTION
**Changes**
Converts the onWaiting method to arrow function to fix the `this` context so that events can be triggered correctly

Fixes: https://github.com/jellyfin/jellyfin-web/issues/7225
