### PR TITLE
Add webOS 24/25 version detection and allow DoVi MKV on webOS 25

### DIFF
--- a/src/scripts/browser.js
+++ b/src/scripts/browser.js
@@ -115,7 +115,11 @@ function web0sVersion(browser) {
 
         // The next is only valid for the app
 
-        if (browser.versionMajor >= 94) {
+        if (browser.versionMajor >= 120) {
+            return 25;
+        } else if (browser.versionMajor >= 108) {
+            return 24;
+        } else if (browser.versionMajor >= 94) {
             return 23;
         } else if (browser.versionMajor >= 87) {
             return 22;

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -1513,10 +1513,13 @@ export default function (options) {
     });
 
     if (browser.web0s && supportsDolbyVision(options)) {
-        // Disallow direct playing of DOVI media in containers not ts or mp4.
+        // Adjust DOVI container rules based on WebOS version.
+        // On WebOS 25 and newer, mp4, ts, and mkv containers are allowed.
+        // On WebOS 24 and lower, only mp4 and ts containers are allowed.
+        const allowedContainers = browser.web0sVersion >= 25 ? ['mp4', 'ts', 'mkv'] : ['mp4', 'ts'];
         profile.CodecProfiles.push({
             Type: 'Video',
-            Container: '-mp4,ts',
+            Container: '-' + allowedContainers.join(','),
             Codec: 'hevc',
             Conditions: [
                 {


### PR DESCRIPTION
webOS 25 (LG 2025 TVs) natively supports Dolby Vision playback from MKV containers. Without proper version detection, these TVs report as webOS 23, and the device profile blocks DoVi in MKV — forcing HLS remux that drops DV metadata to HDR10 and causes audio issues with DTS-HD MA in mpegts segments.

- Add version detection for webOS 24 (Chromium 108+) and webOS 25 (Chromium 120+)
- Allow `mkv` as a valid container for DoVi HEVC direct play on webOS 25+
- Older webOS versions keep the existing mp4/ts restriction

Tested on LG C4 (webOS 25) with DoVi Profile 8.1 MKV.

Addresses jellyfin/jellyfin#16092, jellyfin/jellyfin#16179