### PR TITLE
Allow to play directly Dolby Vision for webOS 6+

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -1201,7 +1201,7 @@ export default function (options) {
         av1VideoRangeTypes += '|HDR10|HDR10Plus';
 
         if (browser.tizenVersion >= 3 || browser.vidaa || browser.webOsVersion >= 6) {
-            // Tizen ang LG TVs does not support Dolby Vision at all, but it can safely play the HDR fallback.
+            // Tizen and LG TVs do not support Dolby Vision at all, but they can safely play the HDR fallback.
             // Advertising the support so that the server doesn't have to remux.
             hevcVideoRangeTypes += '|DOVIWithHDR10|DOVIWithHDR10Plus|DOVIWithEL|DOVIWithELHDR10Plus|DOVIInvalid';
             // Although no official tools exist to create AV1+DV files yet, some of our users managed to use community tools to create such files.


### PR DESCRIPTION
**Changes**

The LG TVs are similar to Tizen ones regarding Dolby Vision, at least some TVs from 2021. They cannot play Dolby Vision, but they can safely play the HDR fallback. I have tested this on my TV (LG 4K Ultra HD TV 55UP77006LB (2021)) and it works flawlessly. I noticed this issue, because from an USB stick my TV was able to play the movies, but Jellyfin remuxed it all the time.

Here is the mediainfo of the movie which I tested this with:


<details>

mediainfo Movie\ 2160p\ iT\ WEB-DL\ DDP5.1\ Atmos\ DV\ HDR\ H265-BYNDR.mkv 
General
Unique ID                                : 149994412888246816760664782127940954387 (0x70D7DF85440FC03AE11DC9A1C1D2E913)
Complete name                            : Movie 2160p iT WEB-DL DDP5.1 Atmos DV HDR H265-BYNDR.mkv
Format                                   : Matroska
Format version                           : Version 4
File size                                : 19.8 GiB
Duration                                 : 1 h 54 min
Overall bit rate                         : 24.7 Mb/s
Frame rate                               : 24.000 FPS
Encoded date                             : 2025-09-22 17:56:15 UTC
Writing application                      : mkvmerge v88.0 ('All I Know') 64-bit
Writing library                          : libebml v1.4.5 + libmatroska v1.7.1

Video
ID                                       : 1
Format                                   : HEVC
Format/Info                              : High Efficiency Video Coding
Format profile                           : Main 10@L5@High
HDR format                               : Dolby Vision, Version 1.0, Profile 8.1, dvhe.08.06, BL+RPU, HDR10 compatible / SMPTE ST 2094 App 4, Version HDR10+ Profile A, HDR10+ Profile A compatible
Codec ID                                 : V_MPEGH/ISO/HEVC
Duration                                 : 1 h 54 min
Bit rate                                 : 23.9 Mb/s
Width                                    : 3 840 pixels
Height                                   : 1 606 pixels
Display aspect ratio                     : 2.39:1
Frame rate mode                          : Constant
Frame rate                               : 24.000 FPS
Color space                              : YUV
Chroma subsampling                       : 4:2:0 (Type 2)
Bit depth                                : 10 bits
Bits/(Pixel*Frame)                       : 0.162
Stream size                              : 19.2 GiB (97%)
Default                                  : Yes
Forced                                   : No
Color range                              : Limited
Color primaries                          : BT.2020
Transfer characteristics                 : PQ
Matrix coefficients                      : BT.2020 non-constant
Mastering display color primaries        : BT.2020
Mastering display luminance              : min: 0.0050 cd/m2, max: 1000 cd/m2
Maximum Content Light Level              : 997 cd/m2
Maximum Frame-Average Light Level        : 463 cd/m2

Audio
ID                                       : 2
Format                                   : E-AC-3 JOC
Format/Info                              : Enhanced AC-3 with Joint Object Coding
Commercial name                          : Dolby Digital Plus with Dolby Atmos
Codec ID                                 : A_EAC3
Duration                                 : 1 h 54 min
Bit rate mode                            : Constant
Bit rate                                 : 768 kb/s
Channel(s)                               : 6 channels
Channel layout                           : L R C LFE Ls Rs
Sampling rate                            : 48.0 kHz
Frame rate                               : 31.250 FPS (1536 SPF)
Compression mode                         : Lossy
Stream size                              : 629 MiB (3%)
Language                                 : English
Service kind                             : Complete Main
Default                                  : Yes
Forced                                   : No
Complexity index                         : 16
Number of dynamic objects                : 15
Bed channel count                        : 1 channel
Bed channel configuration                : LFE

Text
ID                                       : 3
Format                                   : UTF-8
Codec ID                                 : S_TEXT/UTF8
Codec ID/Info                            : UTF-8 Plain Text
Duration                                 : 1 h 54 min
Bit rate                                 : 51 b/s
Frame rate                               : 0.194 FPS
Count of elements                        : 1328
Stream size                              : 43.2 KiB (0%)
Language                                 : English
Default                                  : Yes
Forced                                   : No
</details>

