### PR TITLE
Update ASS subtitles immediately when adjusting subtitle offset

### DIFF
--- a/src/components/subtitlesync/subtitlesync.js
+++ b/src/components/subtitlesync/subtitlesync.js
@@ -87,7 +87,7 @@ function init(instance) {
         updateSubtitleOffset();
     };
 
-    subtitleSyncSlider.addEventListener('change', () => updateSubtitleOffset());
+    subtitleSyncSlider.addEventListener('input', () => updateSubtitleOffset());
 
     subtitleSyncSlider.getBubbleHtml = function (_, value) {
         return '<h1 class="sliderBubbleText">'

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -607,7 +607,6 @@ export class HtmlVideoPlayer {
         if (this.#currentAssRenderer) {
             this.updateCurrentTrackOffset(offsetValue);
             this.#currentAssRenderer.timeOffset = (this._currentPlayOptions.transcodingOffsetTicks || 0) / 10000000 + offsetValue;
-            this.#currentAssRenderer.resetRenderAheadCache(false);
         } else if (this.#currentPgsRenderer) {
             this.updateCurrentTrackOffset(offsetValue);
             this.#currentPgsRenderer.timeOffset = (this._currentPlayOptions.transcodingOffsetTicks || 0) / 10000000 + offsetValue;

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -607,6 +607,7 @@ export class HtmlVideoPlayer {
         if (this.#currentAssRenderer) {
             this.updateCurrentTrackOffset(offsetValue);
             this.#currentAssRenderer.timeOffset = (this._currentPlayOptions.transcodingOffsetTicks || 0) / 10000000 + offsetValue;
+            this.#currentAssRenderer.resetRenderAheadCache(false);
         } else if (this.#currentPgsRenderer) {
             this.updateCurrentTrackOffset(offsetValue);
             this.#currentPgsRenderer.timeOffset = (this._currentPlayOptions.transcodingOffsetTicks || 0) / 10000000 + offsetValue;

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1,5 +1,5 @@
 import DOMPurify from 'dompurify';
-import debounce from 'lodash-es/debounce';
+import throttle from 'lodash-es/throttle';
 import Screenfull from 'screenfull';
 
 import { useCustomSubtitles } from 'apps/stable/features/playback/utils/subtitleStyles';
@@ -595,7 +595,7 @@ export class HtmlVideoPlayer {
         }
     }
 
-    setSubtitleOffset = debounce(this._setSubtitleOffset, 100);
+    setSubtitleOffset = throttle(this._setSubtitleOffset, 100);
 
     /**
      * @private


### PR DESCRIPTION
**Changes**
Fixes an issue where the ASS renderer would not render subtitles when adjusting the offset backwards due to frames for a position further forward being cached.

This PR also makes it so that subtitles update as the subtitle offset scroller is being moved, instead of only when it is released. This is slightly more convenient for setting the offset as desired.

**Issues**
Fixes #7439
