### PR TITLE
Fix duplicate media locations

### DIFF
--- a/src/components/mediaLibraryEditor/mediaLibraryEditor.js
+++ b/src/components/mediaLibraryEditor/mediaLibraryEditor.js
@@ -59,6 +59,13 @@ function onEditLibrary() {
 function addMediaLocation(page, path, networkSharePath) {
     const virtualFolder = currentOptions.library;
     const refreshAfterChange = currentOptions.refresh;
+    const pathLower = path.toLowerCase();
+    const pathFilter = virtualFolder.Locations.filter(p => {
+        return p.toLowerCase() == pathLower;
+    });
+    if (pathFilter.length) {
+        return;
+    }
     ApiClient.addMediaPath(virtualFolder.Name, path, networkSharePath, refreshAfterChange).then(() => {
         hasChanges = true;
         refreshLibraryFromServer(page);


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
Added logic to ignore duplicate folders in the same library similar to what was done in the equivalent function in mediaLibraryCreator.js

**Other Considerations**
A server side check is also necessary to prevent this bug from happening via the api. I can probably get that done after Christmas. 

**Issues**
Fixes jellyfin/jellyfin#15828
