### PR TITLE
fix: handle API error when creating user with invalid username

### DIFF
--- a/src/apps/dashboard/routes/users/add.tsx
+++ b/src/apps/dashboard/routes/users/add.tsx
@@ -27,10 +27,12 @@ const UserNew = () => {
     const [ channelsItems, setChannelsItems ] = useState<ItemsArr[]>([]);
     const [ mediaFoldersItems, setMediaFoldersItems ] = useState<ItemsArr[]>([]);
     const [ isErrorToastOpen, setIsErrorToastOpen ] = useState(false);
+    const [ errorMessage, setErrorMessage ] = useState<string | null>(null);
     const element = useRef<HTMLDivElement>(null);
 
     const handleToastClose = useCallback(() => {
         setIsErrorToastOpen(false);
+        setErrorMessage(null);
     }, []);
     const { data: mediaFolders, isSuccess: isMediaFoldersSuccess } = useLibraryMediaFolders();
     const { data: channels, isSuccess: isChannelsSuccess } = useChannels();
@@ -126,6 +128,12 @@ const UserNew = () => {
                 Password: (page.querySelector('#txtPassword') as HTMLInputElement).value
             };
             createUser.mutate({ createUserByName: userInput }, {
+                onError: (error: unknown) => {
+                    loading.hide();
+                    const apiMessage = (error as any)?.response?.data as string | undefined;
+                    setErrorMessage(typeof apiMessage === 'string' && apiMessage ? apiMessage : null);
+                    setIsErrorToastOpen(true);
+                },
                 onSuccess: (response) => {
                     const user = response.data;
 
@@ -214,7 +222,7 @@ const UserNew = () => {
             <Toast
                 open={isErrorToastOpen}
                 onClose={handleToastClose}
-                message={globalize.translate('ErrorDefault')}
+                message={errorMessage ?? globalize.translate('ErrorDefault')}
             />
             <div ref={element} className='content-primary'>
                 <div className='verticalSection'>


### PR DESCRIPTION
Fixes #6384

When the Jellyfin server rejects a new username containing special characters (e.g. `/`, `+`, `&`), the API returns a 400 response. Previously the `createUser` mutation had no `onError` handler, which caused two problems:

1. The loading spinner was never dismissed (infinite load).
2. The error was silently swallowed — no feedback shown to the user.

**Changes:**
- Added an `onError` handler to `createUser.mutate()` that hides the loading spinner and opens the error toast.
- The toast now shows the API's error message if one is present in the response body, falling back to the generic `ErrorDefault` string otherwise (e.g. if the server says "Error processing request." for an invalid username, that text is surfaced to the user).
- `errorMessage` state is reset when the toast is dismissed.