### PR TITLE
Add line break to card's secondary text

### DIFF
--- a/src/apps/dashboard/components/BaseCard.tsx
+++ b/src/apps/dashboard/components/BaseCard.tsx
@@ -94,7 +94,13 @@ const BaseCard = ({
                             {title}
                         </Typography>
                         {text && (
-                            <Typography variant='body2' color='text.secondary'>
+                            <Typography
+                                variant='body2'
+                                color='text.secondary'
+                                sx={{
+                                    lineBreak: 'anywhere'
+                                }}
+                            >
                                 {text}
                             </Typography>
                         )}


### PR DESCRIPTION
**Changes**
Add line break 'anywhere' to BaseCard's secondary text

**Issues**
Fixes https://github.com/jellyfin/jellyfin-web/issues/7305
