### PR TITLE
ux: right align form dialog buttons

### DIFF
--- a/src/components/formdialog.scss
+++ b/src/components/formdialog.scss
@@ -61,13 +61,13 @@
     left: 0;
     right: 0;
     display: flex;
+    justify-content: flex-end;
     position: absolute;
     padding: 1em 1em;
 
     /* Without this emby-checkbox is able to appear on top */
     z-index: 1;
     align-items: flex-end;
-    justify-content: center;
     flex-wrap: wrap;
 }
 

--- a/src/components/metadataEditor/metadataEditor.template.html
+++ b/src/components/metadataEditor/metadataEditor.template.html
@@ -266,7 +266,7 @@
                 </div>
             </div>
             <br />
-            <div class="formDialogFooter">
+            <div class="formDialogFooter" style="display: flex; justify-content: flex-end;">
                 <button is="emby-button" type="button" class="raised button-cancel block btnCancel formDialogFooterItem">
                     <span>${ButtonCancel}</span>
                 </button>


### PR DESCRIPTION
**Changes**
    
Adjust the button placement in the metadata editor and various dialogs for a more visually-appealing experience and improved usability. This revision right aligns the buttons in a flex container, rather than stacking or centering them.

Happy to make any adjustments, just let me know :-)

Chat on Matrix -> https://matrix.to/#/!xrSDQsdjElWFYUAMoG:matrix.org/$LgwuQXenP0CF5fzyXQbuF9trRcacuTRkCcoUrXu_RL0?via=bonifacelabs.ca&via=t2bot.io&via=matrix.org

**Screenshots**

Before:

<img height="256" alt="jellyfin home brandonrichardson ca_web_ (2)" src="https://github.com/user-attachments/assets/72a73ac1-0163-4fc3-8466-10105e82c218" />
<img height="256" alt="jellyfin home brandonrichardson ca_web_ (4)" src="https://github.com/user-attachments/assets/38ca071d-1129-4dfc-abfc-a63dca19d4e8" />

After:

<img height="256" alt="jellyfin home brandonrichardson ca_web_ (1)" src="https://github.com/user-attachments/assets/ec4f4af2-96ca-4f7c-b30d-ba6cc0c8e41e" />
<img height="256" alt="jellyfin home brandonrichardson ca_web_ (3)" src="https://github.com/user-attachments/assets/52e8c9e4-9985-4160-9bc1-df01de223a69" />

## Disclosure

These changes are completely organic, written by myself, **without** the use of AI. I just want to make this clear, given the current landscape..
