### PR TITLE
Fix sass if syntax

### DIFF
--- a/src/themes/_base/_theme.scss
+++ b/src/themes/_base/_theme.scss
@@ -73,7 +73,14 @@ html {
 }
 
 .pageTitleWithDefaultLogo {
-    background-image: if($dark, url(@jellyfin/ux-web/banner-light.png), url(@jellyfin/ux-web/banner-dark.png));
+    background-image:
+        if(
+            /* NOTE: Stylelint seems to lack support for if() syntax currently */
+            /* stylelint-disable-next-line @stylistic/function-whitespace-after */
+            sass($dark): url(@jellyfin/ux-web/banner-light.png);
+            /* stylelint-disable-next-line @stylistic/function-whitespace-after */
+            else: url(@jellyfin/ux-web/banner-dark.png);
+        );
 
     .layout-tv & {
         background-image: url(@jellyfin/ux-web/icon-transparent.png);


### PR DESCRIPTION
**Changes**
Fixes a sass warning... the supported syntax for `if` statements has changed to match native css

**Issues**
N/A

**Code assistance**
VS Code autocomplete
