### PR TITLE
Revert "Enable use of hls.js when LG WebOS 4 or newer is used."

### DIFF
--- a/src/components/htmlMediaHelper.js
+++ b/src/components/htmlMediaHelper.js
@@ -48,12 +48,6 @@ export function enableHlsJsPlayer(runTimeTicks, mediaType) {
         return false;
     }
 
-    // Native HLS support in WebOS only plays stereo sound. hls.js works better, but works only on WebOS 4 or newer.
-    // Using hls.js also seems to fix fast forward issues that native HLS has.
-    if (browser.web0sVersion >= 4) {
-        return true;
-    }
-
     // The native players on these devices support seeking live streams, no need to use hls.js here
     if (browser.tizen || browser.web0s) {
         return false;

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -137,14 +137,6 @@ function supportsEac3(videoTestElement) {
 }
 
 function supportsAc3InHls(videoTestElement) {
-    // We use hls.js on WebOS 4 and newer and hls.js uses Media Sources Extensions (MSE) API.
-    // On WebOS MSE does support AC-3 and EAC-3 only on audio mp4 file but not on audiovideo mp4
-    // therefore until audio and video is not separated when generating stream and m3u8 this should
-    // return false.
-    if (browser.web0sVersion >= 4) {
-        return false;
-    }
-
     if (browser.tizen || browser.web0s) {
         return true;
     }


### PR DESCRIPTION
This reverts commit 85fc9de45f774f5f4a4baf78f226544dcacc8775.

**Changes**
This should resolve the multitude of issues with DV on webOS in 10.11

**Issues**
Fixes https://github.com/jellyfin/jellyfin-webos/issues/310