### PR TITLE
Blacklist Firefox native mkv playback

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -205,6 +205,13 @@ function testCanPlayMkv(videoTestElement) {
         return true;
     }
 
+    if (browser.firefox) {
+        // As of Firefox 145, its mkv support is buggy and causes playback issues because it would force preloading the
+        // whole mkv file before playback starts, which is extremely undesirable for streaming.
+        // See https://github.com/jellyfin/jellyfin/issues/15521
+        return false;
+    }
+
     if (videoTestElement.canPlayType('video/x-matroska').replace(/no/, '')
             || videoTestElement.canPlayType('video/mkv').replace(/no/, '')) {
         return true;


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

Firefox 145 introduced native playback of mkv files but it is not optimized for streaming use case. For a lot of files, it would require downloading the entire file before the playback could even start, which is not desirable for video streaming.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes https://github.com/jellyfin/jellyfin/issues/15521
