### PR TITLE
When deleting a single item, include the name of the item in the confirmation message

### DIFF
--- a/src/scripts/deleteHelper.js
+++ b/src/scripts/deleteHelper.js
@@ -42,7 +42,7 @@ function getDeletionConfirmContent(item) {
 
     return {
         title: globalize.translate('HeaderDeleteItem'),
-        text: globalize.translate('ConfirmDeleteItem'),
+        text: globalize.translate('ConfirmDeleteItemByName', item.Name),
         confirmText: globalize.translate('Delete'),
         primary: 'delete'
     };

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -183,6 +183,7 @@
     "ConfigureDateAdded": "Set up how metadata for 'Date added' is determined in the Dashboard > Libraries > Display",
     "ConfirmDeleteImage": "Delete image?",
     "ConfirmDeleteItem": "Deleting this item will delete it from both the file system and your media library. Are you sure you wish to continue?",
+    "ConfirmDeleteItemByName": "Deleting \"{0}\" will delete it from both the file system and your media library. Are you sure you wish to continue?",
     "ConfirmDeleteCollection": "Are you sure you wish to delete this collection?",
     "ConfirmDeletePlaylist": "Are you sure you wish to delete this playlist?",
     "ConfirmDeleteSeries": "Deleting this series will delete ALL {0} episodes from both the file system and your media library. Are you sure you wish to continue?",


### PR DESCRIPTION
## Changes
I was deleting something from my library recently and thought it would be helpful if the confirmation text included what's actually being deleted.

If this change looks okay, I will raise further changes to handle multiple items, playlists, etc.

### Before
<img width="1000" height="542" alt="image" src="https://github.com/user-attachments/assets/83156b4b-3d91-4486-8a5f-ffe9dc4e20d5" />


### After
<img width="1000" height="542" alt="image" src="https://github.com/user-attachments/assets/03d8b901-e724-4b6b-a190-fedd3b916a24" />


## Issues
N/A

## Code assistance
N/A
