### PR TITLE
Tizen: Enable direct-play of anamorphic videos

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -297,6 +297,11 @@ function supportedDolbyVisionProfileAv1(videoTestElement) {
     return videoTestElement.canPlayType?.('video/mp4; codecs="dav1.10.06"').replace(/no/, '');
 }
 
+function supportsAnamorphicVideo() {
+    // Tizen applies the aspect ratio correctly
+    return browser.tizenVersion >= 6;
+}
+
 function getDirectPlayProfileForVideoContainer(container, videoAudioCodecs, videoTestElement, options) {
     let supported = false;
     let profileContainer = container;
@@ -1219,12 +1224,6 @@ export default function (options) {
 
     const h264CodecProfileConditions = [
         {
-            Condition: 'NotEquals',
-            Property: 'IsAnamorphic',
-            Value: 'true',
-            IsRequired: false
-        },
-        {
             Condition: 'EqualsAny',
             Property: 'VideoProfile',
             Value: h264Profiles,
@@ -1245,12 +1244,6 @@ export default function (options) {
     ];
 
     const hevcCodecProfileConditions = [
-        {
-            Condition: 'NotEquals',
-            Property: 'IsAnamorphic',
-            Value: 'true',
-            IsRequired: false
-        },
         {
             Condition: 'EqualsAny',
             Property: 'VideoProfile',
@@ -1282,12 +1275,6 @@ export default function (options) {
 
     const av1CodecProfileConditions = [
         {
-            Condition: 'NotEquals',
-            Property: 'IsAnamorphic',
-            Value: 'true',
-            IsRequired: false
-        },
-        {
             Condition: 'EqualsAny',
             Property: 'VideoProfile',
             Value: av1Profiles,
@@ -1306,6 +1293,29 @@ export default function (options) {
             IsRequired: false
         }
     ];
+
+    if (!supportsAnamorphicVideo()) {
+        h264CodecProfileConditions.push({
+            Condition: 'NotEquals',
+            Property: 'IsAnamorphic',
+            Value: 'true',
+            IsRequired: false
+        });
+
+        hevcCodecProfileConditions.push({
+            Condition: 'NotEquals',
+            Property: 'IsAnamorphic',
+            Value: 'true',
+            IsRequired: false
+        });
+
+        av1CodecProfileConditions.push({
+            Condition: 'NotEquals',
+            Property: 'IsAnamorphic',
+            Value: 'true',
+            IsRequired: false
+        });
+    }
 
     if (!browser.edgeUwp && !browser.tizen && !browser.web0s) {
         h264CodecProfileConditions.push({


### PR DESCRIPTION
Anamorphic videos currently require a remux, which apparently breaks the aspect ratio: https://github.com/jellyfin/jellyfin-tizen/issues/376

On my Tizen v9 TV, the web player handles the aspect ratio just fine directly, correctly stretching the 720x472 pixels of some DVD source to a 873x472 view. **Edit**: Tested with HEVC and H264 media.