### PR TITLE
Fix artist links in recently added

### DIFF
--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -775,7 +775,7 @@ function getTextActionButton(item, text, serverId) {
         return text;
     }
 
-    const url = appRouter.getRouteUrl(item);
+    const url = appRouter.getRouteUrl(item, { serverId });
     let html = '<a href="' + url + '" ' + itemShortcuts.getShortcutAttributesHtml(item, serverId) + ' class="itemAction textActionButton" title="' + text + '" data-action="link">';
     html += text;
     html += '</a>';


### PR DESCRIPTION
`ServerId` was always undefined when the Artist links are generated, leading to invalid links

**Changes**
* Pass serverId to URL builder