### PR TITLE
Update Music Videos views in experimental layout

### DIFF
--- a/src/apps/experimental/components/library/SortButton.tsx
+++ b/src/apps/experimental/components/library/SortButton.tsx
@@ -119,6 +119,14 @@ const sortOptionsMapping: SortOptionsMapping = {
         { label: 'OptionPlayCount', value: ItemSortBy.PlayCount },
         { label: 'Runtime', value: ItemSortBy.Runtime },
         { label: 'OptionRandom', value: ItemSortBy.Random }
+    ],
+    [LibraryTab.MusicVideos]: [
+        { label: 'Name', value: ItemSortBy.SortName },
+        { label: 'OptionDateAdded', value: ItemSortBy.DateCreated },
+        { label: 'OptionDatePlayed', value: ItemSortBy.DatePlayed },
+        { label: 'OptionPlayCount', value: ItemSortBy.PlayCount },
+        { label: 'Runtime', value: ItemSortBy.Runtime },
+        { label: 'OptionRandom', value: ItemSortBy.Random }
     ]
 };
 

--- a/src/apps/experimental/features/libraries/constants/libraryRoutes.ts
+++ b/src/apps/experimental/features/libraries/constants/libraryRoutes.ts
@@ -194,5 +194,26 @@ export const LibraryRoutes: LibraryRoute[] = [
                 view: LibraryTab.Videos
             }
         ]
+    },
+    {
+        path: '/musicvideos',
+        views: [
+            {
+                index: 0,
+                label: 'HeaderVideos',
+                view: LibraryTab.MusicVideos,
+                isDefault: true
+            },
+            {
+                index: 1,
+                label: 'Suggestions',
+                view: LibraryTab.Suggestions
+            },
+            {
+                index: 2,
+                label: 'Folders',
+                view: LibraryTab.Folders
+            }
+        ]
     }
 ];

--- a/src/apps/experimental/routes/asyncRoutes/user.ts
+++ b/src/apps/experimental/routes/asyncRoutes/user.ts
@@ -8,6 +8,7 @@ export const ASYNC_USER_ROUTES: AsyncRoute[] = [
     { path: 'movies', type: AppType.Experimental },
     { path: 'music', type: AppType.Experimental },
     { path: 'books', type: AppType.Experimental },
+    { path: 'musicvideos', type: AppType.Experimental },
     { path: 'mypreferencesdisplay', page: 'user/display', type: AppType.Experimental },
     { path: 'mypreferencesmenu', page: 'user/settings' },
     { path: 'quickconnect', page: 'quickConnect' },

--- a/src/apps/experimental/routes/musicvideos/index.tsx
+++ b/src/apps/experimental/routes/musicvideos/index.tsx
@@ -1,0 +1,58 @@
+import { BaseItemKind } from '@jellyfin/sdk/lib/generated-client/models/base-item-kind';
+import React, { type FC } from 'react';
+import useCurrentTab from 'hooks/useCurrentTab';
+import Page from 'components/Page';
+import PageTabContent from '../../components/library/PageTabContent';
+import { LibraryTab } from 'types/libraryTab';
+import { CollectionType } from '@jellyfin/sdk/lib/generated-client/models/collection-type';
+import { LibraryTabContent, LibraryTabMapping } from 'types/libraryTabContent';
+import { MusicVideoSuggestionsSectionsView } from 'types/sections';
+
+const musicVideosTabContent: LibraryTabContent = {
+    viewType: LibraryTab.MusicVideos,
+    collectionType: CollectionType.Musicvideos,
+    isBtnPlayAllEnabled: true,
+    isBtnShuffleEnabled: true,
+    itemType: [BaseItemKind.MusicVideo]
+};
+
+const suggestionsTabContent: LibraryTabContent = {
+    viewType: LibraryTab.Suggestions,
+    collectionType: CollectionType.Musicvideos,
+    sectionsView: MusicVideoSuggestionsSectionsView
+};
+
+const foldersTabContent: LibraryTabContent = {
+    viewType: LibraryTab.Folders,
+    collectionType: CollectionType.Musicvideos,
+    isBtnPlayAllEnabled: false,
+    isBtnShuffleEnabled: false,
+    itemType: [BaseItemKind.Folder, BaseItemKind.MusicVideo]
+};
+
+const musicVideosTabMapping: LibraryTabMapping = {
+    0: musicVideosTabContent,
+    1: suggestionsTabContent,
+    2: foldersTabContent
+};
+
+const MusicVideos: FC = () => {
+    const { libraryId, activeTab } = useCurrentTab();
+    const currentTab = musicVideosTabMapping[activeTab];
+
+    return (
+        <Page
+            id='musicvideos'
+            className='mainAnimatedPage libraryPage backdropPage collectionEditorPage pageWithAbsoluteTabs withTabs'
+            backDropType='video, photo'
+        >
+            <PageTabContent
+                key={`${currentTab.viewType} - ${libraryId}`}
+                currentTab={currentTab}
+                parentId={libraryId}
+            />
+        </Page>
+    );
+};
+
+export default MusicVideos;

--- a/src/components/router/appRouter.js
+++ b/src/components/router/appRouter.js
@@ -442,6 +442,15 @@ class AppRouter {
 
                 return url;
             }
+
+            if (layoutMode === LayoutMode.Experimental && item.CollectionType == CollectionType.Musicvideos) {
+                url = `#/musicvideos?topParentId=${item.Id}&collectionType=${item.CollectionType}`;
+
+                if (options?.section === 'latest') {
+                    url += '&tab=1';
+                }
+                return url;
+            }
         }
 
         const itemTypes = ['Playlist', 'TvChannel', 'Program', 'BoxSet', 'MusicAlbum', 'MusicGenre', 'Person', 'Recording', 'MusicArtist'];

