### PR TITLE
Add the option to display original titles in cards, lists, and item pages

### DIFF
--- a/src/apps/legacy/features/search/constants/queryOptions.test.ts
+++ b/src/apps/legacy/features/search/constants/queryOptions.test.ts
@@ -1,0 +1,10 @@
+import { ItemFields } from '@jellyfin/sdk/lib/generated-client/models/item-fields';
+import { describe, expect, it } from 'vitest';
+
+import { QUERY_OPTIONS } from './queryOptions';
+
+describe('QUERY_OPTIONS', () => {
+    it('should include OriginalTitle field', () => {
+        expect(QUERY_OPTIONS.fields).toContain(ItemFields.OriginalTitle);
+    });
+});

--- a/src/apps/legacy/features/search/constants/queryOptions.ts
+++ b/src/apps/legacy/features/search/constants/queryOptions.ts
@@ -5,7 +5,8 @@ export const QUERY_OPTIONS = {
     fields: [
         ItemFields.PrimaryImageAspectRatio,
         ItemFields.CanDelete,
-        ItemFields.MediaSourceCount
+        ItemFields.MediaSourceCount,
+        ItemFields.OriginalTitle
     ],
     enableTotalRecordCount: false,
     imageTypeLimit: 1

--- a/src/apps/modern/features/preferences/components/LibraryPreferences.tsx
+++ b/src/apps/modern/features/preferences/components/LibraryPreferences.tsx
@@ -112,6 +112,23 @@ export function LibraryPreferences({ onChange, values }: Readonly<LibraryPrefere
                     {globalize.translate('DisplayMissingEpisodesWithinSeasonsHelp')}
                 </FormHelperText>
             </FormControl>
+
+            <FormControl fullWidth>
+                <FormControlLabel
+                    aria-describedby='display-settings-use-original-titles-description'
+                    control={
+                        <Checkbox
+                            checked={values.useOriginalTitles}
+                            onChange={onChange}
+                        />
+                    }
+                    label={globalize.translate('UseOriginalTitles')}
+                    name='useOriginalTitles'
+                />
+                <FormHelperText id='display-settings-use-original-titles-description'>
+                    {globalize.translate('UseOriginalTitlesHelp')}
+                </FormHelperText>
+            </FormControl>
         </Stack>
     );
 }

