### PR TITLE
Fix library not refreshing after adding new media library

### DIFF
--- a/src/apps/dashboard/routes/libraries/index.tsx
+++ b/src/apps/dashboard/routes/libraries/index.tsx
@@ -29,7 +29,8 @@ export const Component = () => {
 
     const showMediaLibraryCreator = useCallback(() => {
         const mediaLibraryCreator = new MediaLibraryCreator({
-            collectionTypeOptions: getCollectionTypeOptions()
+            collectionTypeOptions: getCollectionTypeOptions(),
+            refresh: true
         }) as Promise<boolean>;
 
         void mediaLibraryCreator.then((hasChanges: boolean) => {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->
When adding a new media library, the page didn’t trigger a library refresh because the refresh flag wasn’t set.

**Changes**
Set the refresh flag to true when creating a new Media Library

**Issues**
None reported 
