### PR TITLE
add audiobooks back to book libraries

### DIFF
--- a/src/apps/experimental/routes/books/index.tsx
+++ b/src/apps/experimental/routes/books/index.tsx
@@ -11,7 +11,7 @@ import { BookSuggestionsSectionsView } from 'types/sections';
 const booksTabContent: LibraryTabContent = {
     viewType: LibraryTab.Books,
     collectionType: CollectionType.Books,
-    itemType: [BaseItemKind.Book]
+    itemType: [BaseItemKind.AudioBook, BaseItemKind.Book]
 };
 
 const suggestionsTabContent: LibraryTabContent = {
@@ -23,13 +23,13 @@ const suggestionsTabContent: LibraryTabContent = {
 const genresTabContent: LibraryTabContent = {
     viewType: LibraryTab.Genres,
     collectionType: CollectionType.Books,
-    itemType: [BaseItemKind.Book]
+    itemType: [BaseItemKind.AudioBook, BaseItemKind.Book]
 };
 
 const favoritesTabContent: LibraryTabContent = {
     viewType: LibraryTab.Favorites,
     collectionType: CollectionType.Books,
-    itemType: [BaseItemKind.Book]
+    itemType: [BaseItemKind.AudioBook, BaseItemKind.Book]
 };
 
 const booksTabMapping: LibraryTabMapping = {

--- a/src/utils/sections.ts
+++ b/src/utils/sections.ts
@@ -57,7 +57,7 @@ export const getSuggestionSections = (): Section[] => {
             itemTypes: 'Book',
             type: SectionType.LatestBooks,
             parametersOptions: {
-                includeItemTypes: [BaseItemKind.Book]
+                includeItemTypes: [BaseItemKind.AudioBook, BaseItemKind.Book]
             },
             cardOptions: {
                 overlayPlayButton: true,


### PR DESCRIPTION
### Changes

The experimental view currently lacks support for audiobooks - this fix has been tested on an unstable server and is working fine. Whether or not we want two separate library types is a good future question.

### Issues

None

### Code assistance

None