### PR TITLE
Fix uncaught error when showing notifications without permission

### DIFF
--- a/src/components/notifications/notifications.js
+++ b/src/components/notifications/notifications.js
@@ -89,6 +89,10 @@ function showNonPersistentNotification(title, options, timeoutMs) {
 }
 
 function showNotification(options, timeoutMs, apiClient) {
+    if (!window.Notification || Notification.permission !== 'granted') {
+        return;
+    }
+
     const title = options.title;
 
     options.data = options.data || {};


### PR DESCRIPTION
Check Notification.permission before calling showNotification to prevent TypeError when notification permission has not been granted for the origin.

**Changes**

Added a guard clause at the top of `showNotification()` that returns early if the Notification API is unavailable or permission has not been granted. Without this, server events (e.g. `LibraryChanged`) can trigger `serviceWorkerRegistration.showNotification()` before the user has granted permission, causing an uncaught `TypeError`.

**Issues**

<!-- No existing issue found -->

**Code assistance**

Code fix was generated with assistance from Claude, including identifying the root cause from a browser console error and writing the permission check.