### PR TITLE
Bump Stale Issues & PRs limit to 500

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           repo-token: ${{ secrets.JF_BOT_TOKEN }}
-          operations-per-run: 75
+          operations-per-run: 500
           # Issues receive a stale warning after 120 days and close after an additional 21 days
           days-before-stale: 120
           days-before-close: 21


### PR DESCRIPTION
We currently process 75 Issues & PR's a day. however hit api limits. We seem to have 5000 API requests (a day?) and are only using 75.
<img width="1219" height="322" alt="image" src="https://github.com/user-attachments/assets/05dff7a6-f9bd-47a3-b3d1-5f67cc652892" />