### PR TITLE
Update sort options, default tab, and landing screen options for music videos

### DIFF
--- a/src/apps/experimental/components/library/SortButton.tsx
+++ b/src/apps/experimental/components/library/SortButton.tsx
@@ -50,6 +50,18 @@ const photosOrPhotoAlbumsOptions = [
     { label: 'OptionDateAdded', value: ItemSortBy.DateCreated }
 ];
 
+const videoOrMusicVideoOptions = [
+    { label: 'Name', value: ItemSortBy.SortName },
+    { label: 'OptionRandom', value: ItemSortBy.Random },
+    { label: 'OptionCommunityRating', value: ItemSortBy.CommunityRating },
+    { label: 'OptionDateAdded', value: ItemSortBy.DateCreated },
+    { label: 'OptionDatePlayed', value: ItemSortBy.DatePlayed },
+    { label: 'OptionParentalRating', value: ItemSortBy.OfficialRating },
+    { label: 'OptionPlayCount', value: ItemSortBy.PlayCount },
+    { label: 'OptionReleaseDate', value: ItemSortBy.PremiereDate },
+    { label: 'Runtime', value: ItemSortBy.Runtime }
+];
+
 const sortOptionsMapping: SortOptionsMapping = {
     [LibraryTab.Movies]: movieOrFavoriteOptions,
     [LibraryTab.Collections]: collectionMovieOptions,
@@ -113,28 +125,8 @@ const sortOptionsMapping: SortOptionsMapping = {
     ],
     [LibraryTab.PhotoAlbums]: photosOrPhotoAlbumsOptions,
     [LibraryTab.Photos]: photosOrPhotoAlbumsOptions,
-    [LibraryTab.Videos]: [
-        { label: 'Name', value: ItemSortBy.SortName },
-        { label: 'OptionRandom', value: ItemSortBy.Random },
-        { label: 'OptionCommunityRating', value: ItemSortBy.CommunityRating },
-        { label: 'OptionDateAdded', value: ItemSortBy.DateCreated },
-        { label: 'OptionDatePlayed', value: ItemSortBy.DatePlayed },
-        { label: 'OptionParentalRating', value: ItemSortBy.OfficialRating },
-        { label: 'OptionPlayCount', value: ItemSortBy.PlayCount },
-        { label: 'OptionReleaseDate', value: ItemSortBy.PremiereDate },
-        { label: 'Runtime', value: ItemSortBy.Runtime }
-    ],
-    [LibraryTab.MusicVideos]: [
-        { label: 'Name', value: ItemSortBy.SortName },
-        { label: 'OptionRandom', value: ItemSortBy.Random },
-        { label: 'OptionCommunityRating', value: ItemSortBy.CommunityRating },
-        { label: 'OptionDateAdded', value: ItemSortBy.DateCreated },
-        { label: 'OptionDatePlayed', value: ItemSortBy.DatePlayed },
-        { label: 'OptionParentalRating', value: ItemSortBy.OfficialRating },
-        { label: 'OptionPlayCount', value: ItemSortBy.PlayCount },
-        { label: 'OptionReleaseDate', value: ItemSortBy.PremiereDate },
-        { label: 'Runtime', value: ItemSortBy.Runtime }
-    ],
+    [LibraryTab.Videos]:videoOrMusicVideoOptions,
+    [LibraryTab.MusicVideos]:videoOrMusicVideoOptions,
     [LibraryTab.Folders]: [
         { label: 'Name', value: ItemSortBy.SortName },
         { label: 'OptionRandom', value: ItemSortBy.Random },
@@ -270,7 +262,7 @@ const SortButton: FC<SortButtonProps> = ({
                         {sortOrderMenuOptions.map((option) => (
                             <MenuItem key={option.value} value={option.value}>
                                 <Typography component='span'>
-                                    {option.label}
+                                    {globalize.translate(option.label)}
                                 </Typography>
                             </MenuItem>
                         ))}

--- a/src/apps/experimental/components/library/SortButton.tsx
+++ b/src/apps/experimental/components/library/SortButton.tsx
@@ -24,6 +24,7 @@ type SortOptionsMapping = Record<string, SortOption[]>;
 
 const collectionMovieOptions: SortOption[] = [
     { label: 'Name', value: ItemSortBy.SortName },
+    { label: 'OptionRandom', value: ItemSortBy.Random },
     { label: 'OptionCommunityRating', value: ItemSortBy.CommunityRating },
     { label: 'OptionDateAdded', value: ItemSortBy.DateCreated },
     { label: 'OptionParentalRating', value: ItemSortBy.OfficialRating },
@@ -65,14 +66,14 @@ const sortOptionsMapping: SortOptionsMapping = {
     ],
     [LibraryTab.Episodes]: [
         { label: 'Name', value: ItemSortBy.SeriesSortName },
+        { label: 'OptionRandom', value: ItemSortBy.Random },
         { label: 'OptionCommunityRating', value: ItemSortBy.CommunityRating },
         { label: 'OptionDateAdded', value: ItemSortBy.DateCreated },
         { label: 'OptionReleaseDate', value: ItemSortBy.PremiereDate },
         { label: 'OptionDatePlayed', value: ItemSortBy.DatePlayed },
         { label: 'OptionParentalRating', value: ItemSortBy.OfficialRating },
         { label: 'OptionPlayCount', value: ItemSortBy.PlayCount },
-        { label: 'Runtime', value: ItemSortBy.Runtime },
-        { label: 'OptionRandom', value: ItemSortBy.Random }
+        { label: 'Runtime', value: ItemSortBy.Runtime }
     ],
     [LibraryTab.Albums]: [
         { label: 'Name', value: ItemSortBy.SortName },
@@ -85,13 +86,14 @@ const sortOptionsMapping: SortOptionsMapping = {
     ],
     [LibraryTab.Books]: [
         { label: 'Name', value: ItemSortBy.SortName },
+        { label: 'OptionRandom', value: ItemSortBy.Random },
         { label: 'OptionReleaseDate', value: ItemSortBy.ProductionYear },
         { label: 'OptionDateAdded', value: ItemSortBy.DateCreated },
-        { label: 'OptionDatePlayed', value: ItemSortBy.DatePlayed },
-        { label: 'OptionRandom', value: ItemSortBy.Random }
+        { label: 'OptionDatePlayed', value: ItemSortBy.DatePlayed }
     ],
     [LibraryTab.Songs]: [
         { label: 'Name', value: ItemSortBy.SortName },
+        { label: 'OptionRandom', value: ItemSortBy.Random },
         { label: 'Album', value: ItemSortBy.Album },
         { label: 'AlbumArtist', value: ItemSortBy.AlbumArtist },
         { label: 'Artist', value: ItemSortBy.Artist },
@@ -99,8 +101,7 @@ const sortOptionsMapping: SortOptionsMapping = {
         { label: 'OptionDatePlayed', value: ItemSortBy.DatePlayed },
         { label: 'OptionPlayCount', value: ItemSortBy.PlayCount },
         { label: 'OptionReleaseDate', value: ItemSortBy.PremiereDate },
-        { label: 'Runtime', value: ItemSortBy.Runtime },
-        { label: 'OptionRandom', value: ItemSortBy.Random }
+        { label: 'Runtime', value: ItemSortBy.Runtime }
     ],
     [LibraryTab.Playlists]: [
         { label: 'Name', value: ItemSortBy.SortName },
@@ -114,19 +115,37 @@ const sortOptionsMapping: SortOptionsMapping = {
     [LibraryTab.Photos]: photosOrPhotoAlbumsOptions,
     [LibraryTab.Videos]: [
         { label: 'Name', value: ItemSortBy.SortName },
+        { label: 'OptionRandom', value: ItemSortBy.Random },
+        { label: 'OptionCommunityRating', value: ItemSortBy.CommunityRating },
         { label: 'OptionDateAdded', value: ItemSortBy.DateCreated },
         { label: 'OptionDatePlayed', value: ItemSortBy.DatePlayed },
+        { label: 'OptionParentalRating', value: ItemSortBy.OfficialRating },
         { label: 'OptionPlayCount', value: ItemSortBy.PlayCount },
-        { label: 'Runtime', value: ItemSortBy.Runtime },
-        { label: 'OptionRandom', value: ItemSortBy.Random }
+        { label: 'OptionReleaseDate', value: ItemSortBy.PremiereDate },
+        { label: 'Runtime', value: ItemSortBy.Runtime }
     ],
     [LibraryTab.MusicVideos]: [
         { label: 'Name', value: ItemSortBy.SortName },
+        { label: 'OptionRandom', value: ItemSortBy.Random },
+        { label: 'OptionCommunityRating', value: ItemSortBy.CommunityRating },
         { label: 'OptionDateAdded', value: ItemSortBy.DateCreated },
         { label: 'OptionDatePlayed', value: ItemSortBy.DatePlayed },
+        { label: 'OptionParentalRating', value: ItemSortBy.OfficialRating },
         { label: 'OptionPlayCount', value: ItemSortBy.PlayCount },
-        { label: 'Runtime', value: ItemSortBy.Runtime },
-        { label: 'OptionRandom', value: ItemSortBy.Random }
+        { label: 'OptionReleaseDate', value: ItemSortBy.PremiereDate },
+        { label: 'Runtime', value: ItemSortBy.Runtime }
+    ],
+    [LibraryTab.Folders]: [
+        { label: 'Name', value: ItemSortBy.SortName },
+        { label: 'OptionRandom', value: ItemSortBy.Random },
+        { label: 'OptionCommunityRating', value: ItemSortBy.CommunityRating },
+        { label: 'OptionDateAdded', value: ItemSortBy.DateCreated },
+        { label: 'OptionDatePlayed', value: ItemSortBy.DatePlayed },
+        { label: 'Folders', value: ItemSortBy.IsFolder },
+        { label: 'OptionParentalRating', value: ItemSortBy.OfficialRating },
+        { label: 'OptionPlayCount', value: ItemSortBy.PlayCount },
+        { label: 'OptionReleaseDate', value: ItemSortBy.PremiereDate },
+        { label: 'Runtime', value: ItemSortBy.Runtime }
     ]
 };
 

--- a/src/apps/experimental/components/library/filter/FilterButton.tsx
+++ b/src/apps/experimental/components/library/filter/FilterButton.tsx
@@ -136,6 +136,9 @@ const FilterButton: FC<FilterButtonProps> = ({
             || viewType === LibraryTab.Songs
             || viewType === LibraryTab.Episodes
             || viewType === LibraryTab.Books
+            || viewType === LibraryTab.Folders
+            || viewType === LibraryTab.MusicVideos
+            || viewType === LibraryTab.Videos
         );
     };
 

--- a/src/apps/experimental/features/libraries/constants/libraryRoutes.ts
+++ b/src/apps/experimental/features/libraries/constants/libraryRoutes.ts
@@ -204,8 +204,8 @@ export const LibraryRoutes: LibraryRoute[] = [
         views: [
             {
                 index: 0,
-                label: 'HeaderVideos',
-                view: LibraryTab.MusicVideos,
+                label: 'Folders',
+                view: LibraryTab.Folders,
                 isDefault: true
             },
             {
@@ -215,8 +215,8 @@ export const LibraryRoutes: LibraryRoute[] = [
             },
             {
                 index: 2,
-                label: 'Folders',
-                view: LibraryTab.Folders
+                label: 'HeaderVideos',
+                view: LibraryTab.MusicVideos
             }
         ]
     }

--- a/src/apps/experimental/routes/musicvideos/index.tsx
+++ b/src/apps/experimental/routes/musicvideos/index.tsx
@@ -8,12 +8,12 @@ import { CollectionType } from '@jellyfin/sdk/lib/generated-client/models/collec
 import { LibraryTabContent, LibraryTabMapping } from 'types/libraryTabContent';
 import { MusicVideoSuggestionsSectionsView } from 'types/sections';
 
-const musicVideosTabContent: LibraryTabContent = {
-    viewType: LibraryTab.MusicVideos,
+const foldersTabContent: LibraryTabContent = {
+    viewType: LibraryTab.Folders,
     collectionType: CollectionType.Musicvideos,
     isBtnPlayAllEnabled: true,
     isBtnShuffleEnabled: true,
-    itemType: [BaseItemKind.MusicVideo]
+    itemType: [BaseItemKind.Folder, BaseItemKind.MusicVideo]
 };
 
 const suggestionsTabContent: LibraryTabContent = {
@@ -22,18 +22,18 @@ const suggestionsTabContent: LibraryTabContent = {
     sectionsView: MusicVideoSuggestionsSectionsView
 };
 
-const foldersTabContent: LibraryTabContent = {
-    viewType: LibraryTab.Folders,
+const musicVideosTabContent: LibraryTabContent = {
+    viewType: LibraryTab.MusicVideos,
     collectionType: CollectionType.Musicvideos,
-    isBtnPlayAllEnabled: false,
-    isBtnShuffleEnabled: false,
-    itemType: [BaseItemKind.Folder, BaseItemKind.MusicVideo]
+    isBtnPlayAllEnabled: true,
+    isBtnShuffleEnabled: true,
+    itemType: [BaseItemKind.MusicVideo]
 };
 
 const musicVideosTabMapping: LibraryTabMapping = {
-    0: musicVideosTabContent,
+    0: foldersTabContent,
     1: suggestionsTabContent,
-    2: foldersTabContent
+    2: musicVideosTabContent
 };
 
 const MusicVideos: FC = () => {
@@ -44,7 +44,7 @@ const MusicVideos: FC = () => {
         <Page
             id='musicvideos'
             className='mainAnimatedPage libraryPage backdropPage collectionEditorPage pageWithAbsoluteTabs withTabs'
-            backDropType='video, photo'
+            backDropType='musicvideo'
         >
             <PageTabContent
                 key={`${currentTab.viewType} - ${libraryId}`}

--- a/src/components/homeScreenSettings/homeScreenSettings.js
+++ b/src/components/homeScreenSettings/homeScreenSettings.js
@@ -183,6 +183,22 @@ function getLandingScreenOptions(type) {
                 value: LibraryTab.Videos
             }
         );
+    } else if (type === 'musicvideos') {
+        list.push(
+            {
+                name: globalize.translate('Folders'),
+                value: LibraryTab.Folders,
+                isDefault: true
+            },
+            {
+                name: globalize.translate('Suggestions'),
+                value: LibraryTab.Suggestions
+            },
+            {
+                name: globalize.translate('HeaderVideos'),
+                value: LibraryTab.MusicVideos
+            }
+        );
     }
 
     return list;
@@ -276,7 +292,7 @@ function getPerLibrarySettingsHtml(item, user, userSettings) {
         html = `<div class="checkboxListContainer">${html}</div>`;
     }
 
-    const landingScreenTypes = ['movies', 'tvshows', 'music', 'livetv', 'homevideos'];
+    const landingScreenTypes = ['movies', 'tvshows', 'music', 'livetv', 'homevideos', 'musicvideos'];
     if (landingScreenTypes.includes(item.CollectionType)) {
         const idForLanding = item.CollectionType === 'livetv' ? item.CollectionType : item.Id;
         html += '<div class="selectContainer">';

--- a/src/hooks/useFetchItems.ts
+++ b/src/hooks/useFetchItems.ts
@@ -317,7 +317,9 @@ const fetchGetItemsViewByType = async (
                         ...getFiltersQuery(viewType, libraryViewSettings),
                         ...getLimitQuery(),
                         ...getAlphaPickerQuery(libraryViewSettings),
-                        sortBy: [libraryViewSettings.SortBy],
+                        sortBy: libraryViewSettings.SortBy === ItemSortBy.IsFolder ?
+                            [ItemSortBy.IsFolder, ItemSortBy.SortName] :
+                            [libraryViewSettings.SortBy],
                         sortOrder: [libraryViewSettings.SortOrder],
                         includeItemTypes: itemType,
                         startIndex: libraryViewSettings.StartIndex


### PR DESCRIPTION
### Changes

1) Set the folder tab to be the default view in the Music Videos Library
2) Added default landing screen options for the Music Videos Library
3) Added sort options for the folder tab, based on the options from the legacy view
4) Updated the sort and filter options for the Videos and MusicVideos  tabs
5) Ensured the random option order was consistently applied throughout the various tabs
6) Enabled the Play All and Shuffle buttons on the folder tab
7) Fix missing translations for sort order 

<img width="978" height="365" alt="1" src="https://github.com/user-attachments/assets/a56ecbb2-c882-4cbe-8674-826781962974" />
<br> 
<br> 
<br> 

<img width="978" height="542" alt="2" src="https://github.com/user-attachments/assets/853a8f04-fd4c-4e83-a24c-c995d4919678" />




### Issues
Fixes: #7898

### Code assistance
N/A

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).  (I do a lot around here, stop judging me PR template)

