### PR TITLE
Fix multiselect panel styles

### DIFF
--- a/src/components/multiSelect/multiSelect.scss
+++ b/src/components/multiSelect/multiSelect.scss
@@ -27,7 +27,6 @@
 
 .itemSelectionCount {
     vertical-align: middle;
-    color: #fff !important;
     margin: 0;
 }
 

--- a/src/themes/_base/_theme.scss
+++ b/src/themes/_base/_theme.scss
@@ -209,7 +209,16 @@ a[data-role=button],
 
 .selectionCommandsPanel {
     background: var(--jf-palette-primary-main, $primary-main);
-    color: var(--jf-palette-primary-contrastText, $primary-contrastText);
+    color: var(--jf-palette-primary-contrastText, $primary-contrastText) !important;
+
+    .paper-icon-button-light:not(:disabled) {
+        color: var(--jf-palette-primary-contrastText, $primary-contrastText);
+
+        &:hover,
+        &:focus {
+            background-color: var(--jf-palette-primary-dark, $primary-dark);
+        }
+    }
 }
 
 .upNextDialog-countdownText {


### PR DESCRIPTION
**Changes**
Fixes the colors in the multiselect panel. As seen in the screenshot the count is always white instead of using the correct contrast color for text on the primary color background. Also the buttons would switch to the primary color when hovered making them invisible.

<img width="1412" height="71" alt="Screenshot 2026-03-19 at 16-40-12 Jellyfin Edge" src="https://github.com/user-attachments/assets/bd18e4b0-4a5f-4b9d-bff9-e65fc951a57d" />

**Issues**
N/A

**Code assistance**
VS Code autocomplete
