### PR TITLE
Add nvmpi settings

### DIFF
--- a/src/apps/dashboard/features/playback/constants/codecs.ts
+++ b/src/apps/dashboard/features/playback/constants/codecs.ts
@@ -10,7 +10,8 @@ export const CODECS = [
             'vaapi',
             'rkmpp',
             'videotoolbox',
-            'v4l2m2m'
+            'v4l2m2m',
+            'nvmpi'
         ]
     },
     {
@@ -22,7 +23,8 @@ export const CODECS = [
             'qsv',
             'vaapi',
             'rkmpp',
-            'videotoolbox'
+            'videotoolbox',
+            'nvmpi'
         ]
     },
     {
@@ -38,7 +40,8 @@ export const CODECS = [
             'nvenc',
             'qsv',
             'vaapi',
-            'rkmpp'
+            'rkmpp',
+            'nvmpi'
         ]
     },
     {
@@ -46,7 +49,8 @@ export const CODECS = [
         codec: 'mpeg4',
         types: [
             'nvenc',
-            'rkmpp'
+            'rkmpp',
+            'nvmpi'
         ]
     },
     {
@@ -67,7 +71,8 @@ export const CODECS = [
             'qsv',
             'vaapi',
             'rkmpp',
-            'videotoolbox'
+            'videotoolbox',
+            'nvmpi'
         ]
     },
     {
@@ -79,7 +84,8 @@ export const CODECS = [
             'qsv',
             'vaapi',
             'rkmpp',
-            'videotoolbox'
+            'videotoolbox',
+            'nvmpi'
         ]
     },
     {

--- a/src/apps/dashboard/routes/playback/transcoding.tsx
+++ b/src/apps/dashboard/routes/playback/transcoding.tsx
@@ -149,7 +149,7 @@ export const Component = () => {
     }, [ config ]);
 
     const hardwareAccelType = config?.HardwareAccelerationType || HardwareAccelerationType.None;
-    const isHwaSelected = [ 'amf', 'nvenc', 'qsv', 'vaapi', 'rkmpp', 'videotoolbox' ].includes(hardwareAccelType);
+    const isHwaSelected = [ 'amf', 'nvenc', 'qsv', 'vaapi', 'rkmpp', 'videotoolbox', 'nvmpi' ].includes(hardwareAccelType);
 
     const availableCodecs = useMemo(() => (
         CODECS.filter(codec => codec.types.includes(hardwareAccelType))
@@ -203,6 +203,7 @@ export const Component = () => {
                                 <MenuItem value='rkmpp'>Rockchip MPP (RKMPP)</MenuItem>
                                 <MenuItem value='videotoolbox'>Apple VideoToolBox</MenuItem>
                                 <MenuItem value='v4l2m2m'>Video4Linux2 (V4L2)</MenuItem>
+                                <MenuItem value='nvmpi'>Nvidia Jetson</MenuItem>
                             </TextField>
 
                             {hardwareAccelType === 'vaapi' && (


### PR DESCRIPTION
**Changes**
I've added the possibility to change nvmpi encoding settings on the server.

**Issues**
I guess this is related to https://features.jellyfin.org/posts/1118/add-jetson-ffmpeg-nvmpi-support
This PR is blocked by https://github.com/jellyfin/jellyfin-ffmpeg/pull/653 and https://github.com/jellyfin/jellyfin/pull/16057