--- a/src/apps/modern/features/preferences/hooks/useDisplaySettings.ts
+++ b/src/apps/modern/features/preferences/hooks/useDisplaySettings.ts
@@ -89,6 +89,7 @@ async function loadDisplaySettings({
         dateTimeLocale: settings.dateTimeLocale() || 'auto',
         disableCustomCss: Boolean(settings.disableCustomCss()),
         displayMissingEpisodes: user?.Configuration?.DisplayMissingEpisodes ?? false,
+        useOriginalTitles: Boolean(settings.shouldUseOriginalTitles()),
         enableBlurHash: Boolean(settings.enableBlurhash()),
         enableFasterAnimation: Boolean(settings.enableFastFadein()),
         enableItemDetailsBanner: Boolean(settings.detailsBanner()),
@@ -151,6 +152,7 @@ async function saveDisplaySettings({
     userSettings.backdropScreensaverInterval(newDisplaySettings.backdropScreensaverInterval);
     userSettings.slideshowInterval(newDisplaySettings.slideshowInterval);
     userSettings.theme(newDisplaySettings.theme);
+    userSettings.shouldUseOriginalTitles(newDisplaySettings.useOriginalTitles);
 
     layoutManager.setLayout(normalizeValue(newDisplaySettings.layout));
 

--- a/src/apps/modern/features/preferences/types/displaySettingsValues.ts
+++ b/src/apps/modern/features/preferences/types/displaySettingsValues.ts
@@ -21,4 +21,5 @@ export interface DisplaySettingsValues {
     backdropScreensaverInterval: number;
     slideshowInterval: number;
     theme: string;
+    useOriginalTitles: boolean;
 }

--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -583,7 +583,7 @@ function getCardFooterText(item, apiClient, options, footerClass, progressHtml, 
     }
 
     if (flags.overlayText && showTitle) {
-        lines = [escapeHtml(item.Name)];
+        lines = [escapeHtml(itemHelper.getDisplayName(item))];
     }
 
     const addRightTextMargin = flags.isOuterFooter && options.cardLayout && !options.centerText && options.cardFooterAside !== 'none' && layoutManager.mobile;
@@ -863,7 +863,7 @@ function buildCard(index, item, apiClient, options) {
 
         cardImageContainerClose = '</div>';
     } else {
-        const cardImageContainerAriaLabelAttribute = ` aria-label="${escapeHtml(item.Name)}" role="img"`;
+        const cardImageContainerAriaLabelAttribute = ` aria-label="${escapeHtml(itemHelper.getDisplayName(item))}" role="img"`;
 
         const url = appRouter.getRouteUrl(item);
         // Don't use the IMG tag with safari because it puts a white border around it
@@ -946,7 +946,7 @@ function buildCard(index, item, apiClient, options) {
 
     if (tagName === 'button') {
         actionAttribute = ' data-action="' + action + '"';
-        ariaLabelAttribute = ` aria-label="${escapeHtml(item.Name)}"`;
+        ariaLabelAttribute = ` aria-label="${escapeHtml(itemHelper.getDisplayName(item))}"`;
     } else {
         actionAttribute = '';
     }

--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -586,7 +586,7 @@ function getCardFooterText(item, apiClient, options, footerClass, progressHtml, 
     }
 
     if (flags.overlayText && showTitle) {
-        lines = [escapeHtml(item.Name)];
+        lines = [escapeHtml(itemHelper.getDisplayName(item))];
     }
 
     const addRightTextMargin = flags.isOuterFooter && options.cardLayout && !options.centerText && options.cardFooterAside !== 'none' && layoutManager.mobile;
@@ -866,7 +866,7 @@ function buildCard(index, item, apiClient, options) {
 
         cardImageContainerClose = '</div>';
     } else {
-        const cardImageContainerAriaLabelAttribute = ` aria-label="${escapeHtml(item.Name)}" role="img"`;
+        const cardImageContainerAriaLabelAttribute = ` aria-label="${escapeHtml(itemHelper.getDisplayName(item))}" role="img"`;
 
         const url = appRouter.getRouteUrl(item);
         // Don't use the IMG tag with safari because it puts a white border around it
@@ -949,7 +949,7 @@ function buildCard(index, item, apiClient, options) {
 
     if (tagName === 'button') {
         actionAttribute = ' data-action="' + action + '"';
-        ariaLabelAttribute = ` aria-label="${escapeHtml(item.Name)}"`;
+        ariaLabelAttribute = ` aria-label="${escapeHtml(itemHelper.getDisplayName(item))}"`;
     } else {
         actionAttribute = '';
     }

--- a/src/components/displaySettings/displaySettings.js
+++ b/src/components/displaySettings/displaySettings.js
@@ -122,6 +122,7 @@ function loadForm(context, user, userSettings) {
     context.querySelector('#txtScreensaverTime').value = userSettings.screensaverTime();
 
     context.querySelector('.chkDisplayMissingEpisodes').checked = user.Configuration.DisplayMissingEpisodes || false;
+    context.querySelector('.chkUseOriginalTitles').checked = userSettings.shouldUseOriginalTitles();
 
     context.querySelector('#chkThemeSong').checked = userSettings.enableThemeSongs();
     context.querySelector('#chkThemeVideo').checked = userSettings.enableThemeVideos();
@@ -151,6 +152,7 @@ function loadForm(context, user, userSettings) {
 
 function saveUser(context, user, userSettingsInstance, apiClient) {
     user.Configuration.DisplayMissingEpisodes = context.querySelector('.chkDisplayMissingEpisodes').checked;
+    userSettingsInstance.shouldUseOriginalTitles(context.querySelector('.chkUseOriginalTitles').checked);
 
     if (appHost.supports(AppFeature.DisplayLanguage)) {
         userSettingsInstance.language(context.querySelector('#selectLanguage').value);

--- a/src/components/displaySettings/displaySettings.template.html
+++ b/src/components/displaySettings/displaySettings.template.html
@@ -275,6 +275,14 @@
         <div class="fieldDescription checkboxFieldDescription">${DisplayMissingEpisodesWithinSeasonsHelp}</div>
     </div>
 
+    <div class="checkboxContainer checkboxContainer-withDescription">
+        <label>
+            <input type="checkbox" is="emby-checkbox" class="chkUseOriginalTitles" />
+            <span>${UseOriginalTitles}</span>
+        </label>
+        <div class="fieldDescription checkboxFieldDescription">${UseOriginalTitlesHelp}</div>
+    </div>
+
     <h2 class="sectionTitle">
         ${NextUp}
     </h2>

--- a/src/components/itemHelper.js
+++ b/src/components/itemHelper.js
@@ -9,6 +9,7 @@ import { appHost } from './apphost';
 import { AppFeature } from 'constants/appFeature';
 import globalize from 'lib/globalize';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
+import { shouldUseOriginalTitles } from 'scripts/settings/userSettings';
 
 export function getDisplayName(item, options = {}) {
     if (!item) {
@@ -19,7 +20,12 @@ export function getDisplayName(item, options = {}) {
         item = item.ProgramInfo || item;
     }
 
-    let name = ((item.Type === 'Program' || item.Type === 'Recording') && (item.IsSeries || item.EpisodeTitle) ? item.EpisodeTitle : item.Name) || '';
+    let baseName = item.Name;
+    if (shouldUseOriginalTitles() && item.OriginalTitle) {
+        baseName = item.OriginalTitle;
+    }
+
+    let name = ((item.Type === 'Program' || item.Type === 'Recording') && (item.IsSeries || item.EpisodeTitle) ? item.EpisodeTitle : baseName) || '';
 
     if (item.Type === 'TvChannel') {
         if (item.ChannelNumber) {

--- a/src/components/itemHelper.test.js
+++ b/src/components/itemHelper.test.js
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { getDisplayName } from './itemHelper';
+
+vi.mock('./apphost', () => ({ appHost: { supports: vi.fn() } }));
+vi.mock('lib/globalize', () => ({ default: { translate: vi.fn((key, ...args) => args[0] ?? key) } }));
+vi.mock('lib/jellyfin-apiclient', () => ({ ServerConnections: {} }));
+vi.mock('utils/jellyfin-apiclient/compat', () => ({ toApi: vi.fn() }));
+vi.mock('scripts/settings/userSettings', () => ({ shouldUseOriginalTitles: vi.fn() }));
+
+import { shouldUseOriginalTitles } from 'scripts/settings/userSettings';
+
+describe('getDisplayName', () => {
+    describe('shouldUseOriginalTitles preference', () => {
+        it('should return OriginalTitle when preference is enabled and OriginalTitle is available', () => {
+            shouldUseOriginalTitles.mockReturnValue(true);
+            const item = { Type: 'Movie', Name: 'Spirited Away', OriginalTitle: '千と千尋の神隠し' };
+            expect(getDisplayName(item)).toBe('千と千尋の神隠し');
+        });
+
+        it('should return Name when preference is enabled but OriginalTitle is not set', () => {
+            shouldUseOriginalTitles.mockReturnValue(true);
+            const item = { Type: 'Movie', Name: 'Spirited Away' };
+            expect(getDisplayName(item)).toBe('Spirited Away');
+        });
+
+        it('should return Name when preference is disabled even if OriginalTitle is available', () => {
+            shouldUseOriginalTitles.mockReturnValue(false);
+            const item = { Type: 'Movie', Name: 'Spirited Away', OriginalTitle: '千と千尋の神隠し' };
+            expect(getDisplayName(item)).toBe('Spirited Away');
+        });
+
+        it('should return EpisodeTitle for Program regardless of OriginalTitle when preference is enabled', () => {
+            shouldUseOriginalTitles.mockReturnValue(true);
+            const item = { Type: 'Program', Name: 'Show Name', OriginalTitle: 'Original Show Name', EpisodeTitle: 'Episode Title' };
+            expect(getDisplayName(item)).toBe('Episode Title');
+        });
+    });
+});

--- a/src/components/listview/List/useList.ts
+++ b/src/components/listview/List/useList.ts
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import layoutManager from 'components/layoutManager';
 import { ItemAction } from 'constants/itemAction';
 import { getDataAttributes } from 'utils/items';
+import itemHelper from 'components/itemHelper';
 
 import type { ItemDto } from 'types/base/models/item-dto';
 import type { ListOptions } from 'types/listOptions';
@@ -53,7 +54,7 @@ function useList({ item, listOptions }: UseListProps) {
 
     const getListdWrapperProps = () => ({
         className: listWrapperClass,
-        title: item.Name,
+        title: itemHelper.getDisplayName(item),
         action,
         dataAttributes
     });

--- a/src/hooks/useFetchItems.ts
+++ b/src/hooks/useFetchItems.ts
@@ -24,6 +24,7 @@ import globalize from 'lib/globalize';
 
 import { type JellyfinApiContext, useApi } from './useApi';
 import { getAlphaPickerQuery, getFieldsQuery, getFiltersQuery, getLimitQuery } from 'utils/items';
+import { shouldUseOriginalTitles } from 'scripts/settings/userSettings';
 import { getProgramSections, getSuggestionSections } from 'utils/sections';
 
 import type { LibraryViewSettings, ParentId } from 'types/library';
@@ -242,7 +243,7 @@ const fetchGetItemsViewByType = async (
                         userId: user.Id,
                         parentId: parentId ?? undefined,
                         enableImageTypes: [libraryViewSettings.ImageType, ImageType.Backdrop],
-                        ...getFieldsQuery(viewType, libraryViewSettings),
+                        ...getFieldsQuery(viewType, libraryViewSettings, shouldUseOriginalTitles()),
                         ...getFiltersQuery(viewType, libraryViewSettings),
                         ...getLimitQuery(),
                         ...getAlphaPickerQuery(libraryViewSettings),
@@ -263,7 +264,7 @@ const fetchGetItemsViewByType = async (
                         userId: user.Id,
                         parentId: parentId ?? undefined,
                         enableImageTypes: [libraryViewSettings.ImageType, ImageType.Backdrop],
-                        ...getFieldsQuery(viewType, libraryViewSettings),
+                        ...getFieldsQuery(viewType, libraryViewSettings, shouldUseOriginalTitles()),
                         ...getFiltersQuery(viewType, libraryViewSettings),
                         ...getLimitQuery(),
                         ...getAlphaPickerQuery(libraryViewSettings),
@@ -302,7 +303,7 @@ const fetchGetItemsViewByType = async (
                     {
                         userId: user.Id,
                         parentId: parentId ?? undefined,
-                        ...getFieldsQuery(viewType, libraryViewSettings),
+                        ...getFieldsQuery(viewType, libraryViewSettings, shouldUseOriginalTitles()),
                         ...getLimitQuery(),
                         ...getAlphaPickerQuery(libraryViewSettings),
                         includeItemTypes: itemType,
@@ -374,7 +375,7 @@ const fetchGetItemsViewByType = async (
                         imageTypeLimit: 1,
                         parentId: parentId ?? undefined,
                         enableImageTypes: [libraryViewSettings.ImageType, ImageType.Backdrop],
-                        ...getFieldsQuery(viewType, libraryViewSettings),
+                        ...getFieldsQuery(viewType, libraryViewSettings, shouldUseOriginalTitles()),
                         ...getFiltersQuery(viewType, libraryViewSettings),
                         ...getLimitQuery(),
                         ...getAlphaPickerQuery(libraryViewSettings),

--- a/src/hooks/useFetchItems.ts
+++ b/src/hooks/useFetchItems.ts
@@ -23,6 +23,7 @@ import datetime from 'scripts/datetime';
 
 import { type JellyfinApiContext, useApi } from './useApi';
 import { getAlphaPickerQuery, getFieldsQuery, getFiltersQuery, getLimitQuery } from 'utils/items';
+import { shouldUseOriginalTitles } from 'scripts/settings/userSettings';
 import { getProgramSections, getSuggestionSections } from 'utils/sections';
 
 import type { LibraryViewSettings, ParentId } from 'types/library';
@@ -241,7 +242,7 @@ const fetchGetItemsViewByType = async (
                         userId: user.Id,
                         parentId: parentId ?? undefined,
                         enableImageTypes: [libraryViewSettings.ImageType, ImageType.Backdrop],
-                        ...getFieldsQuery(viewType, libraryViewSettings),
+                        ...getFieldsQuery(viewType, libraryViewSettings, shouldUseOriginalTitles()),
                         ...getFiltersQuery(viewType, libraryViewSettings),
                         ...getLimitQuery(),
                         ...getAlphaPickerQuery(libraryViewSettings),
@@ -262,7 +263,7 @@ const fetchGetItemsViewByType = async (
                         userId: user.Id,
                         parentId: parentId ?? undefined,
                         enableImageTypes: [libraryViewSettings.ImageType, ImageType.Backdrop],
-                        ...getFieldsQuery(viewType, libraryViewSettings),
+                        ...getFieldsQuery(viewType, libraryViewSettings, shouldUseOriginalTitles()),
                         ...getFiltersQuery(viewType, libraryViewSettings),
                         ...getLimitQuery(),
                         ...getAlphaPickerQuery(libraryViewSettings),
@@ -301,7 +302,7 @@ const fetchGetItemsViewByType = async (
                     {
                         userId: user.Id,
                         parentId: parentId ?? undefined,
-                        ...getFieldsQuery(viewType, libraryViewSettings),
+                        ...getFieldsQuery(viewType, libraryViewSettings, shouldUseOriginalTitles()),
                         ...getLimitQuery(),
                         ...getAlphaPickerQuery(libraryViewSettings),
                         includeItemTypes: itemType,
@@ -371,7 +372,7 @@ const fetchGetItemsViewByType = async (
                         imageTypeLimit: 1,
                         parentId: parentId ?? undefined,
                         enableImageTypes: [libraryViewSettings.ImageType, ImageType.Backdrop],
-                        ...getFieldsQuery(viewType, libraryViewSettings),
+                        ...getFieldsQuery(viewType, libraryViewSettings, shouldUseOriginalTitles()),
                         ...getFiltersQuery(viewType, libraryViewSettings),
                         ...getLimitQuery(),
                         ...getAlphaPickerQuery(libraryViewSettings),

--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -314,6 +314,19 @@ export class UserSettings {
     }
 
     /**
+     * Get or set 'Use Original Titles' state.
+     * @param {boolean|undefined} [val] - Flag to enable 'Use Original Titles' or undefined.
+     * @return {boolean} 'Use Original Titles' state.
+     */
+    shouldUseOriginalTitles(val) {
+        if (val !== undefined) {
+            return this.set('useOriginalTitles', val.toString(), true);
+        }
+
+        return toBoolean(this.get('useOriginalTitles', true), false);
+    }
+
+    /**
      * Get or set 'disableCustomCss' state.
      * @param {boolean|undefined} [val] - Flag to enable 'disableCustomCss' or undefined.
      * @return {boolean} 'disableCustomCss' state.
@@ -736,6 +749,7 @@ export const enableThemeVideos = currentSettings.enableThemeVideos.bind(currentS
 export const enableFastFadein = currentSettings.enableFastFadein.bind(currentSettings);
 export const enableBlurhash = currentSettings.enableBlurhash.bind(currentSettings);
 export const enableBackdrops = currentSettings.enableBackdrops.bind(currentSettings);
+export const shouldUseOriginalTitles = currentSettings.shouldUseOriginalTitles.bind(currentSettings);
 export const detailsBanner = currentSettings.detailsBanner.bind(currentSettings);
 export const useEpisodeImagesInNextUpAndResume = currentSettings.useEpisodeImagesInNextUpAndResume.bind(currentSettings);
 export const language = currentSettings.language.bind(currentSettings);

--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -315,6 +315,19 @@ export class UserSettings {
     }
 
     /**
+     * Get or set 'Use Original Titles' state.
+     * @param {boolean|undefined} [val] - Flag to enable 'Use Original Titles' or undefined.
+     * @return {boolean} 'Use Original Titles' state.
+     */
+    shouldUseOriginalTitles(val) {
+        if (val !== undefined) {
+            return this.set('useOriginalTitles', val.toString(), true);
+        }
+
+        return toBoolean(this.get('useOriginalTitles', true), false);
+    }
+
+    /**
      * Get or set 'disableCustomCss' state.
      * @param {boolean|undefined} [val] - Flag to enable 'disableCustomCss' or undefined.
      * @return {boolean} 'disableCustomCss' state.
@@ -737,6 +750,7 @@ export const enableThemeVideos = currentSettings.enableThemeVideos.bind(currentS
 export const enableFastFadein = currentSettings.enableFastFadein.bind(currentSettings);
 export const enableBlurhash = currentSettings.enableBlurhash.bind(currentSettings);
 export const enableBackdrops = currentSettings.enableBackdrops.bind(currentSettings);
+export const shouldUseOriginalTitles = currentSettings.shouldUseOriginalTitles.bind(currentSettings);
 export const detailsBanner = currentSettings.detailsBanner.bind(currentSettings);
 export const useEpisodeImagesInNextUpAndResume = currentSettings.useEpisodeImagesInNextUpAndResume.bind(currentSettings);
 export const language = currentSettings.language.bind(currentSettings);

--- a/src/scripts/settings/userSettings.test.js
+++ b/src/scripts/settings/userSettings.test.js
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../utils/events.ts', () => ({ default: { trigger: vi.fn() } }));
+vi.mock('../browser', () => ({ default: {} }));
+vi.mock('./appSettings', () => ({ default: { get: vi.fn(), set: vi.fn() } }));
+
+import appSettings from './appSettings';
+import { UserSettings } from './userSettings';
+
+describe('UserSettings', () => {
+    let settings;
+
+    beforeEach(() => {
+        settings = new UserSettings();
+        vi.clearAllMocks();
+    });
+
+    describe('shouldUseOriginalTitles', () => {
+        it('reads from server display preferences when they are loaded', () => {
+            settings.displayPrefs = { CustomPrefs: { useOriginalTitles: 'true' } };
+
+            expect(settings.shouldUseOriginalTitles()).toBe(true);
+            expect(appSettings.get).not.toHaveBeenCalled();
+        });
+
+        it('reads false from server display preferences when set to false', () => {
+            settings.displayPrefs = { CustomPrefs: { useOriginalTitles: 'false' } };
+
+            expect(settings.shouldUseOriginalTitles()).toBe(false);
+            expect(appSettings.get).not.toHaveBeenCalled();
+        });
+
+        it('server preference takes precedence over local storage value', () => {
+            settings.displayPrefs = { CustomPrefs: { useOriginalTitles: 'true' } };
+            appSettings.get.mockReturnValue('false');
+
+            expect(settings.shouldUseOriginalTitles()).toBe(true);
+        });
+
+        it('falls back to local storage when server preferences are not loaded', () => {
+            settings.displayPrefs = null;
+            appSettings.get.mockReturnValue('true');
+
+            expect(settings.shouldUseOriginalTitles()).toBe(true);
+            expect(appSettings.get).toHaveBeenCalled();
+        });
+    });
+});

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1720,6 +1720,8 @@
     "UseDoubleRateDeinterlacingHelp": "This setting uses the field rate when deinterlacing, often referred to as bob deinterlacing, which doubles the frame rate of the video to provide full motion like what you would see when viewing interlaced video on a TV.",
     "UseEpisodeImagesInNextUp": "Use episode images in 'Next Up' and 'Continue Watching' sections",
     "UseEpisodeImagesInNextUpHelp": "'Next Up' and 'Continue Watching' sections will use episode images as thumbnails instead of the primary thumbnail of the show.",
+    "UseOriginalTitles": "Use original titles",
+    "UseOriginalTitlesHelp": "Display media using the original language title instead of the localized title.",
     "UserAgentHelp": "Supply a custom 'User-Agent' HTTP header.",
     "UserMenu": "User Menu",
     "UsersEditPageError": "Failed to load users edit page",

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1728,6 +1728,8 @@
     "UseDoubleRateDeinterlacingHelp": "This setting uses the field rate when deinterlacing, often referred to as bob deinterlacing, which doubles the frame rate of the video to provide full motion like what you would see when viewing interlaced video on a TV.",
     "UseEpisodeImagesInNextUp": "Use episode images in 'Next Up' and 'Continue Watching' sections",
     "UseEpisodeImagesInNextUpHelp": "'Next Up' and 'Continue Watching' sections will use episode images as thumbnails instead of the primary thumbnail of the show.",
+    "UseOriginalTitles": "Use original titles",
+    "UseOriginalTitlesHelp": "Display media using the original language title instead of the localized title.",
     "UserAgentHelp": "Supply a custom 'User-Agent' HTTP header.",
     "UserMenu": "User Menu",
     "UsersEditPageError": "Failed to load users edit page",

--- a/src/utils/items.test.ts
+++ b/src/utils/items.test.ts
@@ -1,0 +1,41 @@
+import { ItemFields } from '@jellyfin/sdk/lib/generated-client/models/item-fields';
+import { ImageType } from '@jellyfin/sdk/lib/generated-client/models/image-type';
+import { ItemSortBy } from '@jellyfin/sdk/lib/generated-client/models/item-sort-by';
+import { SortOrder } from '@jellyfin/sdk/lib/generated-client/models/sort-order';
+import { describe, expect, it, vi } from 'vitest';
+
+import { LibraryTab } from 'types/libraryTab';
+import { ViewMode } from 'types/library';
+import type { LibraryViewSettings } from 'types/library';
+
+import { getFieldsQuery } from './items';
+
+vi.mock('scripts/settings/userSettings');
+vi.mock('components/layoutManager', () => ({ default: {} }));
+
+const baseSettings: LibraryViewSettings = {
+    SortBy: ItemSortBy.SortName,
+    SortOrder: SortOrder.Ascending,
+    StartIndex: 0,
+    CardLayout: false,
+    ImageType: ImageType.Primary,
+    ViewMode: ViewMode.GridView,
+    ShowTitle: true
+};
+
+describe('getFieldsQuery', () => {
+    it('should include OriginalTitle field when useOriginalTitles is true', () => {
+        const result = getFieldsQuery(LibraryTab.Movies, baseSettings, true);
+        expect(result.fields).toContain(ItemFields.OriginalTitle);
+    });
+
+    it('should not include OriginalTitle field when useOriginalTitles is false', () => {
+        const result = getFieldsQuery(LibraryTab.Movies, baseSettings, false);
+        expect(result.fields).not.toContain(ItemFields.OriginalTitle);
+    });
+
+    it('should not include OriginalTitle field when useOriginalTitles is not provided', () => {
+        const result = getFieldsQuery(LibraryTab.Movies, baseSettings);
+        expect(result.fields).not.toContain(ItemFields.OriginalTitle);
+    });
+});

--- a/src/utils/items.ts
+++ b/src/utils/items.ts
@@ -88,7 +88,8 @@ export const getEpisodeFilter = (
 
 const getItemFieldsEnum = (
     viewType: LibraryTab,
-    libraryViewSettings: LibraryViewSettings
+    libraryViewSettings: LibraryViewSettings,
+    useOriginalTitles?: boolean
 ) => {
     const itemFields: ItemFields[] = [];
 
@@ -107,15 +108,20 @@ const getItemFieldsEnum = (
         );
     }
 
+    if (useOriginalTitles) {
+        itemFields.push(ItemFields.OriginalTitle);
+    }
+
     return itemFields;
 };
 
 export const getFieldsQuery = (
     viewType: LibraryTab,
-    libraryViewSettings: LibraryViewSettings
+    libraryViewSettings: LibraryViewSettings,
+    useOriginalTitles?: boolean
 ) => {
     return {
-        fields: getItemFieldsEnum(viewType, libraryViewSettings)
+        fields: getItemFieldsEnum(viewType, libraryViewSettings, useOriginalTitles)
     };
 };
 


### PR DESCRIPTION
**Changes**
- Add a `Use original titles` toggle in Display Settings, stored via `userSettings` with server sync for cross-device persistence
- Display the `OriginalTitle` throughout the interface (cards, lists, detail pages, search results) when the preference is enabled

**Issues**

**Code assistance**

Claude Sonnet 4.6
