### PR TITLE
Fix music video random playback

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -1944,7 +1944,7 @@ export class PlaybackManager {
             } else if (firstItem.IsFolder && firstItem.CollectionType === 'musicvideos') {
                 return getItemsForPlayback(serverId, mergePlaybackQueries({
                     ParentId: firstItem.Id,
-                    Filters: 'IsFolder',
+                    Filters: 'IsNotFolder',
                     Recursive: true,
                     SortBy: options.shuffle ? 'Random' : 'SortName',
                     MediaTypes: 'Video',

--- a/src/controllers/list.js
+++ b/src/controllers/list.js
@@ -334,7 +334,7 @@ function getItems(instance, params, item, sortBy, startIndex, limit) {
 
     if (sortBy === 'Random') {
         instance.queryRecursive = true;
-        query.IncludeItemTypes = 'Video,Movie,Series,Music';
+        query.IncludeItemTypes = 'Video,Movie,Series,Music,MusicVideo';
         query.Recursive = true;
     }
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**
Add `MusicVideo`  to `IncludeItemTypes`  for random playback
Set filter to `IsNotFolder` instead of `IsFolder` in the `playbackmanager` for music video collections

**Issues**
Fixes; https://github.com/jellyfin/jellyfin/issues/16299

**Code assistance**
N/A