### PR TITLE
Remove reference to non-existing Recording media type

### DIFF
--- a/src/components/itemHelper.js
+++ b/src/components/itemHelper.js
@@ -267,8 +267,7 @@ export function canMarkPlayed (item) {
     return item.Type === 'Series'
         || item.Type === 'Season'
         || item.Type === 'BoxSet'
-        || item.MediaType === 'Book'
-        || item.MediaType === 'Recording';
+        || item.MediaType === 'Book';
 }
 
 export function canRate (item) {


### PR DESCRIPTION
This change fixes a small bug where a non-existent "Recording" media type is referenced.

This media type does not exist, so initially I thought to change it from `MediaType` to just `Type` since there is a Recording item type. However, upon inspection, a recording is just a specific kind of Video, and there is already a check for `item.MediaType === 'Video'` earlier in the function which covers this. Based on this, I've simply removed the bad clause.