### PR TITLE
Fix the return value for 'behavior' property

### DIFF
--- a/src/components/scrollManager.js
+++ b/src/components/scrollManager.js
@@ -41,7 +41,7 @@ try {
     const opts = Object.defineProperty({}, 'behavior', {
         get: function () {
             supportsScrollToOptions = true;
-            return null;
+            return 'auto';
         }
     });
 


### PR DESCRIPTION
**Changes**
Fix the return value for 'behavior' property. Change `null` to `'auto'`.

**Issues**
> TypeError: Failed to execute 'scrollTo' on 'Element': Failed to read the 'behavior' property from 'ScrollOptions': The provided value 'null' is not a valid enum value of type ScrollBehavior.

