### PR TITLE
Add configurable playback buffer size for HLS player

### DIFF
--- a/src/components/playbackSettings/playbackSettings.js
+++ b/src/components/playbackSettings/playbackSettings.js
@@ -236,6 +236,7 @@ function loadForm(context, user, userSettings, systemInfo, apiClient) {
     context.querySelector('.chkRememberAudioSelections').checked = user.Configuration.RememberAudioSelections || false;
     context.querySelector('.chkRememberSubtitleSelections').checked = user.Configuration.RememberSubtitleSelections || false;
     context.querySelector('.chkExternalVideoPlayer').checked = appSettings.enableSystemExternalPlayers();
+    context.querySelector('#selectPlaybackBufferSize').value = appSettings.playbackBufferSize();
     context.querySelector('.chkLimitSupportedVideoResolution').checked = appSettings.limitSupportedVideoResolution();
     context.querySelector('#selectPreferredTranscodeVideoCodec').value = appSettings.preferredTranscodeVideoCodec();
     context.querySelector('#selectPreferredTranscodeVideoAudioCodec').value = appSettings.preferredTranscodeVideoAudioCodec();
@@ -279,6 +280,7 @@ function saveUser(context, user, userSettingsInstance, apiClient) {
 
     appSettings.maxChromecastBitrate(context.querySelector('.selectChromecastVideoQuality').value);
     appSettings.maxVideoWidth(context.querySelector('.selectMaxVideoWidth').value);
+    appSettings.playbackBufferSize(context.querySelector('#selectPlaybackBufferSize').value);
     appSettings.limitSupportedVideoResolution(context.querySelector('.chkLimitSupportedVideoResolution').checked);
     appSettings.preferredTranscodeVideoCodec(context.querySelector('#selectPreferredTranscodeVideoCodec').value);
     appSettings.preferredTranscodeVideoAudioCodec(context.querySelector('#selectPreferredTranscodeVideoAudioCodec').value);

--- a/src/components/playbackSettings/playbackSettings.template.html
+++ b/src/components/playbackSettings/playbackSettings.template.html
@@ -150,6 +150,15 @@
         </div>
 
         <div class="selectContainer">
+            <select is="emby-select" id="selectPlaybackBufferSize" label="${LabelPlaybackBufferSize}">
+                <option value="auto">${Auto}</option>
+                <option value="large">${PlaybackBufferLarge}</option>
+                <option value="extra_large">${PlaybackBufferExtraLarge}</option>
+            </select>
+            <div class="fieldDescription">${PlaybackBufferSizeHelp}</div>
+        </div>
+
+        <div class="selectContainer">
             <select is="emby-select" class="selectSkipForwardLength" label="${LabelSkipForwardLength}"></select>
         </div>
 

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -440,14 +440,22 @@ export class HtmlVideoPlayer {
     setSrcWithHlsJs(elem, options, url) {
         return new Promise((resolve, reject) => {
             requireHlsPlayer(async () => {
-                let maxBufferLength = 30;
-
-                // Some browsers cannot handle huge fragments in high bitrate.
-                // This issue usually happens when using HWA encoders with a high bitrate setting.
-                // Limit the BufferLength to 6s, it works fine when playing 4k 120Mbps over HLS on chrome.
+                // Reduce buffer for high bitrate streams to avoid browser memory issues
                 // https://github.com/video-dev/hls.js/issues/876
-                if ((browser.chrome || browser.edgeChromium || browser.firefox) && playbackManager.getMaxStreamingBitrate(this) >= 25000000) {
-                    maxBufferLength = 6;
+                const maxBufferLength = (browser.chrome || browser.edgeChromium || browser.firefox) && playbackManager.getMaxStreamingBitrate(this) >= 25000000 ? 6 : 30;
+                const bufferSizeSetting = appSettings.playbackBufferSize();
+                let maxMaxBufferLength;
+                let maxBufferSize;
+
+                if (bufferSizeSetting === 'large') {
+                    maxMaxBufferLength = 120;
+                    maxBufferSize = 500 * 1024 * 1024;
+                } else if (bufferSizeSetting === 'extra_large') {
+                    maxMaxBufferLength = 240;
+                    maxBufferSize = 3 * 1024 * 1024 * 1024;
+                } else {
+                    maxMaxBufferLength = maxBufferLength;
+                    maxBufferSize = 60 * 1000 * 1000;
                 }
 
                 const includeCorsCredentials = await getIncludeCorsCredentials();
@@ -456,7 +464,8 @@ export class HtmlVideoPlayer {
                     startPosition: options.playerStartPositionTicks / 10000000,
                     manifestLoadingTimeOut: 20000,
                     maxBufferLength: maxBufferLength,
-                    maxMaxBufferLength: maxBufferLength,
+                    maxMaxBufferLength: maxMaxBufferLength,
+                    maxBufferSize: maxBufferSize,
                     videoPreference: { preferHDR: true },
                     xhrSetup(xhr) {
                         xhr.withCredentials = includeCorsCredentials;

--- a/src/scripts/settings/appSettings.js
+++ b/src/scripts/settings/appSettings.js
@@ -248,6 +248,19 @@ class AppSettings {
     }
 
     /**
+     * Get or set 'Playback Buffer Size' preset.
+     * @param {string|undefined} val - Buffer size preset ('auto', 'large', 'extra_large') or undefined.
+     * @return {string} Buffer size preset.
+     */
+    playbackBufferSize(val) {
+        if (val !== undefined) {
+            return this.set('playbackBufferSize', val);
+        }
+
+        return this.get('playbackBufferSize') || 'auto';
+    }
+
+    /**
      * Get or set the preferred video aspect ratio.
      * @param {string|undefined} val - The aspect ratio or undefined.
      * @returns {string} The saved aspect ratio state.

--- a/src/strings/en_US.json
+++ b/src/strings/en_US.json
@@ -235,5 +235,9 @@
     "DeleteSeries": "Delete Series",
     "DeleteEpisode": "Delete Episode",
     "DeleteName": "Delete {0}",
-    "DeleteUser": "Delete User"
+    "DeleteUser": "Delete User",
+    "LabelPlaybackBufferSize": "Playback buffer size",
+    "PlaybackBufferLarge": "Large (up to 500 MB)",
+    "PlaybackBufferExtraLarge": "Extra large (up to 3 GB)",
+    "PlaybackBufferSizeHelp": "Controls how far ahead hls.js can buffer video when used for playback. Has no effect on native HLS playback (e.g. Safari, iOS, Tizen, webOS). Larger values help on slow or unstable connections but use significantly more memory and may re-expose browser buffering issues on some clients."
 }


### PR DESCRIPTION
### Changes

FYI: This is written by me, not by LLMs.
This PR adds a playback buffer size setting (Auto / Large / Extra Large) under Settings > Playback that controls how far ahead the HLS player can buffer video.

- **Auto**: preserves current master behavior (30s default, 6s for high-bitrate streams on Chrome/Edge/Firefox per #6985) - check the discussion at https://github.com/jellyfin/jellyfin-web/pull/7455
- **Large**: allows hls.js to buffer up to 120s ahead with a 500 MB memory budget
- **Extra Large**: allows hls.js to buffer up to 240s ahead with a 3 GB memory budget (enough for ~240s of a 100 Mbps stream)

Of course any other defaults, or having maybe a slider (?) could be considered. But having a really long buffer could be really interesting for some devices with access to a lot of resources which have a quite weak Internet connection.

All presets keep the same initial buffer target from #6985 (6s or 30s depending on bitrate). The larger presets raise both the time ceiling (`maxMaxBufferLength`) and the memory ceiling (`maxBufferSize`), so hls.js can actually use the deeper buffer. These are explicit opt-in overrides — users choosing them accept higher memory usage and the possibility of re-exposing browser-side buffering issues on some clients (e.g. the Chrome 138 class of issue from #6985).

FYI2: If #7455 lands first, this branch will need a rebase so that Auto uses the new dynamic bitrate-based calculation instead of the current 30s / 6s behavior.

Companion PRs for the native apps, I will probably add the new "Auto" behavior proposed in the other PR as well when they're merged:
- https://github.com/jellyfin/jellyfin-android/pull/1946
- https://github.com/jellyfin/jellyfin-androidtv/pull/5515

### Issues

Helps with https://github.com/jellyfin/jellyfin-web/issues/7454
Helps with https://github.com/jellyfin/jellyfin/issues/15787