### PR TITLE
Add support for Plugin Page MenuIcon

### DIFF
--- a/src/apps/dashboard/components/drawer/sections/PluginDrawerSection.tsx
+++ b/src/apps/dashboard/components/drawer/sections/PluginDrawerSection.tsx
@@ -1,5 +1,6 @@
 import Extension from '@mui/icons-material/Extension';
 import Folder from '@mui/icons-material/Folder';
+import Icon from '@mui/material/Icon';
 import List from '@mui/material/List';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
@@ -10,6 +11,31 @@ import ListItemLink from 'components/ListItemLink';
 import globalize from 'lib/globalize';
 import Dashboard from 'utils/dashboard';
 import { useConfigurationPages } from 'apps/dashboard/features/plugins/api/useConfigurationPages';
+
+const toMaterialIconLigature = (iconName: string) => {
+    const trimmed = iconName.trim();
+    if (!trimmed) return '';
+
+    // Normalize common separators.
+    const normalized = trimmed.replace(/[\s-]+/g, '_');
+
+    // If the server already provides ligature names (e.g. "settings" or "play_arrow"), keep them.
+    if (normalized.toLowerCase() === normalized) {
+        return normalized;
+    }
+
+    // Convert PascalCase / camelCase (e.g. "SkipNext") to snake_case ("skip_next").
+    return normalized
+        .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+        .toLowerCase();
+};
+
+const PluginPageIcon = ({ iconName }: { iconName?: string | null }) => {
+    const ligature = iconName ? toMaterialIconLigature(iconName) : '';
+    if (!ligature) return <Folder />;
+
+    return <Icon>{ligature}</Icon>;
+};
 
 const PluginDrawerSection = () => {
     const {
@@ -50,8 +76,7 @@ const PluginDrawerSection = () => {
                     to={`/${Dashboard.getPluginUrl(pageInfo.Name)}`}
                 >
                     <ListItemIcon>
-                        {/* TODO: Support different icons? */}
-                        <Folder />
+                        <PluginPageIcon iconName={pageInfo.MenuIcon} />
                     </ListItemIcon>
                     <ListItemText primary={pageInfo.DisplayName} />
                 </ListItemLink>


### PR DESCRIPTION
**Changes**
* Support Plugin Page MenuIcon
* Plugin Author must use `material-ui/material-icons`

<img width="261" height="194" alt="grafik" src="https://github.com/user-attachments/assets/e7397bca-8438-4a69-98ba-c076fd4046b6" />

Example Plugin Commit:

https://github.com/intro-skipper/intro-skipper/commit/8c51c33ff3d821051335a63ea1896bfa7a65050c

**Issues**
* fix TODO