### PR TITLE
Navigate to wizard if not completed on server add

### DIFF
--- a/src/controllers/session/addServer/index.js
+++ b/src/controllers/session/addServer/index.js
@@ -16,7 +16,11 @@ function handleConnectionResult(page, result) {
             break;
         }
         case ConnectionState.ServerSignIn:
-            Dashboard.navigate('login?serverid=' + result.Servers[0].Id, false, 'none');
+            if (result.SystemInfo.StartupWizardCompleted) {
+                Dashboard.navigate('login?serverid=' + result.Servers[0].Id, false, 'none');
+            } else {
+                Dashboard.navigate('/wizard/start');
+            }
             break;
         case ConnectionState.ServerSelection:
             Dashboard.navigate('selectserver', false, 'none');


### PR DESCRIPTION
When adding a server to web, it will navigate to the login page even if the wizard process hasn't been completed yet. This small fix allows the user to configure the startup wizard process on the web-wrapping apps.

**Changes**
Navigate to wizard if not completed on server add

**Issues**
N/A