### PR TITLE
Add Safari DoVi detection fallback for profiles 5 and 8

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -273,9 +273,16 @@ function supportedDolbyVisionProfilesHevc(videoTestElement) {
     const supportedProfiles = [];
     // Profiles 5/8 4k@24fps
     if (videoTestElement.canPlayType) {
-        if (videoTestElement
-            .canPlayType('video/mp4; codecs="dvh1.05.06"')
-            .replace(/no/, '')) {
+        if (
+            videoTestElement
+                .canPlayType('video/mp4; codecs="dvh1.05.06"')
+                .replace(/no/, '')
+            // Safari does not expose DoVi via canPlayType even on capable devices.
+            // AVPlayer handles DoVi when the HLS manifest signals dvh1; canPlayType
+            // only tests bare MP4 which Apple treats as a separate path.
+            // Devices without DoVi fall back to the hvc1 PQ variant in the manifest.
+            || (browser.safari && ((browser.iOS && browser.iOSVersion >= 13) || browser.osx))
+        ) {
             supportedProfiles.push(5);
         }
         if (
@@ -284,10 +291,13 @@ function supportedDolbyVisionProfilesHevc(videoTestElement) {
                 .replace(/no/, '')
             // LG TVs from at least 2020 onwards should support profile 8, but they don't report it.
             || (browser.web0sVersion >= 4)
+            // Safari: same canPlayType limitation as P5. P8 also has an HDR10 base layer as fallback.
+            || (browser.safari && ((browser.iOS && browser.iOSVersion >= 13) || browser.osx))
         ) {
             supportedProfiles.push(8);
         }
     }
+
     return supportedProfiles;
 }
 


### PR DESCRIPTION
## Summary

Safari's `canPlayType()` does not report Dolby Vision support — even on devices with hardware DoVi decoding (VideoToolbox). Apple treats DoVi as a managed HLS capability: `AVPlayer` handles it when the master playlist signals `dvh1`, but `canPlayType` tests bare MP4 playback which is a separate code path.

This means devices like the iPad A16 (2025) that fully support DoVi never get to play it because the browser API returns empty, Jellyfin builds a profile without DoVi, and the server transcodes unnecessarily.

### What this does

Adds inline Safari fallbacks for P5 and P8 detection in `supportedDolbyVisionProfilesHevc()`, matching the existing webOS pattern (`browser.web0sVersion >= 4`).

**Conditions:** Safari on iOS 13+ or macOS.

### Safety

Devices without DoVi hardware are not broken by this change. The HLS master playlist fallback chain from jellyfin/jellyfin#16362 lists both a `dvh1` and an `hvc1` PQ variant pointing to the same stream URL. When a device cannot decode DoVi, the HLS player selects the `hvc1` variant and decodes the base HEVC layer with PQ tone mapping — better than a forced SDR transcode.

### Related

- jellyfin/jellyfin#16362 — Adds spec-compliant `dvh1` variant + `hvc1` PQ fallback in HLS master playlist
- jellyfin/jellyfin#16179 — HLS CODECS signaling discussion

## Test plan

- [ ] Verify Safari on macOS reports DoVi P5 and P8 in device profile
- [ ] Verify Safari on iOS 13+ reports DoVi P5 and P8 in device profile
- [ ] Verify Chrome/Firefox behavior is unchanged (no Safari fallback applied)
- [ ] Verify webOS detection still works independently
- [ ] Play DoVi P5 content on Safari — confirm dvh1 variant selected, no transcode