### PR TITLE
Playback info: Add frame rate, bit depth, color space, color transfer and pixel format

### DIFF
--- a/src/components/playerstats/playerstats.js
+++ b/src/components/playerstats/playerstats.js
@@ -289,13 +289,6 @@ function getMediaSourceStats(session, player) {
         });
     }
 
-    if (videoStream.BitDepth) {
-        sessionStats.push({
-            label: globalize.translate('MediaInfoBitDepth'),
-            value: `${videoStream.BitDepth} bit`
-        });
-    }
-
     if (videoStream.VideoRangeType) {
         sessionStats.push({
             label: globalize.translate('LabelVideoRangeType'),


### PR DESCRIPTION
This is an admittedly totally subjective list of stats that I find useful and have so far had to look up in the 'Media info' instead (which is currently barely usable on TV for me, cannot scroll down and so only see about half of the video stream stats).

Also display the original `VideoRangeType` for DoVi media, not just the 'nice' `VideoDoViTitle` (which e.g. currently doesn't differentiate between HDR10 and HDR10+ fallbacks).