### PR TITLE
Load device information lazily in connection manager

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -22,6 +22,7 @@ import { getPlugins } from './scripts/settings/webSettings';
 import taskButton from './scripts/taskbutton';
 import { pageClassOn, serverAddress } from './utils/dashboard';
 import Events from './utils/events';
+import { initializeServerConnections } from './scripts/serverNotifications';
 
 import RootApp from './RootApp';
 
@@ -37,7 +38,6 @@ import './components/themeMediaPlayer';
 import './scripts/autoThemes';
 import './scripts/mouseManager';
 import './scripts/screensavermanager';
-import './scripts/serverNotifications';
 
 // Import site styles
 import './styles/site.scss';
@@ -109,6 +109,9 @@ build: ${__JF_BUILD_VERSION__}`);
         Events.off(apiClient, 'requestfail', appRouter.onRequestFail);
         Events.on(apiClient, 'requestfail', appRouter.onRequestFail);
     });
+
+    // Start server notifications
+    initializeServerConnections();
 
     // Render the app
     await renderApp();

--- a/src/lib/jellyfin-apiclient/ServerConnections.js
+++ b/src/lib/jellyfin-apiclient/ServerConnections.js
@@ -152,8 +152,8 @@ const capabilities = Dashboard.capabilities(appHost);
 
 export default new ServerConnections(
     credentialProvider,
-    appHost.appName(),
-    appHost.appVersion(),
-    appHost.deviceName(),
-    appHost.deviceId(),
+    () => appHost.appName(),
+    () => appHost.appVersion(),
+    () => appHost.deviceName(),
+    () => appHost.deviceId(),
     capabilities);

--- a/src/lib/jellyfin-apiclient/connectionManager.js
+++ b/src/lib/jellyfin-apiclient/connectionManager.js
@@ -63,13 +63,15 @@ export default class ConnectionManager {
         // Set the minimum version to match the SDK
         self._minServerVersion = MINIMUM_VERSION;
 
-        self.appVersion = () => appVersion;
+        self.appVersion = () => typeof appVersion === 'function' ? appVersion() : appVersion;
 
-        self.appName = () => appName;
+        self.appName = () => typeof appName === 'function' ? appName() : appName;
 
         self.capabilities = () => capabilities;
 
-        self.deviceId = () => deviceId;
+        self.deviceName = () => typeof deviceName === 'function' ? deviceName() : deviceName;
+
+        self.deviceId = () => typeof deviceId === 'function' ? deviceId() : deviceId;
 
         self.credentialProvider = () => credentialProvider;
 
@@ -137,7 +139,7 @@ export default class ConnectionManager {
             let apiClient = self.getApiClient(server.Id);
 
             if (!apiClient) {
-                apiClient = new ApiClient(serverUrl, appName, appVersion, deviceName, deviceId);
+                apiClient = new ApiClient(serverUrl, self.appName(), self.appVersion(), self.deviceName(), self.deviceId());
 
                 self._apiClients.push(apiClient);
 
@@ -232,12 +234,12 @@ export default class ConnectionManager {
                 headers: {
                     [AUTHORIZATION_HEADER]: getAuthorizationHeader(
                         {
-                            name: appName,
-                            version: appVersion
+                            name: self.appName(),
+                            version: self.appVersion()
                         },
                         {
-                            id: deviceId,
-                            name: deviceName
+                            id: self.deviceId(),
+                            name: self.deviceName()
                         },
                         server.AccessToken
                     )

--- a/src/scripts/serverNotifications.js
+++ b/src/scripts/serverNotifications.js
@@ -201,10 +201,12 @@ function bindEvents(apiClient) {
     Events.on(apiClient, 'message', onMessageReceived);
 }
 
-ServerConnections.getApiClients().forEach(bindEvents);
-Events.on(ServerConnections, 'apiclientcreated', function (e, newApiClient) {
-    bindEvents(newApiClient);
-});
+export function initializeServerConnections() {
+    ServerConnections.getApiClients().forEach(bindEvents);
+    Events.on(ServerConnections, 'apiclientcreated', function (e, newApiClient) {
+        bindEvents(newApiClient);
+    });
+}
 
 window.ServerNotifications = serverNotifications;
 


### PR DESCRIPTION
### Changes

We want to avoid using the apphost before it is initialized. To accomplish this 2 changes were needed:

- Lazily load values from apphost in connection manager instead of reading them immediately on connectionmanager import
- Fix the servernotifications initializing itself on import, causing apiclients to be instantiated before apphost init

### Issues

Fixes https://github.com/jellyfin/jellyfin/issues/16534

### Code assistance

If only AI could make sense of this code 🫠 

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
