### PR TITLE
🌟 feat: Add "Keep original title" checkbox in library settings

### DIFF
--- a/src/components/libraryoptionseditor/libraryoptionseditor.js
+++ b/src/components/libraryoptionseditor/libraryoptionseditor.js
@@ -639,6 +639,7 @@ export function getLibraryOptions(parent) {
         MetadataCountryCode: parent.querySelector('#selectCountry').value,
         SeasonZeroDisplayName: parent.querySelector('#txtSeasonZeroName').value,
         AutomaticRefreshIntervalDays: parseInt(parent.querySelector('#selectAutoRefreshInterval').value, 10),
+        KeepOriginalTitle: parent.querySelector('#chkKeepOriginalTitle').checked,
         EnableEmbeddedTitles: parent.querySelector('#chkEnableEmbeddedTitles').checked,
         EnableEmbeddedExtrasTitles: parent.querySelector('#chkEnableEmbeddedExtrasTitles').checked,
         EnableEmbeddedEpisodeInfos: parent.querySelector('#chkEnableEmbeddedEpisodeInfos').checked,
@@ -707,6 +708,7 @@ export function setLibraryOptions(parent, options) {
     parent.querySelector('.chkExtractChapterImages').checked = options.EnableChapterImageExtraction;
     parent.querySelector('#chkSaveLocal').checked = options.SaveLocalMetadata;
     parent.querySelector('.chkAutomaticallyGroupSeries').checked = options.EnableAutomaticSeriesGrouping;
+    parent.querySelector('#chkKeepOriginalTitle').checked = options.KeepOriginalTitle;
     parent.querySelector('#chkEnableEmbeddedTitles').checked = options.EnableEmbeddedTitles;
     parent.querySelector('.chkEnableEmbeddedExtrasTitlesContainer').classList.toggle('hide', !options.EnableEmbeddedTitles);
     parent.querySelector('#chkEnableEmbeddedExtrasTitles').checked = options.EnableEmbeddedExtrasTitles;

--- a/src/components/libraryoptionseditor/libraryoptionseditor.template.html
+++ b/src/components/libraryoptionseditor/libraryoptionseditor.template.html
@@ -10,6 +10,13 @@
 <div class="selectContainer fldMetadataLanguage hide">
     <select is="emby-select" id="selectLanguage" label="${LabelMetadataDownloadLanguage}"></select>
 </div>
+<div class="checkboxContainer checkboxContainer-withDescription chkEnabledContainer">
+    <label>
+        <input type="checkbox" is="emby-checkbox" id="chkKeepOriginalTitle" />
+        <span>${KeepOriginalTitle}</span>
+    </label>
+    <div class="fieldDescription checkboxFieldDescription">${KeepOriginalTitleHelp}</div>
+</div>
 <div class="selectContainer fldMetadataCountry hide">
     <select is="emby-select" id="selectCountry" label="${LabelCountry}"></select>
 </div>

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -593,6 +593,8 @@
     "ItemCount": "{0} items",
     "ItemDetails": "Item Details",
     "Items": "Items",
+    "KeepOriginalTitle": "Keep original title",
+    "KeepOriginalTitleHelp": "Display movies and series with their original language title instead of translated title.",
     "Kids": "Kids",
     "KnownProxiesHelp": "Comma separated list of IP addresses or hostnames of known proxies used when connecting to your Jellyfin instance. This is required to make proper use of 'X-Forwarded-For' headers. Requires a reboot after saving.",
     "Label3DFormat": "3D format",

--- a/src/strings/fr.json
+++ b/src/strings/fr.json
@@ -368,6 +368,8 @@
     "InstantMix": "Mix instantané",
     "ItemCount": "{0} éléments",
     "Items": "Éléments",
+    "KeepOriginalTitle": "Conserver le titre original",
+    "KeepOriginalTitleHelp": "Affiche le titre des films et séries dans leur langue originale.",
     "Kids": "Jeunesse",
     "Label3DFormat": "Format 3D",
     "LabelAbortedByServerShutdown": "Annulé par l'arrêt du serveur",


### PR DESCRIPTION
### Description

Implements the "Keep Original Title" library option.
Feature request: https://features.jellyfin.org/posts/32/keep-original-title-option
Discussion: https://github.com/jellyfin/jellyfin-meta/discussions/80

When enabled on a library, movies and series display their original language title (e.g. "Les Intouchables") instead of the translated title, while still fetching metadata (descriptions, etc.) in the preferred language.

<img width="1332" height="796" alt="image" src="https://github.com/user-attachments/assets/8f301bbf-719a-4a35-a941-7c62ec045594" />

This PR must wait the [server PR](https://github.com/jellyfin/jellyfin/pull/16435) to be merged first.

### Changes

- Added checkbox in library options editor
- Added label and help text translations for this option in English (en-us) and French (fr-fr)