### PR TITLE
Fix Shuffle and Play All for videos in Home Videos libraries

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -1937,8 +1937,7 @@ export class PlaybackManager {
                     Filters: 'IsNotFolder',
                     Recursive: true,
                     SortBy: options.shuffle ? 'Random' : 'SortName',
-                    // Only include Photos because we do not handle mixed queues currently
-                    MediaTypes: 'Photo',
+                    MediaTypes: 'Photo,Video',
                     Limit: UNLIMITED_ITEMS
                 }, queryOptions));
             } else if (firstItem.IsFolder && firstItem.CollectionType === 'musicvideos') {


### PR DESCRIPTION
The homevideos collection type playback query was hardcoded to only include Photos (MediaTypes: 'Photo'), causing Shuffle and Play All to fail with NO_MEDIA_ERROR when the library contains videos.

Changed to 'Photo,Video' so both media types are included in the playback queue.

Fixes jellyfin-web#7176

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

### Changes
  The homevideos collection type playback query in playbackmanager.js was
  hardcoded to only fetch items with MediaTypes: 'Photo'. This caused Shuffle   
  and Play All to fail with PlaybackError.NO_MEDIA_ERROR when the library
  contains videos, because the query returned zero playable items.              
                  
  Changed MediaTypes: 'Photo' to MediaTypes: 'Photo,Video' so both media types  
  are included in the playback queue. Individual video playback was not affected
   because it bypasses translateItemsForPlayback() entirely. 

### Issues
  Fixes #7176  

### Code assistance
  Claude Code was used to trace the bug through the minified bundle back to the 
  source, identifying the hardcoded MediaTypes: 'Photo' filter at line 1941 as
  the root cause.                                                               
                  
  ---
  - I have read and followed the
  https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md.         
  - I have tested these changes.                                       
  - I have verified that this is not duplicating changes in an existing PR.     
  - I have provided a substantive review of                                
  https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Ade
  pendencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A%22merg
  e+conflict%22+-label%3Astale+-author%3A%40me.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
