### PR TITLE
fix(subtitles): Correction for subtitle shifts when transcoding

### DIFF
--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -492,10 +492,10 @@ export class HtmlVideoPlayer {
                             this.hideTextTrackWithActiveCues(textTrack);
                         }
 
-                        Array.from(cues).forEach(cue => {
+                        for (const cue of Array.from(cues)) {
                             cue.startTime -= offsetToApply;
                             cue.endTime -= offsetToApply;
-                        });
+                        }
 
                         if (shouldClearActiveCues) {
                             this.forceClearTextTrackActiveCues(textTrack);

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1515,9 +1515,8 @@ export class HtmlVideoPlayer {
             trackElement = videoElement.addTextTrack('subtitles', 'manualTrack', 'und');
         }
 
-        const player = this;
         // download the track json
-        this.fetchSubtitles(track, item).then(function (data) {
+        this.fetchSubtitles(track, item).then(data => {
             console.debug(`downloaded ${data.TrackEvents.length} track events`);
 
             const subtitleAppearance = userSettings.getSubtitleAppearanceSettings();
@@ -1540,12 +1539,12 @@ export class HtmlVideoPlayer {
                 }
 
                 //Applying the base offset to counteract the stream shift
-                cue.startTime -= player.#hlsStreamTimeShift;
-                cue.endTime -= player.#hlsStreamTimeShift;
+                cue.startTime -= this.#hlsStreamTimeShift;
+                cue.endTime -= this.#hlsStreamTimeShift;
 
                 trackElement.addCue(cue);
             }
-            player.#currentSubtitleCorrectionOffset = player.#hlsStreamTimeShift;
+            this.#currentSubtitleCorrectionOffset = this.#hlsStreamTimeShift;
 
             trackElement.mode = 'showing';
         });


### PR DESCRIPTION
Fixed #7413 submitted by me

**Cause**
The problem was that the native video player did not follow the changes made to the initial PTS while playing an HLS stream. This caused a desync in the original subtitle timings and the HLS library's current time and the subtitles were display a few seconds off. This usually only happened while playing transcoded content after a seek was made.

**Changes**
Hooked up a listener to the **INIT_PTS_FOUND** event of the HLS library, that fires, when the initial PTS value changes. I keep track of the shift overtime and apply a correctional offset to the start and end times of the current text track's cues each time. Now when loading a new text track, it auto-adjusts the start times for the cues. This implementation does not interfere with the existing manual subtitle shifting mechanism. 

**Note**
I attempted a fix for my current instance, while testing in multiple browsers, tho I'm not sure if I covered all possible scenarios for on-client subtitle displaying. Further testing might be needed. 

**Issues**
#7413 
