### PR TITLE
Remove unused showFindNew export from itemidentifier.js

### DIFF
--- a/src/components/itemidentifier/itemidentifier.js
+++ b/src/components/itemidentifier/itemidentifier.js
@@ -401,73 +401,6 @@ function onDialogClosed() {
     }
 }
 
-// TODO investigate where this was used
-function showEditorFindNew(itemName, itemYear, itemType, resolveFunc) {
-    currentItem = null;
-    currentItemType = itemType;
-
-    const dialogOptions = {
-        size: 'small',
-        removeOnClose: true,
-        scrollY: false
-    };
-
-    if (layoutManager.tv) {
-        dialogOptions.size = 'fullscreen';
-    }
-
-    const dlg = dialogHelper.createDialog(dialogOptions);
-
-    dlg.classList.add('formDialog');
-    dlg.classList.add('recordingDialog');
-
-    let html = '';
-    html += globalize.translateHtml(template, 'core');
-
-    dlg.innerHTML = html;
-
-    if (layoutManager.tv) {
-        scrollHelper.centerFocus.on(dlg.querySelector('.formDialogContent'), false);
-    }
-
-    dialogHelper.open(dlg);
-
-    dlg.querySelector('.btnCancel').addEventListener('click', () => {
-        dialogHelper.close(dlg);
-    });
-
-    dlg.querySelector('.popupIdentifyForm').addEventListener('submit', e => {
-        e.preventDefault();
-        searchForIdentificationResults(dlg);
-        return false;
-    });
-
-    dlg.addEventListener('close', () => {
-        loading.hide();
-        const foundItem = hasChanges ? currentSearchResult : null;
-
-        resolveFunc(foundItem);
-    });
-
-    dlg.classList.add('identifyDialog');
-
-    showIdentificationFormFindNew(dlg, itemName, itemYear, itemType);
-}
-
-function showIdentificationFormFindNew(dlg, itemName, itemYear, itemType) {
-    dlg.querySelector('#txtLookupName').value = itemName;
-
-    if (itemType === 'Person' || itemType === 'BoxSet') {
-        dlg.querySelector('.fldLookupYear').classList.add('hide');
-        dlg.querySelector('#txtLookupYear').value = '';
-    } else {
-        dlg.querySelector('.fldLookupYear').classList.remove('hide');
-        dlg.querySelector('#txtLookupYear').value = itemYear;
-    }
-
-    dlg.querySelector('.formDialogHeaderTitle').innerHTML = globalize.translate('Search');
-}
-
 export function show(itemId, serverId) {
     return new Promise((resolve, reject) => {
         currentResolve = resolve;
@@ -479,16 +412,6 @@ export function show(itemId, serverId) {
     });
 }
 
-export function showFindNew(itemName, itemYear, itemType, serverId) {
-    return new Promise((resolve) => {
-        currentServerId = serverId;
-
-        hasChanges = false;
-        showEditorFindNew(itemName, itemYear, itemType, resolve);
-    });
-}
-
 export default {
-    show: show,
-    showFindNew: showFindNew
+    show: show
 };


### PR DESCRIPTION
This removes some dead code from itemidentifier.js

According to comments, this code was suspected to be dead already but not with enough confidence to act on it.

After investigating the history of this code, 

* February 2016 (57684befa): Luke Pulverenti (Emby) added `showFindNew` to `itemidentifier.js` as part of the "auto-organize - support new series" feature. The function was called from fileorganizer.js to allow users to search for and identify new TV series when organizing media files.
* July 2017 (9623af14e): Luke Pulverenti moved the entire auto-organize feature to a separate plugin. The `fileorganizer.js` file (which contained the only caller of `showFindNew`) was deleted from the repository. The showFindNew function was left behind as orphaned code.
* June 2020 (7296dbc28): The code was converted to ES6 modules, and showFindNew was preserved and exported even though it had no callers.

The auto-organize plugin (if it still exists) would have its own implementation and does not depend on this web client code.