### PR TITLE
remove merge group events from main workflow

### DIFF
--- a/.github/workflows/__job_messages.yml
+++ b/.github/workflows/__job_messages.yml
@@ -23,7 +23,7 @@ on:
         type: boolean
       pr_number:
         required: true
-        type: number
+        type: string
       marker:
         description: Hidden marker to detect PR comments composed by the bot
         required: false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,7 +11,6 @@ on:
       - release*
     paths-ignore:
       - '**/*.md'
-  merge_group:
 
 jobs:
   build:


### PR DESCRIPTION
**Changes**

Merge group doesn't work because it's trying to find a PR number (triggered from pull request workflow) on the default branch so there's no attached pull request. There's also a type mismatch in the Job Message workflow.

```
unexpected value '7354'
```

Not entirely sure if it's a number being parsed as a string or the inverse, but I'll wager it's a string value.

**Issues**

None