### PR TITLE
Fix insufficient contrast of Watched button icon on TV/console clients

### DIFF
--- a/src/elements/emby-playstatebutton/PlayedButton.tsx
+++ b/src/elements/emby-playstatebutton/PlayedButton.tsx
@@ -68,7 +68,7 @@ const PlayedButton: FC<PlayedButtonProps> = ({
             onClick={onClick}
         >
             <CheckIcon
-                color={isPlayed ? 'error' : undefined}
+                sx={isPlayed ? { color: '#ffc107' } : undefined}
             />
         </IconButton>
     );

--- a/src/themes/_base/_theme.scss
+++ b/src/themes/_base/_theme.scss
@@ -426,7 +426,7 @@ a[data-role=button],
 
 .ratingbutton-icon-withrating,
 .playstatebutton-icon-played {
-    @include var(color, --jf-palette-error-light, $error-light);
+    color: #ffc107;
 }
 
 .buttonActive {

--- a/src/themes/appletv/theme.scss
+++ b/src/themes/appletv/theme.scss
@@ -470,7 +470,7 @@ a[data-role=button] {
 }
 
 .playstatebutton-icon-played {
-    color: #c33;
+    color: #ffc107;
 }
 
 .buttonActive {

--- a/src/themes/blueradiance/theme.scss
+++ b/src/themes/blueradiance/theme.scss
@@ -464,7 +464,7 @@ a[data-role=button] {
 }
 
 .playstatebutton-icon-played {
-    color: #c33;
+    color: #ffc107;
 }
 
 .buttonActive {

--- a/src/themes/purplehaze/theme.scss
+++ b/src/themes/purplehaze/theme.scss
@@ -561,7 +561,7 @@ a[data-role=button] {
 }
 
 .playstatebutton-icon-played {
-    color: #c33;
+    color: #ffc107;
 }
 
 .buttonActive {

--- a/src/themes/wmc/theme.scss
+++ b/src/themes/wmc/theme.scss
@@ -443,7 +443,7 @@ a[data-role=button] {
 }
 
 .playstatebutton-icon-played {
-    color: #c33;
+    color: #ffc107;
 }
 
 .buttonActive {


### PR DESCRIPTION
Fixes #7736

The "Watched" button check icon used red (#c33 / error-light) which has insufficient contrast against the blue button background on TV/console clients (Xbox, etc.), making it barely distinguishable.

Changed the played icon color from red to amber (#ffc107) across all themes and both component implementations (vanilla JS and React). Amber provides better contrast against both blue (TV/console) and dark (web) backgrounds.