### PR TITLE
Use HTMLMediaElement.loop for RepeatOne mode if applicable

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -4130,6 +4130,10 @@ export class PlaybackManager {
             return player.setRepeatMode(value);
         }
 
+        if (player && typeof player.setNativeLoop === 'function') {
+            player.setNativeLoop(value === 'RepeatOne');
+        }
+
         this._playQueueManager.setRepeatMode(value);
         Events.trigger(player, 'repeatmodechange');
     }

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -206,6 +206,14 @@ export class HtmlVideoPlayer {
      */
     isFetching = false;
     /**
+     * Do we try to use the native loop property on the underlying video element
+     * When true, and the underlying options actually takes effect, we no longer emits
+     * 'stopped' events
+     *
+     * @type {boolean}
+     */
+    isNativeLoop = false;
+    /**
      * @type {HTMLDivElement | null | undefined}
      */
     #videoDialog;
@@ -406,6 +414,13 @@ export class HtmlVideoPlayer {
 
         await this.updateVideoUrl(options);
         return this.setCurrentSrc(elem, options);
+    }
+
+    setNativeLoop(loop) {
+        this.isNativeLoop = loop;
+        if (this.#mediaElement && 'loop' in this.#mediaElement) {
+            this.#mediaElement.loop = loop;
+        }
     }
 
     /**
@@ -1652,6 +1667,10 @@ export class HtmlVideoPlayer {
                 videoElement.addEventListener('waiting', this.onWaiting);
                 if (options.backdropUrl) {
                     videoElement.poster = options.backdropUrl;
+                }
+
+                if ('loop' in videoElement) {
+                    videoElement.loop = this.isNativeLoop;
                 }
 
                 document.body.insertBefore(playerDlg, document.body.firstChild);


### PR DESCRIPTION
This PR allows HTML Video Player to use `HTMLMediaElement.loop` to facilitate the repeat one mode if applicable.

When set to RepeatOne mode, if the platform supports `HTMLMediaElement.loop`, the player won't emit the 'stopped' event when playback ends, instead should just loop. For platforms that do not or incorrectly implement `HTMLMediaElement.loop`, it should fallback to the old behavior, that playback manager handles the repeat mode.

Tested on: Chrome 146.0.7670.2 (Windows), Firefox 147.0.3 (Windows)

**Motivation**
Right now upon repeating, the entire player gets destroyed and recreated, which causes additional delay and buffering. This is especially noticeable with short videos.

**Changes**
Adds a public method in HtmlVideoPlayer: `setNativeLoop`.

When setting RepeatMode, PlaybackManager now invokes the player's `setNativeLoop` method if it exists.

**Issues**
N/A
