### PR TITLE
Tizen: Add AVPlay player plugin

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -32,6 +32,7 @@
   "menuLinks": [],
   "servers": [],
   "plugins": [
+    "avplay/plugin",
     "playAccessValidation/plugin",
     "experimentalWarnings/plugin",
     "htmlAudioPlayer/plugin",

--- a/src/plugins/avplay/style.scss
+++ b/src/plugins/avplay/style.scss
@@ -17,7 +17,6 @@
     left: 0;
     right: 0;
     color: #fff;
-    text-shadow: #000000 0px 0px 7px;
     font-size: 170%;
     padding-left: env(safe-area-inset-left);
     padding-right: env(safe-area-inset-right);
@@ -29,4 +28,5 @@
 
 .avplaySubtitlesInner {
     max-width: 70%;
+    background-color: rgba(0, 0, 0, 0.8);
 }


### PR DESCRIPTION
This adds a Samsung-'native' AVPlay player. It's currently added unconditionally (not just for Tizen), and is automatically preferred over the default HTML player. Basic stuff seems to work on my Tizen 9 TV, incl. direct-play of most media, support for and switching between secondary audio tracks without the need to remux (contrary to the default HTML player on Tizen 8+), and subtitles (embedded ones at least, haven't tried external ones yet).

The code is based on https://github.com/dmitrylyzo/jellyfin-tizen/tree/avplay from @dmitrylyzo ; I've just additionally enabled some AV1 and AC4 direct-play support, switched from a plugin in `jellyfin-tizen` to a plugin here in `jellyfin-web` (to be able to use the `subtitleAppearanceHelper` etc.), and hacked in some subtitles rendering.

This would need more testing and polishing; e.g., subtitles currently cannot be switched during playback (pressing the CC icon does nothing). And restricting the plugin to Tizen only. The main aim of this PR is to make this existing work visible.

A .wgt build based on 10.11 can be downloaded from https://github.com/kinke/jellyfin-tizen-builds/actions/runs/19408070960.

**Edit**: I've noticed one drawback of AVPlay so far - the aspect ratio of direct-played anamorphic videos isn't applied correctly automatically, contrary to the HTML player (#7321).