### PR TITLE
Order MediaMetadata.artwork from highest resolution to smallest

### DIFF
--- a/src/apps/stable/features/playback/utils/mediaSessionSubscriber.ts
+++ b/src/apps/stable/features/playback/utils/mediaSessionSubscriber.ts
@@ -11,8 +11,12 @@ import type { ItemDto } from 'types/base/models/item-dto';
 import type { PlayerState } from 'types/playbackStopInfo';
 import type { Event } from 'utils/events';
 
-/** The default image resolutions to provide to the media session */
-const DEFAULT_IMAGE_SIZES = [96, 128, 192, 256, 384, 512];
+/** The default image resolutions to provide to the media session.
+ * 
+ * Highest-to-lowest order matters; Firefox on Linux seems to use the first
+ * image in the artwork array for its MPRIS interface. (#7630)
+ */
+const DEFAULT_IMAGE_SIZES = [512, 384, 256, 192, 128, 96];
 
 const hasNavigatorSession = 'mediaSession' in navigator;
 const hasNativeShell = !!window.NativeShell;


### PR DESCRIPTION


<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Reverse the order of `DEFAULT_IMAGE_SIZES`, which makes `getArtwork` put the highest available resolution image first in the array of images. 

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #7630. When I tested this, Firefox now chooses the highest resolution image to provide to MPRIS.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->
None