### PR TITLE
Hold and drag on media no longer activates Multi-select

### DIFF
--- a/src/components/multiSelect/multiSelect.js
+++ b/src/components/multiSelect/multiSelect.js
@@ -495,13 +495,35 @@ export default function (options) {
     }
 
     function onMouseDown(e) {
+        touchTarget = null;
+        touchStartX = e.clientX || 0;
+        touchStartY = e.clientY || 0;
+
+        const element = e.target;
+        if (!dom.parentWithClass(element, 'card')) {
+            return;
+        }
+
         if (touchStartTimeout) {
             clearTimeout(touchStartTimeout);
             touchStartTimeout = null;
         }
 
-        touchTarget = e.target;
+        touchTarget = element;
         touchStartTimeout = setTimeout(onTouchStartTimerFired, 550);
+    }
+
+    function onMouseMove(e) {
+        if (!touchTarget) {
+            return;
+        }
+
+        const deltaX = Math.abs((e.clientX || 0) - (touchStartX || 0));
+        const deltaY = Math.abs((e.clientY || 0) - (touchStartY || 0));
+
+        if (deltaX >= 5 || deltaY >= 5) {
+            onMouseOut();
+        }
     }
 
     function onMouseOut() {
@@ -545,6 +567,9 @@ export default function (options) {
             dom.addEventListener(element, 'mousedown', onMouseDown, {
                 passive: true
             });
+            dom.addEventListener(element, 'mousemove', onMouseMove, {
+                passive: true
+            });
             dom.addEventListener(element, 'mouseleave', onMouseOut, {
                 passive: true
             });
@@ -578,6 +603,9 @@ export default function (options) {
             passive: true
         });
         dom.removeEventListener(element, 'mousedown', onMouseDown, {
+            passive: true
+        });
+        dom.removeEventListener(element, 'mousemove', onMouseMove, {
             passive: true
         });
         dom.removeEventListener(element, 'mouseleave', onMouseOut, {


### PR DESCRIPTION
**Changes**
When moving the mouse atleast 5px in either X or Y direction multi-select will no longer activate. Same logic was already in place for touch screen so was almost a copy paste.

**Issues**
Fixes #7288 

**Code assistance**
Codex helped identify that there was already logic in place for touch screens in multiSelect.js