### PR TITLE
Fix duplicate DOM elements when navigating to same page

### DIFF
--- a/src/components/viewContainer.js
+++ b/src/components/viewContainer.js
@@ -38,6 +38,18 @@ export function loadView(options) {
             pageIndex = 0;
         }
 
+        // Remove any previous cached page for the same URL to prevent
+        // duplicate DOM elements (e.g. duplicate #indexPage ids)
+        const mainAnimatedPagesContainer = getMainAnimatedPages();
+        for (let i = 0; i < allPages.length; i++) {
+            if (i !== pageIndex && currentUrls[i] === options.url && allPages[i]) {
+                triggerDestroy(allPages[i]);
+                mainAnimatedPagesContainer?.removeChild(allPages[i]);
+                allPages[i] = null;
+                currentUrls[i] = null;
+            }
+        }
+
         const isPluginpage = options.url.includes('configurationpage');
         const newViewInfo = normalizeNewView(options, isPluginpage);
         const newView = newViewInfo.elem;
@@ -166,7 +178,7 @@ function normalizeNewView(options, isPluginpage) {
 
 function beforeAnimate(allPages, newPageIndex, oldPageIndex) {
     for (let index = 0, length = allPages.length; index < length; index++) {
-        if (newPageIndex !== index && oldPageIndex !== index) {
+        if (newPageIndex !== index && oldPageIndex !== index && allPages[index]) {
             allPages[index].classList.add('hide');
         }
     }
@@ -174,7 +186,7 @@ function beforeAnimate(allPages, newPageIndex, oldPageIndex) {
 
 function afterAnimate(allPages, newPageIndex) {
     for (let index = 0, length = allPages.length; index < length; index++) {
-        if (newPageIndex !== index) {
+        if (newPageIndex !== index && allPages[index]) {
             allPages[index].classList.add('hide');
         }
     }


### PR DESCRIPTION
The view container uses a 3-slot page rotation. When navigating to a page via push navigation (e.g. clicking the Home button), `loadView` creates a fresh page in the next slot without removing any existing cached instance of the same page in another slot. This results in duplicate DOM elements with the same id attribute.

For example: Home (slot 0) → Movie (slot 1) → Home (slot 2) leaves two `#indexPage` divs in the DOM, one visible and one hidden.

This change cleans up any existing cached page with the same URL before creating a new one. It also adds null checks in `beforeAnimate`/`afterAnimate` for cleared slots

Fixes #7570
