### PR TITLE
Disable sonarjs/aws-restricted-ip-admin-access lint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -103,6 +103,7 @@ export default tseslint.config(
             'sonarjs/no-inverted-boolean-check': 'error',
             'sonarjs/no-selector-parameter': 'off',
             'sonarjs/pseudo-random': 'warn',
+            'sonarjs/aws-restricted-ip-admin-access': 'off',
             // TODO: Enable the following sonarjs rules and fix issues
             'sonarjs/no-duplicate-string': 'off',
             'sonarjs/no-nested-functions': 'warn',


### PR DESCRIPTION
This lint rule contributes ~12 seconds to lint time on my machine, the
single largest contribution by any rule. The documentation for this rule
seems to have been taken down, but reading [the source][1] suggests that
it makes sure that AWS CDK resources are firewalled. That is not even
close to relevant to this project.

To time lints I ran `time env TIMING=1 npm run lint`

Lint time before

```
Rule                                   | Time (ms) | Relative
:--------------------------------------|----------:|--------:
sonarjs/aws-restricted-ip-admin-access | 12797.845 |    17.5%
compat/compat                          | 10690.637 |    14.7%
import/namespace                       | 10472.175 |    14.4%
@typescript-eslint/no-deprecated       | 10426.921 |    14.3%
sonarjs/no-redundant-assignments       |  2606.446 |     3.6%
sonarjs/no-dead-store                  |  2232.571 |     3.1%
sonarjs/no-async-constructor           |  1241.067 |     1.7%
@typescript-eslint/naming-convention   |  1027.749 |     1.4%
@stylistic/indent                      |   998.776 |     1.4%
import/default                         |   995.802 |     1.4%

________________________________________________________
Executed in   90.29 secs    fish           external
   usr time  113.99 secs   39.00 micros  113.99 secs
   sys time    2.69 secs  981.00 micros    2.69 secs
```

Lint time after:

```
Rule                                 | Time (ms) | Relative
:------------------------------------|----------:|--------:
@typescript-eslint/no-deprecated     | 10757.130 |    17.9%
import/namespace                     | 10374.169 |    17.2%
compat/compat                        |  9974.127 |    16.6%
sonarjs/no-redundant-assignments     |  2702.038 |     4.5%
sonarjs/no-dead-store                |  2266.311 |     3.8%
sonarjs/no-async-constructor         |  1264.104 |     2.1%
@stylistic/indent                    |  1000.857 |     1.7%
import/default                       |   990.011 |     1.6%
@typescript-eslint/naming-convention |   888.189 |     1.5%
sonarjs/argument-type                |   837.332 |     1.4%

________________________________________________________
Executed in   78.15 secs    fish           external
   usr time  100.32 secs    0.18 millis  100.32 secs
   sys time    2.79 secs    1.01 millis    2.79 secs
```

[1]: https://github.com/SonarSource/SonarJS/blob/e669e615fa81c15e64161a139a8096037613c65d/packages/analysis/src/jsts/rules/S6321/rule.ts

### Changes
Disable sonarjs/aws-restricted-ip-admin-access lint rule

### Issues
No issue filed.

### Code assistance
No AI code assistance was used.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
