### PR TITLE
Respect DisplayMissingEpisodes setting in item details pages

### DIFF
--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -825,7 +825,7 @@ function setInitialCollapsibleState(page, item, apiClient, context, user) {
     } else if (item.Type == 'Studio' || item.Type == 'Person' || item.Type == 'Genre' || item.Type == 'MusicGenre' || item.Type == 'MusicArtist') {
         page.querySelector('#listChildrenCollapsible').classList.remove('hide');
         page.querySelector('#childrenCollapsible').classList.add('hide');
-        renderItemsByName(page, item);
+        renderItemsByName(page, item, user);
     } else if (item.IsFolder) {
         if (item.Type == 'BoxSet') {
             page.querySelector('#listChildrenCollapsible').classList.add('hide');
@@ -1450,9 +1450,9 @@ function renderChildren(page, item) {
     }
 }
 
-function renderItemsByName(page, item) {
+function renderItemsByName(page, item, user) {
     import('../../scripts/itemsByName').then(({ default: ItemsByName }) => {
-        ItemsByName.renderItems(page, item);
+        ItemsByName.renderItems(page, item, user);
     });
 }
 

--- a/src/scripts/itemsByName.js
+++ b/src/scripts/itemsByName.js
@@ -381,7 +381,7 @@ function getQuery(options, item, user) {
         Limit: 100,
         StartIndex: 0,
         CollapseBoxSetItems: false,
-        isMissing: !user.Configuration.DisplayMissingEpisodes ? false : undefined,
+        isMissing: !user?.Configuration?.DisplayMissingEpisodes ? false : undefined,
     };
     query = Object.assign(query, options || {});
     addCurrentItemToQuery(query, item);

--- a/src/scripts/itemsByName.js
+++ b/src/scripts/itemsByName.js
@@ -9,7 +9,7 @@ import { ServerConnections } from 'lib/jellyfin-apiclient';
 import 'elements/emby-itemscontainer/emby-itemscontainer';
 import 'elements/emby-button/emby-button';
 
-function renderItems(page, item) {
+function renderItems(page, item, user) {
     const sections = [];
 
     if (item.ArtistCount) {
@@ -98,11 +98,11 @@ function renderItems(page, item) {
     const sectionElems = elem.querySelectorAll('.verticalSection');
 
     for (let i = 0, length = sectionElems.length; i < length; i++) {
-        renderSection(item, sectionElems[i], sectionElems[i].getAttribute('data-type'));
+        renderSection(item, sectionElems[i], sectionElems[i].getAttribute('data-type'), user);
     }
 }
 
-function renderSection(item, element, type) {
+function renderSection(item, element, type, user) {
     switch (type) {
         case 'Program':
             loadItems(element, item, type, {
@@ -123,7 +123,7 @@ function renderSection(item, element, type) {
                 showAirTime: true,
                 showAirDateTime: true,
                 showChannelName: true
-            });
+            }, user);
             break;
 
         case 'Movie':
@@ -143,7 +143,7 @@ function renderSection(item, element, type) {
                 overlayMoreButton: true,
                 overlayText: false,
                 showYear: true
-            });
+            }, user);
             break;
 
         case 'MusicVideo':
@@ -160,7 +160,7 @@ function renderSection(item, element, type) {
                 showTitle: true,
                 centerText: true,
                 overlayPlayButton: true
-            });
+            }, user);
             break;
 
         case 'Trailer':
@@ -177,7 +177,7 @@ function renderSection(item, element, type) {
                 showTitle: true,
                 centerText: true,
                 overlayPlayButton: true
-            });
+            }, user);
             break;
 
         case 'Series':
@@ -194,7 +194,7 @@ function renderSection(item, element, type) {
                 showTitle: true,
                 centerText: true,
                 overlayMoreButton: true
-            });
+            }, user);
             break;
 
         case 'MusicAlbum':
@@ -214,7 +214,7 @@ function renderSection(item, element, type) {
                 coverImage: true,
                 centerText: true,
                 overlayPlayButton: true
-            });
+            }, user);
             break;
 
         case 'Book':
@@ -250,7 +250,7 @@ function renderSection(item, element, type) {
                 coverImage: true,
                 centerText: true,
                 overlayPlayButton: true
-            });
+            }, user);
             break;
 
         case 'Episode':
@@ -268,7 +268,7 @@ function renderSection(item, element, type) {
                 showParentTitle: true,
                 centerText: true,
                 overlayPlayButton: true
-            });
+            }, user);
             break;
 
         case 'Audio':
@@ -284,13 +284,13 @@ function renderSection(item, element, type) {
                 action: 'playallfromhere',
                 smallIcon: true,
                 artist: true
-            });
+            }, user);
     }
 }
 
