### PR TITLE
Add a gap to stack elements to prevent numbers from other adjacent stack to collapse and appear as one

### DIFF
--- a/src/apps/dashboard/features/metrics/components/MetricCard.tsx
+++ b/src/apps/dashboard/features/metrics/components/MetricCard.tsx
@@ -35,12 +35,12 @@ const MetricCard: FC<MetricCardProps> = ({
         >
             <Stack
                 direction='row'
+                spacing={2}
                 sx={{
                     width: '100%',
                     padding: 2,
                     justifyContent: 'space-between',
-                    alignItems: 'center',
-                    gap: '20px'
+                    alignItems: 'center'
                 }}
             >
                 {metrics.map(({ label, value }) => (


### PR DESCRIPTION
Adds a gap to stack elements in `admin dashboard` to prevent numbers from other adjacent stack to collapse and appear as one at some positions. It is better explained with images:

Issue:
![jellyfin-no-margin-between-numbers](https://github.com/user-attachments/assets/8caef89d-7223-4d9c-9d17-dff26433eb8e)


Fix:
![jellyfin-gap-between-numbers](https://github.com/user-attachments/assets/4eef6e6e-e01b-483a-bdab-89d44c415b05)


**Changes**
```
src\apps\dashboard\features\metrics\components\MetricCard.tsx
```

**Issues**
Fixes https://github.com/jellyfin/jellyfin-web/issues/7352
