### PR TITLE
Revert position change on Poster on details page (.detailImageContainer .card)

### DIFF
--- a/src/styles/librarybrowser.scss
+++ b/src/styles/librarybrowser.scss
@@ -833,7 +833,7 @@
 }
 
 .detailImageContainer .card {
-    position: relative;
+    position: absolute;
     float: left;
     top: 20%;
     max-width: 25vw;


### PR DESCRIPTION
This lets detailPagePrimaryContainer shrink its height smaller than the poster card. On particularly wide or large displays (native 4k), this allows the detailPageSecondaryContent to display directly underneath the other PrimaryContent instead of awkwardly underneath the bottom of the large poster, well below-the-fold.
It reverts a change in #7195 , while the other changes in that PR seem to successfully prevent the initial bug it was targeting.



 
 |Before:|After|
|---|---|
|<img width="3934" height="2056" alt="Screenshot_20260215_230356-1" src="https://github.com/user-attachments/assets/fe3e6a1a-d764-4b0b-9903-d358d99838c2" />|<img width="3922" height="2055" alt="Screenshot_20260215_230127" src="https://github.com/user-attachments/assets/c599cbff-a256-4596-b8ca-6c0b481ba916" />|

Fixes #7511 