### PR TITLE
Remove unused AudioPodcast item type

### DIFF
--- a/src/components/indicators/indicators.js
+++ b/src/components/indicators/indicators.js
@@ -6,8 +6,7 @@ import 'material-design-icons-iconfont';
 
 export function enableProgressIndicator(item) {
     return (item.MediaType === 'Video' && item.Type !== 'TvChannel')
-        || item.Type === 'AudioBook'
-        || item.Type === 'AudioPodcast';
+        || item.Type === 'AudioBook';
 }
 
 export function getProgressHtml(pct, options) {

--- a/src/components/indicators/useIndicator.tsx
+++ b/src/components/indicators/useIndicator.tsx
@@ -43,7 +43,6 @@ const enableProgressIndicator = (
     return (
         (itemMediaType === ItemMediaKind.Video && itemType !== ItemKind.TvChannel)
         || itemType === ItemKind.AudioBook
-        || itemType === ItemKind.AudioPodcast
     );
 };
 

--- a/src/components/itemHelper.js
+++ b/src/components/itemHelper.js
@@ -256,9 +256,6 @@ export function canMarkPlayed (item) {
             return true;
         }
     } else if (item.MediaType === 'Audio') {
-        if (item.Type === 'AudioPodcast') {
-            return true;
-        }
         if (item.Type === 'AudioBook') {
             return true;
         }

--- a/src/elements/emby-playstatebutton/emby-playstatebutton.js
+++ b/src/elements/emby-playstatebutton/emby-playstatebutton.js
@@ -69,7 +69,7 @@ function setState(button, played, updateAttribute) {
 }
 
 function setTitle(button, itemType, played) {
-    if (itemType !== 'AudioBook' && itemType !== 'AudioPodcast') {
+    if (itemType !== 'AudioBook') {
         button.title = played ? globalize.translate('Watched') : globalize.translate('MarkPlayed');
     } else {
         button.title = played ? globalize.translate('Played') : globalize.translate('MarkPlayed');

--- a/src/types/base/models/item-kind.ts
+++ b/src/types/base/models/item-kind.ts
@@ -3,8 +3,7 @@ import { BaseItemKind } from '@jellyfin/sdk/lib/generated-client/models/base-ite
 export const ItemKind = {
     ...BaseItemKind,
     Timer: 'Timer',
-    SeriesTimer: 'SeriesTimer',
-    AudioPodcast: 'AudioPodcast'
+    SeriesTimer: 'SeriesTimer'
 } as const;
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare


### PR DESCRIPTION
This change removes all references to the AudioPodcast item type.

This is legacy dead code from Emby days (pre-fork in 2018). The item type was speculatively added in commit 7d752911c on December 12, 2016 by Luke Pulverenti (original Emby developer) for a podcast feature that was never implemented on the server side.