### PR TITLE
Add frame scrubbing controls

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -1346,8 +1346,8 @@ export class PlaybackManager {
         };
 
         self.getFps = function (player) {
-            self.currentMediaSource(player).MediaStreams.find(s => s.Type === "Video")?.RealFrameRate
-        }
+            return self.currentMediaSource(player).MediaStreams.find(s => s.Type === 'Video')?.RealFrameRate;
+        };
 
         function getSavedMaxStreamingBitrate(apiClient, mediaType) {
             if (!apiClient) {

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -1347,7 +1347,7 @@ export class PlaybackManager {
         };
 
         self.getFps = function (player) {
-            return self.currentMediaSource(player).MediaStreams.find(s => s.Type === 'Video')?.RealFrameRate;
+            return self.currentMediaSource(player).MediaStreams.find(s => s.Type === 'Video')?.ReferenceFrameRate;
         };
 
         function getSavedMaxStreamingBitrate(apiClient, mediaType) {
@@ -3891,14 +3891,14 @@ export class PlaybackManager {
 
     nextFrame(player = this._currentPlayer) {
         const fps = this.getFps(player);
-        if (fps != null) {
+        if (fps) {
             this.seekRelative(TICKS_PER_SECOND / fps, player);
         }
     }
 
     previousFrame(player = this._currentPlayer) {
         const fps = this.getFps(player);
-        if (fps != null) {
+        if (fps) {
             this.seekRelative(-TICKS_PER_SECOND / fps, player);
         }
     }

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -3891,14 +3891,14 @@ export class PlaybackManager {
     nextFrame(player = this._currentPlayer) {
         const fps = this.getFps(player);
         if (fps != null) {
-            this.seekRelative(1e6 / fps, player);
+            this.seekRelative(1e5 / fps, player);
         }
     }
 
     previousFrame(player = this._currentPlayer) {
         const fps = this.getFps(player);
         if (fps != null) {
-            this.seekRelative(-1e6 / fps, player);
+            this.seekRelative(-1e5 / fps, player);
         }
     }
 

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -3888,7 +3888,6 @@ export class PlaybackManager {
         this.seekRelative(offsetTicks, player);
     }
 
-    // tick = ⅒ns, so ticks/frame = 1e10 ns / 1e5 *
     nextFrame(player = this._currentPlayer) {
         const fps = this.getFps(player);
         if (fps != null) {

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -27,6 +27,7 @@ import { PlayerEvent } from 'apps/stable/features/playback/constants/playerEvent
 import { bindMediaSegmentManager } from 'apps/stable/features/playback/utils/mediaSegmentManager';
 import { bindMediaSessionSubscriber } from 'apps/stable/features/playback/utils/mediaSessionSubscriber';
 import { AppFeature } from 'constants/appFeature';
+import { TICKS_PER_SECOND } from 'constants/time';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
 import { MediaError } from 'types/mediaError';
 import { getMediaError } from 'utils/mediaError';
@@ -3891,14 +3892,14 @@ export class PlaybackManager {
     nextFrame(player = this._currentPlayer) {
         const fps = this.getFps(player);
         if (fps != null) {
-            this.seekRelative(1e7 / fps, player);
+            this.seekRelative(TICKS_PER_SECOND / fps, player);
         }
     }
 
     previousFrame(player = this._currentPlayer) {
         const fps = this.getFps(player);
         if (fps != null) {
-            this.seekRelative(-1e7 / fps, player);
+            this.seekRelative(-TICKS_PER_SECOND / fps, player);
         }
     }
 

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -3888,17 +3888,18 @@ export class PlaybackManager {
         this.seekRelative(offsetTicks, player);
     }
 
+    // tick = ⅒ns, so ticks/frame = 1e10 ns / 1e5 *
     nextFrame(player = this._currentPlayer) {
         const fps = this.getFps(player);
         if (fps != null) {
-            this.seekRelative(1e5 / fps, player);
+            this.seekRelative(1e7 / fps, player);
         }
     }
 
     previousFrame(player = this._currentPlayer) {
         const fps = this.getFps(player);
         if (fps != null) {
-            this.seekRelative(-1e5 / fps, player);
+            this.seekRelative(-1e7 / fps, player);
         }
     }
 

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -1346,10 +1346,6 @@ export class PlaybackManager {
             }
         };
 
-        self.getFps = function (player) {
-            return self.currentMediaSource(player).MediaStreams.find(s => s.Type === 'Video')?.ReferenceFrameRate;
-        };
-
         function getSavedMaxStreamingBitrate(apiClient, mediaType) {
             if (!apiClient) {
                 // This should hopefully never happen
@@ -3889,17 +3885,16 @@ export class PlaybackManager {
         this.seekRelative(offsetTicks, player);
     }
 
-    nextFrame(player = this._currentPlayer) {
-        const fps = this.getFps(player);
-        if (fps) {
-            this.seekRelative(TICKS_PER_SECOND / fps, player);
-        }
-    }
+    seekFrames(frames = 1, player = this._currentPlayer) {
+        // Only allow seeking by frames when paused
+        if (!player.paused()) return;
 
-    previousFrame(player = this._currentPlayer) {
-        const fps = this.getFps(player);
-        if (fps) {
-            this.seekRelative(-TICKS_PER_SECOND / fps, player);
+        const source = this.currentMediaSource(player);
+        const videoStream = source?.MediaStreams?.find(s => s.Type === MediaType.Video);
+        // It only makes sense to seek video streams by frames
+        if (videoStream) {
+            const fps = videoStream.ReferenceFrameRate || 24;
+            this.seekRelative(frames / fps * TICKS_PER_SECOND, player);
         }
     }
 

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -1345,6 +1345,10 @@ export class PlaybackManager {
             }
         };
 
+        self.getFps = function (player) {
+            self.currentMediaSource(player).MediaStreams.find(s => s.Type === "Video")?.RealFrameRate
+        }
+
         function getSavedMaxStreamingBitrate(apiClient, mediaType) {
             if (!apiClient) {
                 // This should hopefully never happen
@@ -3882,6 +3886,20 @@ export class PlaybackManager {
         const offsetTicks = 0 - (userSettings.skipBackLength() * 10000);
 
         this.seekRelative(offsetTicks, player);
+    }
+
+    nextFrame(player = this._currentPlayer) {
+        const fps = this.getFps(player);
+        if (fps != null) {
+            this.seekRelative(1e6 / fps, player);
+        }
+    }
+
+    previousFrame(player = this._currentPlayer) {
+        const fps = this.getFps(player);
+        if (fps != null) {
+            this.seekRelative(-1e6 / fps, player);
+        }
     }
 
     seekPercent(percent, player = this._currentPlayer) {

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1312,6 +1312,18 @@ export default function (view) {
                     showOsd(btnFastForward);
                 }
                 break;
+            case ',':
+                if (!e.shiftKey) {
+                    e.preventDefault();
+                    playbackManager.seekRelative(currentPlayer, 1);
+                }
+                break;
+            case '.':
+                if (!e.shiftKey) {
+                    e.preventDefault();
+                    playbackManager.seekRelative(currentPlayer, -1);
+                }
+                break;
             case 'j':
             case 'J':
             case 'ArrowLeft':

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1315,13 +1315,13 @@ export default function (view) {
             case ',':
                 if (!e.shiftKey) {
                     e.preventDefault();
-                    playbackManager.seekRelative(-1, currentPlayer);
+                    playbackManager.seekRelative(-4e4, currentPlayer);
                 }
                 break;
             case '.':
                 if (!e.shiftKey) {
                     e.preventDefault();
-                    playbackManager.seekRelative(1, currentPlayer);
+                    playbackManager.seekRelative(4e4, currentPlayer);
                 }
                 break;
             case 'j':

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1315,13 +1315,13 @@ export default function (view) {
             case ',':
                 if (!e.shiftKey) {
                     e.preventDefault();
-                    playbackManager.seekRelative(-4e4, currentPlayer);
+                    playbackManager.previousFrame(currentPlayer);
                 }
                 break;
             case '.':
                 if (!e.shiftKey) {
                     e.preventDefault();
-                    playbackManager.seekRelative(4e4, currentPlayer);
+                    playbackManager.nextFrame(currentPlayer);
                 }
                 break;
             case 'j':

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1315,13 +1315,13 @@ export default function (view) {
             case ',':
                 if (!e.shiftKey) {
                     e.preventDefault();
-                    playbackManager.seekRelative(currentPlayer, -1);
+                    playbackManager.seekRelative(-1, currentPlayer);
                 }
                 break;
             case '.':
                 if (!e.shiftKey) {
                     e.preventDefault();
-                    playbackManager.seekRelative(currentPlayer, 1);
+                    playbackManager.seekRelative(1, currentPlayer);
                 }
                 break;
             case 'j':

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1315,13 +1315,13 @@ export default function (view) {
             case ',':
                 if (!e.shiftKey) {
                     e.preventDefault();
-                    playbackManager.previousFrame(currentPlayer);
+                    playbackManager.seekFrames(-1, currentPlayer);
                 }
                 break;
             case '.':
                 if (!e.shiftKey) {
                     e.preventDefault();
-                    playbackManager.nextFrame(currentPlayer);
+                    playbackManager.seekFrames(1, currentPlayer);
                 }
                 break;
             case 'j':
@@ -2084,4 +2084,3 @@ export default function (view) {
         });
     }
 }
-

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1315,13 +1315,13 @@ export default function (view) {
             case ',':
                 if (!e.shiftKey) {
                     e.preventDefault();
-                    playbackManager.seekRelative(currentPlayer, 1);
+                    playbackManager.seekRelative(currentPlayer, -1);
                 }
                 break;
             case '.':
                 if (!e.shiftKey) {
                     e.preventDefault();
-                    playbackManager.seekRelative(currentPlayer, -1);
+                    playbackManager.seekRelative(currentPlayer, 1);
                 }
                 break;
             case 'j':


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->


**Changes**
Register `,` and `.` as controls to scrub frame-by-frame.

These are the same keys that YouTube uses for this functionality, which seems to be the interface you’re mirroring with these keybinds.

**Issues**
Resolves #3087, closes #7132
Implements https://features.jellyfin.org/posts/3545/seeking-video-frame-by-frame

TODO:
- [x] Use current media stream FPS to calculate ticks to jump forward/backward