### PR TITLE
Replace the buildin xbox limit it with a native shell option

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -411,8 +411,6 @@ function getGlobalMaxVideoBitrate() {
     let bitrate = null;
     if (browser.ps4) {
         bitrate = 8000000;
-    } else if (browser.xboxOne) {
-        bitrate = globalThis.xboxBitrateLimit ?? null;
     } else if (browser.tizen && isTizenFhd) {
         bitrate = 20000000;
     }
@@ -1396,7 +1394,7 @@ export default function (options) {
         });
     }
 
-    const globalMaxVideoBitrate = (getGlobalMaxVideoBitrate() || '').toString();
+    const globalMaxVideoBitrate = (options.globalMaxVideoBitrate || getGlobalMaxVideoBitrate() || '').toString();
 
     const h264MaxVideoBitrate = globalMaxVideoBitrate;
 


### PR DESCRIPTION

**Changes**
Removes the fixed bitrate limit
Use a new option in the deviceProfile instead so it can be set though the settings UI within the xbox GUI if desired

**Issues**
https://github.com/jellyfin/jellyfin-xbox/issues/148#issuecomment-4032262913

**Code assistance**
No LLM was used