### PR TITLE
Add a folder view to the modern home videos library layout

### DIFF
--- a/src/apps/experimental/features/libraries/constants/libraryRoutes.ts
+++ b/src/apps/experimental/features/libraries/constants/libraryRoutes.ts
@@ -178,25 +178,24 @@ export const LibraryRoutes: LibraryRoute[] = [
         views: [
             {
                 index: 0,
-                label: 'Photos',
-                view: LibraryTab.Photos,
+                label: 'Folders',
+                view: LibraryTab.Folders,
                 isDefault: true
             },
             {
                 index: 1,
-                label: 'HeaderPhotoAlbums',
-                view: LibraryTab.PhotoAlbums,
-                isDefault: true
+                label: 'Photos',
+                view: LibraryTab.Photos
             },
             {
                 index: 2,
-                label: 'HeaderVideos',
-                view: LibraryTab.Videos
+                label: 'HeaderPhotoAlbums',
+                view: LibraryTab.PhotoAlbums
             },
             {
                 index: 3,
-                label: 'Folders',
-                view: LibraryTab.Folders
+                label: 'HeaderVideos',
+                view: LibraryTab.Videos
             }
         ]
     },

--- a/src/apps/experimental/routes/homevideos/index.tsx
+++ b/src/apps/experimental/routes/homevideos/index.tsx
@@ -7,6 +7,14 @@ import { LibraryTab } from 'types/libraryTab';
 import { CollectionType } from '@jellyfin/sdk/lib/generated-client/models/collection-type';
 import { LibraryTabContent, LibraryTabMapping } from 'types/libraryTabContent';
 
+const foldersTabContent: LibraryTabContent = {
+    viewType: LibraryTab.Folders,
+    collectionType: CollectionType.Homevideos,
+    isBtnPlayAllEnabled: true,
+    isBtnShuffleEnabled: true,
+    itemType: [BaseItemKind.Folder, BaseItemKind.Photo, BaseItemKind.PhotoAlbum, BaseItemKind.Video]
+};
+
 const photosTabContent: LibraryTabContent = {
     viewType: LibraryTab.Photos,
     collectionType: CollectionType.Homevideos,
@@ -31,19 +39,11 @@ const videosTabContent: LibraryTabContent = {
     itemType: [BaseItemKind.Video]
 };
 
-const foldersTabContent: LibraryTabContent = {
-    viewType: LibraryTab.Folders,
-    collectionType: CollectionType.Homevideos,
-    isBtnPlayAllEnabled: true,
-    isBtnShuffleEnabled: true,
-    itemType: [BaseItemKind.Folder, BaseItemKind.Photo, BaseItemKind.PhotoAlbum, BaseItemKind.Video]
-};
-
 const homevideosTabMapping: LibraryTabMapping = {
-    0: photosTabContent,
-    1: photoAlbumsTabContent,
-    2: videosTabContent,
-    3: foldersTabContent
+    0: foldersTabContent,
+    1: photosTabContent,
+    2: photoAlbumsTabContent,
+    3: videosTabContent
 };
 
 const HomeVideos: FC = () => {

--- a/src/components/homeScreenSettings/homeScreenSettings.js
+++ b/src/components/homeScreenSettings/homeScreenSettings.js
@@ -166,9 +166,13 @@ function getLandingScreenOptions(type) {
     } else if (type === 'homevideos') {
         list.push(
             {
-                name: globalize.translate('Photos'),
-                value: LibraryTab.Photos,
+                name: globalize.translate('Folders'),
+                value: LibraryTab.Folders,
                 isDefault: true
+            },
+            {
+                name: globalize.translate('Photos'),
+                value: LibraryTab.Photos
             },
             {
                 name: globalize.translate('HeaderPhotoAlbums'),
@@ -177,10 +181,6 @@ function getLandingScreenOptions(type) {
             {
                 name: globalize.translate('HeaderVideos'),
                 value: LibraryTab.Videos
-            },
-            {
-                name: globalize.translate('Folders'),
-                value: LibraryTab.Folders
             }
         );
     }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

### Changes
<!--
Describe your changes here in 1-5 sentences.
Please include before/after screenshots of any UI changes.
-->
Adds a new default folder tab to the Home Videos and Photos library in the modern/experimental layout. Update corresponding default landing screen options. 

This enables users to view media with the same folder structure as in the legacy view.


<img width="973" height="516" alt="1" src="https://github.com/user-attachments/assets/a4d3dbdf-98ea-4b11-8cb9-6f81a6ff3748" />

### Issues
N/A

### Code assistance
N/A
