### PR TITLE
Playback info: Promote out of settings menu to OSD footer icon

### DIFF
--- a/src/controllers/playback/video/index.html
+++ b/src/controllers/playback/video/index.html
@@ -87,6 +87,9 @@
                 <button is="paper-icon-button-light" class="btnVideoOsdSettings autoSize" title="${Settings}">
                     <span class="largePaperIconButton material-icons settings" aria-hidden="true"></span>
                 </button>
+                <button is="paper-icon-button-light" class="btnPlayerStats autoSize" title="${PlaybackData}">
+                    <span class="largePaperIconButton material-icons info" aria-hidden="true"></span>
+                </button>
                 <button is="paper-icon-button-light" class="btnAirPlay hide autoSize" title="${AirPlay}">
                     <span class="xlargePaperIconButton material-icons airplay" aria-hidden="true"></span>
                 </button>

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -971,7 +971,7 @@ export default function (view) {
                     player: player,
                     positionTo: btn,
                     quality: state.MediaSource?.SupportsTranscoding,
-                    stats: true,
+                    stats: false,
                     suboffset: showSubOffset,
                     onOption: onSettingsOption
                 }).finally(() => {
@@ -1776,6 +1776,7 @@ export default function (view) {
         playbackManager.toggleAirPlay(currentPlayer);
     });
     view.querySelector('.btnVideoOsdSettings').addEventListener('click', onSettingsButtonClick);
+    view.querySelector('.btnPlayerStats').addEventListener('click', toggleStats);
     view.addEventListener('viewhide', function () {
         headerElement.classList.remove('hide');
     });


### PR DESCRIPTION
To make it less cumbersome to toggle it on/off. On TV (the only platform I've tested this on), this saves about 4 key presses on the remote, for each toggling. In particular, closing it takes a single OK-press while the OSD is still visible (from toggling it on).