### PR TITLE
Make library header sticky

### DIFF
--- a/src/apps/experimental/components/OffsetAppBar.tsx
+++ b/src/apps/experimental/components/OffsetAppBar.tsx
@@ -1,0 +1,77 @@
+import AppBar, { type AppBarProps } from '@mui/material/AppBar';
+import useScrollTrigger from '@mui/material/useScrollTrigger';
+import React, { useLayoutEffect, useRef, useState, type FC, type PropsWithChildren } from 'react';
+
+/** The default height of an AppBar. Note the dense Toolbar variant would be 48 instead. */
+const DEFAULT_APP_BAR_HEIGHT = 64;
+
+/**
+ * AppBar wrapper with a fixed position and a spacer to prevent content from rendering underneath.
+ */
+const OffsetAppBar: FC<PropsWithChildren<AppBarProps>> = ({
+    children,
+    ...props
+}) => {
+    const appBarRef = useRef<HTMLHtmlElement>(null);
+    const [height, setHeight] = useState(DEFAULT_APP_BAR_HEIGHT);
+
+    const scrollTrigger = useScrollTrigger({
+        disableHysteresis: true,
+        threshold: 0
+    });
+
+    useLayoutEffect(() => {
+        const el = appBarRef.current;
+        if (!el) return;
+
+        // Set initial measured height
+        const updateHeight = () => {
+            setHeight(Math.ceil(el.getBoundingClientRect().height || 0));
+        };
+
+        updateHeight();
+
+        // Use ResizeObserver for dynamic changes
+        const observer = new ResizeObserver(entries => {
+            // Use requestAnimationFrame to batch DOM writes
+            window.requestAnimationFrame(() => {
+                for (const entry of entries) {
+                    setHeight(Math.ceil(entry.contentRect.height || 0));
+                }
+            });
+        });
+        observer.observe(el);
+        // Update on window resize as a fallback
+        window.addEventListener('resize', updateHeight);
+
+        return () => {
+            observer.disconnect();
+            window.removeEventListener('resize', updateHeight);
+        };
+    }, []);
+
+    return (
+        <>
+            <AppBar
+                {...props}
+                ref={appBarRef}
+                position='fixed'
+                color={scrollTrigger ? 'default' : 'transparent'}
+                elevation={scrollTrigger ? 1 : 0}
+            >
+                {children}
+            </AppBar>
+            {/* Spacer to prevent content rendering under the AppBar */}
+            <div
+                aria-hidden='true'
+                style={{
+                    height,
+                    width: '100%',
+                    flexShrink: 0
+                }}
+            />
+        </>
+    );
+};
+
+export default OffsetAppBar;

--- a/src/apps/experimental/components/library/AlphabetPicker.tsx
+++ b/src/apps/experimental/components/library/AlphabetPicker.tsx
@@ -16,6 +16,8 @@ interface AlphabetPickerProps {
     >;
 }
 
