### PR TITLE
Added option to preview login disclaimer in Branding settings

### DIFF
--- a/src/apps/dashboard/routes/branding/index.tsx
+++ b/src/apps/dashboard/routes/branding/index.tsx
@@ -171,13 +171,12 @@ export const Component = () => {
     }, [ brandingOptions ]);
 
     const previewLoginDisclaimer = useCallback(() => {
-        console.log('Toastbrot');
-        baseAlert({
+        void baseAlert({
             title: 'Login disclaimer Preview:',
             html: [
                 brandingOptions.LoginDisclaimer
             ]
-        })
+        });
     }, [ brandingOptions ]);
 
     const onSubmit = useCallback(() => {

--- a/src/apps/dashboard/routes/branding/index.tsx
+++ b/src/apps/dashboard/routes/branding/index.tsx
@@ -24,6 +24,7 @@ import globalize from 'lib/globalize';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
 import { queryClient } from 'utils/query/queryClient';
 import { ActionData } from 'types/actionData';
+import baseAlert from 'components/alert';
 
 const BRANDING_CONFIG_KEY = 'branding';
 const BrandingOption = {
@@ -169,6 +170,16 @@ export const Component = () => {
         }
     }, [ brandingOptions ]);
 
+    const previewLoginDisclaimer = useCallback(() => {
+        console.log('Toastbrot');
+        baseAlert({
+            title: 'Login disclaimer Preview:',
+            html: [
+                brandingOptions.LoginDisclaimer
+            ]
+        })
+    }, [ brandingOptions ]);
+
     const onSubmit = useCallback(() => {
         setError(undefined);
     }, []);
@@ -283,6 +294,14 @@ export const Component = () => {
                                 }
                             }}
                         />
+
+                        <Button
+                            size='large'
+                            sx={{ width: 'fit-content' }}
+                            onClick={previewLoginDisclaimer}
+                        >
+                            {globalize.translate('Preview')}
+                        </Button>
 
                         <TextField
                             fullWidth


### PR DESCRIPTION
Added a button to preview current login page disclaimer with correct HTML formatting.

<img width="886" height="550" alt="image" src="https://github.com/user-attachments/assets/a4168251-0cef-4e1d-a686-8b2c98b97670" />
<img width="457" height="485" alt="image" src="https://github.com/user-attachments/assets/6fc16ce6-ea98-4253-b1cf-446acd0ccbfa" />

Adds request from #6335


