### PR TITLE
Wraps registration of all mediaSession action handlers in try catch.

### DIFF
--- a/src/apps/stable/features/playback/utils/mediaSessionSubscriber.ts
+++ b/src/apps/stable/features/playback/utils/mediaSessionSubscriber.ts
@@ -51,24 +51,20 @@ class MediaSessionSubscriber extends PlaybackSubscriber {
     }
 
     private bindNavigatorSession() {
-        /* eslint-disable compat/compat */
-        navigator.mediaSession.setActionHandler('pause', this.onMediaSessionAction.bind(this));
-        navigator.mediaSession.setActionHandler('play', this.onMediaSessionAction.bind(this));
-        // NOTE: Some legacy (TV) browsers lack support for the stop action
-        try {
-            navigator.mediaSession.setActionHandler('stop', this.onMediaSessionAction.bind(this));
-        } catch (err) {
-            console.warn('[MediaSessionSubscriber] Failed to add \'stop\' action handler', err);
-        }
-        navigator.mediaSession.setActionHandler('previoustrack', this.onMediaSessionAction.bind(this));
-        navigator.mediaSession.setActionHandler('nexttrack', this.onMediaSessionAction.bind(this));
-        navigator.mediaSession.setActionHandler('seekto', this.onMediaSessionAction.bind(this));
+        const actions: MediaSessionAction[] = ['pause', 'play', 'previoustrack', 'nexttrack', 'stop', 'seekto'];
+
         // iOS will only show next/prev track controls or seek controls
-        if (!browser.iOS) {
-            navigator.mediaSession.setActionHandler('seekbackward', this.onMediaSessionAction.bind(this));
-            navigator.mediaSession.setActionHandler('seekforward', this.onMediaSessionAction.bind(this));
+        if (!browser.iOS) actions.push('seekbackward', 'seekforward');
+
+        for (const action of actions) {
+            try {
+                /* eslint-disable-next-line compat/compat */
+                navigator.mediaSession.setActionHandler(action, this.onMediaSessionAction.bind(this));
+            } catch (err) {
+                // NOTE: Some legacy (TV) browsers lack support for the stop and seekto actions
+                console.warn(`[MediaSessionSubscriber] Failed to add "${action}" action handler`, err);
+            }
         }
-        /* eslint-enable compat/compat */
     }
 
     private onMediaSessionAction(details: MediaSessionActionDetails) {


### PR DESCRIPTION
**Changes**
Follow up change to https://github.com/jellyfin/jellyfin-web/pull/7240 that fixes registration of `seekto` action.

**Issues**
Fixes https://github.com/jellyfin/jellyfin-tizen/issues/367 for even older TV models that run Chromium 76.

Before:
<img width="1206" height="644" alt="2025-10-24 18_14_53-Jellyfin - Chromium" src="https://github.com/user-attachments/assets/87b9c2a7-67cb-4107-970a-bcb73a125733" />

After:
<img width="1190" height="353" alt="2025-10-24 18_17_39-Pandora - Chromium" src="https://github.com/user-attachments/assets/41df05a3-f4a1-4d6e-87de-18b4d8a9138e" />
