### PR TITLE
Fix forced subtitle background in Chromium

### DIFF
--- a/src/apps/stable/features/playback/utils/subtitleStyles.ts
+++ b/src/apps/stable/features/playback/utils/subtitleStyles.ts
@@ -38,6 +38,10 @@ export function useCustomSubtitles(userSettings: UserSettings) {
             // iOS/macOS global caption settings are causing huge font-size and margins
             if (browser.safari) return true;
 
+            // Native cue rendering in Chromium can force subtitle background boxes
+            // even when subtitle background is configured as transparent.
+            if (browser.chrome) return true;
+
             return false;
     }
 }

--- a/src/plugins/htmlVideoPlayer/style.scss
+++ b/src/plugins/htmlVideoPlayer/style.scss
@@ -68,12 +68,12 @@ video[controls]::-webkit-media-controls {
 
 .videoSubtitlesInner {
     max-width: 70%;
-    background-color: rgba(0, 0, 0, 0.8);
+    background-color: transparent;
 }
 
 .videoSecondarySubtitlesInner {
     max-width: 70%;
-    background-color: rgba(0, 0, 0, 0.8);
+    background-color: transparent;
     min-height: 0 !important;
     margin-top: 0.5em !important;
     margin-bottom: 0.5em !important;

--- a/src/scripts/browser.d.ts
+++ b/src/scripts/browser.d.ts
@@ -10,6 +10,7 @@ declare namespace browser {
     export { versionMajor };
     export let edge: boolean;
     export let edgeChromium: boolean;
+    export let chrome: boolean;
     export let firefox: boolean;
     export let safari: boolean;
     export let osx: boolean;


### PR DESCRIPTION
**Changes**
- Force custom subtitle rendering on Chromium to avoid unwanted background boxes on native cues.
- Ensure subtitle container background is transparent.

**Issues**
Fixes #1425

Note: Code done by codex (gpt-5.3-codex)
