### PR TITLE
Implement continuous checking of the behavior of track control buttons in a playlist

### DIFF
--- a/src/apps/legacy/controllers/playback/video/index.js
+++ b/src/apps/legacy/controllers/playback/video/index.js
@@ -1343,18 +1343,12 @@ export default function (view) {
                 if (e.shiftKey) {
                     e.preventDefault();
                     playbackManager.previousTrack(currentPlayer);
-
-                    const currentPlaylist = await playbackManager.getPlaylist();
-                    updateTrackButtonsState(currentPlaylist);
                 }
                 break;
             case 'KeyN':
                 if (e.shiftKey) {
                     e.preventDefault();
                     playbackManager.nextTrack(currentPlayer);
-
-                    const currentPlaylist = await playbackManager.getPlaylist();
-                    updateTrackButtonsState(currentPlaylist);
                 }
                 break;
             case 'NavigationLeft':
@@ -1963,9 +1957,6 @@ export default function (view) {
 
     view.querySelector('.btnPreviousTrack').addEventListener('click', async function () {
         playbackManager.previousTrack(currentPlayer);
-
-        const currentPlaylist = await playbackManager.getPlaylist();
-        updateTrackButtonsState(currentPlaylist);
     });
     view.querySelector('.btnPreviousChapter').addEventListener('click', function () {
         playbackManager.previousChapter(currentPlayer);
@@ -1978,9 +1969,6 @@ export default function (view) {
     });
     view.querySelector('.btnNextTrack').addEventListener('click', async function () {
         playbackManager.nextTrack(currentPlayer);
-
-        const currentPlaylist = await playbackManager.getPlaylist();
-        updateTrackButtonsState(currentPlaylist);
     });
     btnRewind.addEventListener('click', function () {
         playbackManager.rewind(currentPlayer);

--- a/src/apps/legacy/controllers/playback/video/index.js
+++ b/src/apps/legacy/controllers/playback/video/index.js
@@ -911,20 +911,8 @@ export default function (view) {
     }
 
     async function updatePlaylist() {
-        try {
-            const playlist = await playbackManager.getPlaylist();
-
-            if (playlist && playlist.length > 1) {
-                const btnPreviousTrack = view.querySelector('.btnPreviousTrack');
-                const btnNextTrack = view.querySelector('.btnNextTrack');
-                btnPreviousTrack.classList.remove('hide');
-                btnNextTrack.classList.remove('hide');
-                btnPreviousTrack.disabled = false;
-                btnNextTrack.disabled = false;
-            }
-        } catch (err) {
-            console.error('[VideoPlayer] failed to get playlist', err);
-        }
+        const currentPlaylist = await playbackManager.getPlaylist();
+        updateTrackButtonsState(currentPlaylist);
     }
 
     function updateTimeText(elem, ticks, divider) {
@@ -1212,7 +1200,7 @@ export default function (view) {
         }
     }
 
-    function onKeyDown(e) {
+    async function onKeyDown(e) {
         clickedElement = e.target;
 
         const isKeyModified = e.ctrlKey || e.altKey || e.metaKey;
@@ -1355,12 +1343,18 @@ export default function (view) {
                 if (e.shiftKey) {
                     e.preventDefault();
                     playbackManager.previousTrack(currentPlayer);
+
+                    const currentPlaylist = await playbackManager.getPlaylist();
+                    updateTrackButtonsState(currentPlaylist);
                 }
                 break;
             case 'KeyN':
                 if (e.shiftKey) {
                     e.preventDefault();
                     playbackManager.nextTrack(currentPlayer);
+
+                    const currentPlaylist = await playbackManager.getPlaylist();
+                    updateTrackButtonsState(currentPlaylist);
                 }
                 break;
             case 'NavigationLeft':
@@ -1609,6 +1603,47 @@ export default function (view) {
         const playbackRateSpeed = sessionStorage.getItem('playbackRateSpeed');
         if (playbackRateSpeed !== null) {
             player.setPlaybackRate(playbackRateSpeed);
+        }
+    }
+
+    function updateTrackButtonsState(currentPlaylist) {
+        try {
+            const currentPlaylistItemId = playbackManager.getCurrentPlaylistIndex() + 1;
+
+            const btnPreviousTrack = view.querySelector('.btnPreviousTrack');
+            const btnNextTrack = view.querySelector('.btnNextTrack');
+
+            if (currentPlaylist && currentPlaylistItemId !== currentPlaylist.length) {
+                if (btnPreviousTrack) {
+                    btnPreviousTrack.classList.remove('hide');
+                    btnPreviousTrack.disabled = false;
+                } else {
+                    console.error('[VideoPlayer] failed to get "btnPreviousTrack"', btnPreviousTrack);
+                }
+
+                if (btnNextTrack) {
+                    btnNextTrack.classList.remove('hide');
+                    btnNextTrack.disabled = false;
+                } else {
+                    console.error('[VideoPlayer] failed to get "btnNextTrack"', btnNextTrack);
+                }
+            } else {
+                if (btnPreviousTrack) {
+                    btnPreviousTrack.classList.add('hide');
+                    btnPreviousTrack.disabled = true;
+                } else {
+                    console.error('[VideoPlayer] failed to get "btnPreviousTrack"', btnPreviousTrack);
+                }
+
+                if (btnNextTrack) {
+                    btnNextTrack.classList.add('hide');
+                    btnNextTrack.disabled = true;
+                } else {
+                    console.error('[VideoPlayer] failed to get "btnNextTrack"', btnNextTrack);
+                }
+            }
+        } catch (err) {
+            console.error('[VideoPlayer] failed to get playlist', err);
         }
     }
 
@@ -1930,8 +1965,11 @@ export default function (view) {
         })) || [];
     };
 
-    view.querySelector('.btnPreviousTrack').addEventListener('click', function () {
+    view.querySelector('.btnPreviousTrack').addEventListener('click', async function () {
         playbackManager.previousTrack(currentPlayer);
+
+        const currentPlaylist = await playbackManager.getPlaylist();
+        updateTrackButtonsState(currentPlaylist);
     });
     view.querySelector('.btnPreviousChapter').addEventListener('click', function () {
         playbackManager.previousChapter(currentPlayer);
@@ -1942,8 +1980,11 @@ export default function (view) {
     view.querySelector('.btnNextChapter').addEventListener('click', function () {
         playbackManager.nextChapter(currentPlayer);
     });
-    view.querySelector('.btnNextTrack').addEventListener('click', function () {
+    view.querySelector('.btnNextTrack').addEventListener('click', async function () {
         playbackManager.nextTrack(currentPlayer);
+
+        const currentPlaylist = await playbackManager.getPlaylist();
+        updateTrackButtonsState(currentPlaylist);
     });
     btnRewind.addEventListener('click', function () {
         playbackManager.rewind(currentPlayer);

--- a/src/apps/legacy/controllers/playback/video/index.js
+++ b/src/apps/legacy/controllers/playback/video/index.js
@@ -1343,12 +1343,14 @@ export default function (view) {
                 if (e.shiftKey) {
                     e.preventDefault();
                     playbackManager.previousTrack(currentPlayer);
+                    showOsd(btnPreviousTrack);
                 }
                 break;
             case 'KeyN':
                 if (e.shiftKey) {
                     e.preventDefault();
                     playbackManager.nextTrack(currentPlayer);
+                    showOsd(btnNextTrack);
                 }
                 break;
             case 'NavigationLeft':
@@ -1603,9 +1605,6 @@ export default function (view) {
     function updateTrackButtonsState(currentPlaylist) {
         try {
             if (currentPlaylist) {
-                const btnPreviousTrack = view.querySelector('.btnPreviousTrack');
-                const btnNextTrack = view.querySelector('.btnNextTrack');
-
                 const currentPlaylistIndex = playbackManager.getCurrentPlaylistIndex() + 1;
 
                 if (btnPreviousTrack) {
@@ -1630,6 +1629,10 @@ export default function (view) {
                     }
                 } else {
                     console.error('[VideoPlayer] failed to get "btnNextTrack"', btnNextTrack);
+                }
+
+                if (currentPlaylist.length === 1 || currentPlaylistIndex === currentPlaylistIndex) {
+                    showOsd();
                 }
             }
         } catch (err) {
@@ -1667,6 +1670,8 @@ export default function (view) {
     const startTimeText = view.querySelector('.startTimeText');
     const endTimeText = view.querySelector('.endTimeText');
     const endsAtText = view.querySelector('.endsAtText');
+    const btnPreviousTrack = view.querySelector('.btnPreviousTrack');
+    const btnNextTrack = view.querySelector('.btnNextTrack');
     const btnRewind = view.querySelector('.btnRewind');
     const btnFastForward = view.querySelector('.btnFastForward');
     const transitionEndEventName = dom.whichTransitionEvent();

--- a/src/apps/legacy/controllers/playback/video/index.js
+++ b/src/apps/legacy/controllers/playback/video/index.js
@@ -1608,36 +1608,32 @@ export default function (view) {
 
     function updateTrackButtonsState(currentPlaylist) {
         try {
-            const currentPlaylistItemId = playbackManager.getCurrentPlaylistIndex() + 1;
+            if (currentPlaylist) {
+                const btnPreviousTrack = view.querySelector('.btnPreviousTrack');
+                const btnNextTrack = view.querySelector('.btnNextTrack');
 
-            const btnPreviousTrack = view.querySelector('.btnPreviousTrack');
-            const btnNextTrack = view.querySelector('.btnNextTrack');
+                const currentPlaylistIndex = playbackManager.getCurrentPlaylistIndex() + 1;
 
-            if (currentPlaylist && currentPlaylistItemId !== currentPlaylist.length) {
                 if (btnPreviousTrack) {
-                    btnPreviousTrack.classList.remove('hide');
-                    btnPreviousTrack.disabled = false;
+                    if (currentPlaylistIndex === 1) {
+                        btnPreviousTrack.classList.add('hide');
+                        btnPreviousTrack.disabled = true;
+                    } else {
+                        btnPreviousTrack.classList.remove('hide');
+                        btnPreviousTrack.disabled = false;
+                    }
                 } else {
                     console.error('[VideoPlayer] failed to get "btnPreviousTrack"', btnPreviousTrack);
                 }
 
                 if (btnNextTrack) {
-                    btnNextTrack.classList.remove('hide');
-                    btnNextTrack.disabled = false;
-                } else {
-                    console.error('[VideoPlayer] failed to get "btnNextTrack"', btnNextTrack);
-                }
-            } else {
-                if (btnPreviousTrack) {
-                    btnPreviousTrack.classList.add('hide');
-                    btnPreviousTrack.disabled = true;
-                } else {
-                    console.error('[VideoPlayer] failed to get "btnPreviousTrack"', btnPreviousTrack);
-                }
-
-                if (btnNextTrack) {
-                    btnNextTrack.classList.add('hide');
-                    btnNextTrack.disabled = true;
+                    if (currentPlaylist.length === currentPlaylistIndex) {
+                        btnNextTrack.classList.add('hide');
+                        btnNextTrack.disabled = true;
+                    } else {
+                        btnNextTrack.classList.remove('hide');
+                        btnNextTrack.disabled = false;
+                    }
                 } else {
                     console.error('[VideoPlayer] failed to get "btnNextTrack"', btnNextTrack);
                 }

--- a/src/apps/legacy/controllers/playback/video/index.js
+++ b/src/apps/legacy/controllers/playback/video/index.js
@@ -1212,7 +1212,7 @@ export default function (view) {
         }
     }
 
-    async function onKeyDown(e) {
+    function onKeyDown(e) {
         clickedElement = e.target;
 
         const isKeyModified = e.ctrlKey || e.altKey || e.metaKey;
@@ -1976,7 +1976,7 @@ export default function (view) {
         })) || [];
     };
 
-    view.querySelector('.btnPreviousTrack').addEventListener('click', async function () {
+    view.querySelector('.btnPreviousTrack').addEventListener('click', function () {
         playbackManager.previousTrack(currentPlayer);
     });
     view.querySelector('.btnPreviousChapter').addEventListener('click', function () {
@@ -1988,7 +1988,7 @@ export default function (view) {
     view.querySelector('.btnNextChapter').addEventListener('click', function () {
         playbackManager.nextChapter(currentPlayer);
     });
-    view.querySelector('.btnNextTrack').addEventListener('click', async function () {
+    view.querySelector('.btnNextTrack').addEventListener('click', function () {
         playbackManager.nextTrack(currentPlayer);
     });
     btnRewind.addEventListener('click', function () {

--- a/src/apps/legacy/controllers/playback/video/index.js
+++ b/src/apps/legacy/controllers/playback/video/index.js
@@ -515,7 +515,7 @@ export default function (view) {
         if (state.NowPlayingItem) {
             isEnabled = true;
             updatePlayerStateInternal(event, player, state);
-            updatePlaylist();
+            updatePlaylist().then(switchFocus => switchFocusFromTrackControlButtonsIfNeeded(switchFocus));
             enableStopOnBack(true);
             updatePlaybackRate(player);
         }
@@ -911,8 +911,20 @@ export default function (view) {
     }
 
     async function updatePlaylist() {
-        const currentPlaylist = await playbackManager.getPlaylist();
-        updateTrackButtonsState(currentPlaylist);
+        try {
+            const playlist = await playbackManager.getPlaylist();
+
+            if (!playlist) {
+                console.error('[VideoPlayer] failed to get playlist');
+                return false;
+            }
+
+            return updateTrackControlButtonsState(playlist);
+        } catch (err) {
+            console.error('[VideoPlayer] failed to update playlist', err);
+        }
+
+        return false;
     }
 
     function updateTimeText(elem, ticks, divider) {
@@ -1343,14 +1355,20 @@ export default function (view) {
                 if (e.shiftKey) {
                     e.preventDefault();
                     playbackManager.previousTrack(currentPlayer);
-                    showOsd(btnPreviousTrack);
+
+                    if (!btnPreviousTrack.disabled && !btnPreviousTrack.classList.contains('hide')) {
+                        showOsd(btnPreviousTrack);
+                    }
                 }
                 break;
             case 'KeyN':
                 if (e.shiftKey) {
                     e.preventDefault();
                     playbackManager.nextTrack(currentPlayer);
-                    showOsd(btnNextTrack);
+
+                    if (!btnNextTrack.disabled && !btnNextTrack.classList.contains('hide')) {
+                        showOsd(btnNextTrack);
+                    }
                 }
                 break;
             case 'NavigationLeft':
@@ -1602,42 +1620,40 @@ export default function (view) {
         }
     }
 
-    function updateTrackButtonsState(currentPlaylist) {
-        try {
-            if (currentPlaylist) {
-                const currentPlaylistIndex = playbackManager.getCurrentPlaylistIndex() + 1;
+    function updateTrackControlButtonsState(currentPlaylist) {
+        const currentPlaylistNumber = playbackManager.getCurrentPlaylistIndex() + 1;
 
-                if (btnPreviousTrack) {
-                    if (currentPlaylistIndex === 1) {
-                        btnPreviousTrack.classList.add('hide');
-                        btnPreviousTrack.disabled = true;
-                    } else {
-                        btnPreviousTrack.classList.remove('hide');
-                        btnPreviousTrack.disabled = false;
-                    }
-                } else {
-                    console.error('[VideoPlayer] failed to get "btnPreviousTrack"', btnPreviousTrack);
-                }
+        if (btnPreviousTrack) {
+            const isBtnPreviousTrackDisabled = currentPlaylistNumber === 1;
 
-                if (btnNextTrack) {
-                    if (currentPlaylist.length === currentPlaylistIndex) {
-                        btnNextTrack.classList.add('hide');
-                        btnNextTrack.disabled = true;
-                    } else {
-                        btnNextTrack.classList.remove('hide');
-                        btnNextTrack.disabled = false;
-                    }
-                } else {
-                    console.error('[VideoPlayer] failed to get "btnNextTrack"', btnNextTrack);
-                }
-
-                if (currentPlaylist.length === 1 || currentPlaylistIndex === currentPlaylistIndex) {
-                    showOsd();
-                }
-            }
-        } catch (err) {
-            console.error('[VideoPlayer] failed to get playlist', err);
+            btnPreviousTrack.classList.toggle('hide', isBtnPreviousTrackDisabled);
+            btnPreviousTrack.disabled = isBtnPreviousTrackDisabled;
+        } else {
+            console.error('[VideoPlayer] failed to get "btnPreviousTrack"', btnPreviousTrack);
         }
+
+        if (btnNextTrack) {
+            const isBtnNextTrackDisabled = currentPlaylistNumber === currentPlaylist.length;
+
+            btnNextTrack.classList.toggle('hide', isBtnNextTrackDisabled);
+            btnNextTrack.disabled = isBtnNextTrackDisabled;
+        } else {
+            console.error('[VideoPlayer] failed to get "btnNextTrack"', btnNextTrack);
+        }
+
+        // Switch focus to the pause button or keep focus on a track control button?
+        return currentPlaylistNumber === 1 || currentPlaylistNumber === currentPlaylist.length;
+    }
+
+    function switchFocusFromTrackControlButtonsIfNeeded(switchFocus) {
+        // Switch focus from track control buttons to the pause button if needed.
+        if (currentVisibleMenu !== 'osd' || !switchFocus) {
+            return;
+        }
+
+        // Switch the focus to the pause button if OSD menu is visible and focus switching is requested.
+        const btnPause = osdBottomElement.querySelector('.btnPause');
+        _focus(btnPause);
     }
 
     shell.enableFullscreen();


### PR DESCRIPTION
Now track control buttons will disappear when the user reaches last track watching the playlist.

**Changes**
The behavior of track control buttons is checked each time a track is switched (pressing on the `Previous track`, `Next track` buttons via interface or using keyboard shortcuts).

**Issues**
Fixes #7432
