### PR TITLE
Fix backdrop size changing on mobile

### DIFF
--- a/src/components/backdrop/backdrop.scss
+++ b/src/components/backdrop/backdrop.scss
@@ -1,5 +1,11 @@
 .backdropContainer {
     contain: layout style size;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 100vh;
+    z-index: -1;
 }
 
 .backdropImage {

--- a/src/styles/librarybrowser.scss
+++ b/src/styles/librarybrowser.scss
@@ -441,15 +441,6 @@
     }
 }
 
-.backdropContainer {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    z-index: -1;
-}
-
 .libraryPage .header {
     padding-bottom: 0;
 }


### PR DESCRIPTION
### Changes
* Fixes the backdrop size changing because the viewport size changes when scrolling on mobile
* Moves backdrop styles to the proper sass file

### Issues
None

### Code assistance
Zed autocomplete

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
