### PR TITLE
Double tap to rewind/fast-forward for touch devices

### DIFF
--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -1841,6 +1841,22 @@ export default function (view) {
 
     dom.addEventListener(view, 'dblclick', (e) => {
         if (e.target !== view) return;
+
+        if (browser.touch) {
+            const rect = view.getBoundingClientRect();
+            const x = e.clientX - rect.left;
+
+            if (x < rect.width * 0.33) {
+                playbackManager.rewind(currentPlayer);
+                showOsd(btnRewind);
+                return;
+            } else if (x > rect.width * 0.66) {
+                playbackManager.fastForward(currentPlayer);
+                showOsd(btnFastForward);
+                return;
+            }
+        }
+
         playbackManager.toggleFullscreen(currentPlayer);
     });
 


### PR DESCRIPTION
### Changes
This PR implements the double-tap functionality for rewind and fast-forward requested in [Feature Request #131](https://features.jellyfin.org/posts/131/double-tap-to-fast-forward-or-rewind).

For touch screens, it adds support to rewind and fast-forward by double-tapping on the left/right areas of the video player. It uses the same logic as the rewind and fast-forward buttons and therefore the jump interval can be configured in the user settings.

There are already 2 pull requests for this. One of them is a draft ([#6519](https://github.com/jellyfin/jellyfin-web/pull/6519)) and the other one was closed because of not resolved merge conflicts ([#6898](https://github.com/jellyfin/jellyfin-web/pull/6898)). Because of this I have no problem with adding them as contributors if wished.

### Issues
[Double-Tap to Skip Forward and Backward](https://features.jellyfin.org/posts/2997/double-tap-to-skip-forward-and-backward)
[Double tap to fast forward or rewind](https://features.jellyfin.org/posts/131/double-tap-to-fast-forward-or-rewind)
