### PR TITLE
Add autofocus to ConnectionErrorPage and FallbackRoute

### DIFF
--- a/src/components/ConnectionErrorPage.tsx
+++ b/src/components/ConnectionErrorPage.tsx
@@ -64,6 +64,7 @@ const ConnectionErrorPage: FC<ConnectionErrorPageProps> = ({
             id='connectionErrorPage'
             className='mainAnimatedPage standalonePage'
             isBackButtonEnabled={false}
+            shouldAutoFocus
         >
             <div className='padded-left padded-right'>
                 <h1>{title}</h1>

--- a/src/components/router/FallbackRoute.tsx
+++ b/src/components/router/FallbackRoute.tsx
@@ -42,6 +42,7 @@ const FallbackRoute = () => {
             id='fallbackPage'
             title={globalize.translate('HeaderPageNotFound')}
             className='mainAnimatedPage libraryPage'
+            shouldAutoFocus
         >
             <div className='padded-left padded-right'>
                 <h1>{globalize.translate('HeaderPageNotFound')}</h1>


### PR DESCRIPTION
I added (_but didn't test_) autofocus to FallbackRoute just because it has only one button, so we need to move the focus to it.

**Changes**
Add autofocus to ConnectionErrorPage and FallbackRoute.

**Issues**
Fixes https://github.com/jellyfin/jellyfin-webos/issues/313

We also need https://github.com/jellyfin/jellyfin-webos/pull/324 to reset ID in the app (before ConnectionErrorPage).