### PR TITLE
Add configurable trickplay image preloading

### DIFF
--- a/src/components/playbackSettings/playbackSettings.js
+++ b/src/components/playbackSettings/playbackSettings.js
@@ -230,6 +230,7 @@ function loadForm(context, user, userSettings, systemInfo, apiClient) {
     context.querySelector('.chkEnableDts').checked = appSettings.enableDts();
     context.querySelector('.chkEnableTrueHd').checked = appSettings.enableTrueHd();
     context.querySelector('.chkEnableHi10p').checked = appSettings.enableHi10p();
+    context.querySelector('.chkEnablePreloadTrickplayImages').checked = userSettings.enablePreloadTrickplayImages();
     context.querySelector('.chkEnableCinemaMode').checked = userSettings.enableCinemaMode();
     context.querySelector('#selectAudioNormalization').value = userSettings.selectAudioNormalization();
     context.querySelector('.chkEnableNextVideoOverlay').checked = userSettings.enableNextVideoInfoOverlay();
@@ -301,6 +302,7 @@ function saveUser(context, user, userSettingsInstance, apiClient) {
     user.Configuration.EnableNextEpisodeAutoPlay = context.querySelector('.chkEpisodeAutoPlay').checked;
     userSettingsInstance.preferFmp4HlsContainer(context.querySelector('.chkPreferFmp4HlsContainer').checked);
     userSettingsInstance.limitSegmentLength(context.querySelector('.chkLimitSegmentLength').checked);
+    userSettingsInstance.enablePreloadTrickplayImages(context.querySelector('.chkEnablePreloadTrickplayImages').checked);
     userSettingsInstance.enableCinemaMode(context.querySelector('.chkEnableCinemaMode').checked);
     userSettingsInstance.selectAudioNormalization(context.querySelector('#selectAudioNormalization').value);
     userSettingsInstance.enableNextVideoInfoOverlay(context.querySelector('.chkEnableNextVideoOverlay').checked);

--- a/src/components/playbackSettings/playbackSettings.template.html
+++ b/src/components/playbackSettings/playbackSettings.template.html
@@ -96,6 +96,14 @@
             <div class="fieldDescription checkboxFieldDescription">${PreferFmp4HlsContainerHelp}</div>
         </div>
 
+        <div class="checkboxContainer checkboxContainer-withDescription">
+            <label>
+                <input type="checkbox" is="emby-checkbox" class="chkEnablePreloadTrickplayImages" />
+                <span>${EnablePreloadTrickplayImages}</span>
+            </label>
+            <div class="fieldDescription checkboxFieldDescription">${EnablePreloadTrickplayImagesHelp}</div>
+        </div>
+
         <div class="checkboxContainer checkboxContainer-withDescription cinemaModeOptions">
             <label>
                 <input type="checkbox" is="emby-checkbox" class="chkEnableCinemaMode" />

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -155,6 +155,21 @@ export default function (view) {
             }
 
             if (bestWidth) trickplayResolution = trickplayResolutions[bestWidth];
+
+            // Preload all trickplay sprite sheets so hover previews are instant
+            if (trickplayResolution && userSettings.enablePreloadTrickplayImages()) {
+                const tileSize = trickplayResolution.TileWidth * trickplayResolution.TileHeight;
+                const totalTiles = Math.ceil(trickplayResolution.ThumbnailCount / tileSize);
+                const apiClient = ServerConnections.getApiClient(item.ServerId);
+
+                for (let i = 0; i < totalTiles; i++) {
+                    const img = new Image();
+                    img.src = apiClient.getUrl(
+                        'Videos/' + item.Id + '/Trickplay/' + bestWidth + '/' + i + '.jpg',
+                        { ApiKey: apiClient.accessToken(), MediaSourceId: mediaSourceId }
+                    );
+                }
+            }
         }
     }
 

--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -169,6 +169,19 @@ export class UserSettings {
     }
 
     /**
+     * Get or set 'Preload Trickplay Images' state.
+     * @param {boolean|undefined} val - Flag to enable preloading or undefined.
+     * @return {boolean} 'Preload Trickplay Images' state.
+     */
+    enablePreloadTrickplayImages(val) {
+        if (val !== undefined) {
+            return this.set('enablePreloadTrickplayImages', val.toString(), false);
+        }
+
+        return toBoolean(this.get('enablePreloadTrickplayImages', false), false);
+    }
+
+    /**
      * Get or set 'Cinema Mode' state.
      * @param {boolean|undefined} val - Flag to enable 'Cinema Mode' or undefined.
      * @return {boolean} 'Cinema Mode' state.
@@ -686,6 +699,7 @@ export const serverConfig = currentSettings.serverConfig.bind(currentSettings);
 export const allowedAudioChannels = currentSettings.allowedAudioChannels.bind(currentSettings);
 export const preferFmp4HlsContainer = currentSettings.preferFmp4HlsContainer.bind(currentSettings);
 export const limitSegmentLength = currentSettings.limitSegmentLength.bind(currentSettings);
+export const enablePreloadTrickplayImages = currentSettings.enablePreloadTrickplayImages.bind(currentSettings);
 export const enableCinemaMode = currentSettings.enableCinemaMode.bind(currentSettings);
 export const selectAudioNormalization = currentSettings.selectAudioNormalization.bind(currentSettings);
 export const enableNextVideoInfoOverlay = currentSettings.enableNextVideoInfoOverlay.bind(currentSettings);

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -284,6 +284,8 @@
     "EnableBlurHash": "Enable blurred placeholders for images",
     "EnableBlurHashHelp": "Images that are still being loaded will be displayed with a unique placeholder.",
     "EnableCinemaMode": "Cinema mode",
+    "EnablePreloadTrickplayImages": "Preload trickplay images",
+    "EnablePreloadTrickplayImagesHelp": "Loads all trickplay thumbnail sprites when a video starts playing, so scrub previews appear instantly without delay.",
     "EnableColorCodedBackgrounds": "Color coded backgrounds",
     "EnableDecodingColorDepth10Hevc": "Enable 10-bit hardware decoding for HEVC",
     "EnableDecodingColorDepth10Vp9": "Enable 10-bit hardware decoding for VP9",


### PR DESCRIPTION
### Changes

Add an optional per-user setting to preload all trickplay sprite sheet images when a video starts playing. When enabled, the client fires GET requests for all sprite sheet tiles at playback start using `new Image()` objects, which populates the browser's HTTP cache. When the user later hovers the progress bar, the same URLs are served from cache instead of making new network requests, eliminating the ~300ms delay per tile.

The setting is a checkbox in the user's Playback settings page (Advanced section), defaulting to off.

### Issues

Related discussion: https://github.com/orgs/jellyfin/discussions/14182

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A%22merge+conflict%22+-label%3Astale+-author%3A%40me).