### PR TITLE
Fix genres not showing for collections and playlists

### DIFF
--- a/src/components/itemDetails/ItemDetailsMetadataList.tsx
+++ b/src/components/itemDetails/ItemDetailsMetadataList.tsx
@@ -89,16 +89,15 @@ function getRouteType(type: BaseItemKind | PersonKind, context: string): string 
 }
 
 function getMetadataItems(type: BaseItemKind | PersonKind, item: BaseItemDto): NameGuidPair[] | null {
-    if (item.Type === BaseItemKind.BoxSet || item.Type === BaseItemKind.Playlist) {
-        return null;
-    }
-
     switch (type) {
         case PersonKind.Author:
         case PersonKind.Director:
         case PersonKind.Writer:
             return item.People?.filter(person => person.Type === type).map(person => ({ Id: person.Id, Name: person.Name })) ?? null;
         case BaseItemKind.Studio:
+            if (item.Type === BaseItemKind.BoxSet || item.Type === BaseItemKind.Playlist) {
+                return null;
+            }
             return item.Studios ?? null;
         case BaseItemKind.Genre:
             return item.GenreItems ?? null;


### PR DESCRIPTION
Due to a regression in #7656, genres and other metadata items were blocked in collections and playlists.

### Changes
Scope the guard to only studios, as in prior code. 

### Issues
Before: 
<img width="1302" height="621" alt="1" src="https://github.com/user-attachments/assets/766a9f6f-ee2d-496a-b56e-fa7b3d89e2d8" />
<br> <br>
After:
 
<img width="916" height="570" alt="2" src="https://github.com/user-attachments/assets/2f97d79d-125d-43af-b174-c708d0998553" />


### Code assistance
N/A
---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
