### PR TITLE
Remove old irrelevant comment about 'LabelSyncPlayTimeOffset'

### DIFF
--- a/src/components/playerstats/playerstats.js
+++ b/src/components/playerstats/playerstats.js
@@ -352,7 +352,6 @@ function getSyncPlayStats() {
     });
 
     syncStats.push({
-        // TODO: clean old string 'LabelSyncPlayTimeOffset' from translations.
         label: globalize.translate('LabelSyncPlayTimeSyncOffset'),
         value: stats.TimeSyncOffset + ' ' + globalize.translate('MillisecondsUnit')
     });


### PR DESCRIPTION
This simply removes a TODO in `src/components/playerstats/playerstats.js` since the strings are now gone