### PR TITLE
Add chapter name inside osd slider bubble

### DIFF
--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1575,22 +1575,24 @@ export default function (view) {
         }
 
         const src = getImgUrl(item, chapter, index, 400, apiClient);
+        let html = '<div class="chapterThumbContainer chapterBubblePosition">';
 
         if (src) {
-            let html = '<div class="chapterThumbContainer">';
             html += '<img class="chapterThumb" src="' + src + '" />';
             html += '<div class="chapterThumbTextContainer">';
-            html += '<div class="chapterThumbText chapterThumbText-dim">';
-            html += escapeHtml(chapter.Name);
-            html += '</div>';
-            html += '<h2 class="chapterThumbText">';
-            html += datetime.getDisplayRunningTime(positionTicks);
-            html += '</h2>';
-            html += '</div>';
-            return html + '</div>';
+        } else {
+            html += '<div class="chapterThumbTextContainer chapterBubblePosition">';
         }
 
-        return null;
+        html += '<div class="chapterThumbText chapterThumbText-dim">';
+        html += escapeHtml(chapter.Name);
+        html += '</div>';
+        html += '<h2 class="chapterThumbText">';
+        html += datetime.getDisplayRunningTime(positionTicks);
+        html += '</h2>';
+        html += '</div>';
+
+        return html + '</div>';
     }
 
     let playPauseClickTimeout;
@@ -1920,7 +1922,7 @@ export default function (view) {
         ticks *= value;
         const item = currentItem;
 
-        if (item?.Chapters?.length && item.Chapters[0].ImageTag) {
+        if (item?.Chapters?.length) {
             const html = getChapterBubbleHtml(ServerConnections.getApiClient(item.ServerId), item, item.Chapters, ticks);
 
             if (html) {

--- a/src/styles/videoosd.scss
+++ b/src/styles/videoosd.scss
@@ -54,7 +54,10 @@
 .chapterThumbContainer {
     box-shadow: 0 0 1.9vh #000;
     flex-grow: 1;
-    position: relative;
+}
+
+.chapterBubblePosition {
+    position: relative !important;
 }
 
 .chapterThumb {
@@ -88,6 +91,7 @@
     background: none;
     padding: 0.25em 0.5em;
     user-select: none;
+    min-width: fit-content;
 }
 
 .chapterThumbText {
@@ -96,6 +100,8 @@
     opacity: 1;
     color: #fff;
     text-shadow: 0 0 25px #000, 0 0 6px #000;
+    white-space: nowrap;
+    min-width: fit-content;
 }
 
 .chapterThumbText-dim {


### PR DESCRIPTION
The goal of this PR is to restores the chapter name into the osd slider bubble. This was previously requiring an chapter image, something that I personally never seen before.

### Changes

Before:
<img width="204" height="107" alt="image" src="https://github.com/user-attachments/assets/195d78b7-908c-4404-a574-1ff03328aa55" />

After:
<img width="166" height="150" alt="image" src="https://github.com/user-attachments/assets/65fc6096-5c3b-44fc-a4c8-9babbb7aec30" />

### Issues

- None

### Code assistance

- None

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
