### PR TITLE
Fix behavior when applying filters and switching pages

### DIFF
--- a/src/apps/experimental/components/library/Pagination.tsx
+++ b/src/apps/experimental/components/library/Pagination.tsx
@@ -42,6 +42,7 @@ const Pagination: FC<PaginationProps> = ({
             ...prevState,
             StartIndex: newIndex
         }));
+        window.scrollTo(0, 0);
     }, [limit, setLibraryViewSettings, startIndex]);
 
     const onPreviousPageClick = useCallback(() => {
@@ -50,6 +51,7 @@ const Pagination: FC<PaginationProps> = ({
             ...prevState,
             StartIndex: newIndex
         }));
+        window.scrollTo(0, 0);
     }, [limit, setLibraryViewSettings, startIndex]);
 
     return (

--- a/src/apps/experimental/components/library/filter/FilterButton.tsx
+++ b/src/apps/experimental/components/library/filter/FilterButton.tsx
@@ -155,13 +155,6 @@ const FilterButton: FC<FilterButtonProps> = ({
         );
     };
 
-    const isFiltersVideoTypesEnabled = () => {
-        return (
-            viewType === LibraryTab.Movies
-            || viewType === LibraryTab.Series
-            || viewType === LibraryTab.Episodes
-        );
-    };
 
     const isFiltersSeriesStatusEnabled = () => {
         return viewType === LibraryTab.Series;
@@ -296,7 +289,7 @@ const FilterButton: FC<FilterButtonProps> = ({
                     </Accordion>
                 )}
 
-                {isFiltersVideoTypesEnabled() && (
+                {isFiltersFeaturesEnabled() && (
                     <Accordion
                         expanded={expanded === 'filtersVideoTypes'}
                         onChange={handleChange('filtersVideoTypes')}

--- a/src/apps/experimental/components/library/filter/FilterButton.tsx
+++ b/src/apps/experimental/components/library/filter/FilterButton.tsx
@@ -158,6 +158,7 @@ const FilterButton: FC<FilterButtonProps> = ({
     const isFiltersVideoTypesEnabled = () => {
         return (
             viewType === LibraryTab.Movies
+            || viewType === LibraryTab.Series
             || viewType === LibraryTab.Episodes
         );
     };

--- a/src/apps/experimental/components/library/filter/FilterButton.tsx
+++ b/src/apps/experimental/components/library/filter/FilterButton.tsx
@@ -155,7 +155,6 @@ const FilterButton: FC<FilterButtonProps> = ({
         );
     };
 
-
     const isFiltersSeriesStatusEnabled = () => {
         return viewType === LibraryTab.Series;
     };

--- a/src/apps/experimental/components/library/filter/FilterButton.tsx
+++ b/src/apps/experimental/components/library/filter/FilterButton.tsx
@@ -164,6 +164,7 @@ const FilterButton: FC<FilterButtonProps> = ({
     const isFiltersVideoTypesEnabled = () => {
         return (
             viewType === LibraryTab.Movies
+            || viewType === LibraryTab.Series
             || viewType === LibraryTab.Episodes
         );
     };

--- a/src/apps/experimental/components/library/filter/FilterButton.tsx
+++ b/src/apps/experimental/components/library/filter/FilterButton.tsx
@@ -161,7 +161,6 @@ const FilterButton: FC<FilterButtonProps> = ({
         );
     };
 
-
     const isFiltersSeriesStatusEnabled = () => {
         return viewType === LibraryTab.Series;
     };

--- a/src/apps/experimental/components/library/filter/FilterButton.tsx
+++ b/src/apps/experimental/components/library/filter/FilterButton.tsx
@@ -161,13 +161,6 @@ const FilterButton: FC<FilterButtonProps> = ({
         );
     };
 
-    const isFiltersVideoTypesEnabled = () => {
-        return (
-            viewType === LibraryTab.Movies
-            || viewType === LibraryTab.Series
-            || viewType === LibraryTab.Episodes
-        );
-    };
 
     const isFiltersSeriesStatusEnabled = () => {
         return viewType === LibraryTab.Series;
@@ -302,7 +295,7 @@ const FilterButton: FC<FilterButtonProps> = ({
                     </Accordion>
                 )}
 
-                {isFiltersVideoTypesEnabled() && (
+                {isFiltersFeaturesEnabled() && (
                     <Accordion
                         expanded={expanded === 'filtersVideoTypes'}
                         onChange={handleChange('filtersVideoTypes')}

--- a/src/apps/experimental/components/library/filter/FiltersVideoTypes.tsx
+++ b/src/apps/experimental/components/library/filter/FiltersVideoTypes.tsx
@@ -40,6 +40,7 @@ const FiltersVideoTypes: FC<FiltersVideoTypesProps> = ({
 
             setLibraryViewSettings((prevState) => ({
                 ...prevState,
+                StartIndex: 0,
                 Filters: {
                     ...prevState.Filters,
                     VideoBasicFilter: updatedVideoBasicFilter.length ? updatedVideoBasicFilter : undefined

--- a/src/components/filterdialog/filterdialog.js
+++ b/src/components/filterdialog/filterdialog.js
@@ -139,7 +139,7 @@ function setVisibility(context, options) {
         context.querySelector('.yearFilters').classList.remove('hide');
     }
 
-    if (options.mode === 'movies' || options.mode === 'episodes') {
+    if (options.mode === 'movies' || options.mode === 'series' || options.mode === 'episodes') {
         context.querySelector('.videoTypeFilters').classList.remove('hide');
     }
 

--- a/src/controllers/shows/episodes.js
+++ b/src/controllers/shows/episodes.js
@@ -177,6 +177,7 @@ export default function (view, params, tabContent) {
                 serverId: ApiClient.serverId()
             });
             Events.on(filterDialog, 'filterchange', function () {
+                getQuery().StartIndex = 0;
                 reloadItems(tabContent);
             });
             filterDialog.show();


### PR DESCRIPTION
### Changes
* When applying filters, jump back to page one
* When switching pages, jump back to top
* Expose additional filters on tv libraries

### Code assistance
Claude Code with Opus 4.6 was used for exploration.

---

* [X] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [X] I have tested these changes.
* [X] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
