### PR TITLE
Fix details banner on small screens

### DIFF
--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -510,7 +510,7 @@ function setTrailerButtonVisibility(page, item) {
 }
 
 function renderBackdrop(page, item) {
-    if (!layoutManager.mobile && dom.getWindowSize().innerWidth >= 1000) {
+    if (!layoutManager.mobile) {
         const isBannerEnabled = !layoutManager.tv && userSettings.detailsBanner();
         // If backdrops are disabled, but the header banner is enabled, add a class to the page to disable the transparency
         page.classList.toggle('noBackdropTransparency', isBannerEnabled && !userSettings.enableBackdrops());


### PR DESCRIPTION
Currently the details banner does not load when the window size is too small. This can be fixed by removing the dom.getWindowSize check in the renderBackdrop function of the itemDetails controller.

Fixes #7308 

