### PR TITLE
Hide #seriesScheduleSection when user has no permission instead of throwing error

### DIFF
--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -1652,6 +1652,12 @@ function renderSeriesSchedule(page, item) {
         imageLoader.lazyChildren(scheduleTab);
 
         loading.hide();
+    }).catch(function (resp) {
+        if (resp.response === 403) {
+            page.querySelector('#seriesScheduleSection').classList.add('hide');
+        }
+
+        loading.hide();
     });
 }
 

--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -1652,8 +1652,8 @@ function renderSeriesSchedule(page, item) {
         imageLoader.lazyChildren(scheduleTab);
 
         loading.hide();
-    }).catch(function (resp) {
-        if (resp.status === 403) {
+    }).catch(function (err) {
+        if (err.status === 403) {
             page.querySelector('#seriesScheduleSection').classList.add('hide');
         }
 

--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -1653,7 +1653,7 @@ function renderSeriesSchedule(page, item) {
 
         loading.hide();
     }).catch(function (resp) {
-        if (resp.response === 403) {
+        if (resp.status === 403) {
             page.querySelector('#seriesScheduleSection').classList.add('hide');
         }
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

**Changes**

When I'm developing with jellyfin-web and open a show as a user without `Allow Live TV access` permission, it will pop up a window saying there are uncaught runtime errors. After check the source code, I found it doesn't process the situation where server returns 403.

**Issues**

Fixes #6977 