--- a/src/hooks/useFetchItems.ts
+++ b/src/hooks/useFetchItems.ts
@@ -305,6 +305,29 @@ const fetchGetItemsViewByType = async (
                 );
                 break;
             }
+            case LibraryTab.Folders: {
+                response = await getItemsApi(api).getItems(
+                    {
+                        userId: user.Id,
+                        recursive: false,
+                        imageTypeLimit: 1,
+                        parentId: parentId ?? undefined,
+                        enableImageTypes: [libraryViewSettings.ImageType, ImageType.Backdrop],
+                        ...getFieldsQuery(viewType, libraryViewSettings),
+                        ...getFiltersQuery(viewType, libraryViewSettings),
+                        ...getLimitQuery(),
+                        ...getAlphaPickerQuery(libraryViewSettings),
+                        sortBy: [libraryViewSettings.SortBy],
+                        sortOrder: [libraryViewSettings.SortOrder],
+                        includeItemTypes: itemType,
+                        startIndex: libraryViewSettings.StartIndex
+                    },
+                    {
+                        signal: options?.signal
+                    }
+                );
+                break;
+            }
             case LibraryTab.SeriesTimers:
                 response = await getLiveTvApi(api).getSeriesTimers(
                     {
@@ -391,7 +414,9 @@ export const useGetItemsViewByType = (
                 LibraryTab.Photos,
                 LibraryTab.Videos,
                 LibraryTab.Channels,
-                LibraryTab.SeriesTimers
+                LibraryTab.SeriesTimers,
+                LibraryTab.MusicVideos,
+                LibraryTab.Folders
             ].includes(viewType)
     });
 };

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -465,6 +465,7 @@
     "HeaderLatestMedia": "Recently Added Media",
     "HeaderLatestMovies": "Recently Added Movies",
     "HeaderLatestMusic": "Recently Added Music",
+    "HeaderLatestMusicVideos": "Recently Added Music Videos",
     "HeaderLatestRecordings": "Recently Added Recordings",
     "HeaderLibraries": "Libraries",
     "HeaderLibraryAccess": "Library Access",

--- a/src/types/libraryTab.ts
+++ b/src/types/libraryTab.ts
@@ -22,5 +22,7 @@ export enum LibraryTab {
     PhotoAlbums = 'photoalbums',
     Photos = 'photos',
     Videos = 'videos',
-    Books = 'books'
+    Books = 'books',
+    MusicVideos = 'musicvideos',
+    Folders = 'folders'
 }

