### PR TITLE
Add a toggle in the admin UI to inhibit power

### DIFF
--- a/src/apps/dashboard/routes/settings/index.tsx
+++ b/src/apps/dashboard/routes/settings/index.tsx
@@ -17,6 +17,7 @@ import SearchIcon from '@mui/icons-material/Search';
 import InputAdornment from '@mui/material/InputAdornment';
 import FormControl from '@mui/material/FormControl';
 import FormControlLabel from '@mui/material/FormControlLabel';
+import FormHelperText from '@mui/material/FormHelperText';
 import Checkbox from '@mui/material/Checkbox';
 import Button from '@mui/material/Button';
 import Link from '@mui/material/Link';
@@ -37,6 +38,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     config.CachePath = formData.get('CachePath')?.toString();
     config.MetadataPath = formData.get('MetadataPath')?.toString();
     config.QuickConnectAvailable = formData.get('QuickConnectAvailable')?.toString() === 'on';
+    config.EnablePlaybackInhibitors = formData.get('EnablePlaybackInhibitors')?.toString() === 'on';
     config.LibraryScanFanoutConcurrency = parseInt(formData.get('LibraryScanFanoutConcurrency')?.toString() || '0', 10);
     config.ParallelImageEncodingLimit = parseInt(formData.get('ParallelImageEncodingLimit')?.toString() || '0', 10);
 
@@ -225,6 +227,21 @@ export const Component = () => {
                                     }
                                     label={globalize.translate('EnableQuickConnect')}
                                 />
+                            </FormControl>
+
+                            <Typography variant='h2'>{globalize.translate('HeaderPlayback')}</Typography>
+
+                            <FormControl>
+                                <FormControlLabel
+                                    control={
+                                        <Checkbox
+                                            name='EnablePlaybackInhibitors'
+                                            defaultChecked={config.EnablePlaybackInhibitors}
+                                        />
+                                    }
+                                    label={globalize.translate('EnablePlaybackInhibitors')}
+                                />
+                                <FormHelperText>{globalize.translate('EnablePlaybackInhibitorsHelp')}</FormHelperText>
                             </FormControl>
 
                             <Typography variant='h2'>{globalize.translate('HeaderPerformance')}</Typography>

--- a/src/strings/en-gb.json
+++ b/src/strings/en-gb.json
@@ -1247,6 +1247,8 @@
     "KnownProxiesHelp": "Comma separated list of IP addresses or hostnames of known proxies used when connecting to your Jellyfin instance. This is required to make proper use of 'X-Forwarded-For' headers. Requires a reboot after saving.",
     "Other": "Other",
     "EnableQuickConnect": "Enable Quick Connect on this server",
+    "EnablePlaybackInhibitors": "Prevent system sleep during playback",
+    "EnablePlaybackInhibitorsHelp": "When enabled, Jellyfin will inhibit system shutdown, sleep, and suspend while media is playing.",
     "ButtonUseQuickConnect": "Use Quick Connect",
     "ButtonActivate": "Activate",
     "Authorize": "Authorise",

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -303,6 +303,8 @@
     "EnableRewatchingNextUp": "Enable Rewatching in Next Up",
     "EnableRewatchingNextUpHelp": "Enable showing already watched episodes in 'Next Up' sections.",
     "EnableQuickConnect": "Enable Quick Connect on this server",
+    "EnablePlaybackInhibitors": "Prevent system sleep during playback",
+    "EnablePlaybackInhibitorsHelp": "When enabled, Jellyfin will inhibit system shutdown, sleep, and suspend while media is playing.",
     "EnableSmoothScroll": "Enable smooth scroll",
     "EnableStreamLooping": "Auto-loop live streams",
     "EnableStreamLoopingHelp": "Enable this if live streams only contain a few seconds of data and need to be continuously requested. Enabling this when not needed may cause problems.",

--- a/src/strings/ta.json
+++ b/src/strings/ta.json
@@ -1237,6 +1237,8 @@
     "LabelQuickConnectCode": "விரைவு இணைப்பு குறியீடு",
     "LabelCurrentStatus": "தற்போதைய நிலை",
     "EnableQuickConnect": "இந்த சேவையகத்தில் விரைவான இணைப்பை இயக்கவும்",
+    "EnablePlaybackInhibitors": "பிளேபேக் போது கணினி உறக்கத்தைத் தடுக்கவும்",
+    "EnablePlaybackInhibitorsHelp": "இயக்கப்பட்டால், மீடியா இயங்கும் போது Jellyfin கணினி நிறுத்தம், உறக்கம் மற்றும் இடைநிறுத்தத்தைத் தடுக்கிறது.",
     "ButtonUseQuickConnect": "விரைவு இணைப்பைப் பயன்படுத்தவும்",
     "ButtonActivate": "செயல்படுத்து",
     "Authorize": "அதிகாரமளி",


### PR DESCRIPTION
# Admin Toggle to Inhibit Power Transitions During Playback

Add a toggle that exposes the new setting in jellyfin to inhibit power transitions during playback.

**Changes**

Adds a toggle in the admin UI that enables power inhibition during playback using the new inhibition service I
added to jellyfin in https://github.com/jellyfin/jellyfin/pull/16346.
