### PR TITLE
Stop remote playback on active cast disconnect

### DIFF
--- a/src/components/playback/playerSelectionMenu.js
+++ b/src/components/playback/playerSelectionMenu.js
@@ -162,6 +162,10 @@ function disconnectFromPlayer(currentDeviceName) {
             // dialog closed
         });
     } else {
+        const player = playbackManager.getCurrentPlayer();
+        if (player && !player.isLocalPlayer) {
+            playbackManager.stop(player);
+        }
         playbackManager.setDefaultPlayerActive();
     }
 }


### PR DESCRIPTION
### Changes

When the user actively ends a cast session via the player-selection menu, the remote stream keeps running on the receiver until someone switches the stream off manually. This does not match the "end casting stops the receiver" UX of other cast protocols. This patch issues a regular`playbackManager.stop()` on non-local players in that else-branch before the active-player switch.

### Issues

No open duplicate found. Loosely related: #910 / #671 (both closed).

### Code assistance

LLM (Claude Opus 4.7) assisted with pinpointing the gated else-branch, reviewing the `sessionPlayer` / `chromecastPlayer` `stop()` + `endSession()` contracts to confirm the patch reuses the correct existing mechanism, and reviewing the commit  message / this PR body. Patch verification against a live Jellyfin 10.11.8 server (disconnect from mobile web cast menu -> receiver stops within one WebSocket round-trip, verified at the receiver's `Playstate:Stop` log and `Sessions/Playing/Stopped` POST) were were verified by me.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
