### PR TITLE
Fix `.nvrmc` to `.nvmrc` typo in PR GitHub workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Setup node environment
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
-          node-version-file: .nvrmc
+          node-version-file: .nvmrc
           cache: npm
           check-latest: true 
     


### PR DESCRIPTION
Quick follow up to https://github.com/jellyfin/jellyfin-web/pull/7282 to fix a typo in the PR GitHub workflow. :man_facepalming: 

See: https://github.com/jellyfin/jellyfin-web/actions/runs/21266760438/job/61207747049?pr=7474