### PR TITLE
Add PreferOriginalReleaseDate Option for Music

### DIFF
--- a/src/components/libraryoptionseditor/libraryoptionseditor.js
+++ b/src/components/libraryoptionseditor/libraryoptionseditor.js
@@ -649,6 +649,7 @@ export function getLibraryOptions(parent) {
         SaveLyricsWithMedia: parent.querySelector('#chkSaveLyricsLocally').checked,
         RequirePerfectSubtitleMatch: parent.querySelector('#chkRequirePerfectMatch').checked,
         AutomaticallyAddToCollection: parent.querySelector('#chkAutomaticallyAddToCollection').checked,
+        PreferOriginalReleaseDate: parent.querySelector('#chkPreferOriginalReleaseDate').checked,
         PreferNonstandardArtistsTag: parent.querySelector('#chkPreferNonstandardArtistsTag').checked,
         UseCustomTagDelimiters: parent.querySelector('#chkUseCustomTagDelimiters').checked,
         MetadataSavers: Array.prototype.map.call(Array.prototype.filter.call(parent.querySelectorAll('.chkMetadataSaver'), elem => {
@@ -718,6 +719,7 @@ export function setLibraryOptions(parent, options) {
     parent.querySelector('#chkSkipIfAudioTrackPresent').checked = options.SkipSubtitlesIfAudioTrackMatches;
     parent.querySelector('#chkRequirePerfectMatch').checked = options.RequirePerfectSubtitleMatch;
     parent.querySelector('#chkAutomaticallyAddToCollection').checked = options.AutomaticallyAddToCollection;
+    parent.querySelector('#chkPreferOriginalReleaseDate').checked = options.PreferOriginalReleaseDate;
     parent.querySelector('#chkPreferNonstandardArtistsTag').checked = options.PreferNonstandardArtistsTag;
     parent.querySelector('#chkUseCustomTagDelimiters').checked = options.UseCustomTagDelimiters;
     Array.prototype.forEach.call(parent.querySelectorAll('.chkMetadataSaver'), elem => {

--- a/src/components/libraryoptionseditor/libraryoptionseditor.template.html
+++ b/src/components/libraryoptionseditor/libraryoptionseditor.template.html
@@ -224,6 +224,13 @@
     <h2>${LabelAudioTagSettings}</h2>
     <div class="checkboxContainer checkboxContainer-withDescription advanced">
         <label>
+            <input type="checkbox" is="emby-checkbox" id="chkPreferOriginalReleaseDate" />
+            <span>${PreferOriginalReleaseDate}</span>
+        </label>
+        <div class="fieldDescription checkboxFieldDescription">${PreferOriginalReleaseDateHelp}</div>
+    </div>
+    <div class="checkboxContainer checkboxContainer-withDescription advanced">
+        <label>
             <input type="checkbox" is="emby-checkbox" id="chkPreferNonstandardArtistsTag" />
             <span>${PreferNonstandardArtistsTag}</span>
         </label>

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1419,6 +1419,8 @@
     "PreferEmbeddedTitlesOverFileNamesHelp": "Determine the display title to use when no internet metadata or local metadata is available.",
     "PreferNonstandardArtistsTag": "Prefer ARTISTS tag if available",
     "PreferNonstandardArtistsTagHelp": "Use the non-standard ARTISTS tag instead of ARTIST tag when available.",
+    "PreferOriginalReleaseDate": "Prefer ORIGINALDATE tag if available",
+    "PreferOriginalReleaseDateHelp": "Prefer the ORIGINALDATE tag to the DATE tag when available.",
     "AllowEmbeddedSubtitles": "Disable different types of embedded subtitles",
     "AllowEmbeddedSubtitlesHelp": "Disable subtitles that are packaged within media containers. Requires a full library refresh.",
     "AllowEmbeddedSubtitlesAllowAllOption": "Allow All",


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
Adds an "PreferOriginalReleaseDate" option in the music "Audio Tag" settings that prefers the ORIGINALDATE tag of music files to the normal DATE tag (that is intended to be used as a release date for a specifc issue, e.g. 50year anniversary editions)

**Issues**
depends on https://github.com/jellyfin/jellyfin/pull/16103
