### PR TITLE
Media info dialog: Shrink font size on TV to work around non-scrollability

### DIFF
--- a/src/styles/site.scss
+++ b/src/styles/site.scss
@@ -136,6 +136,11 @@ form {
     width: 85%;
 }
 
+.layout-tv .mediaInfoContent {
+    font-size: 0.6em;
+    width: 90%;
+}
+
 .headroom {
     will-change: transform;
     transition: transform 200ms linear;


### PR DESCRIPTION
At least on Tizen 9, I don't know how to scroll down. The pretty large default font size, coupled with rather long media paths, leads to not even half of the video stream stats being visible for DoVi media with their lots of extra info. Let alone dozens of subtitle streams etc.

Shrinking the dialog content font-size to 60% and slightly increasing the width from 85 to 90%, on TV only, is in my case just enough to display the video stream card in full. It's still easily readable, in my case from about 2 meters to a 65" 4K TV.