### PR TITLE
Add default font family for fallback

### DIFF
--- a/src/styles/site.scss
+++ b/src/styles/site.scss
@@ -37,6 +37,9 @@
 
 html {
     @include fullpage;
+
+    /* Set the default font for cases we don't load the brand font */
+    font-family: Arial, Helvetica, sans-serif;
     line-height: 1.35;
 }
 


### PR DESCRIPTION
**Changes**
Add a default font family for cases where we don't load Noto

**Issues**
Related to https://github.com/jellyfin/jellyfin-xbox/issues/129
