### PR TITLE
Fix chromium browsers not cleaning up backdrops

### DIFF
--- a/src/components/backdrop/backdrop.js
+++ b/src/components/backdrop/backdrop.js
@@ -249,7 +249,7 @@ function onRotationInterval() {
     setTimeout(() => {
         const oldImages = getBackdropContainer().querySelectorAll(`.backdropImage:not([data-url="${currentImage}"])`);
         oldImages.forEach(img => {
-            img.parentNode?.removeChild(img);
+            img.remove();
         });
     }, 1600);
 }


### PR DESCRIPTION
**Changes**
Chromium based browsers do not run `onanimationend` when a tab is in the background. We used this event to cleanup old backdrop elements from the dom so over time this would add up. This switches to just using `setTimeout` to cleanup any elements that don't contain the current url set as a data attribute.

**Issues**
Fixes #3916
Supersedes #4826 

**Code assistance**
VS Code autocomplete
