### PR TITLE
Wait for app host to initialize before proceeding

### DIFF
--- a/src/components/apphost.js
+++ b/src/components/apphost.js
@@ -456,5 +456,3 @@ if (window.addEventListener) {
     window.addEventListener('blur', onAppHidden);
 }
 
-// load app host on module load
-appHost.init();

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -66,6 +66,9 @@ build: ${__JF_BUILD_VERSION__}`);
         document.querySelector('.skinHeader').classList.remove('noHeaderRight');
     });
 
+    // Initialize app host
+    await appHost.init();
+
     // Initialize the api client
     const serverUrl = await serverAddress();
     if (serverUrl) {


### PR DESCRIPTION
On Titan OS the only way to retrieve device information is using an asynchronous function. Unfortunately jellyfin-web registers an ApiClient immediately on load making a web-wrapper unable to execute any async code to set device info.

This PR changes the initialization code to not call appHost.init() once from the app initialization code, before attempting to do any api client stuff. Giving some room for web wrappers to do async work.

**Changes**

- Move `appHost.init()` call from `apphost.js` module load
- Await `appHost.init()` call - only affects web-wrappers that return a promise like jellyfin-android and jellyfin-titanos.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
