### PR TITLE
Remove getData() and importFrom() dead code from userSettings.js

### DIFF
--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -73,16 +73,6 @@ export class UserSettings {
         });
     }
 
-    // FIXME: Seems unused
-    getData() {
-        return this.displayPrefs;
-    }
-
-    // FIXME: Seems unused
-    importFrom(instance) {
-        this.displayPrefs = instance.getData();
-    }
-
     // FIXME: 'appSettings.set' doesn't return any value
     /**
      * Set value of setting.
@@ -690,8 +680,6 @@ export const currentSettings = new UserSettings;
 
 // Wrappers for non-ES6 modules and backward compatibility
 export const setUserInfo = currentSettings.setUserInfo.bind(currentSettings);
-export const getData = currentSettings.getData.bind(currentSettings);
-export const importFrom = currentSettings.importFrom.bind(currentSettings);
 export const set = currentSettings.set.bind(currentSettings);
 export const get = currentSettings.get.bind(currentSettings);
 export const serverConfig = currentSettings.serverConfig.bind(currentSettings);


### PR DESCRIPTION
This removes some dead code from userSettings.js

The code comments suggests someone believed these to be unused but weren't confident enough to actually remove them. Here are the results of my spelunking into history to help explain why it is indeed safe to remove this code:

* December 2016 (ec06f3cc6): Luke Pulverenti (Emby) added getData() and importFrom() to usersettingsbuilder.js for syncing user settings between instances
* October 2017 (e5f32b2f9): Added usage via refreshGlobalUserSettings() in displaysettings.js
* October 2017 (f66cd30b4): The only caller (refreshGlobalUserSettings()) was removed in the same month, making both functions dead code
* December 2018: Jellyfin forked from Emby, inheriting the already-dead code
* April 2020 (dbf63c723): dkanada converted to ES6 modules, preserving the dead functions
* April 2020 (a802079ba): MrTimscampi added the functions to the module exports

So the functions have been dead code since October 2017 (over 7 years) and have never been called in Jellyfin's history. They were legacy Emby code that was converted to ES6 but never actually used.