### PR TITLE
Fix Chromecast disconnect crash due to null player in MediaSessionSubscriber

### DIFF
--- a/src/apps/stable/features/playback/utils/mediaSessionSubscriber.ts
+++ b/src/apps/stable/features/playback/utils/mediaSessionSubscriber.ts
@@ -96,15 +96,17 @@ class MediaSessionSubscriber extends PlaybackSubscriber {
 
     private onMediaSessionUpdate(
         { type: action }: Event,
-        stateOverride?: PlayerState
+        state?: PlayerState
     ) {
-        if (!this.player) {
-            console.debug('[MediaSessionSubscriber] no active player; resetting media session');
-            return resetMediaSession();
+        if (!state) {
+            if (!this.player) {
+                console.debug('[MediaSessionSubscriber] no active player; resetting media session');
+                return resetMediaSession();
+            }
+            state = this.playbackManager.getPlayerState(this.player);
         }
 
-        const state: PlayerState = stateOverride || this.playbackManager.getPlayerState(this.player);
-        const item = state.NowPlayingItem;
+        const item = state?.NowPlayingItem;
 
         if (!item) {
             console.debug('[MediaSessionSubscriber] no now playing item; resetting media session', state);
@@ -150,10 +152,10 @@ class MediaSessionSubscriber extends PlaybackSubscriber {
                 artist,
                 album,
                 duration: item.RunTimeTicks ? Math.round(item.RunTimeTicks / TICKS_PER_MILLISECOND) : 0,
-                position: state.PlayState.PositionTicks ? Math.round(state.PlayState.PositionTicks / TICKS_PER_MILLISECOND) : 0,
+                position: state?.PlayState.PositionTicks ? Math.round(state.PlayState.PositionTicks / TICKS_PER_MILLISECOND) : 0,
                 imageUrl: getImageUrl(item, { maxHeight: 3_000 }),
-                canSeek: !!state.PlayState.CanSeek,
-                isPaused: !!state.PlayState.IsPaused
+                canSeek: !!state?.PlayState.CanSeek,
+                isPaused: !!state?.PlayState.IsPaused
             });
         }
     }


### PR DESCRIPTION
When disconnecting from a Chromecast, `setCurrentPlayerInternal(null, null)` is called, which triggers a `playerchange` event. By the time `MediaSessionSubscriber.onPlayerChange()` fires, `this.player` has already been set to null by `PlaybackSubscriber.bindPlayerEvents()`. The original code used a default parameter that eagerly called `getPlayerState(this.player)`, which throws when player is null.

This change guards against a null player by checking `this.player` before calling `getPlayerState()`. When there is no active player, reset the media session instead.

Note: The `?.` optional chaining on `state` in the rest of the function is a TypeScript concession. After the guard, `state` is always defined, but TS can't narrow through reassignment of an optional parameter.

Fixes #7585