### PR TITLE
Fix mixed libraries showing thumbnail cards in homepage

### DIFF
--- a/src/components/homesections/sections/recentlyAdded.ts
+++ b/src/components/homesections/sections/recentlyAdded.ts
@@ -6,7 +6,7 @@ import escapeHtml from 'escape-html';
 import type { ApiClient } from 'jellyfin-apiclient';
 
 import cardBuilder from 'components/cardbuilder/cardBuilder';
-import { getBackdropShape, getPortraitShape, getSquareShape } from 'components/cardbuilder/utils/shape';
+import { getPortraitShape, getSquareShape } from 'components/cardbuilder/utils/shape';
 import layoutManager from 'components/layoutManager';
 import { appRouter } from 'components/router/appRouter';
 import globalize from 'lib/globalize';
@@ -56,18 +56,16 @@ function getLatestItemsHtmlFn(
     return function (items: BaseItemDto[]) {
         const cardLayout = false;
         let shape;
-        if (itemType === 'Channel' || viewType === 'movies' || viewType === 'books' || viewType === 'tvshows') {
-            shape = getPortraitShape(enableOverflow);
-        } else if (viewType === 'music' || viewType === 'homevideos') {
+        if (viewType === 'music' || viewType === 'homevideos') {
             shape = getSquareShape(enableOverflow);
         } else {
-            shape = getBackdropShape(enableOverflow);
+            shape = getPortraitShape(enableOverflow);
         }
 
         return cardBuilder.getCardsHtml({
             items: items,
             shape: shape,
-            preferThumb: viewType !== 'movies' && viewType !== 'tvshows' && itemType !== 'Channel' && viewType !== 'music' ? 'auto' : null,
+            preferThumb: viewType === 'homevideos' || viewType === 'photos' ? 'auto' : null,
             showUnplayedIndicator: false,
             showChildCountIndicator: true,
             context: 'home',


### PR DESCRIPTION

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

### Changes
<!--
Describe your changes here in 1-5 sentences.
Please include before/after screenshots of any UI changes.
-->

Mixed (untyped) libraries previously fell through to the backdrop (landscape) shape in the recently added home sections. This changes the default card type to portrait so that mixed libraries are consistent with movies, TV shows, books, and channels. Music and home videos continue to use landscape thumbnail cards.

### Issues
<!--
Tag any issues that this PR solves here.
ex. Fixes #
-->
Fixes https://github.com/jellyfin/jellyfin-web/issues/6907
Fixes https://github.com/jellyfin/jellyfin-web/issues/5191
### Code assistance
<!--
If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance.
-->

Claude was used to scrub the codebase.

---

* [X] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [X] I have tested these changes.
* [X] I have verified that this is not duplicating changes in an existing PR.
* [X] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