+const LETTER_VALUES = ['#', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'];
+
 const AlphabetPicker: React.FC<AlphabetPickerProps> = ({
     className,
     libraryViewSettings,
@@ -46,19 +48,20 @@ const AlphabetPicker: React.FC<AlphabetPickerProps> = ({
         'alphaPickerButton'
     );
 
-    const letters = ['#', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'];
-
     return (
         <Box
             className={containerClassName}
-            sx={{
+            // eslint-disable-next-line react/jsx-no-bind
+            sx={theme => ({
                 position: 'fixed',
                 bottom: '1.5em',
                 fontSize: {
                     xs: '80%',
                     lg: '88%'
-                }
-            }}
+                },
+                // This should render under the main AppBar but above the ItemsView AppBar
+                zIndex: theme.zIndex.appBar - 1
+            })}
         >
             <ToggleButtonGroup
                 orientation='vertical'
@@ -68,7 +71,7 @@ const AlphabetPicker: React.FC<AlphabetPickerProps> = ({
                 size='small'
                 onChange={handleValue}
             >
-                {letters.map((l) => (
+                {LETTER_VALUES.map((l) => (
                     <ToggleButton
                         key={l}
                         value={l}

--- a/src/apps/experimental/components/library/ItemsView.tsx
+++ b/src/apps/experimental/components/library/ItemsView.tsx
@@ -2,9 +2,11 @@ import type { BaseItemKind } from '@jellyfin/sdk/lib/generated-client/models/bas
 import { CollectionType } from '@jellyfin/sdk/lib/generated-client/models/collection-type';
 import { ImageType } from '@jellyfin/sdk/lib/generated-client/models/image-type';
 import { ItemSortBy } from '@jellyfin/sdk/lib/generated-client/models/item-sort-by';
+import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
 import ButtonGroup from '@mui/material/ButtonGroup';
 import type { Theme } from '@mui/material/styles';
+import Toolbar from '@mui/material/Toolbar';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import classNames from 'classnames';
 import React, { type FC, useCallback } from 'react';
@@ -236,143 +238,156 @@ const ItemsView: FC<ItemsViewProps> = ({
 
     return (
         <Box className='padded-bottom-page'>
-            <Box
-                className={classNames(
-                    'padded-top padded-left padded-right',
-                    { 'padded-right-withalphapicker': isAlphabetPickerEnabled }
-                )}
-                sx={{
-                    display: 'flex',
-                    flexWrap: 'wrap',
-                    alignItems: 'center'
-                }}
+            <AppBar
+                position='sticky'
+                elevation={0}
+                // eslint-disable-next-line react/jsx-no-bind
+                sx={theme => ({
+                    top: '3.25rem',
+                    backgroundColor: `var(--jf-palette-background-default, ${theme.palette.background.default}) !important`,
+                    // This should render under the main AppBar and AlphabetPicker
+                    zIndex: theme.zIndex.appBar - 2
+                })}
             >
-                <Box
-                    sx={{ marginRight: 1 }}
-                >
-                    <LibraryViewMenu />
-                </Box>
-
-                <Box
+                <Toolbar
+                    variant='dense'
+                    className={classNames(
+                        'padded-top padded-left padded-right',
+                        { 'padded-right-withalphapicker': isAlphabetPickerEnabled }
+                    )}
                     sx={{
-                        flexGrow: {
-                            xs: 1,
-                            sm: 0
-                        },
-                        marginRight: 1
+                        display: 'flex',
+                        flexWrap: 'wrap',
+                        alignItems: 'center'
                     }}
                 >
-                    <ButtonGroup
-                        color='inherit'
-                        variant='text'
+                    <Box
+                        sx={{ marginRight: 1 }}
                     >
-                        {isBtnFilterEnabled && (
-                            <FilterButton
-                                parentId={parentId}
-                                itemType={itemType}
-                                viewType={viewType}
-                                hasFilters={hasFilters}
+                        <LibraryViewMenu />
+                    </Box>
+
+                    <Box
+                        sx={{
+                            flexGrow: {
+                                xs: 1,
+                                sm: 0
+                            },
+                            marginRight: 1
+                        }}
+                    >
+                        <ButtonGroup
+                            color='inherit'
+                            variant='text'
+                        >
+                            {isBtnFilterEnabled && (
+                                <FilterButton
+                                    parentId={parentId}
+                                    itemType={itemType}
+                                    viewType={viewType}
+                                    hasFilters={hasFilters}
+                                    libraryViewSettings={libraryViewSettings}
+                                    setLibraryViewSettings={setLibraryViewSettings}
+                                />
+                            )}
+
+                            {isBtnSortEnabled && (
+                                <SortButton
+                                    viewType={viewType}
+                                    libraryViewSettings={libraryViewSettings}
+                                    setLibraryViewSettings={setLibraryViewSettings}
+                                />
+                            )}
+
+                            {isBtnGridListEnabled && (
+                                <ViewSettingsButton
+                                    viewType={viewType}
+                                    libraryViewSettings={libraryViewSettings}
+                                    setLibraryViewSettings={setLibraryViewSettings}
+                                />
+                            )}
+                        </ButtonGroup>
+                    </Box>
+
+                    <Box
+                        sx={{
+                            display: 'flex',
+                            flexGrow: {
+                                xs: 1,
+                                sm: 0
+                            },
+                            justifyContent: 'flex-end'
+                        }}
+                    >
+                        {!isPending && (
+                            <>
+                                <ButtonGroup
+                                    variant='contained'
+                                >
+                                    {isBtnPlayAllEnabled && (
+                                        <PlayAllButton
+                                            item={item}
+                                            items={items}
+                                            viewType={viewType}
+                                            hasFilters={hasFilters}
+                                            isTextVisible={isSmallScreen}
+                                            libraryViewSettings={libraryViewSettings}
+                                        />
+                                    )}
+
+                                    {isBtnShuffleEnabled && totalRecordCount > 1 && (
+                                        <ShuffleButton
+                                            item={item}
+                                            items={items}
+                                            viewType={viewType}
+                                            hasFilters={hasFilters}
+                                            isTextVisible={isSmallScreen && !isBtnPlayAllEnabled}
+                                            libraryViewSettings={libraryViewSettings}
+                                        />
+                                    )}
+
+                                    {isBtnQueueEnabled && item && playbackManager.canQueue(item) && (
+                                        <QueueButton
+                                            item={item}
+                                            items={items}
+                                            hasFilters={hasFilters}
+                                            isTextVisible={isSmallScreen && !isBtnPlayAllEnabled && !isBtnShuffleEnabled}
+                                        />
+                                    )}
+                                </ButtonGroup>
+
+                                {isBtnNewCollectionEnabled && <NewCollectionButton isTextVisible={isSmallScreen} />}
+                                {isBtnNewPlaylistEnabled && <NewPlaylistButton isTextVisible={isSmallScreen} />}
+                            </>
+                        )}
+                    </Box>
+
+                    <Box
+                        sx={{
+                            display: 'flex',
+                            justifyContent: 'end',
+                            flexBasis: {
+                                xs: '100%',
+                                sm: 'auto'
+                            },
+                            flexGrow: 1,
+                            marginTop: {
+                                xs: 0.5,
+                                sm: 0
+                            }
+                        }}
+                    >
+                        {!isPending && isPaginationEnabled && (
+                            <Pagination
+                                totalRecordCount={totalRecordCount}
                                 libraryViewSettings={libraryViewSettings}
+                                isPlaceholderData={isPlaceholderData}
                                 setLibraryViewSettings={setLibraryViewSettings}
                             />
                         )}
-
-                        {isBtnSortEnabled && (
-                            <SortButton
-                                viewType={viewType}
-                                libraryViewSettings={libraryViewSettings}
-                                setLibraryViewSettings={setLibraryViewSettings}
-                            />
-                        )}
-
-                        {isBtnGridListEnabled && (
-                            <ViewSettingsButton
-                                viewType={viewType}
-                                libraryViewSettings={libraryViewSettings}
-                                setLibraryViewSettings={setLibraryViewSettings}
-                            />
-                        )}
-                    </ButtonGroup>
-                </Box>
-
-                <Box
-                    sx={{
-                        display: 'flex',
-                        flexGrow: {
-                            xs: 1,
-                            sm: 0
-                        },
-                        justifyContent: 'flex-end'
-                    }}
-                >
-                    {!isPending && (
-                        <>
-                            <ButtonGroup
-                                variant='contained'
-                            >
-                                {isBtnPlayAllEnabled && (
-                                    <PlayAllButton
-                                        item={item}
-                                        items={items}
-                                        viewType={viewType}
-                                        hasFilters={hasFilters}
-                                        isTextVisible={isSmallScreen}
-                                        libraryViewSettings={libraryViewSettings}
-                                    />
-                                )}
-
-                                {isBtnShuffleEnabled && totalRecordCount > 1 && (
-                                    <ShuffleButton
-                                        item={item}
-                                        items={items}
-                                        viewType={viewType}
-                                        hasFilters={hasFilters}
-                                        isTextVisible={isSmallScreen && !isBtnPlayAllEnabled}
-                                        libraryViewSettings={libraryViewSettings}
-                                    />
-                                )}
-
-                                {isBtnQueueEnabled && item && playbackManager.canQueue(item) && (
-                                    <QueueButton
-                                        item={item}
-                                        items={items}
-                                        hasFilters={hasFilters}
-                                        isTextVisible={isSmallScreen && !isBtnPlayAllEnabled && !isBtnShuffleEnabled}
-                                    />
-                                )}
-                            </ButtonGroup>
-
-                            {isBtnNewCollectionEnabled && <NewCollectionButton isTextVisible={isSmallScreen} />}
-                            {isBtnNewPlaylistEnabled && <NewPlaylistButton isTextVisible={isSmallScreen} />}
-                        </>
-                    )}
-                </Box>
-
-                <Box
-                    sx={{
-                        display: 'flex',
-                        justifyContent: 'end',
-                        flexBasis: {
-                            xs: '100%',
-                            sm: 'auto'
-                        },
-                        flexGrow: 1,
-                        marginTop: {
-                            xs: 0.5,
-                            sm: 0
-                        }
-                    }}
-                >
-                    {!isPending && isPaginationEnabled && (
-                        <Pagination
-                            totalRecordCount={totalRecordCount}
-                            libraryViewSettings={libraryViewSettings}
-                            isPlaceholderData={isPlaceholderData}
-                            setLibraryViewSettings={setLibraryViewSettings}
-                        />
-                    )}
-                </Box>
-            </Box>
+                    </Box>
+                </Toolbar>
+            </AppBar>
 
             {isAlphabetPickerEnabled && hasSortName && (
                 <AlphabetPicker
@@ -392,26 +407,6 @@ const ItemsView: FC<ItemsViewProps> = ({
                 >
                     {getItems()}
                 </ItemsContainer>
-            )}
-
-            {!isPending && isPaginationEnabled && (
-                <Box
-                    className={classNames(
-                        'padded-left padded-right',
-                        { 'padded-right-withalphapicker': isAlphabetPickerEnabled }
-                    )}
-                    sx={{
-                        display: 'flex',
-                        justifyContent: 'flex-end'
-                    }}
-                >
-                    <Pagination
-                        totalRecordCount={totalRecordCount}
-                        libraryViewSettings={libraryViewSettings}
-                        isPlaceholderData={isPlaceholderData}
-                        setLibraryViewSettings={setLibraryViewSettings}
-                    />
-                </Box>
             )}
         </Box>
     );

--- a/src/apps/experimental/components/library/ItemsView.tsx
+++ b/src/apps/experimental/components/library/ItemsView.tsx
@@ -2,7 +2,6 @@ import type { BaseItemKind } from '@jellyfin/sdk/lib/generated-client/models/bas
 import { CollectionType } from '@jellyfin/sdk/lib/generated-client/models/collection-type';
 import { ImageType } from '@jellyfin/sdk/lib/generated-client/models/image-type';
 import { ItemSortBy } from '@jellyfin/sdk/lib/generated-client/models/item-sort-by';
-import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
 import ButtonGroup from '@mui/material/ButtonGroup';
 import type { Theme } from '@mui/material/styles';
@@ -28,6 +27,8 @@ import { type LibraryViewSettings, type ParentId, ViewMode } from 'types/library
 import type { CardOptions } from 'types/cardOptions';
 import type { ListOptions } from 'types/listOptions';
 import { useItem } from 'hooks/useItem';
+
+import OffsetAppBar from '../OffsetAppBar';
 
 import AlphabetPicker from './AlphabetPicker';
 import FilterButton from './filter/FilterButton';
@@ -238,21 +239,18 @@ const ItemsView: FC<ItemsViewProps> = ({
 
     return (
         <Box className='padded-bottom-page'>
-            <AppBar
-                position='sticky'
-                elevation={0}
+            <OffsetAppBar
                 // eslint-disable-next-line react/jsx-no-bind
                 sx={theme => ({
-                    top: '3.25rem',
-                    backgroundColor: `var(--jf-palette-background-default, ${theme.palette.background.default}) !important`,
+                    top: 0,
+                    paddingTop: 6,
                     // This should render under the main AppBar and AlphabetPicker
                     zIndex: theme.zIndex.appBar - 2
                 })}
             >
                 <Toolbar
-                    variant='dense'
                     className={classNames(
-                        'padded-top padded-left padded-right',
+                        'padded-left padded-right',
                         { 'padded-right-withalphapicker': isAlphabetPickerEnabled }
                     )}
                     sx={{
@@ -387,7 +385,7 @@ const ItemsView: FC<ItemsViewProps> = ({
                         )}
                     </Box>
                 </Toolbar>
-            </AppBar>
+            </OffsetAppBar>
 
             {isAlphabetPickerEnabled && hasSortName && (
                 <AlphabetPicker


### PR DESCRIPTION
### Changes
Makes the library header "sticky" so it remains fixed when scrolling and removes the bottom pagination

Best reviewed with whitespace off

### Issues
N/A

### Code assistance
Zed autocomplete

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
