### PR TITLE
Fix title truncation without ellipsis in Identify search results

### DIFF
--- a/src/components/cardbuilder/card.scss
+++ b/src/components/cardbuilder/card.scss
@@ -317,6 +317,12 @@ button::-moz-focus-inner {
     text-overflow: initial;
 }
 
+.identificationSearchResultList .cardText {
+    white-space: nowrap !important;
+    overflow: hidden !important;
+    text-overflow: ellipsis !important;
+}
+
 .cardText-secondary {
     font-size: 86%;
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Add a targeted CSS override to restore the text-overflow ellipsis indicator for truncated titles specifically in the Item Identifier search results.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #7368 