### PR TITLE
Support DOVI in mkv container on WebOS 25 and newer

### DIFF
--- a/src/scripts/browser.js
+++ b/src/scripts/browser.js
@@ -115,7 +115,11 @@ function web0sVersion(browser) {
 
         // The next is only valid for the app
 
-        if (browser.versionMajor >= 94) {
+        if (browser.versionMajor >= 120) {
+            return 25;
+        } else if (browser.versionMajor >= 108) {
+            return 24;
+        } else if (browser.versionMajor >= 94) {
             return 23;
         } else if (browser.versionMajor >= 87) {
             return 22;

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -1500,7 +1500,6 @@ export default function (options) {
         // On WebOS 25 and newer, mp4, ts, and mkv containers are allowed.
         // On WebOS 24 and lower, only mp4 and ts containers are allowed.
         const allowedContainers = browser.web0sVersion >= 10 ? ['mp4', 'ts', 'mkv'] : ['mp4', 'ts'];
-        
         profile.CodecProfiles.push({
             Type: 'Video',
             Container: '-' + allowedContainers.join(','),

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -1496,10 +1496,14 @@ export default function (options) {
     });
 
     if (browser.web0s && supportsDolbyVision(options)) {
-        // Disallow direct playing of DOVI media in containers not ts or mp4.
+        // Adjust DOVI container rules based on WebOS version.
+        // On WebOS 25 and newer, mp4, ts, and mkv containers are allowed.
+        // On WebOS 24 and lower, only mp4 and ts containers are allowed.
+        const allowedContainers = browser.web0sVersion >= 10 ? ['mp4', 'ts', 'mkv'] : ['mp4', 'ts'];	
+        
         profile.CodecProfiles.push({
             Type: 'Video',
-            Container: '-mp4,ts',
+            Container: '-' + allowedContainers.join(','),
             Codec: 'hevc',
             Conditions: [
                 {

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -1499,7 +1499,7 @@ export default function (options) {
         // Adjust DOVI container rules based on WebOS version.
         // On WebOS 25 and newer, mp4, ts, and mkv containers are allowed.
         // On WebOS 24 and lower, only mp4 and ts containers are allowed.
-        const allowedContainers = browser.web0sVersion >= 10 ? ['mp4', 'ts', 'mkv'] : ['mp4', 'ts'];	
+        const allowedContainers = browser.web0sVersion >= 10 ? ['mp4', 'ts', 'mkv'] : ['mp4', 'ts'];
         
         profile.CodecProfiles.push({
             Type: 'Video',

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -1499,7 +1499,7 @@ export default function (options) {
         // Adjust DOVI container rules based on WebOS version.
         // On WebOS 25 and newer, mp4, ts, and mkv containers are allowed.
         // On WebOS 24 and lower, only mp4 and ts containers are allowed.
-        const allowedContainers = browser.web0sVersion >= 10 ? ['mp4', 'ts', 'mkv'] : ['mp4', 'ts'];
+        const allowedContainers = browser.web0sVersion >= 25 ? ['mp4', 'ts', 'mkv'] : ['mp4', 'ts'];
         profile.CodecProfiles.push({
             Type: 'Video',
             Container: '-' + allowedContainers.join(','),


### PR DESCRIPTION
This change enables Direct Play of DOVI files in MKV container on WebOS 25, while still blocking it on earlier versions that do not support it, allowing remuxing on C1, CX and other devices that won't receive the latest update.

LG’s internal player is still far from perfect, but it is improving. A recent software update (version 33.22.52) fixed the stuttering issue I experienced when playing MKV files with many embedded subtitles on earlier version 33.22.15 (tested on an LG C2). Since the update, I haven’t encountered any other issues when directly playing MKV files with DOVI, so this might be a good time to merge the change.

Seeking forward and backward now works much better compared to remuxing to TS or MP4 containers. I also haven’t been able to get subtitles out of sync like I could before. This change may fix other issues like audio passthrough problems that I'm unable to test myself. 