### PR TITLE
Relax dynamic HDR device Profile

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -1193,6 +1193,9 @@ export default function (options) {
             // Tizen TV does not support Dolby Vision at all, but it can safely play the HDR fallback.
             // Advertising the support so that the server doesn't have to remux.
             hevcVideoRangeTypes += '|DOVIWithHDR10|DOVIWithHDR10Plus|DOVIWithEL|DOVIWithELHDR10Plus|DOVIInvalid';
+            // Although no official tools exist to create AV1+DV files yet, some of our users managed to use community tools to create such files.
+            // These files should also be playable on Tizen TVs.
+            av1VideoRangeTypes += '|DOVIWithHDR10|DOVIWithHDR10Plus|DOVIWithEL|DOVIWithELHDR10Plus|DOVIInvalid';
         }
     }
 
@@ -1223,6 +1226,11 @@ export default function (options) {
 
         if (supportedDolbyVisionProfileAv1(videoTestElement)) {
             av1VideoRangeTypes += '|DOVI|DOVIWithHDR10|DOVIWithHLG|DOVIWithSDR|DOVIWithHDR10Plus';
+            if (browser.web0s) {
+                // For webOS, we should allow direct play of some not fully supported DV profiles to avoid unnecessary remux/transcode
+                // webOS seems to be able to play the fallback of Profile 7 and most invalid profiles
+                av1VideoRangeTypes += '|DOVIWithEL|DOVIWithELHDR10Plus|DOVIInvalid';
+            }
         }
     }
 


### PR DESCRIPTION
HDR10+ are designed to be backward-compatible with HDR10 which means we can just advertise HDR10+ as supported for HDR10 supported clients. This will avoid the server to force a remux to remove the HDR10+ metadata to ensure compatibility. At least the server-side removal is not needed for major web browsers and the tvs that uses the web client.

For TVs, we need to relax the device profile even more by exposing not-supported but can be played ranges. This is due to the HLS support on TVs are often lacking features and the remux on server side would end up removing more than just the dynamic range. I don't personally own any of the TVs, so I'm not sure if this relaxed profile would break anything though.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes https://github.com/jellyfin/jellyfin/discussions/15223

Fixes https://github.com/jellyfin/jellyfin/issues/15271

Fixes https://github.com/jellyfin/jellyfin-webos/issues/310

Related: https://github.com/jellyfin/jellyfin-web/pull/7296

The revert is still needed to retain full features, but the profile also has to be relaxed.
