### PR TITLE
Add device id to StorageListItem

### DIFF
--- a/src/apps/dashboard/features/storage/components/StorageListItem.tsx
+++ b/src/apps/dashboard/features/storage/components/StorageListItem.tsx
@@ -1,4 +1,5 @@
 import type { FolderStorageDto } from '@jellyfin/sdk/lib/generated-client';
+import Box from '@mui/material/Box';
 import LinearProgress from '@mui/material/LinearProgress';
 import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
@@ -79,15 +80,29 @@ const StorageListItem: FC<StorageListItemProps> = ({
                             color={statusColor}
                             value={usedPercentage}
                         />
-                        <Typography
-                            variant='body2'
-                            color='textSecondary'
+                        <Box
                             sx={{
-                                textAlign: 'end'
+                                display: 'flex',
+                                flexWrap: 'wrap'
                             }}
                         >
-                            {`${readableUsedSpace} / ${readableTotalSpace}`}
-                        </Typography>
+                            <Typography
+                                variant='body2'
+                                color='textSecondary'
+                            >
+                                {globalize.translate('OnFilesystem', folder?.DeviceId || '?')}
+                            </Typography>
+                            <Typography
+                                variant='body2'
+                                color='textSecondary'
+                                sx={{
+                                    flexGrow: 1,
+                                    textAlign: 'end'
+                                }}
+                            >
+                                {`${readableUsedSpace} / ${readableTotalSpace}`}
+                            </Typography>
+                        </Box>
                     </>
                 }
                 slots={{

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1278,6 +1278,7 @@
     "NumLocationsValue": "{0} folders",
     "Off": "Off",
     "OnApplicationStartup": "On application startup",
+    "OnFilesystem": "On filesystem: {0}",
     "OneChannel": "One channel",
     "OnlyForcedSubtitles": "Only Forced",
     "OnlyForcedSubtitlesHelp": "Only subtitles marked as forced will be loaded.",


### PR DESCRIPTION
### Changes
Adds "On filesystem: X" under the storage progress bar in StorageListItem

<img width="371" height="97" alt="Screenshot 2026-03-24 at 12-19-13 Dashboard" src="https://github.com/user-attachments/assets/28a7c1d2-7791-4822-9c25-664061a503c6" />

### Issues
Fixes #7323
Depends on https://github.com/jellyfin/jellyfin/pull/16456

### Code assistance
VS Code autocomplete

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
