### PR TITLE
Allow to play Dolby Vision with fallback on webOS

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -1185,7 +1185,9 @@ export default function (options) {
     let vp9VideoRangeTypes = 'SDR';
     let av1VideoRangeTypes = 'SDR';
 
-    if (browser.tizenVersion >= 3) {
+    const isWebOsWithoutDolbyVision = browser.web0s && !supportsDolbyVision(options);
+
+    if (browser.tizenVersion >= 3 || isWebOsWithoutDolbyVision) {
         hevcVideoRangeTypes += '|DOVIWithSDR';
     }
 
@@ -1195,8 +1197,9 @@ export default function (options) {
         vp9VideoRangeTypes += '|HDR10|HDR10Plus';
         av1VideoRangeTypes += '|HDR10|HDR10Plus';
 
-        if (browser.tizenVersion >= 3 || browser.vidaa) {
+        if (browser.tizenVersion >= 3 || browser.vidaa || isWebOsWithoutDolbyVision) {
             // Tizen TV does not support Dolby Vision at all, but it can safely play the HDR fallback.
+            // LG TVs that don't support Dolby Vision still can play the HDR fallback without issues.
             // Advertising the support so that the server doesn't have to remux.
             hevcVideoRangeTypes += '|DOVIWithHDR10|DOVIWithHDR10Plus|DOVIWithEL|DOVIWithELHDR10Plus|DOVIInvalid';
             // Although no official tools exist to create AV1+DV files yet, some of our users managed to use community tools to create such files.
@@ -1210,7 +1213,7 @@ export default function (options) {
         vp9VideoRangeTypes += '|HLG';
         av1VideoRangeTypes += '|HLG';
 
-        if (browser.tizenVersion >= 3) {
+        if (browser.tizenVersion >= 3 || isWebOsWithoutDolbyVision) {
             hevcVideoRangeTypes += '|DOVIWithHLG';
         }
     }


### PR DESCRIPTION
**Changes**
Allowed to play Dolby Vision files with fallback on webOS when Dolby Vision is not supported.

I run into this issue by noticing that my TV can play some files from a USB stick, but Jellyfin rejects to direct play them. I have created another [PR](https://github.com/jellyfin/jellyfin-web/pull/7524) previously, but because of the radically different approach that @nyanmisaka proposed, I thought it is better to open a new PR.