### PR TITLE
Hide home loading indicator optimistically

### DIFF
--- a/src/controllers/hometab.js
+++ b/src/controllers/hometab.js
@@ -1,5 +1,4 @@
 import * as userSettings from '../scripts/settings/userSettings';
-import loading from '../components/loading/loading';
 import focusManager from '../components/focusManager';
 import homeSections from '../components/homesections/homesections';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
@@ -25,7 +24,6 @@ class HomeTab {
             return Promise.resolve();
         }
 
-        loading.show();
         const view = this.view;
         const apiClient = this.apiClient;
         this.destroyHomeSections();
@@ -38,8 +36,6 @@ class HomeTab {
                 }
             }).catch(err => {
                 console.error(err);
-            }).finally(() => {
-                loading.hide();
             });
     }
     onPause() {


### PR DESCRIPTION
**Changes**
Optimistically hide the loading indicator on the home screen instead of displaying it until all sections are loaded

**Issues**
N/A

**Code assistance**
VS Code autocomplete
