### PR TITLE
Fix missing title attribute for play button in card component

### DIFF
--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -1157,7 +1157,8 @@ function getHoverMenuHtml(item, action) {
     const btnCssClass = 'cardOverlayButton cardOverlayButton-hover itemAction paper-icon-button-light';
 
     if (playbackManager.canPlay(item)) {
-        html += `<button is="paper-icon-button-light" class="${btnCssClass} cardOverlayFab-primary" data-action="${ItemAction.Resume}"><span class="material-icons cardOverlayButtonIcon cardOverlayButtonIcon-hover play_arrow" aria-hidden="true"></span></button>`;
+        const isResumable = item.UserData && item.UserData.PlaybackPositionTicks > 0;
+        html += `<button is="paper-icon-button-light" class="${btnCssClass} cardOverlayFab-primary" data-action="${ItemAction.Resume}" title="${globalize.translate(isResumable ? 'ButtonResume' : 'Play')}"><span class="material-icons cardOverlayButtonIcon cardOverlayButtonIcon-hover play_arrow" aria-hidden="true"></span></button>`;
     }
 
     html += '<div class="cardOverlayButton-br flex">';


### PR DESCRIPTION
**Changes**
Fix missing title attribute for the Play/Resume button in the legacy card component.
This uses the `globalize` function in a `title` attribute to translate the string to be consistent with other buttons in the same location. 
The translation uses either 'ButtonResume' or 'Play' depending on if it has progress tracked yet or not.

**Issues**
Fixes #7457 