### PR TITLE
ui: Swap location of chapter images + trickplay options

### DIFF
--- a/src/components/libraryoptionseditor/libraryoptionseditor.js
+++ b/src/components/libraryoptionseditor/libraryoptionseditor.js
@@ -472,8 +472,8 @@ export function setContentType(parent, contentType) {
     }
 
     const hasChapterOptions = !contentType /* Mixed */ || CHAPTER_CONTENT_TYPES.includes(contentType);
-    parent.querySelector('.trickplaySettingsSection').classList.toggle('hide', !hasChapterOptions);
     parent.querySelector('.chapterSettingsSection').classList.toggle('hide', !hasChapterOptions);
+    parent.querySelector('.trickplaySettingsSection').classList.toggle('hide', !hasChapterOptions);
 
     if (contentType === 'tvshows') {
         parent.querySelector('.chkAutomaticallyGroupSeriesContainer').classList.remove('hide');

--- a/src/components/libraryoptionseditor/libraryoptionseditor.template.html
+++ b/src/components/libraryoptionseditor/libraryoptionseditor.template.html
@@ -115,6 +115,25 @@
 <div class="mediaSegmentProviders advanced hide" style="margin-bottom: 2em;">
 </div>
 
+<div class="chapterSettingsSection hide">
+    <h2>${HeaderChapterImages}</h2>
+    <div class="checkboxContainer checkboxContainer-withDescription fldExtractChapterImages">
+        <label>
+            <input type="checkbox" is="emby-checkbox" class="chkExtractChapterImages" />
+            <span>${OptionExtractChapterImage}</span>
+        </label>
+        <div class="fieldDescription checkboxFieldDescription">${ExtractChapterImagesHelp}</div>
+    </div>
+
+    <div class="checkboxContainer checkboxContainer-withDescription fldExtractChaptersDuringLibraryScan advanced">
+        <label>
+            <input type="checkbox" is="emby-checkbox" class="chkExtractChaptersDuringLibraryScan" />
+            <span>${LabelExtractChaptersDuringLibraryScan}</span>
+        </label>
+        <div class="fieldDescription checkboxFieldDescription">${LabelExtractChaptersDuringLibraryScanHelp}</div>
+    </div>
+</div>
+
 <div class="trickplaySettingsSection hide">
     <h2>${Trickplay}</h2>
     <div class="checkboxContainer checkboxContainer-withDescription fldExtractTrickplayImages">
@@ -139,25 +158,6 @@
             <span>${LabelSaveTrickplayLocally}</span>
         </label>
         <div class="fieldDescription checkboxFieldDescription">${LabelSaveTrickplayLocallyHelp}</div>
-    </div>
-</div>
-
-<div class="chapterSettingsSection hide">
-    <h2>${HeaderChapterImages}</h2>
-    <div class="checkboxContainer checkboxContainer-withDescription fldExtractChapterImages">
-        <label>
-            <input type="checkbox" is="emby-checkbox" class="chkExtractChapterImages" />
-            <span>${OptionExtractChapterImage}</span>
-        </label>
-        <div class="fieldDescription checkboxFieldDescription">${ExtractChapterImagesHelp}</div>
-    </div>
-
-    <div class="checkboxContainer checkboxContainer-withDescription fldExtractChaptersDuringLibraryScan advanced">
-        <label>
-            <input type="checkbox" is="emby-checkbox" class="chkExtractChaptersDuringLibraryScan" />
-            <span>${LabelExtractChaptersDuringLibraryScan}</span>
-        </label>
-        <div class="fieldDescription checkboxFieldDescription">${LabelExtractChaptersDuringLibraryScanHelp}</div>
     </div>
 </div>
 


### PR DESCRIPTION
Chapter images is the more lightweight option so should go first, with the more intensive and advanced TrickPlay going second.