### PR TITLE
Improve performance by disabling unnecessary user data when retrieving list of playlists

### DIFF
--- a/src/components/playlisteditor/playlisteditor.ts
+++ b/src/components/playlisteditor/playlisteditor.ts
@@ -189,7 +189,8 @@ function populatePlaylists(editorOptions: PlaylistEditorOptions, panel: DialogEl
             userId: apiClient.getCurrentUserId(),
             includeItemTypes: [ BaseItemKind.Playlist ],
             sortBy: [ ItemSortBy.SortName ],
-            recursive: true
+            recursive: true,
+            enableUserData: false
         })
         .then(({ data }) => {
             return Promise.all((data.Items || []).map(item => {


### PR DESCRIPTION
**Changes**

When populating the list of playlists, it appears user data is not needed but that can cause a significant performance impact with a lot of large playlists, so disable it.

**Issues**

Fixes #7260