### PR TITLE
UI(storage): display per-folder storage usage in Paths widget

### DIFF
--- a/src/apps/dashboard/features/storage/api/useSystemStorage.ts
+++ b/src/apps/dashboard/features/storage/api/useSystemStorage.ts
@@ -9,21 +9,25 @@ const fetchSystemStorage = async (
     api: Api,
     options?: AxiosRequestConfig
 ) => {
-    const response = await getSystemApi(api)
-        .getSystemStorage(options);
+    const response = await getSystemApi(api).getSystemStorage(options);
     return response.data;
 };
 
-const getSystemStorageQuery = (
-    api?: Api
-) => queryOptions({
-    queryKey: [ 'SystemStorage' ],
-    queryFn: ({ signal }) => fetchSystemStorage(api!, { signal }),
-    enabled: !!api,
-    refetchOnWindowFocus: false
-});
+const getSystemStorageQuery = (api?: Api) =>
+    queryOptions({
+        queryKey: ['SystemStorage'],
+        queryFn: ({ signal }) => fetchSystemStorage(api!, { signal }),
+        enabled: !!api,
+        refetchOnWindowFocus: false,
+    });
 
 export const useSystemStorage = () => {
     const { api } = useApi();
-    return useQuery(getSystemStorageQuery(api));
+    const query = useQuery(getSystemStorageQuery(api));
+
+    if (query.data) {
+        console.log('📦 System Storage API response:', query.data);
+    }
+
+    return query;
 };

