### PR TITLE
Add playback speed controls for audiobooks

### DIFF
--- a/src/components/nowPlayingBar/nowPlayingBar.js
+++ b/src/components/nowPlayingBar/nowPlayingBar.js
@@ -90,6 +90,8 @@ function getNowPlayingBarHtml() {
 
     html += `<button is="paper-icon-button-light" class="openLyricsButton mediaButton hide" title="${globalize.translate('Lyrics')}"><span class="material-icons lyrics" style="top:0.1em" aria-hidden="true"></span></button>`;
 
+    html += `<button is="paper-icon-button-light" class="btnAudioSettings mediaButton" title="${globalize.translate('Settings')}"><span class="material-icons settings" aria-hidden="true"></span></button>`;
+
     html += `<button is="paper-icon-button-light" class="toggleRepeatButton mediaButton" title="${globalize.translate('Repeat')}"><span class="material-icons repeat" aria-hidden="true"></span></button>`;
     html += `<button is="paper-icon-button-light" class="btnShuffleQueue mediaButton" title="${globalize.translate('Shuffle')}"><span class="material-icons shuffle" aria-hidden="true"></span></button>`;
 
@@ -227,6 +229,24 @@ function bindEvents(elem) {
         } else {
             appRouter.show('lyrics');
         }
+    });
+
+    elem.querySelector('.btnAudioSettings').addEventListener('click', function() {
+        const btn = this;
+
+        import('../playback/playersettingsmenu').then((playerSettingsMenu) => {
+            const player = currentPlayer;
+
+            if (player) {
+                playerSettingsMenu.show({
+                    mediaType: 'Audio',
+                    player: player,
+                    positionTo: btn
+                }).catch(() => {
+                    // User cancelled
+                });
+            }
+        });
     });
 
     toggleRepeatButton = elem.querySelector('.toggleRepeatButton');

--- a/src/plugins/htmlAudioPlayer/plugin.js
+++ b/src/plugins/htmlAudioPlayer/plugin.js
@@ -197,6 +197,12 @@ class HtmlAudioPlayer {
                 return htmlMediaHelper.applySrc(elem, val, options).then(function () {
                     self._currentSrc = val;
 
+                    // Restore playback rate from session storage
+                    const playbackRateSpeed = sessionStorage.getItem('playbackRateSpeed');
+                    if (playbackRateSpeed !== null) {
+                        self.setPlaybackRate(playbackRateSpeed);
+                    }
+
                     return htmlMediaHelper.playWithPromise(elem, onError);
                 });
             });
@@ -515,6 +521,34 @@ class HtmlAudioPlayer {
             return mediaElement.playbackRate;
         }
         return null;
+    }
+
+    getSupportedPlaybackRates() {
+        return [{
+            name: '0.5x',
+            id: 0.5
+        }, {
+            name: '0.75x',
+            id: 0.75
+        }, {
+            name: '1x',
+            id: 1.0
+        }, {
+            name: '1.25x',
+            id: 1.25
+        }, {
+            name: '1.5x',
+            id: 1.5
+        }, {
+            name: '1.75x',
+            id: 1.75
+        }, {
+            name: '2x',
+            id: 2.0
+        }, {
+            name: '2.5x',
+            id: 2.5
+        }];
     }
 
     setVolume(val) {


### PR DESCRIPTION
**Changes**
Adds playback speed controls (0.5x to 2.5x) for audiobook playback and a settings button to the audio player's now playing bar. Playback speed preference is persisted across sessions using sessionStorage.

**Issues**
Adds feature parity with other audiobook apps (Audible, LibreVox) for playback speed control.