### PR TITLE
listview: collapsible overview

### DIFF
--- a/src/components/listview/listview.js
+++ b/src/components/listview/listview.js
@@ -424,7 +424,8 @@ export function getListViewHtml(options) {
             // eslint-disable-next-line sonarjs/disabled-auto-escaping
             const overview = DOMPurify.sanitize(markdownIt({ html: true }).render(item.Overview || ''));
             html += '<div class="secondary listItem-overview listItemBodyText">';
-            html += '<bdi>' + overview + '</bdi>';
+            html += '<bdi class="listItem-overview-clamped">' + overview + '</bdi>';
+            html += `<button class="listItem-overview-toggle">${globalize.translate('ShowMore')}</button>`;
             html += '</div>';
         }
 
@@ -488,7 +489,8 @@ export function getListViewHtml(options) {
 
             if (enableOverview && item.Overview) {
                 html += '<div class="listItem-bottomoverview secondary">';
-                html += '<bdi>' + item.Overview + '</bdi>';
+                html += '<bdi class="listItem-overview-clamped">' + item.Overview + '</bdi>';
+                html += `<button class="listItem-overview-toggle">${globalize.translate('ShowMore')}</button>`;
                 html += '</div>';
             }
         }
@@ -501,6 +503,32 @@ export function getListViewHtml(options) {
     return outerHtml;
 }
 
+function updateToggleVisibility(btn) {
+    const bdi = btn.previousElementSibling;
+    if (!bdi) return;
+    btn.style.display = bdi.scrollHeight > bdi.clientHeight ? 'inline-block' : 'none';
+}
+
+function onToggleClick(e) {
+    e.stopPropagation();
+    e.preventDefault();
+    const btn = e.currentTarget;
+    const bdi = btn.previousElementSibling;
+    const clamped = bdi.classList.toggle('listItem-overview-clamped');
+    btn.textContent = clamped ? globalize.translate('ShowMore') : globalize.translate('ShowLess');
+    if (clamped) {
+        updateToggleVisibility(btn);
+    }
+}
+
+export function initOverviewToggles(container) {
+    for (const btn of container.querySelectorAll('.listItem-overview-toggle')) {
+        btn.addEventListener('click', onToggleClick);
+        updateToggleVisibility(btn);
+    }
+}
+
 export default {
-    getListViewHtml
+    getListViewHtml,
+    initOverviewToggles
 };

--- a/src/components/listview/listview.js
+++ b/src/components/listview/listview.js
@@ -427,7 +427,8 @@ export function getListViewHtml(options) {
 
         if (enableOverview && safeOverviewHtml) {
             html += '<div class="secondary listItem-overview listItemBodyText">';
-            html += `<bdi>${safeOverviewHtml}</bdi>`;
+            html += `<bdi class="listItem-overview-clamped">${safeOverviewHtml}</bdi>`;
+            html += `<button class="listItem-overview-toggle">${globalize.translate('ShowMore')}</button>`;
             html += '</div>';
         }
 
@@ -491,7 +492,8 @@ export function getListViewHtml(options) {
 
             if (enableOverview && safeOverviewHtml) {
                 html += '<div class="listItem-bottomoverview secondary">';
-                html += `<bdi>${safeOverviewHtml}</bdi>`;
+                html += `<bdi class="listItem-overview-clamped">${safeOverviewHtml}</bdi>`;
+                html += `<button class="listItem-overview-toggle">${globalize.translate('ShowMore')}</button>`;
                 html += '</div>';
             }
         }
@@ -504,6 +506,32 @@ export function getListViewHtml(options) {
     return outerHtml;
 }
 
+function updateToggleVisibility(btn) {
+    const bdi = btn.previousElementSibling;
+    if (!bdi) return;
+    btn.style.display = bdi.scrollHeight > bdi.clientHeight ? 'inline-block' : 'none';
+}
+
+function onToggleClick(e) {
+    e.stopPropagation();
+    e.preventDefault();
+    const btn = e.currentTarget;
+    const bdi = btn.previousElementSibling;
+    const clamped = bdi.classList.toggle('listItem-overview-clamped');
+    btn.textContent = clamped ? globalize.translate('ShowMore') : globalize.translate('ShowLess');
+    if (clamped) {
+        updateToggleVisibility(btn);
+    }
+}
+
+export function initOverviewToggles(container) {
+    for (const btn of container.querySelectorAll('.listItem-overview-toggle')) {
+        btn.addEventListener('click', onToggleClick);
+        updateToggleVisibility(btn);
+    }
+}
+
 export default {
-    getListViewHtml
+    getListViewHtml,
+    initOverviewToggles
 };

--- a/src/components/listview/listview.scss
+++ b/src/components/listview/listview.scss
@@ -309,6 +309,25 @@
     margin-top: 0.2em;
 }
 
+.listItem-overview-clamped {
+    display: -webkit-box;
+    -webkit-line-clamp: 4;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.listItem-overview-toggle {
+    background: none;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    padding: 0;
+    font-size: inherit;
+    font-family: inherit;
+    margin-top: 0.25em;
+    display: none;
+}
+
 @media all and (max-width: 50em) {
     .listItem .endsAt,
     .listItem .criticRating,

--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -1402,6 +1402,7 @@ function renderChildren(page, item) {
             childrenItemsContainer.classList.remove('padded-right');
         }
         childrenItemsContainer.innerHTML = html;
+        listView.initOverviewToggles(childrenItemsContainer);
         imageLoader.lazyChildren(childrenItemsContainer);
         if (item.Type == 'BoxSet') {
             const collectionItemTypes = [{

--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -1407,6 +1407,7 @@ function renderChildren(page, item) {
             childrenItemsContainer.classList.remove('padded-right');
         }
         childrenItemsContainer.innerHTML = html;
+        listView.initOverviewToggles(childrenItemsContainer);
         imageLoader.lazyChildren(childrenItemsContainer);
         if (item.Type == 'BoxSet') {
             const collectionItemTypes = [{


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

### Changes
<!--
Describe your changes here in 1-5 sentences.
Please include before/after screenshots of any UI changes.
-->
I made descriptions (overview) of episodes collapsible.
If description doesn't fit in 4 lines of text a button `Show more` is shown.
I tried to have a similar style to existing button in a video details.

My personal use case are downloaded YouTube videos which often have very long descriptions: they easily can take full screen.

[jellyfin-web-collapsible-description.webm](https://github.com/user-attachments/assets/1f106972-e324-45eb-afad-9b4f30d8e799)

| Before | After (collapsed) | After (expanded) |
| - | - | - |
| <img width="1681" height="1232" alt="image" src="https://github.com/user-attachments/assets/059c7bc8-1590-4265-86a0-92279ce14dc7" /> | <img width="1684" height="1215" alt="image" src="https://github.com/user-attachments/assets/08740111-9db1-4f78-a667-777c9fef84e4" /> | <img width="1679" height="1216" alt="image" src="https://github.com/user-attachments/assets/44b091de-7856-452a-b342-99f7c9148f41" /> |

### Code assistance
<!--
If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance.
-->
I used Claude Code (LLM). It suggested where and what changes could be made.
I heavily refactored (especially simplification) suggested snippets

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
