### PR TITLE
fix: handle API error when renaming user to an invalid name

### DIFF
--- a/src/apps/dashboard/routes/users/profile.tsx
+++ b/src/apps/dashboard/routes/users/profile.tsx
@@ -13,6 +13,7 @@ import SectionTabs from '../../../../components/dashboard/users/SectionTabs';
 import loading from '../../../../components/loading/loading';
 import SelectElement from '../../../../elements/SelectElement';
 import Page from '../../../../components/Page';
+import Toast from 'apps/dashboard/components/Toast';
 import { useUser } from 'apps/dashboard/features/users/api/useUser';
 import { useAuthProviders } from 'apps/dashboard/features/users/api/useAuthProviders';
 import { usePasswordResetProviders } from 'apps/dashboard/features/users/api/usePasswordResetProviders';
@@ -38,8 +39,13 @@ const UserEdit = () => {
     const [ deleteFoldersAccess, setDeleteFoldersAccess ] = useState<ResetProvider[]>([]);
     const libraryMenu = useMemo(async () => ((await import('../../../../scripts/libraryMenu')).default), []);
 
+    const [ isErrorToastOpen, setIsErrorToastOpen ] = useState(false);
     const [ authenticationProviderId, setAuthenticationProviderId ] = useState('');
     const [ passwordResetProviderId, setPasswordResetProviderId ] = useState('');
+
+    const handleToastClose = useCallback(() => {
+        setIsErrorToastOpen(false);
+    }, []);
 
     const { data: userDto, isSuccess: isUserSuccess } = useUser(userId ? { userId: userId } : undefined);
     const { data: authProviders, isSuccess: isAuthProvidersSuccess } = useAuthProviders();
@@ -266,9 +272,17 @@ const UserEdit = () => {
                                 navigate('/dashboard/users', {
                                     state: { openSavedToast: true }
                                 });
+                            },
+                            onError: () => {
+                                loading.hide();
+                                setIsErrorToastOpen(true);
                             }
                         });
                     }
+                },
+                onError: () => {
+                    loading.hide();
+                    setIsErrorToastOpen(true);
                 }
             });
         };
@@ -323,6 +337,11 @@ const UserEdit = () => {
             id='editUserPage'
             className='mainAnimatedPage type-interior'
         >
+            <Toast
+                open={isErrorToastOpen}
+                onClose={handleToastClose}
+                message={globalize.translate('ErrorDefault')}
+            />
             <div ref={element} className='content-primary'>
                 <div className='verticalSection'>
                     <SectionTitleContainer


### PR DESCRIPTION
## Summary

Fixes #7613

When attempting to rename a user account to a name containing characters like `&` that the Jellyfin server rejects, the save button would show an indefinite loading spinner because neither `updateUser.mutate()` nor `updateUserPolicy.mutate()` had `onError` handlers.

## Changes

- Add `onError` callback to `updateUser.mutate()` to hide loading and show an error toast when the rename API call fails
- Add `onError` callback to `updateUserPolicy.mutate()` to hide loading and show an error toast when the policy update API call fails
- Import `Toast` component and add corresponding state + handler (following the same pattern used in `add.tsx`)

## Testing

1. Navigate to Dashboard → Users → select any user
2. Change the Name field to contain `&` (e.g. `A&B`)
3. Click Save

**Before:** Loading spinner spins indefinitely with no feedback  
**After:** Loading spinner clears and an error toast appears informing the user that the save failed
