### PR TITLE
Fix dialog box not appearing for chromecast disconnect

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -103,6 +103,7 @@
 - [TheBosZ](https://github.com/thebosz)
 - [qm3jp](https://github.com/qm3jp)
 - [johnnyg](https://github.com/johnnyg)
+- [Alex Sanchez-Stern](https://github.com/HazardousPeach)
 
 ## Emby Contributors
 

--- a/src/apps/experimental/components/AppToolbar/menus/RemotePlayActiveMenu.tsx
+++ b/src/apps/experimental/components/AppToolbar/menus/RemotePlayActiveMenu.tsx
@@ -67,7 +67,9 @@ const RemotePlayActiveMenu: FC<RemotePlayActiveMenuProps> = ({
                 onMenuClose();
 
                 if (id === 'yes') {
-                    playbackManager.getCurrentPlayer().endSession();
+                    playbackManager.sendCommand(
+                        { Name: 'EndSession' },
+                        playbackManager.getCurrentPlayer());
                 }
                 playbackManager.setDefaultPlayerActive();
             }).catch(() => {

--- a/src/apps/stable/features/playback/utils/playbackSubscriber.ts
+++ b/src/apps/stable/features/playback/utils/playbackSubscriber.ts
@@ -42,7 +42,7 @@ export interface PlaybackSubscriber {
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export abstract class PlaybackSubscriber {
-    protected player: PlayerPlugin | undefined;
+    protected player: PlayerPlugin | null = null;
 
     private readonly playbackManagerEvents = {
         [PlaybackManagerEvent.PlaybackCancelled]: this.onPlaybackCancelled?.bind(this),

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -3736,6 +3736,7 @@ export class PlaybackManager {
         this._skipSegment = bindSkipSegment(self);
     }
 
+    /** @returns {import('types/plugin').PlayerPlugin | null} */
     getCurrentPlayer() {
         return this._currentPlayer;
     }
@@ -4287,6 +4288,12 @@ export class PlaybackManager {
             case 'ToggleFullscreen':
                 this.toggleFullscreen(player);
                 break;
+            case 'EndSession':
+                if ('endSession' in player && typeof player.endSession === 'function') {
+                    player.endSession();
+                    break;
+                }
+                // falls through
             default:
                 if (player.sendCommand) {
                     player.sendCommand(cmd);

--- a/src/components/playback/playerSelectionMenu.js
+++ b/src/components/playback/playerSelectionMenu.js
@@ -149,7 +149,9 @@ function disconnectFromPlayer(currentDeviceName) {
         }).then(function (id) {
             switch (id) {
                 case 'yes':
-                    playbackManager.getCurrentPlayer().endSession();
+                    playbackManager.sendCommand(
+                        { Name: 'EndSession' },
+                        playbackManager.getCurrentPlayer());
                     playbackManager.setDefaultPlayerActive();
                     break;
                 case 'no':

--- a/src/plugins/chromecastPlayer/plugin.js
+++ b/src/plugins/chromecastPlayer/plugin.js
@@ -678,7 +678,8 @@ class ChromecastPlayer {
                 'SetAudioStreamIndex',
                 'SetSubtitleStreamIndex',
                 'DisplayContent',
-                'SetRepeatMode'
+                'SetRepeatMode',
+                'EndSession'
             ]
         };
     }


### PR DESCRIPTION
Fix a bug introduced in 588e9e38f7 preventing the chromecast from being detected as supporting ending a session, causing the dialog box about whether you want to end the session or not to not appear.

**Background**

There are two supported ways for Jellyfin to end a session with a PlayerPlugin: sending an "EndSession" command, or calling endSession on the chromecast SDK. The code used to check if the PlayerPlugin listed "EndSession" as a supported command, and if so, called the endSession method. But, the chromecast doesn't actually support "EndSession" as a message, so someone removed it from the list of supported messages, even though its the only PlayerPlugin that has the endSession method that is actually called.

I think this logic also would have failed if a remote session player reported EndSession as a supported command, since the remote session player plugin doesn't have an endSession method.

**Changes**

I added a type annotation into plugin manager that would surface some of the duck-typed weirdness leading to these edge cases. Instead of calling endSession when the "EndSession" **message** is supported, I just call sendMessage with that message. Then, I changed the chromecast plugin to report the EndSession message as supported, but added another case in sendMessage that would call endSession on anything that had it on the EndSession command. This should fix both the chromecast issue and any weirdness with other remote sessions that did support EndSession as a message (not a method).

The type annotation surfaced one other bug, that this.player was typed as PlayerPlugin | undefined, but it was copied from a place that was actually PlayerPlugin | null, so I fixed that there too, hope that's the right thing for this maintainer community.

**Issues**
Fixes #7591