### PR TITLE
Fix library menu button disappearing when name is too long

### DIFF
--- a/src/apps/dashboard/components/BaseCard.tsx
+++ b/src/apps/dashboard/components/BaseCard.tsx
@@ -85,7 +85,7 @@ const BaseCard = ({
                     }
                 }}>
                 <Stack flexGrow={1} direction='row'>
-                    <Stack flexGrow={1}>
+                    <Stack flexGrow={1} sx={{ overflow: 'hidden' }}>
                         <Typography gutterBottom sx={{
                             overflow: 'hidden',
                             whiteSpace: 'nowrap',


### PR DESCRIPTION
Fixes the titles "text-overflow: ellipsis;" property by setting parents overflow property to "hidden".

Currently the button to manage a library in the dashboard would be pushed into the overflow if the library name was too long. The text element has the text-overflow property set to "ellipsis" but this doesn't do anything unless the parent element has its overflow property set to "hidden".

Fixes #7464 
