### PR TITLE
Fix: use hls.js workerPath to avoid CSP blob: worker errors

### DIFF
--- a/src/plugins/htmlAudioPlayer/plugin.js
+++ b/src/plugins/htmlAudioPlayer/plugin.js
@@ -171,6 +171,7 @@ class HtmlAudioPlayer {
 
                         const hls = new Hls({
                             manifestLoadingTimeOut: 20000,
+                            workerPath: 'libraries/hls.worker.js',
                             xhrSetup: function (xhr) {
                                 xhr.withCredentials = includeCorsCredentials;
                             }

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -458,6 +458,7 @@ export class HtmlVideoPlayer {
                     maxBufferLength: maxBufferLength,
                     maxMaxBufferLength: maxBufferLength,
                     videoPreference: { preferHDR: true },
+                    workerPath: 'libraries/hls.worker.js',
                     xhrSetup(xhr) {
                         xhr.withCredentials = includeCorsCredentials;
                     }

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -17,7 +17,8 @@ const Assets = [
     '@jellyfin/libass-wasm/dist/js/subtitles-octopus-worker.wasm',
     '@jellyfin/libass-wasm/dist/js/subtitles-octopus-worker-legacy.js',
     'pdfjs-dist/build/pdf.worker.js',
-    'libpgs/dist/libpgs.worker.js'
+    'libpgs/dist/libpgs.worker.js',
+    'hls.js/dist/hls.worker.js'
 ];
 
 const DEV_MODE = process.env.NODE_ENV !== 'production';


### PR DESCRIPTION
## Summary
- Configures hls.js to load its worker from a file (`libraries/hls.worker.js`) instead of creating a `blob:` URL
- Adds `workerPath` option to both the HTML audio and video player hls.js configurations
- Copies `hls.js/dist/hls.worker.js` into the bundled assets via webpack

This avoids `blob:` CSP violations for users who set strict Content-Security-Policy headers on their reverse proxy, without requiring `blob:` in `worker-src`.

Relates to jellyfin/jellyfin-web#293

## Test plan
- [ ] Verify HLS playback works with default CSP (no strict headers)
- [ ] Verify HLS playback works with strict CSP that disallows `blob:` in `worker-src`
- [ ] Confirm `hls.worker.js` is present in the build output under `libraries/`