### PR TITLE
Fix carousel buttons for "My Media"  appearing needlessly

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -104,6 +104,7 @@
 - [qm3jp](https://github.com/qm3jp)
 - [johnnyg](https://github.com/johnnyg)
 - [lmaotrigine](https://github.com/lmaotrigine)
+- [bjorntp](https://github.com/bjorntp)
 
 ## Emby Contributors
 

--- a/src/elements/emby-scrollbuttons/emby-scrollbuttons.js
+++ b/src/elements/emby-scrollbuttons/emby-scrollbuttons.js
@@ -162,6 +162,10 @@ EmbyScrollButtonsPrototype.attachedCallback = function () {
         capture: false,
         passive: true
     });
+
+    requestAnimationFrame(() => {
+        this.scrollHandler();
+    });
 };
 
 EmbyScrollButtonsPrototype.detachedCallback = function () {


### PR DESCRIPTION
**Changes**
- The scrollHandler() is called every time an emby-scroller is created
- This was event based before which caused race conditions on the first render

**Issues**
Fixes #7374  

Edit:
Before
<img width="2428" height="331" alt="bild" src="https://github.com/user-attachments/assets/bd131ca3-9951-4de1-b0f7-e7f07cf9ea8c" />
After
<img width="2448" height="315" alt="bild" src="https://github.com/user-attachments/assets/da23ac3b-ebaa-4781-819b-628b1c2f887e" />
