### PR TITLE
Avoid clipping thumbnails in episode lists

### DIFF
--- a/src/components/listview/listview.scss
+++ b/src/components/listview/listview.scss
@@ -144,7 +144,7 @@
     min-width: 2.78em;
     min-height: 2.78em;
     background-repeat: no-repeat;
-    background-size: cover;
+    background-size: contain;
     flex-shrink: 0;
     background-position: center center;
     position: relative;


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

Currently, `.listItemImage` has `background-size: cover`, which scales the picture to avoid empty space _even if that hides part of the image_. This can cause unwanted cropping:

<img width="3658" height="1820" alt="Screenshot 2025-11-09 at 21-03-04 Jellyfin" src="https://github.com/user-attachments/assets/c87018c6-778a-41ad-8e30-57cafe7912d2" />

With this change, it has `background-size: contain`, which scales the picture to ensure the entire image is visible, but _may leave empty space around the image_. This is how the same page looks with the change applied by (mis)using the "Custom CSS Code" in the server settings:

<img width="3658" height="1820" alt="Screenshot 2025-11-09 at 21-03-13 Jellyfin" src="https://github.com/user-attachments/assets/271657a4-0e2f-486f-8a6e-579bbe1bb588" />