### PR TITLE
Fix keyboard controls working only on latin keyboard layouts

### DIFF
--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1280,8 +1280,7 @@ export default function (view) {
                     e.stopPropagation();
                 }
                 break;
-            case 'k':
-            case 'K':
+            case 'KeyK':
                 if (!e.shiftKey) {
                     e.preventDefault();
                     playbackManager.playPause(currentPlayer);
@@ -1302,8 +1301,7 @@ export default function (view) {
                     playbackManager.volumeDown(currentPlayer);
                 }
                 break;
-            case 'l':
-            case 'L':
+            case 'KeyL':
             case 'ArrowRight':
             case 'Right':
                 if (!e.shiftKey) {
@@ -1312,20 +1310,19 @@ export default function (view) {
                     showOsd(btnFastForward);
                 }
                 break;
-            case ',':
+            case 'Comma':
                 if (!e.shiftKey) {
                     e.preventDefault();
                     playbackManager.seekFrames(-1, currentPlayer);
                 }
                 break;
-            case '.':
+            case 'Period':
                 if (!e.shiftKey) {
                     e.preventDefault();
                     playbackManager.seekFrames(1, currentPlayer);
                 }
                 break;
-            case 'j':
-            case 'J':
+            case 'KeyJ':
             case 'ArrowLeft':
             case 'Left':
                 if (!e.shiftKey) {
@@ -1334,29 +1331,25 @@ export default function (view) {
                     showOsd(btnRewind);
                 }
                 break;
-            case 'f':
-            case 'F':
+            case 'KeyF':
                 if (!e.shiftKey) {
                     e.preventDefault();
                     playbackManager.toggleFullscreen(currentPlayer);
                 }
                 break;
-            case 'm':
-            case 'M':
+            case 'KeyM':
                 if (!e.shiftKey) {
                     e.preventDefault();
                     playbackManager.toggleMute(currentPlayer);
                 }
                 break;
-            case 'p':
-            case 'P':
+            case 'KeyP':
                 if (e.shiftKey) {
                     e.preventDefault();
                     playbackManager.previousTrack(currentPlayer);
                 }
                 break;
-            case 'n':
-            case 'N':
+            case 'KeyN':
                 if (e.shiftKey) {
                     e.preventDefault();
                     playbackManager.nextTrack(currentPlayer);
@@ -1392,26 +1385,26 @@ export default function (view) {
                     playbackManager.seekPercent(100, currentPlayer);
                 }
                 break;
-            case '0':
-            case '1':
-            case '2':
-            case '3':
-            case '4':
-            case '5':
-            case '6':
-            case '7':
-            case '8':
-            case '9': { // no Shift
+            case 'Digit0':
+            case 'Digit1':
+            case 'Digit2':
+            case 'Digit3':
+            case 'Digit4':
+            case 'Digit5':
+            case 'Digit6':
+            case 'Digit7':
+            case 'Digit8':
+            case 'Digit9': { // no Shift
                 e.preventDefault();
-                const percent = parseInt(key, 10) * 10;
+                const percent = parseInt(key.replace('Digit', ''), 10) * 10;
                 playbackManager.seekPercent(percent, currentPlayer);
                 break;
             }
-            case '>': // Shift+.
+            case 'Period': // Shift+.
                 e.preventDefault();
                 playbackManager.increasePlaybackRate(currentPlayer);
                 break;
-            case '<': // Shift+,
+            case 'Comma': // Shift+,
                 e.preventDefault();
                 playbackManager.decreasePlaybackRate(currentPlayer);
                 break;
@@ -1427,15 +1420,13 @@ export default function (view) {
                     playbackManager.previousChapter(currentPlayer);
                 }
                 break;
-            case 'g':
-            case 'G':
+            case 'KeyG':
                 if (!e.shiftKey) {
                     e.preventDefault();
                     subtitleSyncOverlay?.decrementOffset();
                 }
                 break;
-            case 'h':
-            case 'H':
+            case 'KeyH':
                 if (!e.shiftKey) {
                     e.preventDefault();
                     subtitleSyncOverlay?.incrementOffset();

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1268,6 +1268,14 @@ export default function (view) {
             return;
         }
 
+        if (key.startsWith('Digit') || key.startsWith('Numpad')) {
+            const num = parseInt(key.replace('Digit', '').replace('Numpad', ''), 10);
+            if (!isNaN(num) && num >= 0 && num <= 9) {
+                playbackManager.seekPercent(num * 10, currentPlayer);
+                return;
+            }
+        }
+
         switch (key) {
             case 'Enter':
                 showOsd();
@@ -1311,15 +1319,19 @@ export default function (view) {
                 }
                 break;
             case 'Comma':
+                e.preventDefault();
                 if (!e.shiftKey) {
-                    e.preventDefault();
                     playbackManager.seekFrames(-1, currentPlayer);
+                } else {
+                    playbackManager.decreasePlaybackRate(currentPlayer);
                 }
                 break;
             case 'Period':
+                e.preventDefault();
                 if (!e.shiftKey) {
-                    e.preventDefault();
                     playbackManager.seekFrames(1, currentPlayer);
+                } else {
+                    playbackManager.increasePlaybackRate(currentPlayer);
                 }
                 break;
             case 'KeyJ':
@@ -1384,29 +1396,6 @@ export default function (view) {
                     e.preventDefault();
                     playbackManager.seekPercent(100, currentPlayer);
                 }
-                break;
-            case 'Digit0':
-            case 'Digit1':
-            case 'Digit2':
-            case 'Digit3':
-            case 'Digit4':
-            case 'Digit5':
-            case 'Digit6':
-            case 'Digit7':
-            case 'Digit8':
-            case 'Digit9': { // no Shift
-                e.preventDefault();
-                const percent = parseInt(key.replace('Digit', ''), 10) * 10;
-                playbackManager.seekPercent(percent, currentPlayer);
-                break;
-            }
-            case 'Period': // Shift+.
-                e.preventDefault();
-                playbackManager.increasePlaybackRate(currentPlayer);
-                break;
-            case 'Comma': // Shift+,
-                e.preventDefault();
-                playbackManager.decreasePlaybackRate(currentPlayer);
                 break;
             case 'PageUp':
                 if (!e.shiftKey) {

--- a/src/plugins/bookPlayer/plugin.js
+++ b/src/plugins/bookPlayer/plugin.js
@@ -150,13 +150,13 @@ export class BookPlayer {
 
         if (!this.loaded) return;
         switch (key) {
-            case 'l':
+            case 'KeyL':
             case 'ArrowRight':
             case 'Right':
                 e.preventDefault();
                 this.next();
                 break;
-            case 'j':
+            case 'KeyJ':
             case 'ArrowLeft':
             case 'Left':
                 e.preventDefault();

--- a/src/plugins/pdfPlayer/plugin.js
+++ b/src/plugins/pdfPlayer/plugin.js
@@ -101,13 +101,13 @@ export class PdfPlayer {
         const key = keyboardnavigation.getKeyName(e);
 
         switch (key) {
-            case 'l':
+            case 'KeyL':
             case 'ArrowRight':
             case 'Right':
                 e.preventDefault();
                 this.next();
                 break;
-            case 'j':
+            case 'KeyJ':
             case 'ArrowLeft':
             case 'Left':
                 e.preventDefault();

--- a/src/scripts/keyboardNavigation.js
+++ b/src/scripts/keyboardNavigation.js
@@ -124,7 +124,7 @@ if (!hasFieldKey) {
  */
 export function getKeyName(event) {
     const key = KeyNames[event.keyCode] || event.key;
-    return KeyAliases[key] || key;
+    return KeyAliases[key] || event.code;
 }
 
 /**


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
Made keyboardNavigation return event.code instead of key, which resolves to same string regardless of layout

<img width="844" height="74" alt="image" src="https://github.com/user-attachments/assets/440e965f-7e98-4d0a-b7c5-928e9c3faaf1" />

Applied changes wherever getKeyName is used, tested with media playback and it seems to be working just fine.

Not sure about TVs and stuff like that, maybe someone more knowledgeable can say if this breaks anything. I hope it doesn't :eyes: 

Tested:
[Screencast_20260407_190512.webm](https://github.com/user-attachments/assets/4e4a5038-78cb-4336-9acf-aefa6757b8f5)


<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #7397 