### PR TITLE
Fix theming for reactUtils component rendering

### DIFF
--- a/src/utils/reactUtils.tsx
+++ b/src/utils/reactUtils.tsx
@@ -1,16 +1,21 @@
-import { ThemeProvider } from '@mui/material/styles';
+import { type SupportedColorScheme, ThemeProvider, useColorScheme } from '@mui/material/styles';
 import { QueryClientProvider } from '@tanstack/react-query';
-import * as React from 'react';
+import React, { type FC, type PropsWithChildren, useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
 
 import { ApiProvider } from 'hooks/useApi';
 import { UserSettingsProvider } from 'hooks/useUserSettings';
+import { useUserTheme } from 'hooks/useUserTheme';
 import { WebConfigProvider } from 'hooks/useWebConfig';
 import appTheme from 'themes';
 import { queryClient } from 'utils/query/queryClient';
 
+/**
+ * Render a React component outside of the main React app context
+ * i.e. within a legacy view/controller page.
+ */
 export const renderComponent = <P extends object> (
-    Component: React.FC<P>,
+    Component: FC<P>,
     props: P,
     element: HTMLElement
 ) => {
@@ -26,14 +31,41 @@ export const renderComponent = <P extends object> (
     return () => setTimeout(() => root.unmount());
 };
 
-const RootContext: React.FC<React.PropsWithChildren> = ({ children }) => {
+/** Component that syncs the MUI theme with our user theme. */
+const CustomThemeProvider: FC<PropsWithChildren> = ({ children }) => {
+    const { theme } = useUserTheme();
+    const { setColorScheme } = useColorScheme();
+
+    useEffect(() => {
+        setColorScheme(theme as SupportedColorScheme);
+    }, [ theme, setColorScheme ]);
+
+    return (
+        // NOTE: Suppress warning about inconsistent return type
+        // eslint-disable-next-line react/jsx-no-useless-fragment
+        <>
+            {children}
+        </>
+    );
+};
+
+/** Component that provides a root context that matches the application root. */
+const RootContext: FC<PropsWithChildren> = ({ children }) => {
     return (
         <QueryClientProvider client={queryClient}>
             <ApiProvider>
                 <UserSettingsProvider>
                     <WebConfigProvider>
-                        <ThemeProvider theme={appTheme} defaultMode='dark'>
-                            {children}
+                        <ThemeProvider
+                            theme={appTheme}
+                            // Disable color scheme management since we're handling it manually
+                            colorSchemeNode={null}
+                            storageManager={null}
+                            disableStyleSheetGeneration
+                        >
+                            <CustomThemeProvider>
+                                {children}
+                            </CustomThemeProvider>
                         </ThemeProvider>
                     </WebConfigProvider>
                 </UserSettingsProvider>


### PR DESCRIPTION
### Changes
Fixes the theming of components rendered using our reactUtils. Currently the app is partially forced into the dark theme when visiting the item details screen.

<img width="1396" height="750" alt="Screenshot 2026-04-01 at 12-02-46 Jellyfin Edge" src="https://github.com/user-attachments/assets/75e1024d-6b0f-451c-b231-b22117422afc" />
(Screenshot of the bug for reference)

### Issues
N/A

### Code assistance
VS Code autocomplete

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
