### PR TITLE
Fix add-to-collection for multi-version items

### DIFF
--- a/src/components/itemContextMenu.js
+++ b/src/components/itemContextMenu.js
@@ -388,6 +388,7 @@ function getResolveFunction(resolve, commandId, changed, deleted, itemId) {
 
 function executeCommand(item, id, options) {
     const itemId = item.Id;
+    const collectionItemId = options.collectionItemId || item.Id;
     const serverId = item.ServerId;
     const apiClient = ServerConnections.getApiClient(serverId);
     const api = toApi(apiClient);
@@ -399,7 +400,7 @@ function executeCommand(item, id, options) {
                 import('./collectionEditor/collectionEditor').then(({ default: CollectionEditor }) => {
                     const collectionEditor = new CollectionEditor();
                     collectionEditor.show({
-                        items: [itemId],
+                        items: [collectionItemId],
                         serverId: serverId
                     }).then(getResolveFunction(resolve, id, true), getResolveFunction(resolve, id));
                 });

--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -98,7 +98,7 @@ function hideAll(page, className, show) {
     }
 }
 
-function getContextMenuOptions(item, user, button) {
+function getContextMenuOptions(item, user, button, collectionItemId) {
     return {
         item: item,
         open: false,
@@ -112,7 +112,8 @@ function getContextMenuOptions(item, user, button) {
         shuffle: false,
         instantMix: false,
         user: user,
-        share: true
+        share: true,
+        collectionItemId: collectionItemId
     };
 }
 
@@ -2044,6 +2045,7 @@ export default function (view, params) {
     function onMoreCommandsClick() {
         const button = this;
         let selectedItem = view.querySelector('.selectSource').value || currentItem.Id;
+        const collectionItemId = currentItem?.Id;
 
         const apiClient = getApiClient();
 
@@ -2051,7 +2053,7 @@ export default function (view, params) {
             selectedItem = item;
 
             apiClient.getCurrentUser().then(function (user) {
-                itemContextMenu.show(getContextMenuOptions(selectedItem, user, button))
+                itemContextMenu.show(getContextMenuOptions(selectedItem, user, button, collectionItemId))
                     .then(function (result) {
                         if (result.deleted) {
                             const parentId = selectedItem.SeasonId || selectedItem.SeriesId || selectedItem.ParentId;


### PR DESCRIPTION
**Changes**
- Use the parent item id when adding to collections from the item details page, even when a specific version is selected.
- Keep other context menu actions using the selected media item.

**Issues**
Fixes #1858

Note: Code change done by codex (gpt-5.2-codex)