--- a/src/apps/dashboard/features/storage/components/StorageListItem.tsx
+++ b/src/apps/dashboard/features/storage/components/StorageListItem.tsx
@@ -28,11 +28,9 @@ const getStatusColor = (percent: number) => {
 
 const getStorageTypeText = (type?: string | null) => {
     if (!type) return undefined;
-
     if (Object.keys(StorageType).includes(type)) {
         return globalize.translate(`StorageType.${type}`);
     }
-
     return type;
 };
 
@@ -46,6 +44,12 @@ const StorageListItem: FC<StorageListItemProps> = ({
     const readableTotalSpace = (totalSpace < 0) ? '?' : getReadableSize(totalSpace);
     const usedPercentage = calculateUsedPercentage(folder);
     const statusColor = folder ? getStatusColor(usedPercentage) : 'primary';
+
+    const folderSize = (folder as any)?.FolderSizeBytes ?? (folder as any)?.SizeBytes ?? (folder as any)?.Size;
+    const hasFolderSize = typeof folderSize === 'number' && folderSize >= 0;
+    const driveTotal = (folder as any)?.DriveTotalBytes ?? (folder as any)?.DriveCapacity;
+    const readableFolderSize = hasFolderSize ? getReadableSize(folderSize) : undefined;
+    const readableDriveTotal = typeof driveTotal === 'number' && driveTotal >= 0 ? getReadableSize(driveTotal) : undefined;
 
     return (
         <ListItem>
@@ -70,24 +74,33 @@ const StorageListItem: FC<StorageListItemProps> = ({
                                 lineBreak: 'anywhere'
                             }}
                         >
-                            {folder ? folder.Path : (
-                                <Skeleton />
-                            )}
+                            {folder ? folder.Path : <Skeleton />}
                         </Typography>
-                        <LinearProgress
-                            variant={folder ? 'determinate' : 'indeterminate'}
-                            color={statusColor}
-                            value={usedPercentage}
-                        />
-                        <Typography
-                            variant='body2'
-                            color='textSecondary'
-                            sx={{
-                                textAlign: 'end'
-                            }}
-                        >
-                            {`${readableUsedSpace} / ${readableTotalSpace}`}
-                        </Typography>
+
+                        {hasFolderSize ? (
+                            <>
+                                <LinearProgress
+                                    variant='determinate'
+                                    color={statusColor}
+                                    value={usedPercentage}
+                                />
+                                <Typography
+                                    variant='body2'
+                                    color='textSecondary'
+                                    sx={{ textAlign: 'end' }}
+                                >
+                                    {`${readableFolderSize}${readableDriveTotal ? ` / ${readableDriveTotal}` : ''}`}
+                                </Typography>
+                            </>
+                        ) : (
+                            <Typography
+                                variant='body2'
+                                color='textSecondary'
+                                sx={{ textAlign: 'end' }}
+                            >
+                                {readableUsedSpace === '?' ? '' : `${readableUsedSpace}`}
+                            </Typography>
+                        )}
                     </>
                 }
                 slots={{

--- a/src/apps/dashboard/features/storage/utils/space.ts
+++ b/src/apps/dashboard/features/storage/utils/space.ts
@@ -1,9 +1,12 @@
 import type { FolderStorageDto } from '@jellyfin/sdk/lib/generated-client/models/folder-storage-dto';
 
 export const calculateTotal = (folder?: FolderStorageDto) => {
-    if (typeof folder?.UsedSpace === 'undefined' || folder.UsedSpace < 0) {
-        return -1;
-    }
+    if (!folder) return -1;
+
+    const folderSize = (folder as any)?.FolderSizeBytes ?? (folder as any)?.SizeBytes ?? (folder as any)?.Size;
+    if (typeof folderSize === 'number' && folderSize >= 0) return folderSize;
+
+    if (typeof folder?.UsedSpace === 'undefined' || folder.UsedSpace < 0) return -1;
 
     const freeSpace = Math.max(0, folder.FreeSpace || 0);
     const usedSpace = Math.max(0, folder.UsedSpace);
@@ -11,10 +14,18 @@ export const calculateTotal = (folder?: FolderStorageDto) => {
 };
 
 export const calculateUsedPercentage = (folder?: FolderStorageDto) => {
-    const totalSpace = calculateTotal(folder);
-    if (totalSpace <= 0) return 0;
+    if (!folder) return 0;
 
-    const usedSpace = folder?.UsedSpace || 0;
+    const used = Math.max(0, folder.UsedSpace || 0);
 
-    return Math.min(100, (usedSpace / totalSpace) * 100);
+    const driveTotal = (folder as any)?.DriveTotalBytes ?? (folder as any)?.DriveCapacity;
+    const folderTotal = (folder as any)?.FolderSizeBytes ?? (folder as any)?.SizeBytes ?? (folder as any)?.Size;
+
+    const total = (typeof driveTotal === 'number' && driveTotal > 0) ? driveTotal
+        : (typeof folderTotal === 'number' && folderTotal > 0) ? folderTotal
+        : calculateTotal(folder);
+
+    if (total <= 0) return 0;
+
+    return Math.min(100, (used / total) * 100);
 };


### PR DESCRIPTION
Fixes jellyfin/jellyfin-web#7323

### Summary
Prefer per-folder `FolderSizeBytes` and `DriveTotalBytes` returned by the backend when rendering the Dashboard → Paths widget. Only show a progress bar when folder-level sizes exist to avoid misleading identical bars per path.

### Changes
- Use `FolderSizeBytes` / `DriveTotalBytes` in `src/apps/dashboard/features/storage/utils/space.ts`.
- Render progress bar and text in `StorageListItem.tsx` only when per-folder sizes exist.
- Added debug logging in `useSystemStorage` to confirm API returns the new fields.
- Recovered/updated `src/lib/jellyfin-apiclient/*` files as needed.

### Verification
- Confirmed locally on Windows: each path shows unique storage usage.
- `Web` folder on `T:\` shows its separate drive capacity; other paths on `C:\` show different totals.
- Screenshots attached (before/after).

### Notes
This PR depends on backend changes that provide `FolderSizeBytes` and `DriveTotalBytes` via the System Storage API. See backend PR: `jellyfin/jellyfin#<backend-pr-number>` (link when created).

<img width="895" height="926" alt="Screenshot 2025-11-11 231054" src="https://github.com/user-attachments/assets/a5809e59-a3ad-42b0-93fa-56410386c735" />
