### PR TITLE
Fix infinite loading when fetching subtitles times out

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -103,6 +103,7 @@
 - [TheBosZ](https://github.com/thebosz)
 - [qm3jp](https://github.com/qm3jp)
 - [johnnyg](https://github.com/johnnyg)
+- [Zn00t] (https://github.com/Zn00t)
 
 ## Emby Contributors
 

--- a/src/components/subtitleeditor/subtitleeditor.js
+++ b/src/components/subtitleeditor/subtitleeditor.js
@@ -278,8 +278,24 @@ function searchForSubtitles(context, language) {
     const apiClient = ServerConnections.getApiClient(currentItem.ServerId);
     const url = apiClient.getUrl('Items/' + currentItem.Id + '/RemoteSearch/Subtitles/' + language);
 
-    apiClient.getJSON(url).then(function (results) {
+    apiClient.ajax({
+        url: url,
+        type: 'GET',
+        dataType: 'json',
+        timeout: 300000 // 5 minutes in milliseconds
+    }).then(function (results) {
         renderSearchResults(context, results);
+    }).catch(function (error) {
+        loading.hide();
+
+        if (!error) {
+            toast(globalize.translate('SubtitleSearchTimeout'));
+        } else {
+            toast(globalize.translate('SubtitleSearchError'));
+        }
+
+        context.querySelector('.subtitleResults').innerHTML = '';
+        context.querySelector('.noSearchResults').classList.remove('hide');
     });
 }
 

--- a/src/strings/en_US.json
+++ b/src/strings/en_US.json
@@ -178,5 +178,7 @@
     "ConfigureDateAdded": "Setting up how metadata for 'Date added' is determined in the Dashboard >Libraries>Display",
     "ConfirmDeleteImage": "Do you want to delete this image?",
     "ConfirmDeleteItem": "Deleting this item will delete it from both the file system and the media library. Are you sure you wish to continue?",
-    "ConfirmDeleteSeries": "Deleting this series will delete All{0} episodes from both the file system and your media library. Are you sure you wish to continue?"
+    "ConfirmDeleteSeries": "Deleting this series will delete All{0} episodes from both the file system and your media library. Are you sure you wish to continue?",
+    "SubtitleSearchTimeout": "Subtitle search timed out. The provider may be slow - please try again.",
+    "SubtitleSearchError": "An error occurred while searching for subtitles."
 }


### PR DESCRIPTION
**Changes**
Changed the apiClient request to a request with a 5 minutes timeout and added a catch block to hide the loading spinner and display a toast depending on the exact error (timeout or anything else)

**Issues**
Fixes https://github.com/jellyfin/jellyfin-web/issues/7438
