### PR TITLE
Fix trickplay not displaying when content is played from a playlist

### DIFF
--- a/src/scripts/playlistViewer.js
+++ b/src/scripts/playlistViewer.js
@@ -7,7 +7,7 @@ import { toApi } from 'utils/jellyfin-apiclient/compat';
 function getFetchPlaylistItemsFn(apiClient, itemId) {
     return function () {
         const query = {
-            Fields: 'PrimaryImageAspectRatio',
+            Fields: 'PrimaryImageAspectRatio,MediaSourceCount,Chapters,Trickplay',
             EnableImageTypes: 'Primary,Backdrop,Banner,Thumb',
             UserId: apiClient.getCurrentUserId()
         };


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
Add `MediaSourceCount`, `Chapters`, `Trickplay` fields to `getFetchPlaylistItemsFn`

**Issues**
 Fixes #7292