### PR TITLE
Shift subtitles above OSD controls when visible

### DIFF
--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -323,6 +323,15 @@ export default function (view) {
         elem.removeEventListener(transitionEndEventName, onHideAnimationComplete);
     }
 
+    function updateSubtitlePosition(osdVisible) {
+        const subtitleContainer = document.querySelector('.videoPlayerContainer .libassjs-canvas-parent')
+            || document.querySelector('.videoPlayerContainer .videoSubtitles');
+        if (!subtitleContainer) return;
+
+        subtitleContainer.style.transition = 'transform 0.3s ease';
+        subtitleContainer.style.transform = osdVisible ? 'translateY(-80px)' : '';
+    }
+
     function onHideAnimationComplete(e) {
         const elem = e.target;
         if (elem !== osdBottomElement && elem !== headerElement) return;
@@ -348,6 +357,7 @@ export default function (view) {
             clearHideAnimationEventListeners(elem);
             elem.classList.remove('hide');
             elem.classList.remove('videoOsdBottom-hidden');
+            updateSubtitlePosition(true);
 
             if (!layoutManager.mobile) {
                 _focus(focusElement);
@@ -363,6 +373,7 @@ export default function (view) {
             const elem = osdBottomElement;
             clearHideAnimationEventListeners(elem);
             elem.classList.add('videoOsdBottom-hidden');
+            updateSubtitlePosition(false);
 
             elem.addEventListener(transitionEndEventName, onHideAnimationComplete);
             currentVisibleMenu = null;

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1383,6 +1383,11 @@ export class HtmlVideoPlayer {
                 this.#videoSubtitlesElem = subtitlesElement;
                 this.setSubtitleAppearance(subtitlesContainer, this.#videoSubtitlesElem);
                 videoElement.parentNode.appendChild(subtitlesContainer);
+                const osdBottom = document.querySelector('.videoOsdBottom');
+                if (osdBottom && !osdBottom.classList.contains('videoOsdBottom-hidden')) {
+                    subtitlesContainer.style.transition = 'transform 0.3s ease';
+                    subtitlesContainer.style.transform = 'translateY(-80px)';
+                }
                 this.#currentTrackEvents = subtitleData.TrackEvents;
             } else if (!this.#videoSecondarySubtitlesElem && this.isSecondaryTrack(targetTextTrackIndex)) {
                 const subtitlesContainer = document.querySelector('.videoSubtitles');

--- a/src/plugins/htmlVideoPlayer/style.scss
+++ b/src/plugins/htmlVideoPlayer/style.scss
@@ -15,6 +15,7 @@
 
 .videoPlayerContainer .libassjs-canvas-parent {
     order: -1;
+    transition: transform 0.3s ease;
 }
 
 /* Controls are enabled for devices that don't support autoplay. They will be hidden when playback starts.
@@ -51,6 +52,7 @@ video[controls]::-webkit-media-controls {
 }
 
 .videoSubtitles {
+    transition: transform 0.3s ease;
     position: fixed;
     bottom: 0;
     text-align: center;


### PR DESCRIPTION
### Changes
The video player controls can obscure the subtitles. This PR fixes this by moving the subtitles up when the OSD is shown

- `src/controllers/playback/video/index.js` -> added a `updateSubtitlePosition(visible)` helper function to apply/remove `translateY(-80px)` on the subtitle container. 

- `src/plugins/htmlVideoPlayer/style.scss` -> added a `transition: transform 0.3s ease` to animate smoothly.

- `src/plugins/htmlVideoPlayer/plugin.js` -> when switching subtitle tracks, this reapplies the transform.

### Issues
Addresses feature request [2520](https://features.jellyfin.org/posts/2520).

### Code assistance
Claude Code with Opus 4.6 was used for to brainstorm the implementation.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
