### PR TITLE
Skipping subfolders during 'play all from here'

### DIFF
--- a/src/components/shortcuts.js
+++ b/src/components/shortcuts.js
@@ -34,13 +34,13 @@ function playAllFromHere(card, serverId, queue) {
             const filteredItems = result.Items.filter(item => item.Type !== 'Folder');
             if (queue) {
                 return playbackManager.queue({
-                    items: filteredItems,
+                    items: filteredItems
                 });
             } else {
                 const filteredStartIndex = filteredItems.findIndex(item => item.Id === startId);
                 return playbackManager.play({
                     items: filteredItems,
-                    startIndex: filteredStartIndex,
+                    startIndex: filteredStartIndex
                 });
             }
         });
@@ -50,7 +50,7 @@ function playAllFromHere(card, serverId, queue) {
     let ids = cardsArray
         .filter(c => c.getAttribute('data-type') !== 'Folder')
         .map(c => c.getAttribute('data-id'));
-    let filteredStartIndex = ids.indexOf(startId);
+    const filteredStartIndex = ids.indexOf(startId);
 
     // Sanity check: nobody should play all from a folder
     if (filteredStartIndex === -1) {


### PR DESCRIPTION
Skips all subfolders in the view when using 'play all from here'.

**Changes**
This PR does two things:
1. Filters out folders when selecting 'play all from here', to avoid them interfering with backend data requests.
2. Makes sure playback manager uses the item that's going to be played first as the filter that is sent to backend.

Do we need to remap startIndex according to backend-returned data?

**Issues**
Fixes #7583 