-function loadItems(element, item, type, query, listOptions) {
-    query = getQuery(query, item);
-    getItemsFunction(query, item)(query.StartIndex, query.Limit, query.Fields).then(function (result) {
+function loadItems(element, item, type, query, listOptions, user) {
+    query = getQuery(query, item, user);
+    getItemsFunction(query, item, user)(query.StartIndex, query.Limit, query.Fields).then(function (result) {
         // If results are empty, hide the section
         if (!result.Items?.length) {
             element.classList.add('hide');
@@ -372,7 +372,7 @@ function addCurrentItemToQuery(query, item) {
     }
 }
 
-function getQuery(options, item) {
+function getQuery(options, item, user) {
     let query = {
         SortOrder: 'Ascending',
         IncludeItemTypes: '',
@@ -380,15 +380,16 @@ function getQuery(options, item) {
         Fields: 'ParentId,PrimaryImageAspectRatio',
         Limit: 100,
         StartIndex: 0,
-        CollapseBoxSetItems: false
+        CollapseBoxSetItems: false,
+        isMissing: !user.Configuration.DisplayMissingEpisodes ? false : undefined,
     };
     query = Object.assign(query, options || {});
     addCurrentItemToQuery(query, item);
     return query;
 }
 
-function getItemsFunction(options, item) {
-    const query = getQuery(options, item);
+function getItemsFunction(options, item, user) {
+    const query = getQuery(options, item, user);
     return function (index, limit, fields) {
         query.StartIndex = index;
         query.Limit = limit;

--- a/src/scripts/itemsByName.js
+++ b/src/scripts/itemsByName.js
@@ -123,7 +123,7 @@ function renderSection(item, element, type, user) {
                 showAirTime: true,
                 showAirDateTime: true,
                 showChannelName: true
-            }, user);
+            });
             break;
 
         case 'Movie':
@@ -143,7 +143,7 @@ function renderSection(item, element, type, user) {
                 overlayMoreButton: true,
                 overlayText: false,
                 showYear: true
-            }, user);
+            });
             break;
 
         case 'MusicVideo':
@@ -160,7 +160,7 @@ function renderSection(item, element, type, user) {
                 showTitle: true,
                 centerText: true,
                 overlayPlayButton: true
-            }, user);
+            });
             break;
 
         case 'Trailer':
@@ -177,7 +177,7 @@ function renderSection(item, element, type, user) {
                 showTitle: true,
                 centerText: true,
                 overlayPlayButton: true
-            }, user);
+            });
             break;
 
         case 'Series':
@@ -194,7 +194,7 @@ function renderSection(item, element, type, user) {
                 showTitle: true,
                 centerText: true,
                 overlayMoreButton: true
-            }, user);
+            });
             break;
 
         case 'MusicAlbum':
@@ -214,7 +214,7 @@ function renderSection(item, element, type, user) {
                 coverImage: true,
                 centerText: true,
                 overlayPlayButton: true
-            }, user);
+            });
             break;
 
         case 'Book':
@@ -250,7 +250,7 @@ function renderSection(item, element, type, user) {
                 coverImage: true,
                 centerText: true,
                 overlayPlayButton: true
-            }, user);
+            });
             break;
 
         case 'Episode':
@@ -261,14 +261,15 @@ function renderSection(item, element, type, user) {
                 ArtistIds: '',
                 AlbumArtistIds: '',
                 Limit: 6,
-                SortBy: 'SortName'
+                SortBy: 'SortName',
+                isMissing: !user?.Configuration?.DisplayMissingEpisodes ? false : undefined
             }, {
                 shape: 'overflowBackdrop',
                 showTitle: true,
                 showParentTitle: true,
                 centerText: true,
                 overlayPlayButton: true
-            }, user);
+            });
             break;
 
         case 'Audio':
@@ -284,13 +285,13 @@ function renderSection(item, element, type, user) {
                 action: 'playallfromhere',
                 smallIcon: true,
                 artist: true
-            }, user);
+            });
     }
 }
 
-function loadItems(element, item, type, query, listOptions, user) {
-    query = getQuery(query, item, user);
-    getItemsFunction(query, item, user)(query.StartIndex, query.Limit, query.Fields).then(function (result) {
+function loadItems(element, item, type, query, listOptions) {
+    query = getQuery(query, item);
+    getItemsFunction(query, item)(query.StartIndex, query.Limit, query.Fields).then(function (result) {
         // If results are empty, hide the section
         if (!result.Items?.length) {
             element.classList.add('hide');
@@ -372,7 +373,7 @@ function addCurrentItemToQuery(query, item) {
     }
 }
 
-function getQuery(options, item, user) {
+function getQuery(options, item) {
     let query = {
         SortOrder: 'Ascending',
         IncludeItemTypes: '',
@@ -380,16 +381,15 @@ function getQuery(options, item, user) {
         Fields: 'ParentId,PrimaryImageAspectRatio',
         Limit: 100,
         StartIndex: 0,
-        CollapseBoxSetItems: false,
-        isMissing: !user?.Configuration?.DisplayMissingEpisodes ? false : undefined,
+        CollapseBoxSetItems: false
     };
     query = Object.assign(query, options || {});
     addCurrentItemToQuery(query, item);
     return query;
 }
 
-function getItemsFunction(options, item, user) {
-    const query = getQuery(options, item, user);
+function getItemsFunction(options, item) {
+    const query = getQuery(options, item);
     return function (index, limit, fields) {
         query.StartIndex = index;
         query.Limit = limit;


### PR DESCRIPTION

Follows up on PR https://github.com/jellyfin/jellyfin-web/pull/7528

This PR does not display missing episodes in item details pages unless the user has `DisplayMissingEpisodes` enabled.

I noticed this happening in Person details pages, and I'm not sure if anything else is affected. I was initially wary of attempting this because the `scripts` directory had an ominous here-be-dragons warning, but this file does not seem to be referenced anywhere else.

### Changes
The query parameters for child items in `/details` pages include `isMissing` based the user's preferences. Not sure if this is ideal but from initial testing it seems to work, since I think
this parameter is just ignored for non-episode items..? Unless there is an edge case not present in my own library.

I did consider just passing around the relevant boolean instead of the user object but I see that other such usage in the library passes around the `user` itself, so I have done the same.

### Issues
None reported

### Code assistance
no.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
