### PR TITLE
Handle Seasons in recently added

### DIFF
--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -372,7 +372,7 @@ function getCardFooterText(item, apiClient, options, footerClass, progressHtml, 
     let titleAdded;
 
     if (showOtherText && (options.showParentTitle || options.showParentTitleOrTitle) && !parentTitleUnderneath) {
-        if (flags.isOuterFooter && item.Type === 'Episode' && item.SeriesName) {
+        if (flags.isOuterFooter && (item.Type === 'Episode' || item.Type === 'Season') && item.SeriesName) {
             if (item.SeriesId) {
                 lines.push(getTextActionButton({
                     Id: item.SeriesId,


### PR DESCRIPTION
https://github.com/jellyfin/jellyfin/pull/16062 returns season objects for recently added and right now these don't have a series link in web, this adds the series link to the card