### PR TITLE
Fix missing Live TV sections in experimental layout

### DIFF
--- a/src/utils/sections.ts
+++ b/src/utils/sections.ts
@@ -196,7 +196,6 @@ export const getProgramSections = (): Section[] => {
             apiMethod: SectionApiMethod.LiveTvPrograms,
             type: SectionType.UpcomingEpisodes,
             parametersOptions: {
-                isAiring: false,
                 hasAired: false,
                 isMovie: false,
                 isSports: false,
@@ -221,7 +220,6 @@ export const getProgramSections = (): Section[] => {
             apiMethod: SectionApiMethod.LiveTvPrograms,
             type: SectionType.UpcomingMovies,
             parametersOptions: {
-                isAiring: false,
                 hasAired: false,
                 isMovie: true
             },
@@ -242,7 +240,6 @@ export const getProgramSections = (): Section[] => {
             apiMethod: SectionApiMethod.LiveTvPrograms,
             type: SectionType.UpcomingSports,
             parametersOptions: {
-                isAiring: false,
                 hasAired: false,
                 isSports: true
             },
@@ -263,7 +260,6 @@ export const getProgramSections = (): Section[] => {
             apiMethod: SectionApiMethod.LiveTvPrograms,
             type: SectionType.UpcomingKids,
             parametersOptions: {
-                isAiring: false,
                 hasAired: false,
                 isKids: true
             },
@@ -284,7 +280,6 @@ export const getProgramSections = (): Section[] => {
             apiMethod: SectionApiMethod.LiveTvPrograms,
             type: SectionType.UpcomingNews,
             parametersOptions: {
-                isAiring: false,
                 hasAired: false,
                 isNews: true
             },


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->
The sections had` isAiring: false` which excluded currently airing programs, so only the "On Now" section (with` isAiring: true`) had data.

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Remove` isAiring: false` from the UpcomingEpisodes, UpcomingMovies, UpcomingSports, UpcomingKids, and UpcomingNews sections to show both currently airing and upcoming programs.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # --> 


| Before | After |
|--------|-------|
| <img width="210" height="918" alt="1" src="https://github.com/user-attachments/assets/cee8e7ed-9e40-450d-ae6d-351bf5d57491" /> | <img width="221" height="885" alt="2" src="https://github.com/user-attachments/assets/4c553434-8bdb-4d6a-93d9-218e59b44e6b" /> |

