### PR TITLE
Enable AC-4 audio codec if supported

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -157,6 +157,19 @@ function supportsAc3InHls(videoTestElement) {
     return false;
 }
 
+function supportsAc4(videoTestElement) {
+    return videoTestElement.canPlayType && videoTestElement.canPlayType('audio/mp4; codecs="ac-4"').replace(/no/, '');
+}
+
+function supportsAc4InHls(videoTestElement) {
+    if (videoTestElement.canPlayType) {
+        return videoTestElement.canPlayType('application/x-mpegurl; codecs="avc1.42E01E, ac-4"').replace(/no/, '')
+                || videoTestElement.canPlayType('application/vnd.apple.mpegURL; codecs="avc1.42E01E, ac-4"').replace(/no/, '');
+    }
+
+    return false;
+}
+
 function supportsMp3InHls(videoTestElement) {
     if (videoTestElement.canPlayType) {
         return videoTestElement.canPlayType('application/x-mpegurl; codecs="avc1.64001E, mp4a.40.34"').replace(/no/, '')
@@ -579,6 +592,15 @@ export default function (options) {
                 hlsInTsVideoAudioCodecs.push('eac3');
                 hlsInFmp4VideoAudioCodecs.push('eac3');
             }
+        }
+    }
+
+    if (supportsAc4(videoTestElement)) {
+        videoAudioCodecs.push('ac4');
+
+        if (supportsAc4InHls(videoTestElement)) {
+            hlsInTsVideoAudioCodecs.push('ac4');
+            hlsInFmp4VideoAudioCodecs.push('ac4');
         }
     }
 


### PR DESCRIPTION
Enable direct-play of AC-4 audio streams if the player claims support for it.

I've tested this on a Tizen 9 TV:
* An [.mp4](https://ott.dolby.com/OnDelKits/AC-4/Dolby_AC-4_Online_Delivery_Kit_1.5/Test_Signals/muxed_streams/MP4/Example/Audio_ID_720p_25fps_h265_6ch_128kbps_ac4.mp4) (from https://ott.dolby.com/OnDelKits/AC-4/Dolby_AC-4_Online_Delivery_Kit_1.5/help_files/topics/kit_wrapper_MP4_multiplexed_streams.html) direct-plays fine. I haven't tested the file earlier with vanilla jellyfin-web.
  ```
  Stream #0:0[0x1](eng): Audio: ac4 (ac-4 / 0x342D6361), 48000 Hz, 6 channels, 128 kb/s (default)
  Stream #0:1[0x2](und): Video: hevc (Main 10) (hvc1 / 0x31637668), yuv420p10le(tv), 1280x720 [SAR 1:1 DAR 16:9], 1015 kb/s, 25 fps, 25 tbr, 25k tbn (default)
  ```
* A [.ts](https://trac.ffmpeg.org/raw-attachment/ticket/8349/atsc3.ts) now can't be played back anymore, so that's currently a regression. Before these changes, the audio stream got transcoded to aac and then played back fine. Now I still see a DirectStream log file for each attempt (actually, 2 files for each attempt), both with the unexpected aac transcoding still, but the playback fails. 
  ```
  Input #0, mpegts, from 'file:/jellyfin/Samples/atsc3.ts':
    Duration: 00:00:10.08, start: 13664.044767, bitrate: 1292 kb/s
    Program 3 
    Stream #0:0[0x31]: Video: hevc (Main 10) ([36][0][0][0] / 0x0024), yuv420p10le(tv, bt709), 640x360 [SAR 1:1 DAR 16:9], 29.97 fps, 29.97 tbr, 90k tbn
    Stream #0:1[0x32](eng): Audio: ac4 (AC-4 / 0x342D4341), 46034 Hz, 5.1(side), fltp
  Stream mapping:
    Stream #0:0 -> #0:0 (copy)
    Stream #0:1 -> #0:1 (ac4 (native) -> aac (libfdk_aac))
  Press [q] to stop, [?] for help
  Output #0, hls, to '/var/cache/jellyfin/transcodes/a04fa586b10c2e97876e2e50b0ac38cc.m3u8':
    Stream #0:0: Video: hevc (Main 10) (hvc1 / 0x31637668), yuv420p10le(tv, bt709), 640x360 [SAR 1:1 DAR 16:9], q=2-31, 29.97 fps, 29.97 tbr, 90k tbn
    Stream #0:1: Audio: aac, 44100 Hz, 5.1, s16, 640 kb/s
  ```