### PR TITLE
Enable HDR10+ and DoVi fallback profiles

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -1188,7 +1188,18 @@ export default function (options) {
         vp9VideoRangeTypes += '|HDR10';
         av1VideoRangeTypes += '|HDR10';
 
-        if (browser.tizenVersion >= 3 || browser.vidaa) {
+        if (browser.tizenVersion >= 3) {
+            hevcVideoRangeTypes += '|HDR10Plus';
+            vp9VideoRangeTypes += '|HDR10Plus';
+            av1VideoRangeTypes += '|HDR10Plus';
+
+            // the player falls back to HDR10[+], no need to strip DoVi metadata
+            hevcVideoRangeTypes += '|DOVIWithHDR10';
+            hevcVideoRangeTypes += '|DOVIWithEL';
+            hevcVideoRangeTypes += '|DOVIWithHDR10Plus';
+            hevcVideoRangeTypes += '|DOVIWithELHDR10Plus';
+            hevcVideoRangeTypes += '|DOVIInvalid';
+        } else if (browser.vidaa) {
             hevcVideoRangeTypes += '|DOVIWithHDR10';
         }
     }


### PR DESCRIPTION
The 10.11 server introduced new `VideoRangeType` values in https://github.com/jellyfin/jellyfin/pull/13277, but the web client apparently wasn't updated accordingly. This is one cause of regression #7231, leading e.g. to `DOVIWithHDR10Plus` media being remuxed instead of direct-played.

I've tested `HDR10Plus`, `DOVIWithHDR10` and `DOVIWithHDR10Plus` media successfully on Tizen v9. The author of the linked issue additionally tested `DOVIWithELHDR10Plus` (and I think `DOVIWithEL`) and `DOVIInvalid` on Tizen 6.