### PR TITLE
Compact the "playback info" overlay to add more infos

### DIFF
--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -2139,6 +2139,8 @@ export class HtmlVideoPlayer {
         };
         categories.push(mediaCategory);
 
+        const mediaInfos = [];
+        mediaInfos.push(this._hlsPlayer ? 'HLS' : 'Video');
         if (playOptions.url) {
             //  create an anchor element (note: no need to append this element to the document)
             let link = document.createElement('a');
@@ -2147,24 +2149,15 @@ export class HtmlVideoPlayer {
             const protocol = (link.protocol || '').replace(':', '');
 
             if (protocol) {
-                mediaCategory.stats.push({
-                    label: globalize.translate('LabelProtocol'),
-                    value: protocol
-                });
+                mediaInfos.push(`(${protocol})`);
             }
 
             link = null;
         }
-
-        if (this._hlsPlayer) {
+        if (mediaInfos.length) {
             mediaCategory.stats.push({
                 label: globalize.translate('LabelStreamType'),
-                value: 'HLS'
-            });
-        } else {
-            mediaCategory.stats.push({
-                label: globalize.translate('LabelStreamType'),
-                value: 'Video'
+                value: mediaInfos.join('  ')
             });
         }
 
@@ -2179,37 +2172,37 @@ export class HtmlVideoPlayer {
         let height = Math.round(rect.height * devicePixelRatio);
         let width = Math.round(rect.width * devicePixelRatio);
 
-        // Don't show player dimensions on smart TVs because the app UI could be lower resolution than the video and this causes users to think there is a problem
+        const viewInfos = [];
+        // Don't show player dimensions on smart TVs because the app UI could be lower
+        // resolution than the video and this causes users to think there is a problem
         if (width && height && !browser.tv) {
-            videoCategory.stats.push({
-                label: globalize.translate('LabelPlayerDimensions'),
-                value: `${width}x${height}`
-            });
+            viewInfos.push(`${width}x${height}`);
         }
 
         height = mediaElement.videoHeight;
         width = mediaElement.videoWidth;
-
         if (width && height) {
+            viewInfos.push(`${width}x${height}`);
+        }
+        if (viewInfos.length) {
             videoCategory.stats.push({
-                label: globalize.translate('LabelVideoResolution'),
-                value: `${width}x${height}`
+                label: globalize.translate('LabelPlayerSizes'),
+                value: viewInfos.join(' / ')
             });
         }
 
         if (mediaElement.getVideoPlaybackQuality) {
             const playbackQuality = mediaElement.getVideoPlaybackQuality();
-
             const droppedVideoFrames = playbackQuality.droppedVideoFrames || 0;
-            videoCategory.stats.push({
-                label: globalize.translate('LabelDroppedFrames'),
-                value: droppedVideoFrames
-            });
-
             const corruptedVideoFrames = playbackQuality.corruptedVideoFrames || 0;
+
+            const qualityInfos = [];
+            qualityInfos.push(droppedVideoFrames);
+            qualityInfos.push(corruptedVideoFrames);
+
             videoCategory.stats.push({
-                label: globalize.translate('LabelCorruptedFrames'),
-                value: corruptedVideoFrames
+                label: globalize.translate('LabelPlaybackQuality'),
+                value: qualityInfos.join(' / ')
             });
         }
 

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1894,5 +1894,14 @@
     "LabelExternalServerUriHelp": "Published server URI for external access.",
     "LabelExtractTrickplayDuringLibraryScan": "Extract trickplay images during the library scan",
     "LabelExtractTrickplayDuringLibraryScanHelp": "Generate trickplay images when videos are imported during the library scan. Otherwise, they will be extracted during the trickplay images scheduled task. If generation is set to non-blocking this will not affect the time a library scan takes to complete.",
-    "LogLoadFailure": "Failed to load the log file. It may still be actively written to."
+    "LogLoadFailure": "Failed to load the log file. It may still be actively written to.",
+    "LabelVideoAttributes": "Video attributes",
+    "LabelVideoColors": "Video colors",
+    "LabelVideoBitDepth": "Video bit depth",
+    "LabelAudioAttributes": "Audio attributes",
+    "LabelTargetCodecs": "Target codecs",
+    "LabelProgressAndSpeed": "Progress / speed",
+    "LabelReasons": "Reasons",
+    "LabelPlayerSizes": "Player sizes",
+    "LabelPlaybackQuality": "Frame dropped / corrupted"
 }


### PR DESCRIPTION
This should supersede #7286

**Changes**
- Compact the "playback info" overlay to add more infos
	- Utilize horizontal space to display more items, this should also avoid the overlay extending beyond the screen on mobile devices.
	- Add more video information such as video color, pixel format, bit depth, framerate, and level.

**Issues**
- The overlay is too long on mobile devices

<img width="260" alt="osd1" src="https://github.com/user-attachments/assets/56eea2f9-f6b7-4a1c-8911-2515f2694d90" />
<img width="260" alt="osd2" src="https://github.com/user-attachments/assets/3ede32e8-a8ec-4531-adda-1861d2c18ed7" />
<img width="260" alt="osd3" src="https://github.com/user-attachments/assets/9ecbe283-1444-4cf5-902c-d07f63d3a74b" />