### PR TITLE
Generalize multiselect across different cards/list items

### DIFF
--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -962,7 +962,8 @@ function buildCard(index, item, apiClient, options) {
         showChildCountIndicator: options.showChildCountIndicator,
         childCount: item.ChildCount,
         tagName: tagName,
-        itemType: item.Type
+        itemType: item.Type,
+        isMultiselectable: options.isMultiselectable
     });
 
     const positionTicksData = item.UserData?.PlaybackPositionTicks ? (' data-positionticks="' + item.UserData.PlaybackPositionTicks + '"') : '';

--- a/src/components/cardbuilder/utils/builder.test.ts
+++ b/src/components/cardbuilder/utils/builder.test.ts
@@ -660,11 +660,11 @@ describe('resolveCardImageContainerCssClasses', () => {
 });
 
 describe('resolveCardBoxCssClasses', () => {
-    test('non-card layout', () => expect(resolveCardBoxCssClasses({ cardLayout: false, hasOuterCardFooter: false })).toEqual('cardBox'));
+    test('non-card layout', () => expect(resolveCardBoxCssClasses({ cardLayout: false, hasOuterCardFooter: false })).toEqual('cardBox multiselect-container'));
 
-    test('card layout', () => expect(resolveCardBoxCssClasses({ cardLayout: true, hasOuterCardFooter: false })).toEqual('cardBox visualCardBox'));
+    test('card layout', () => expect(resolveCardBoxCssClasses({ cardLayout: true, hasOuterCardFooter: false })).toEqual('cardBox visualCardBox multiselect-container'));
 
-    test('has outer card footer', () => expect(resolveCardBoxCssClasses({ cardLayout: false, hasOuterCardFooter: true })).toEqual('cardBox cardBox-bottompadded'));
+    test('has outer card footer', () => expect(resolveCardBoxCssClasses({ cardLayout: false, hasOuterCardFooter: true })).toEqual('cardBox cardBox-bottompadded multiselect-container'));
 });
 
 describe('getDefaultBackgroundClass', () => {

--- a/src/components/cardbuilder/utils/builder.ts
+++ b/src/components/cardbuilder/utils/builder.ts
@@ -80,7 +80,8 @@ type CardCssClassOpts = {
     showChildCountIndicator: boolean,
     isTV: boolean,
     enableFocusTransform: boolean,
-    isDesktop: boolean
+    isDesktop: boolean,
+    isMultiselectable?: boolean,
 };
 
 /**
@@ -98,7 +99,8 @@ export const resolveCardCssClasses = (opts: CardCssClassOpts): string => {
         'show-animation': opts.isTV && opts.enableFocusTransform,
         'groupedCard': opts.showChildCountIndicator && opts.childCount,
         'card-withuserdata': !['MusicAlbum', 'MusicArtist', 'Audio'].includes(opts.itemType),
-        'itemAction': opts.tagName === 'button'
+        'itemAction': opts.tagName === 'button',
+        'multiselectable': opts.isMultiselectable || false,
     });
 };
 
@@ -123,7 +125,8 @@ export const resolveCardBoxCssClasses = (opts: { cardLayout: boolean, hasOuterCa
     return classNames({
         'cardBox': true,
         'visualCardBox': opts.cardLayout,
-        'cardBox-bottompadded': opts.hasOuterCardFooter && !opts.cardLayout
+        'cardBox-bottompadded': opts.hasOuterCardFooter && !opts.cardLayout,
+        'multiselect-container': true,
     });
 };
 

--- a/src/components/cardbuilder/utils/builder.ts
+++ b/src/components/cardbuilder/utils/builder.ts
@@ -100,7 +100,7 @@ export const resolveCardCssClasses = (opts: CardCssClassOpts): string => {
         'groupedCard': opts.showChildCountIndicator && opts.childCount,
         'card-withuserdata': !['MusicAlbum', 'MusicArtist', 'Audio'].includes(opts.itemType),
         'itemAction': opts.tagName === 'button',
-        'multiselectable': opts.isMultiselectable || false,
+        'multiselectable': opts.isMultiselectable || false
     });
 };
 
@@ -126,7 +126,7 @@ export const resolveCardBoxCssClasses = (opts: { cardLayout: boolean, hasOuterCa
         'cardBox': true,
         'visualCardBox': opts.cardLayout,
         'cardBox-bottompadded': opts.hasOuterCardFooter && !opts.cardLayout,
-        'multiselect-container': true,
+        'multiselect-container': true
     });
 };
 

--- a/src/components/itemContextMenu.js
+++ b/src/components/itemContextMenu.js
@@ -133,7 +133,7 @@ export async function getCommands(options) {
     if (!browser.tv) {
         // Multiselect is currrently only ran on long clicks of card components
         // This disables Select on any context menu not originating from a card i.e songs
-        if (options.positionTo && (dom.parentWithClass(options.positionTo, 'card') !== null)) {
+        if (options.positionTo) {
             commands.push({
                 name:  globalize.translate('Select'),
                 id: 'multiSelect',

--- a/src/components/itemContextMenu.js
+++ b/src/components/itemContextMenu.js
@@ -132,8 +132,8 @@ export async function getCommands(options) {
 
     if (!browser.tv) {
         // Multiselect is currrently only ran on long clicks of card components
-        // This disables Select on any context menu not originating from a card i.e songs
-        if (options.positionTo) {
+        // This disables Select on any context menu not originating from a multiselectable.
+        if (options.positionTo && (dom.parentWithClass(options.positionTo, 'multiselectable') !== null)) {
             commands.push({
                 name:  globalize.translate('Select'),
                 id: 'multiSelect',
@@ -533,7 +533,7 @@ function executeCommand(item, id, options) {
                 break;
             case 'multiSelect':
                 import('./multiSelect/multiSelect').then(({ startMultiSelect }) => {
-                    const card = dom.parentWithClass(options.positionTo, 'card');
+                    const card = dom.parentWithClass(options.positionTo, 'multiselectable');
                     startMultiSelect(card);
                 });
                 break;

--- a/src/components/listview/listview.js
+++ b/src/components/listview/listview.js
@@ -239,6 +239,10 @@ export function getListViewHtml(options) {
             cssClass += ' listItem-largeImage';
             downloadWidth = 500;
         }
+        if (options.isMultiselectable){
+            cssClass += ' multiselectable';
+
+        }
 
         const playlistItemId = item.PlaylistItemId ? (` data-playlistitemid="${item.PlaylistItemId}"`) : '';
 
@@ -256,7 +260,10 @@ export function getListViewHtml(options) {
         html += `<${outerTagName} class="${cssClass}"${playlistItemId} data-action="${action}" data-isfolder="${item.IsFolder}" data-id="${item.Id}" data-serverid="${item.ServerId}" data-type="${item.Type}"${mediaTypeData}${collectionTypeData}${channelIdData}${positionTicksData}${collectionIdData}${playlistIdData}>`;
 
         if (enableContentWrapper) {
-            html += '<div class="listItem-content">';
+            html += `<div class="listItem-content ${options.isMultiselectable ? 'multiselect-container' : ''}">`;
+        }
+        else{
+            html += `<div style='align-self: flex-start;' class="${options.isMultiselectable ? 'multiselect-container' : ''}"> </div>`;
         }
 
         if (!clickEntireItem && options.dragHandle) {

--- a/src/components/listview/listview.js
+++ b/src/components/listview/listview.js
@@ -239,9 +239,8 @@ export function getListViewHtml(options) {
             cssClass += ' listItem-largeImage';
             downloadWidth = 500;
         }
-        if (options.isMultiselectable){
+        if (options.isMultiselectable) {
             cssClass += ' multiselectable';
-
         }
 
         const playlistItemId = item.PlaylistItemId ? (` data-playlistitemid="${item.PlaylistItemId}"`) : '';
@@ -261,8 +260,7 @@ export function getListViewHtml(options) {
 
         if (enableContentWrapper) {
             html += `<div class="listItem-content ${options.isMultiselectable ? 'multiselect-container' : ''}">`;
-        }
-        else{
+        } else {
             html += `<div style='align-self: flex-start;' class="${options.isMultiselectable ? 'multiselect-container' : ''}"> </div>`;
         }
 

--- a/src/components/multiSelect/multiSelect.js
+++ b/src/components/multiSelect/multiSelect.js
@@ -393,7 +393,7 @@ function onContainerClick(e) {
     const target = e.target;
 
     if (selectedItems.length) {
-        const card = dom.parentWithClass(target, 'multiselectable') || dom.parentWithClass(target, 'multiselectable');
+        const card = dom.parentWithClass(target, 'multiselectable');
         if (card) {
             const itemSelectionPanel = card.querySelector('.itemSelectionPanel');
             if (itemSelectionPanel) {

--- a/src/components/multiSelect/multiSelect.js
+++ b/src/components/multiSelect/multiSelect.js
@@ -93,7 +93,6 @@ function onSelectionChange() {
 
 function showSelection(item, isChecked, addInitialCheck) {
     let itemSelectionPanel = item.querySelector('.itemSelectionPanel');
-
     if (!itemSelectionPanel) {
         itemSelectionPanel = document.createElement('div');
         itemSelectionPanel.classList.add('itemSelectionPanel');
@@ -386,6 +385,7 @@ function showSelections(initialCard, addInitialCheck) {
         }
 
         showSelectionCommands();
+
         updateItemSelection(initialCard, true);
     });
 }
@@ -587,6 +587,12 @@ export default function (options) {
 
 export const startMultiSelect = (card) => {
     showSelections(card, false);
+    const chkItemSelect = card.querySelector('.chkItemSelect');
+    if (chkItemSelect){ // If select pressed from context menu when multiselect already open, then this toggles the checkbox of the input
+        const newValue = !chkItemSelect.checked;
+        chkItemSelect.checked = newValue;
+        updateItemSelection(chkItemSelect, newValue);
+    }
 };
 
 export const stopMultiSelect = () => {

--- a/src/components/multiSelect/multiSelect.js
+++ b/src/components/multiSelect/multiSelect.js
@@ -55,8 +55,9 @@ function onItemSelectionPanelClick(e, itemSelectionPanel) {
 
 function updateItemSelection(chkItemSelect, selected) {
     const id = dom.parentWithAttribute(chkItemSelect, 'data-id')?.getAttribute('data-id');
-    if (!id)
+    if (!id) {
         return;
+    }
 
     if (selected) {
         const current = selectedItems.filter(i => {
@@ -207,14 +208,14 @@ function showMenuForSelectedItems(e) {
                 // Disabled because there is no callback for this item
             }
 
-            if (user.Policy.IsAdministrator && type != "Audio" && type != "Episode") {
+            if (user.Policy.IsAdministrator && type != 'Audio' && type != 'Episode') {
                 menuItems.push({
                     name: globalize.translate('GroupVersions'),
                     id: 'groupvideos',
                     icon: 'call_merge'
                 });
             }
-            if (type != "Audio") {
+            if (type != 'Audio') {
                 menuItems.push({
                     name: globalize.translate('MarkPlayed'),
                     id: 'markplayed',
@@ -247,7 +248,7 @@ function showMenuForSelectedItems(e) {
                         const serverId = apiClient.serverInfo().Id;
 
                         switch (id) {
-                        case 'selectall': {
+                            case 'selectall': {
                                 const elems = document.querySelectorAll('.itemSelectionPanel');
                                 for (let i = 0, length = elems.length; i < length; i++) {
                                     const chkItemSelect = elems[i].querySelector('.chkItemSelect');
@@ -258,76 +259,76 @@ function showMenuForSelectedItems(e) {
                                     }
                                 }
                             }
-                            break;
-                        case 'addtocollection':
-                            import('../collectionEditor/collectionEditor').then(({
-                                default:
+                                break;
+                            case 'addtocollection':
+                                import('../collectionEditor/collectionEditor').then(({
+                                    default:
                                     CollectionEditor
                                 }) => {
-                                const collectionEditor = new CollectionEditor();
-                                collectionEditor.show({
-                                    items: items,
-                                    serverId: serverId
+                                    const collectionEditor = new CollectionEditor();
+                                    collectionEditor.show({
+                                        items: items,
+                                        serverId: serverId
+                                    });
                                 });
-                            });
-                            hideSelections();
-                            dispatchNeedsRefresh();
-                            break;
-                        case 'playlist':
-                            import('../playlisteditor/playlisteditor').then(({
-                                default:
+                                hideSelections();
+                                dispatchNeedsRefresh();
+                                break;
+                            case 'playlist':
+                                import('../playlisteditor/playlisteditor').then(({
+                                    default:
                                     PlaylistEditor
                                 }) => {
-                                const playlistEditor = new PlaylistEditor();
-                                playlistEditor.show({
-                                    items: items,
-                                    serverId: serverId
-                                }).catch(() => {
+                                    const playlistEditor = new PlaylistEditor();
+                                    playlistEditor.show({
+                                        items: items,
+                                        serverId: serverId
+                                    }).catch(() => {
                                     // Dialog closed
+                                    });
+                                }).catch(err => {
+                                    console.error('[AddToPlaylist] failed to load playlist editor', err);
                                 });
-                            }).catch(err => {
-                                console.error('[AddToPlaylist] failed to load playlist editor', err);
-                            });
-                            hideSelections();
-                            dispatchNeedsRefresh();
-                            break;
-                        case 'delete':
-                            deleteItems(apiClient, items).then(dispatchNeedsRefresh);
-                            hideSelections();
-                            dispatchNeedsRefresh();
-                            break;
-                        case 'groupvideos':
-                            combineVersions(apiClient, items);
-                            break;
-                        case 'markplayed':
-                            items.forEach(itemId => {
-                                apiClient.markPlayed(apiClient.getCurrentUserId(), itemId);
-                            });
-                            hideSelections();
-                            dispatchNeedsRefresh();
-                            break;
-                        case 'markunplayed':
-                            items.forEach(itemId => {
-                                apiClient.markUnplayed(apiClient.getCurrentUserId(), itemId);
-                            });
-                            hideSelections();
-                            dispatchNeedsRefresh();
-                            break;
-                        case 'refresh':
-                            import('../refreshdialog/refreshdialog').then(({
-                                default:
+                                hideSelections();
+                                dispatchNeedsRefresh();
+                                break;
+                            case 'delete':
+                                deleteItems(apiClient, items).then(dispatchNeedsRefresh);
+                                hideSelections();
+                                dispatchNeedsRefresh();
+                                break;
+                            case 'groupvideos':
+                                combineVersions(apiClient, items);
+                                break;
+                            case 'markplayed':
+                                items.forEach(itemId => {
+                                    apiClient.markPlayed(apiClient.getCurrentUserId(), itemId);
+                                });
+                                hideSelections();
+                                dispatchNeedsRefresh();
+                                break;
+                            case 'markunplayed':
+                                items.forEach(itemId => {
+                                    apiClient.markUnplayed(apiClient.getCurrentUserId(), itemId);
+                                });
+                                hideSelections();
+                                dispatchNeedsRefresh();
+                                break;
+                            case 'refresh':
+                                import('../refreshdialog/refreshdialog').then(({
+                                    default:
                                     RefreshDialog
                                 }) => {
-                                new RefreshDialog({
-                                    itemIds: items,
-                                    serverId: serverId
-                                }).show();
-                            });
-                            hideSelections();
-                            dispatchNeedsRefresh();
-                            break;
-                        default:
-                            break;
+                                    new RefreshDialog({
+                                        itemIds: items,
+                                        serverId: serverId
+                                    }).show();
+                                });
+                                hideSelections();
+                                dispatchNeedsRefresh();
+                                break;
+                            default:
+                                break;
                         }
                     }
                 });

--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -1324,7 +1324,8 @@ function renderChildren(page, item) {
                 action: 'playallfromhere',
                 image: false,
                 artist: showArtist,
-                containerAlbumArtists: item.AlbumArtists
+                containerAlbumArtists: item.AlbumArtists,
+                isMultiselectable: true
             });
             isList = true;
         } else if (item.Type == 'Series') {
@@ -1336,7 +1337,8 @@ function renderChildren(page, item) {
                 centerText: true,
                 lazy: true,
                 overlayPlayButton: true,
-                allowBottomPadding: !scrollX
+                allowBottomPadding: !scrollX,
+                isMultiselectable: true
             });
         } else if (item.Type == 'Season' || item.Type == 'Episode') {
             if (item.Type !== 'Episode') {
@@ -1359,7 +1361,8 @@ function renderChildren(page, item) {
                     showDetailsMenu: true,
                     overlayPlayButton: true,
                     allowBottomPadding: !scrollX,
-                    includeParentInfoInTitle: false
+                    includeParentInfoInTitle: false,
+                isMultiselectable: true
                 });
             } else if (item.Type === 'Season') {
                 html = listView.getListViewHtml({
@@ -1373,7 +1376,8 @@ function renderChildren(page, item) {
                     highlight: false,
                     action: !layoutManager.desktop ? 'link' : 'none',
                     imagePlayButton: true,
-                    includeParentInfoInTitle: false
+                    includeParentInfoInTitle: false,
+                    isMultiselectable: true
                 });
             }
         }
@@ -1679,7 +1683,8 @@ function renderCollectionItemType(page, parentItem, type, items) {
         overlayMoreButton: true,
         showAddToCollection: false,
         showRemoveFromCollection: true,
-        collectionId: parentItem.Id
+        collectionId: parentItem.Id,
+        isMultiselectable: true
     });
     html += '</div>';
     html += '</div>';
@@ -1755,7 +1760,8 @@ function getVideosHtml(items) {
         action: 'play',
         overlayText: false,
         centerText: true,
-        showRuntime: true
+        showRuntime: true,
+        isMultiselectable: true
     });
 }
 

--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -1362,7 +1362,7 @@ function renderChildren(page, item) {
                     overlayPlayButton: true,
                     allowBottomPadding: !scrollX,
                     includeParentInfoInTitle: false,
-                isMultiselectable: true
+                    isMultiselectable: true
                 });
             } else if (item.Type === 'Season') {
                 html = listView.getListViewHtml({

--- a/src/controllers/list.js
+++ b/src/controllers/list.js
@@ -566,6 +566,7 @@ class ItemsView {
                 overlayMoreButton: true,
                 overlayText: !settings.showTitle,
                 defaultShape: defaultShape,
+                isMultiselectable: true,
                 action: params.type === 'Audio' ? 'playallfromhere' : null
             };
 

--- a/src/controllers/movies/moviecollections.js
+++ b/src/controllers/movies/moviecollections.js
@@ -139,7 +139,7 @@ export default function (view, params, tabContent) {
                     items: result.Items,
                     context: 'movies',
                     sortBy: query.SortBy,
-                    isMultiselectable: true,
+                    isMultiselectable: true
                 });
             } else if (viewStyle == 'PosterCard') {
                 html = cardBuilder.getCardsHtml({

--- a/src/controllers/movies/moviecollections.js
+++ b/src/controllers/movies/moviecollections.js
@@ -111,7 +111,8 @@ export default function (view, params, tabContent) {
                     context: 'movies',
                     overlayPlayButton: true,
                     centerText: true,
-                    showTitle: true
+                    showTitle: true,
+                    isMultiselectable: true
                 });
             } else if (viewStyle == 'ThumbCard') {
                 html = cardBuilder.getCardsHtml({
@@ -121,7 +122,8 @@ export default function (view, params, tabContent) {
                     context: 'movies',
                     lazy: true,
                     cardLayout: true,
-                    showTitle: true
+                    showTitle: true,
+                    isMultiselectable: true
                 });
             } else if (viewStyle == 'Banner') {
                 html = cardBuilder.getCardsHtml({
@@ -129,13 +131,15 @@ export default function (view, params, tabContent) {
                     shape: 'banner',
                     preferBanner: true,
                     context: 'movies',
-                    lazy: true
+                    lazy: true,
+                    isMultiselectable: true
                 });
             } else if (viewStyle == 'List') {
                 html = listView.getListViewHtml({
                     items: result.Items,
                     context: 'movies',
-                    sortBy: query.SortBy
+                    sortBy: query.SortBy,
+                    isMultiselectable: true,
                 });
             } else if (viewStyle == 'PosterCard') {
                 html = cardBuilder.getCardsHtml({
@@ -144,7 +148,8 @@ export default function (view, params, tabContent) {
                     context: 'movies',
                     showTitle: true,
                     centerText: false,
-                    cardLayout: true
+                    cardLayout: true,
+                    isMultiselectable: true
                 });
             } else {
                 html = cardBuilder.getCardsHtml({
@@ -153,7 +158,8 @@ export default function (view, params, tabContent) {
                     context: 'movies',
                     centerText: true,
                     overlayPlayButton: true,
-                    showTitle: true
+                    showTitle: true,
+                    isMultiselectable: true
                 });
             }
 

--- a/src/controllers/movies/movies.js
+++ b/src/controllers/movies/movies.js
@@ -127,7 +127,8 @@ export default function (view, params, tabContent, options) {
                 overlayPlayButton: true,
                 showTitle: true,
                 showYear: true,
-                centerText: true
+                centerText: true,
+                isMultiselectable: true
             });
         } else if (viewStyle == 'ThumbCard') {
             html = cardBuilder.getCardsHtml({
@@ -139,7 +140,8 @@ export default function (view, params, tabContent, options) {
                 cardLayout: true,
                 showTitle: true,
                 showYear: true,
-                centerText: true
+                centerText: true,
+                isMultiselectable: true
             });
         } else if (viewStyle == 'Banner') {
             html = cardBuilder.getCardsHtml({
@@ -147,13 +149,15 @@ export default function (view, params, tabContent, options) {
                 shape: 'banner',
                 preferBanner: true,
                 context: 'movies',
-                lazy: true
+                lazy: true,
+                isMultiselectable: true
             });
         } else if (viewStyle == 'List') {
             html = listView.getListViewHtml({
                 items: items,
                 context: 'movies',
-                sortBy: query.SortBy
+                sortBy: query.SortBy,
+                isMultiselectable: true
             });
         } else if (viewStyle == 'PosterCard') {
             html = cardBuilder.getCardsHtml({
@@ -164,7 +168,8 @@ export default function (view, params, tabContent, options) {
                 showYear: true,
                 centerText: true,
                 lazy: true,
-                cardLayout: true
+                cardLayout: true,
+                isMultiselectable: true
             });
         } else {
             html = cardBuilder.getCardsHtml({
@@ -174,7 +179,8 @@ export default function (view, params, tabContent, options) {
                 overlayPlayButton: true,
                 showTitle: true,
                 showYear: true,
-                centerText: true
+                centerText: true,
+                isMultiselectable: true
             });
         }
 

--- a/src/controllers/music/musicalbums.js
+++ b/src/controllers/music/musicalbums.js
@@ -129,7 +129,7 @@ export default function (view, params, tabContent) {
                     context: 'music',
                     sortBy: query.SortBy,
                     addToListButton: true,
-                    isMultiselectable: true,
+                    isMultiselectable: true
                 });
             } else if (viewStyle == 'PosterCard') {
                 html = cardBuilder.getCardsHtml({
@@ -141,7 +141,7 @@ export default function (view, params, tabContent) {
                     showParentTitle: true,
                     lazy: true,
                     cardLayout: true,
-                    isMultiselectable: true,
+                    isMultiselectable: true
                 });
             } else {
                 html = cardBuilder.getCardsHtml({
@@ -153,7 +153,7 @@ export default function (view, params, tabContent) {
                     lazy: true,
                     centerText: true,
                     overlayPlayButton: true,
-                    isMultiselectable: true,
+                    isMultiselectable: true
                 });
             }
 

--- a/src/controllers/music/musicalbums.js
+++ b/src/controllers/music/musicalbums.js
@@ -128,7 +128,8 @@ export default function (view, params, tabContent) {
                     items: result.Items,
                     context: 'music',
                     sortBy: query.SortBy,
-                    addToListButton: true
+                    addToListButton: true,
+                    isMultiselectable: true,
                 });
             } else if (viewStyle == 'PosterCard') {
                 html = cardBuilder.getCardsHtml({
@@ -139,7 +140,8 @@ export default function (view, params, tabContent) {
                     coverImage: true,
                     showParentTitle: true,
                     lazy: true,
-                    cardLayout: true
+                    cardLayout: true,
+                    isMultiselectable: true,
                 });
             } else {
                 html = cardBuilder.getCardsHtml({
@@ -150,7 +152,8 @@ export default function (view, params, tabContent) {
                     showParentTitle: true,
                     lazy: true,
                     centerText: true,
-                    overlayPlayButton: true
+                    overlayPlayButton: true,
+                    isMultiselectable: true,
                 });
             }
 

--- a/src/controllers/music/musicartists.js
+++ b/src/controllers/music/musicartists.js
@@ -113,7 +113,8 @@ export default function (view, params, tabContent, options) {
             if (viewStyle == 'List') {
                 html = listView.getListViewHtml({
                     items: result.Items,
-                    sortBy: query.SortBy
+                    sortBy: query.SortBy,
+                    isMultiselectable: true
                 });
             } else if (viewStyle == 'PosterCard') {
                 html = cardBuilder.getCardsHtml({
@@ -122,7 +123,8 @@ export default function (view, params, tabContent, options) {
                     context: 'music',
                     showTitle: true,
                     coverImage: true,
-                    cardLayout: true
+                    cardLayout: true,
+                    isMultiselectable: true
                 });
             } else {
                 html = cardBuilder.getCardsHtml({
@@ -133,7 +135,8 @@ export default function (view, params, tabContent, options) {
                     coverImage: true,
                     lazy: true,
                     centerText: true,
-                    overlayPlayButton: true
+                    overlayPlayButton: true,
+                    isMultiselectable: true
                 });
             }
             let elems = tabContent.querySelectorAll('.paging');

--- a/src/controllers/music/musicgenres.js
+++ b/src/controllers/music/musicgenres.js
@@ -54,7 +54,8 @@ export default function (view, params, tabContent) {
                     context: 'music',
                     centerText: true,
                     overlayMoreButton: true,
-                    showTitle: true
+                    showTitle: true,
+                    isMultiselectable: true
                 });
             } else if (viewStyle == 'ThumbCard') {
                 html = cardBuilder.getCardsHtml({
@@ -63,7 +64,8 @@ export default function (view, params, tabContent) {
                     preferThumb: true,
                     context: 'music',
                     cardLayout: true,
-                    showTitle: true
+                    showTitle: true,
+                    isMultiselectable: true
                 });
             } else if (viewStyle == 'PosterCard') {
                 html = cardBuilder.getCardsHtml({
@@ -71,7 +73,8 @@ export default function (view, params, tabContent) {
                     shape: 'auto',
                     context: 'music',
                     cardLayout: true,
-                    showTitle: true
+                    showTitle: true,
+                    isMultiselectable: true
                 });
             } else if (viewStyle == 'Poster') {
                 html = cardBuilder.getCardsHtml({
@@ -80,7 +83,8 @@ export default function (view, params, tabContent) {
                     context: 'music',
                     centerText: true,
                     overlayMoreButton: true,
-                    showTitle: true
+                    showTitle: true,
+                    isMultiselectable: true
                 });
             }
 

--- a/src/controllers/music/musicplaylists.js
+++ b/src/controllers/music/musicplaylists.js
@@ -52,7 +52,8 @@ export default function (view, params, tabContent) {
                 centerText: true,
                 overlayPlayButton: true,
                 allowBottomPadding: true,
-                cardLayout: false
+                cardLayout: false,
+                isMultiselectable: true,
             });
             const elem = context.querySelector('#items');
             elem.innerHTML = html;

--- a/src/controllers/music/musicplaylists.js
+++ b/src/controllers/music/musicplaylists.js
@@ -53,7 +53,7 @@ export default function (view, params, tabContent) {
                 overlayPlayButton: true,
                 allowBottomPadding: true,
                 cardLayout: false,
-                isMultiselectable: true,
+                isMultiselectable: true
             });
             const elem = context.querySelector('#items');
             elem.innerHTML = html;

--- a/src/controllers/music/songs.js
+++ b/src/controllers/music/songs.js
@@ -95,7 +95,8 @@ export default function (view, params, tabContent) {
                 action: 'playallfromhere',
                 smallIcon: true,
                 artist: true,
-                addToListButton: true
+                addToListButton: true,
+                isMultiselectable: true
             });
             let elems = tabContent.querySelectorAll('.paging');
 

--- a/src/controllers/shows/episodes.js
+++ b/src/controllers/shows/episodes.js
@@ -114,7 +114,7 @@ export default function (view, params, tabContent) {
                     items: result.Items,
                     sortBy: query.SortBy,
                     showParentTitle: true,
-                    isMultiselectable: true,
+                    isMultiselectable: true
                 });
             } else if (viewStyle == 'PosterCard') {
                 html = cardBuilder.getCardsHtml({
@@ -124,7 +124,7 @@ export default function (view, params, tabContent) {
                     showParentTitle: true,
                     scalable: true,
                     cardLayout: true,
-                    isMultiselectable: true,
+                    isMultiselectable: true
                 });
             } else {
                 html = cardBuilder.getCardsHtml({
@@ -136,7 +136,7 @@ export default function (view, params, tabContent) {
                     centerText: true,
                     scalable: true,
                     overlayPlayButton: true,
-                    isMultiselectable: true,
+                    isMultiselectable: true
                 });
             }
             let elems;

--- a/src/controllers/shows/episodes.js
+++ b/src/controllers/shows/episodes.js
@@ -113,7 +113,8 @@ export default function (view, params, tabContent) {
                 html = listView.getListViewHtml({
                     items: result.Items,
                     sortBy: query.SortBy,
-                    showParentTitle: true
+                    showParentTitle: true,
+                    isMultiselectable: true,
                 });
             } else if (viewStyle == 'PosterCard') {
                 html = cardBuilder.getCardsHtml({
@@ -122,7 +123,8 @@ export default function (view, params, tabContent) {
                     showTitle: true,
                     showParentTitle: true,
                     scalable: true,
-                    cardLayout: true
+                    cardLayout: true,
+                    isMultiselectable: true,
                 });
             } else {
                 html = cardBuilder.getCardsHtml({
@@ -133,7 +135,8 @@ export default function (view, params, tabContent) {
                     overlayText: false,
                     centerText: true,
                     scalable: true,
-                    overlayPlayButton: true
+                    overlayPlayButton: true,
+                    isMultiselectable: true,
                 });
             }
             let elems;

--- a/src/controllers/shows/tvshows.js
+++ b/src/controllers/shows/tvshows.js
@@ -117,7 +117,7 @@ export default function (view, params, tabContent) {
                     overlayMoreButton: true,
                     showTitle: true,
                     centerText: true,
-                    isMultiselectable: true,
+                    isMultiselectable: true
                 });
             } else if (viewStyle == 'ThumbCard') {
                 html = cardBuilder.getCardsHtml({
@@ -129,7 +129,7 @@ export default function (view, params, tabContent) {
                     showTitle: true,
                     showYear: true,
                     centerText: true,
-                    isMultiselectable: true,
+                    isMultiselectable: true
                 });
             } else if (viewStyle == 'Banner') {
                 html = cardBuilder.getCardsHtml({
@@ -137,14 +137,14 @@ export default function (view, params, tabContent) {
                     shape: 'banner',
                     preferBanner: true,
                     context: 'tvshows',
-                    isMultiselectable: true,
+                    isMultiselectable: true
                 });
             } else if (viewStyle == 'List') {
                 html = listView.getListViewHtml({
                     items: result.Items,
                     context: 'tvshows',
                     sortBy: query.SortBy,
-                    isMultiselectable: true,
+                    isMultiselectable: true
                 });
             } else if (viewStyle == 'PosterCard') {
                 html = cardBuilder.getCardsHtml({
@@ -155,7 +155,7 @@ export default function (view, params, tabContent) {
                     showYear: true,
                     centerText: true,
                     cardLayout: true,
-                    isMultiselectable: true,
+                    isMultiselectable: true
                 });
             } else {
                 html = cardBuilder.getCardsHtml({
@@ -167,7 +167,7 @@ export default function (view, params, tabContent) {
                     overlayMoreButton: true,
                     showTitle: true,
                     showYear: true,
-                    isMultiselectable: true,
+                    isMultiselectable: true
                 });
             }
 

--- a/src/controllers/shows/tvshows.js
+++ b/src/controllers/shows/tvshows.js
@@ -116,7 +116,8 @@ export default function (view, params, tabContent) {
                     context: 'tvshows',
                     overlayMoreButton: true,
                     showTitle: true,
-                    centerText: true
+                    centerText: true,
+                    isMultiselectable: true,
                 });
             } else if (viewStyle == 'ThumbCard') {
                 html = cardBuilder.getCardsHtml({
@@ -127,20 +128,23 @@ export default function (view, params, tabContent) {
                     cardLayout: true,
                     showTitle: true,
                     showYear: true,
-                    centerText: true
+                    centerText: true,
+                    isMultiselectable: true,
                 });
             } else if (viewStyle == 'Banner') {
                 html = cardBuilder.getCardsHtml({
                     items: result.Items,
                     shape: 'banner',
                     preferBanner: true,
-                    context: 'tvshows'
+                    context: 'tvshows',
+                    isMultiselectable: true,
                 });
             } else if (viewStyle == 'List') {
                 html = listView.getListViewHtml({
                     items: result.Items,
                     context: 'tvshows',
-                    sortBy: query.SortBy
+                    sortBy: query.SortBy,
+                    isMultiselectable: true,
                 });
             } else if (viewStyle == 'PosterCard') {
                 html = cardBuilder.getCardsHtml({
@@ -150,7 +154,8 @@ export default function (view, params, tabContent) {
                     showTitle: true,
                     showYear: true,
                     centerText: true,
-                    cardLayout: true
+                    cardLayout: true,
+                    isMultiselectable: true,
                 });
             } else {
                 html = cardBuilder.getCardsHtml({
@@ -161,7 +166,8 @@ export default function (view, params, tabContent) {
                     lazy: true,
                     overlayMoreButton: true,
                     showTitle: true,
-                    showYear: true
+                    showYear: true,
+                    isMultiselectable: true,
                 });
             }
 

--- a/src/scripts/playlistViewer.js
+++ b/src/scripts/playlistViewer.js
@@ -25,7 +25,8 @@ function getItemsHtmlFn(playlistId, isEditable = false) {
             smallIcon: true,
             dragHandle: isEditable,
             playlistId,
-            showParentTitle: true
+            showParentTitle: true,
+            isMultiselectable: true
         });
     };
 }


### PR DESCRIPTION

**Changes**
Add a new parameter to ListItem and Card, 'isMultiselectable', which adds the '.multiselectable' class to the item. The multiselect component now matches on this class, so theoretically it can be expanded to other items, as long as they have 'data-id' prop.

Also fixes issue with some cards being selectable that shouldn't be, like tv series posters, next up, and cast and crew.

I believe I have passed this property in to all constructors where it is appropriate, but its possible I missed some previously used cases, but I don't have some things like live-tv to test.

**Issues**
Addresses request https://features.jellyfin.org/posts/187/multi-select-in-lists . Music, TvShows, etc are now multiselect capable and can be mass-added to playlists and such.
