### PR TITLE
Mitigate pull_request_target privilege escalation

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,7 +5,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - master
       - release*


### PR DESCRIPTION
Hotfix: replace `pull_request_target` with `pull_request` to stop granting write permissions and secret access to fork PRs.

Some workflows will break (PR comments, labeling, deploy previews). Can be restored later with `workflow_run`.

https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/

See also: https://github.com/jellyfin/jellyfin-web/pull/7555