### PR TITLE
Use hls.js instead of native HLS in Chromium

### DIFF
--- a/src/components/htmlMediaHelper.js
+++ b/src/components/htmlMediaHelper.js
@@ -65,6 +65,12 @@ export function enableHlsJsPlayer(runTimeTicks, mediaType) {
             return true;
         }
 
+        // Chromium 141+ brings native HLS support that does not support switching HDR/SDR playlists.
+        // Always use hls.js to avoid falling back to transcoding from remuxing and client side tone-mapping.
+        if (browser.chrome || browser.edgeChromium || browser.opera) {
+            return true;
+        }
+
         // simple playback should use the native support
         if (runTimeTicks) {
             return false;


### PR DESCRIPTION
Chromium 141+ brings native HLS support that does not support switching HDR/SDR playlists.
Always use hls.js to avoid falling back to transcoding from remuxing and client side tone-mapping.

**Changes**
- Using hls.js instead of native HLS in Chromium

**Issues**
- HDR+MKV content on Chrome 142 is now always transcoded on SDR displays because the server-provided m3u8 playlist includes an SDR entry as a fallback.
