### PR TITLE
fix(subtitles): Previously active subtitles won't show

### DIFF
--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1246,8 +1246,9 @@ export class HtmlVideoPlayer {
             targetTrackIndex = this.#customSecondaryTrackIndex;
         }
 
-        // skip if already playing this track
-        if (targetTrackIndex === track.Index) {
+        const activeTextTracks = this.getTextTracks();
+        // skip if already playing this track and the track is active
+        if (targetTrackIndex === track.Index && activeTextTracks && activeTextTracks.length) {
             return;
         }
 

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1248,7 +1248,7 @@ export class HtmlVideoPlayer {
 
         const activeTextTracks = this.getTextTracks();
         // skip if already playing this track and the track is active
-        if (targetTrackIndex === track.Index && activeTextTracks && activeTextTracks.length) {
+        if (targetTrackIndex === track.Index && activeTextTracks?.length) {
             return;
         }
 


### PR DESCRIPTION
**Cause**
In Chromium browsers the text track of the native player resets after each video/audio stream switch. Generally, the function prevents applying the same subtitles multiple times to the same track, but it fails to account for the scenario, where the active text tracks were reset. In this single case we should allow the reapplication of the same text track.

**Changes**
I've implemented a check to only return the function if the targeted track is truly active and the native text track wasn't reset.

**Note**
In Firefox based browsers this problem didn't occur, but my fix does not change the intended behavior there, rather implements a fail-safe. 

**Issues**
Fixed #7417 