### PR TITLE
Fix images failing to load during fast scrolling and back-navigation

### DIFF
--- a/src/components/images/imageLoader.js
+++ b/src/components/images/imageLoader.js
@@ -86,8 +86,6 @@ export function fillImage(entry) {
         if (source) {
             fillImageElement(target, source);
         }
-    } else if (!source) {
-        emptyImageElement(target);
     }
 }
 
@@ -105,7 +103,7 @@ function onAnimationEnd(event) {
     elem.removeEventListener('animationend', onAnimationEnd);
 }
 
-function fillImageElement(elem, url) {
+function fillImageElement(elem, url, retries = 2) {
     if (url === undefined) {
         throw new TypeError('url cannot be undefined');
     }
@@ -132,6 +130,12 @@ function fillImageElement(elem, url) {
             }
             elem.classList.remove('lazy-hidden');
         });
+    });
+
+    preloaderImg.addEventListener('error', () => {
+        if (retries > 0) {
+            setTimeout(() => fillImageElement(elem, url, retries - 1), 1000);
+        }
     });
 }
 


### PR DESCRIPTION
## Summary
- Remove aggressive image unloading when elements scroll out of the intersection observer viewport, which caused images to disappear during fast scrolling and back-navigation
- Add retry logic (up to 2 retries with 1s delay) for failed image preloads so cards don't stay permanently grey

## Test plan
- [ ] Rapidly scroll through a large library and verify images load consistently
- [ ] Navigate into an item and press back — verify the library view still shows images
- [ ] Throttle network in devtools and confirm failed images retry and eventually appear