### PR TITLE
Add `caniuse-lite` as dev dependency to keep it updated and update it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,6 +90,7 @@
         "@vitest/coverage-v8": "3.2.4",
         "autoprefixer": "10.4.21",
         "babel-loader": "10.0.0",
+        "caniuse-lite": "1.0.30001762",
         "clean-webpack-plugin": "4.0.0",
         "confusing-browser-globals": "1.0.11",
         "copy-webpack-plugin": "13.0.0",
@@ -8080,9 +8081,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001726",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001726.tgz",
-      "integrity": "sha512-VQAUIUzBiZ/UnlM28fSp2CRF3ivUn1BWEvxMcVTNwpw91Py1pGbPIyIKtd+tzct9C3ouceCVdGAXxZOpZAsgdw==",
+      "version": "1.0.30001762",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001762.tgz",
+      "integrity": "sha512-PxZwGNvH7Ak8WX5iXzoK1KPZttBXNPuaOvI2ZYU7NrlM+d9Ov+TUvlLOBNGzVXAntMSMMlJPd+jY6ovrVjSmUw==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@vitest/coverage-v8": "3.2.4",
     "autoprefixer": "10.4.21",
     "babel-loader": "10.0.0",
+    "caniuse-lite": "1.0.30001762",
     "clean-webpack-plugin": "4.0.0",
     "confusing-browser-globals": "1.0.11",
     "copy-webpack-plugin": "13.0.0",


### PR DESCRIPTION
**Changes**

1. Adds `caniuse-lite` as a dev dependency ideally leading to automated bump PRs in the future.
2. Updates `caniuse-lite` to latest version as apparently the version in `master` is 7 months old.

<img width="1698" height="334" alt="Screenshot From 2026-01-03 15-33-35" src="https://github.com/user-attachments/assets/53f59e95-6bfb-4b3d-a2d6-3743b24edc51" />

Repo for reference: https://github.com/browserslist/caniuse-lite