### PR TITLE
Restrict recently added max-32-streams limit to Tizen < v6.5

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -924,7 +924,7 @@ export default function (options) {
 
     profile.ContainerProfiles = [];
 
-    if (browser.tizen) {
+    if (browser.tizenVersion < 6.5) {
         // Tizen doesn't support more than 32 streams in a single file
         profile.ContainerProfiles.push({
             Type: 'Video',


### PR DESCRIPTION
v10.11 introduced that limit for Tizen in general, causing all formerly direct-playable media with more than 32 streams to be remuxed - one cause of regression #7231.

According to https://github.com/jellyfin/jellyfin-tizen/issues/289#issuecomment-2581270727, Tizen v5 only supports max 32 streams. This limit seems to have been lifted in v6, according to https://github.com/jellyfin/jellyfin-web/issues/7231#issuecomment-3474685133. I'm using Tizen v9 and don't have any problems with around 100 streams.