### PR TITLE
Fix react card text missing keys

### DIFF
--- a/src/components/cardbuilder/Card/CardText.tsx
+++ b/src/components/cardbuilder/Card/CardText.tsx
@@ -19,7 +19,7 @@ const CardText: FC<CardTextProps> = ({ className, textLine }) => {
         <Box className={className}>
             {titleAction ? (
                 ensureArray(titleAction).map((action, i, arr) => (
-                    <>
+                    <React.Fragment key={action.title}>
                         <a
                             className='itemAction textActionButton'
                             href={action.url}
@@ -30,7 +30,7 @@ const CardText: FC<CardTextProps> = ({ className, textLine }) => {
                         </a>
                         {/* If there are more items, add the separator */}
                         {(i < arr.length - 1) && SEPARATOR}
-                    </>
+                    </React.Fragment>
                 ))
             ) : (
                 ensureArray(title).join(SEPARATOR)


### PR DESCRIPTION
**Changes**
Fixes a console warning because we failed to add `key` attributes to card text

**Issues**
N/A

**Code assistance**
VS Code autocomplete