### PR TITLE
Fix duplicate years due to type mismatch

### DIFF
--- a/src/components/filterdialog/filterdialog.js
+++ b/src/components/filterdialog/filterdialog.js
@@ -53,7 +53,7 @@ function renderFilters(context, result, query) {
         const delimeter = '|';
         return (delimeter + (query.Tags || '') + delimeter).includes(delimeter + i + delimeter);
     });
-    renderOptions(context, '.yearFilters', 'chkYearFilter', merge(result.Years, query.Years, ','), function (i) {
+    renderOptions(context, '.yearFilters', 'chkYearFilter', merge(result.Years.map(String), query.Years, ','), function (i) {
         const delimeter = ',';
         return (delimeter + (query.Years || '') + delimeter).includes(delimeter + i + delimeter);
     });


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->
# Summary
In the renderFilters function the query and api result years are passed into the lodash union function to be de-duplicated. Previously the api result was passed in as an array of integers while the query a split comma separated string. Because the lodash union function performs strict comparisons we should ensure that all values passed in are of the same type. This change converts the list of integer years into a list of string years.

**Changes**
* Convert api result years into strings. 

**Issues**
Fixes https://github.com/jellyfin/jellyfin-web/issues/7361
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
