### PR TITLE
Add osdButtons class name

### DIFF
--- a/src/controllers/playback/video/index.html
+++ b/src/controllers/playback/video/index.html
@@ -28,7 +28,7 @@
             </div>
 
             <div class="buttons focuscontainer-x">
-                <div dir="ltr">
+                <div class="osdButtons" dir="ltr">
                     <button is="paper-icon-button-light" class="btnRecord autoSize hide">
                         <span class="xlargePaperIconButton material-icons fiber_manual_record" aria-hidden="true"></span>
                     </button>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

This PR adds a class name "osdButtons" to the div encapsulating playback control buttons.

This allows users to customize the placement of these buttons. The buttons could be placed in the middle of the screen by using the following custom CSS: 

```css
.osdButtons {
  position: fixed !important;
  top: 50%;
  left: 50%;
  transform: translate(-50%, -50%);
}
```

I have found that this makes the UX much better on mobile phones where the default proximity between the play/pause button and the slider caused me on multiple occasions to missclick and move the slider instead of pausing.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->
