### PR TITLE
Fix clock icon alignment on scheduled tasks page

### DIFF
--- a/src/apps/dashboard/features/tasks/components/Task.tsx
+++ b/src/apps/dashboard/features/tasks/components/Task.tsx
@@ -43,7 +43,7 @@ const Task: FunctionComponent<TaskProps> = ({ task }: TaskProps) => {
             <ListItemLink to={`/dashboard/tasks/${task.Id}`}>
                 <ListItemAvatar>
                     <Avatar sx={{ bgcolor: 'primary.main' }}>
-                        <AccessTimeIcon sx={{ color: '#fff' }} />
+                        <AccessTimeIcon sx={{ color: '#fff', fontSize: 24 }} />
                     </Avatar>
                 </ListItemAvatar>
                 <ListItemText


### PR DESCRIPTION
### Changes
The project sets the root font-size to 93%, and MUI's `SvgIcon` sizes itself in `rem`. That combination made the clock icon inside the blue avatar come out at a fractional pixel width, which shifted its inner element to the left of center. My change sets `fontSize` to `24` (pixels) on this icon, which makes it render at a whole-pixel size and the icon is centered again. Scoped to this one icon.


#### Before
<img width="550" height="737" alt="image" src="https://github.com/user-attachments/assets/a07dd7e0-b1f2-4810-b7c8-6f8163d9b2cb" />

### After
<img width="245" height="738" alt="image" src="https://github.com/user-attachments/assets/40c6e220-445c-4dce-aa24-7ee7b7749ba3" />


                                        

### Issues
Fixes #7840  

### Code assistance
  Used Claude (LLM) to explore code base and locate the relevant component

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
