### PR TITLE
Add toggle for truncating titles in list view

### DIFF
--- a/src/components/listview/listview.js
+++ b/src/components/listview/listview.js
@@ -130,7 +130,7 @@ function getChannelImageUrl(item, size) {
     }
 }
 
-function getTextLinesHtml(textlines, isLargeStyle) {
+function getTextLinesHtml(textlines, isLargeStyle, truncate) {
     let html = '';
 
     const largeTitleTagName = layoutManager.tv ? 'h2' : 'div';
@@ -154,6 +154,10 @@ function getTextLinesHtml(textlines, isLargeStyle) {
         }
 
         elem.classList.add('listItemBodyText');
+
+        if (truncate) {
+            elem.classList.add('listItemBodyText-truncate');
+        }
 
         elem.innerHTML = '<bdi>' + escapeHtml(text) + '</bdi>';
 
@@ -405,7 +409,7 @@ export function getListViewHtml(options) {
 
         html += `<div class="${cssClass}">`;
 
-        html += getTextLinesHtml(textlines, isLargeStyle);
+        html += getTextLinesHtml(textlines, isLargeStyle, options.truncateLongTitles);
 
         if (options.mediaInfo !== false && !enableSideMediaInfo) {
             const mediaInfoClass = 'secondary listItemMediaInfo listItemBodyText';

--- a/src/components/listview/listview.scss
+++ b/src/components/listview/listview.scss
@@ -127,6 +127,7 @@
     padding: 0.1em 0;
     overflow: hidden;
     text-overflow: ellipsis;
+    overflow-wrap: anywhere;
     font-weight: 400;
 }
 
@@ -134,8 +135,8 @@
     line-height: 1.2em;
 }
 
-.listItemBodyText-nowrap {
-    white-space: nowrap;
+.listItemBodyText-truncate {
+    overflow-wrap: normal;
 }
 
 .listItemImage {

--- a/src/components/viewSettings/viewSettings.js
+++ b/src/components/viewSettings/viewSettings.js
@@ -101,6 +101,7 @@ class ViewSettings {
             dlg.querySelector('.selectImageType').addEventListener('change', function () {
                 showIfAllowed(dlg, '.chkTitleContainer', this.value !== 'list' && this.value !== 'banner');
                 showIfAllowed(dlg, '.chkYearContainer', this.value !== 'list' && this.value !== 'banner');
+                showIfAllowed(dlg, '.chkTruncateContainer', this.value === 'list');
             });
 
             dlg.querySelector('.btnCancel').addEventListener('click', function () {

--- a/src/components/viewSettings/viewSettings.template.html
+++ b/src/components/viewSettings/viewSettings.template.html
@@ -29,6 +29,13 @@
                     </label>
                 </div>
 
+                <div class="checkboxContainer viewSetting viewSetting-checkboxContainer hide chkTruncateContainer" data-settingname="truncateLongTitles">
+                    <label>
+                        <input is="emby-checkbox" type="checkbox" class="chkTruncateLongTitles" />
+                        <span>${TruncateLongTitles}</span>
+                    </label>
+                </div>
+
                 <div class="checkboxContainer viewSetting viewSetting-checkboxContainer hide" data-settingname="groupBySeries">
                     <label>
                         <input is="emby-checkbox" type="checkbox" class="chkGroupBySeries" />

--- a/src/controllers/list.js
+++ b/src/controllers/list.js
@@ -1207,8 +1207,7 @@ class ItemsView {
             fields.push('imageType');
         }
 
-        fields.push('viewType');
-        fields.push('truncateLongTitles');
+        fields.push('viewType', 'truncateLongTitles');
         return fields;
     }
 

--- a/src/controllers/list.js
+++ b/src/controllers/list.js
@@ -519,7 +519,8 @@ class ItemsView {
 
             if (settings.imageType === 'list') {
                 return listView.getListViewHtml({
-                    items: items
+                    items: items,
+                    truncateLongTitles: settings.truncateLongTitles
                 });
             }
 
@@ -1207,6 +1208,7 @@ class ItemsView {
         }
 
         fields.push('viewType');
+        fields.push('truncateLongTitles');
         return fields;
     }
 
@@ -1240,7 +1242,8 @@ class ItemsView {
             showTitle,
             showYear: userSettings.get(basekey + '-showYear') !== 'false',
             imageType: imageType || 'primary',
-            viewType: userSettings.get(basekey + '-viewType') || 'images'
+            viewType: userSettings.get(basekey + '-viewType') || 'images',
+            truncateLongTitles: userSettings.get(basekey + '-truncateLongTitles') !== 'false'
         };
     }
 

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1642,6 +1642,7 @@
     "Trailers": "Trailers",
     "Transcoding": "Transcoding",
     "TranscodingLoadError": "Failed to load transcoding settings",
+    "TruncateLongTitles": "Truncate long titles",
     "Translator": "Translator",
     "Tuesday": "Tuesday",
     "TV": "TV",

--- a/src/styles/librarybrowser.scss
+++ b/src/styles/librarybrowser.scss
@@ -1162,6 +1162,7 @@ div.itemDetailGalleryLink.defaultCardBackground {
 .mediaInfoStreamType {
     display: block;
     margin: 0.622em 0; /* copy button height compensation */
+    overflow-wrap: anywhere;
 }
 
 .layout-tv .mediaInfoStreamType {
@@ -1171,6 +1172,10 @@ div.itemDetailGalleryLink.defaultCardBackground {
 .mediaInfoAttribute,
 .mediaInfoLabel {
     display: inline-block;
+}
+
+.mediaInfoAttribute {
+    overflow-wrap: anywhere;
 }
 
 .mediaInfoLabel {


### PR DESCRIPTION
Media titles or filenames that lack [normal word break points](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/overflow-wrap#normal) are hidden with ellipsis. In the "Media Info" view, these titles are allowed to overflow. Long titles become impossible to view fully, particularly on platforms where mouse hover tooltips are unavailable.

**Changes**
- Add an option for the List view that allows the user to disable truncating long titles. Defaults to checked, which is the existing behavior.
  <img width="300" alt="Screenshot from 2026-02-19 14-11-15" src="https://github.com/user-attachments/assets/15d51973-88ac-4fea-9253-de453727dbe7" />

  Checked (existing behavior):
  <img width="300" alt="Screenshot from 2026-02-19 14-11-30" src="https://github.com/user-attachments/assets/ec639542-e9a6-4a49-bb43-3362d4c4bcc7" />

  Unchecked:
  <img width="300" alt="Screenshot from 2026-02-19 14-11-42" src="https://github.com/user-attachments/assets/8f477cb3-af6d-4df2-8577-3a2e4b55b30a" />

- Tweak Media Info CSS to allow wrapping.

  Before:
  <img width="300" alt="Screenshot from 2026-02-19 12-07-18" src="https://github.com/user-attachments/assets/32c97238-9103-4591-ac77-8a8f3c54fb6b" />

  After:
  <img width="300" alt="Screenshot from 2026-02-19 12-07-00" src="https://github.com/user-attachments/assets/e568bd24-3a14-440b-93f5-cc8d2e725bc8" />
  
**Alternatives**
The setting complexity could be avoided by simply changing the CSS and making this the default behavior moving forward.