### PR TITLE
Fix subtitles need to be uploaded twice

### DIFF
--- a/src/components/subtitleuploader/subtitleuploader.js
+++ b/src/components/subtitleuploader/subtitleuploader.js
@@ -80,11 +80,12 @@ function setFiles(page, files) {
 }
 
 async function onSubmit(e) {
+    e.preventDefault();
+
     const file = currentFile;
 
     if (!isValidSubtitleFile(file)) {
         toast(globalize.translate('MessageSubtitleFileTypeAllowed'));
-        e.preventDefault();
         return;
     }
 
@@ -109,8 +110,6 @@ async function onSubmit(e) {
         hasChanges = true;
         dialogHelper.close(dlg);
     });
-
-    e.preventDefault();
 }
 
 function initEditor(page) {


### PR DESCRIPTION
**Changes**
Fix the need to upload subtitles twice.
The issue was that since the `preventDefault` method was called after an asynchronous task, it was never reach. Hence the page reload which is the default behavior of an `onSubmit` form event. 

**Issues**
Fixes #7194 