### PR TITLE
Fix recently added cards using backdrop instead of poster for mixed libraries

### DIFF
--- a/src/components/homesections/sections/recentlyAdded.ts
+++ b/src/components/homesections/sections/recentlyAdded.ts
@@ -56,18 +56,16 @@ function getLatestItemsHtmlFn(
     return function (items: BaseItemDto[]) {
         const cardLayout = false;
         let shape;
-        if (itemType === 'Channel' || viewType === 'movies' || viewType === 'books' || viewType === 'tvshows') {
-            shape = getPortraitShape(enableOverflow);
-        } else if (viewType === 'music' || viewType === 'homevideos') {
+        if (viewType === 'music' || viewType === 'homevideos') {
             shape = getSquareShape(enableOverflow);
         } else {
-            shape = getBackdropShape(enableOverflow);
+            shape = getPortraitShape(enableOverflow);
         }
 
         return cardBuilder.getCardsHtml({
             items: items,
             shape: shape,
-            preferThumb: viewType !== 'movies' && viewType !== 'tvshows' && itemType !== 'Channel' && viewType !== 'music' ? 'auto' : null,
+            preferThumb: viewType === 'homevideos' || viewType === 'photos' ? 'auto' : null,
             showUnplayedIndicator: false,
             showChildCountIndicator: true,
             context: 'home',


### PR DESCRIPTION
## Summary
- Default the recently added home section to portrait (poster) cards instead of backdrop cards, so mixed-content libraries show tall posters like dedicated movie/TV libraries do
- Simplify the shape selection logic: only music and home videos use square cards, everything else gets portrait
- Only prefer thumbnail images for home videos and photos, where posters aren't typically available

Fixes #6907
Fixes #5191

## Test plan
- [ ] Verify a mixed movie/TV show library shows tall poster cards on the home screen
- [ ] Verify dedicated movie and TV show libraries still show tall poster cards
- [ ] Verify music libraries still show square cards
- [ ] Verify home video / photo libraries still show square cards with thumbnails