--- a/src/types/sections.ts
+++ b/src/types/sections.ts
@@ -53,7 +53,10 @@ export enum SectionType {
     ActiveRecordings = 'ActiveRecordings',
     ContinueReading = 'ContinueReading',
     LatestBooks = 'LatestBooks',
-    UpcomingRecordings = 'UpcomingRecordings'
+    UpcomingRecordings = 'UpcomingRecordings',
+    LatestMusicVideos = 'latestmusicvideos',
+    RecentlyPlayedMusicVideos = 'recentlyplayedmusicvideos',
+    FrequentlyPlayedMusicVideos = 'frequentlyplayedmusicvideos'
 }
 
 export interface Section {
@@ -93,6 +96,14 @@ export const MusicSuggestionsSectionsView: SectionsView = {
         SectionType.LatestMusic,
         SectionType.FrequentlyPlayedMusic,
         SectionType.RecentlyPlayedMusic
+    ]
+};
+
+export const MusicVideoSuggestionsSectionsView: SectionsView = {
+    suggestionSections: [
+        SectionType.LatestMusicVideos,
+        SectionType.FrequentlyPlayedMusicVideos,
+        SectionType.RecentlyPlayedMusicVideos
     ]
 };
 

--- a/src/utils/sections.ts
+++ b/src/utils/sections.ts
@@ -181,6 +181,58 @@ export const getSuggestionSections = (): Section[] => {
                 overlayMoreButton: true,
                 coverImage: true
             }
+        },
+        {
+            name: 'HeaderLatestMusicVideos',
+            apiMethod: SectionApiMethod.LatestMedia,
+            itemTypes: 'Video',
+            type: SectionType.LatestMusicVideos,
+            parametersOptions: {
+                includeItemTypes: [BaseItemKind.MusicVideo]
+            },
+            cardOptions: {
+                showUnplayedIndicator: false,
+                shape: CardShape.BackdropOverflow,
+                showParentTitle: true,
+                overlayPlayButton: true,
+                coverImage: true
+            }
+        },
+        {
+            name: 'HeaderRecentlyPlayed',
+            itemTypes: 'Video',
+            type: SectionType.RecentlyPlayedMusicVideos,
+            parametersOptions: {
+                sortBy: [ItemSortBy.DatePlayed],
+                sortOrder: [SortOrder.Descending],
+                includeItemTypes: [BaseItemKind.MusicVideo],
+                ...parametersOptions
+            },
+            cardOptions: {
+                showUnplayedIndicator: false,
+                shape: CardShape.BackdropOverflow,
+                showParentTitle: true,
+                overlayMoreButton: true,
+                coverImage: true
+            }
+        },
+        {
+            name: 'HeaderFrequentlyPlayed',
+            itemTypes: 'Video',
+            type: SectionType.FrequentlyPlayedMusicVideos,
+            parametersOptions: {
+                sortBy: [ItemSortBy.PlayCount],
+                sortOrder: [SortOrder.Descending],
+                includeItemTypes: [BaseItemKind.MusicVideo],
+                ...parametersOptions
+            },
+            cardOptions: {
+                showUnplayedIndicator: false,
+                shape: CardShape.BackdropOverflow,
+                showParentTitle: true,
+                overlayMoreButton: true,
+                coverImage: true
+            }
         }
     ];
 };


### PR DESCRIPTION
**Changes**
Update the design of the Music Videos library for the experimental layout, including three new tabs: Videos, Suggestions, and Folders

<img width="946" height="623" alt="1" src="https://github.com/user-attachments/assets/e6f79017-a6b1-4b1f-850d-22af7ac21137" />

---

<img width="952" height="565" alt="2" src="https://github.com/user-attachments/assets/a1dd7449-ff36-4fd1-8b2d-22b846035285" />

---

<img width="951" height="435" alt="3" src="https://github.com/user-attachments/assets/768a4b2a-03bf-4fdf-a345-c6ce7cad4530" />

---

**Issues**
 N/A