### PR TITLE
Add folders tab to experimental view in book libraries

### DIFF
--- a/src/apps/experimental/features/libraries/constants/libraryRoutes.ts
+++ b/src/apps/experimental/features/libraries/constants/libraryRoutes.ts
@@ -44,22 +44,27 @@ export const LibraryRoutes: LibraryRoute[] = [
         views: [
             {
                 index: 0,
-                label: 'Books',
-                view: LibraryTab.Books,
+                label: 'Folders',
+                view: LibraryTab.Folders,
                 isDefault: true
             },
             {
                 index: 1,
+                label: 'Books',
+                view: LibraryTab.Books
+            },
+            {
+                index: 2,
                 label: 'Suggestions',
                 view: LibraryTab.Suggestions
             },
             {
-                index: 2,
+                index: 3,
                 label: 'Genres',
                 view: LibraryTab.Genres
             },
             {
-                index: 3,
+                index: 4,
                 label: 'Favorites',
                 view: LibraryTab.Favorites
             }

--- a/src/apps/experimental/routes/books/index.tsx
+++ b/src/apps/experimental/routes/books/index.tsx
@@ -8,6 +8,12 @@ import { CollectionType } from '@jellyfin/sdk/lib/generated-client/models/collec
 import { LibraryTabContent, LibraryTabMapping } from 'types/libraryTabContent';
 import { BookSuggestionsSectionsView } from 'types/sections';
 
+const foldersTabContent: LibraryTabContent = {
+    viewType: LibraryTab.Folders,
+    collectionType: CollectionType.Books,
+    itemType: [BaseItemKind.Folder, BaseItemKind.AudioBook, BaseItemKind.Book]
+};
+
 const booksTabContent: LibraryTabContent = {
     viewType: LibraryTab.Books,
     collectionType: CollectionType.Books,
@@ -33,10 +39,11 @@ const favoritesTabContent: LibraryTabContent = {
 };
 
 const booksTabMapping: LibraryTabMapping = {
-    0: booksTabContent,
-    1: suggestionsTabContent,
-    2: genresTabContent,
-    3: favoritesTabContent
+    0: foldersTabContent,
+    1: booksTabContent,
+    2: suggestionsTabContent,
+    3: genresTabContent,
+    4: favoritesTabContent
 };
 
 const Books: FC = () => {


### PR DESCRIPTION
### Changes

Adds back the folder view to book libraries. I envision this as a stopgap until Author and Series tabs are supported, at which point folders can be sidelined.

### Issues

None

### Code Assistance

None