### PR TITLE
Implement Add Server page in experimental app

### DIFF
--- a/src/apps/experimental/features/session/components/AddServerForm.tsx
+++ b/src/apps/experimental/features/session/components/AddServerForm.tsx
@@ -1,6 +1,7 @@
 import React, { ChangeEventHandler, FC, useCallback, useEffect, useRef, useState } from 'react';
 
 import { ConnectionState, ServerConnections } from 'lib/jellyfin-apiclient';
+import appSettings from 'scripts/settings/appSettings';
 import { appRouter } from 'components/router/appRouter';
 import loading from 'components/loading/loading';
 import Input from 'elements/emby-input/Input';
@@ -10,7 +11,7 @@ import { useServerConnectionResultHandler } from '../hooks/useServerConnectionRe
 
 const AddServerForm: FC = () => {
     const ref = useRef<HTMLInputElement>(null);
-    const [host, setHost] = useState<string>();
+    const [host, setHost] = useState<string>('');
 
     const handleConnectionResult = useServerConnectionResultHandler();
 
@@ -28,8 +29,11 @@ const AddServerForm: FC = () => {
         e.preventDefault();
         loading.show();
 
-        ServerConnections.connectToAddress(host, {
-            enableAutoLogin: true // TODO
+        // eslint-disable-next-line sonarjs/slow-regex
+        const hostTrimmed = host.replace(/\/+$/, '');
+
+        ServerConnections.connectToAddress(hostTrimmed, {
+            enableAutoLogin: appSettings.enableAutoLogin
         })
             .then((result) => {
                 handleConnectionResult(result);

--- a/src/apps/experimental/features/session/components/AddServerForm.tsx
+++ b/src/apps/experimental/features/session/components/AddServerForm.tsx
@@ -1,0 +1,90 @@
+import React, { ChangeEventHandler, FC, useCallback, useEffect, useRef, useState } from 'react';
+
+import { ConnectionState, ServerConnections } from 'lib/jellyfin-apiclient';
+import { appRouter } from 'components/router/appRouter';
+import loading from 'components/loading/loading';
+import Input from 'elements/emby-input/Input';
+import Button from 'elements/emby-button/Button';
+import globalize from 'lib/globalize';
+import { useServerConnectionResultHandler } from '../hooks/useServerConnectionResultHandler';
+
+const AddServerForm: FC = () => {
+    const ref = useRef<HTMLInputElement>(null);
+    const [host, setHost] = useState<string>();
+
+    const handleConnectionResult = useServerConnectionResultHandler();
+
+    const onHostChange = useCallback<ChangeEventHandler<HTMLInputElement>>(e => setHost(e.target.value), []);
+
+    const onCancel = useCallback(() => {
+        appRouter
+            .back()
+            .catch(err => {
+                console.log('[AddServerForm] Failed to navigate back.', err);
+            });
+    }, []);
+
+    const onSubmit = useCallback<React.FormEventHandler>((e) => {
+        e.preventDefault();
+        loading.show();
+
+        ServerConnections.connectToAddress(host, {
+            enableAutoLogin: true // TODO
+        })
+            .then((result) => {
+                handleConnectionResult(result);
+            })
+            .catch((err) => {
+                handleConnectionResult({
+                    State: ConnectionState.Unavailable
+                });
+
+                console.log('[AddServerForm] Failed to connect.', err);
+            })
+            .finally(() => {
+                loading.hide();
+            });
+    }, [host, handleConnectionResult]);
+
+    useEffect(() => {
+        ref.current?.focus();
+    }, []);
+
+    return (
+        <form
+            className='addServerForm'
+            style={{ margin: '0 auto' }}
+            noValidate
+            onSubmit={onSubmit}
+        >
+
+            <h1>{globalize.translate('HeaderConnectToServer')}</h1>
+            <div className='inputContainer'>
+                <Input
+                    id='txtServerHost'
+                    type='url'
+                    required
+                    ref={ref}
+                    label={globalize.translate('LabelServerHost')}
+                    value={host}
+                    onChange={onHostChange}
+                />
+                <div className='fieldDescription'>{globalize.translate('LabelServerHostHelp')}</div>
+            </div>
+            <br />
+            <Button
+                type='submit'
+                className='raised button-submit block'
+                title={globalize.translate('Connect')}
+            />
+            <Button
+                type='button'
+                className='raised button-cancel block btnCancel'
+                title={globalize.translate('ButtonCancel')}
+                onClick={onCancel}
+            />
+        </form>
+    );
+};
+
+export default AddServerForm;

--- a/src/apps/experimental/features/session/hooks/useServerConnectionResultHandler.ts
+++ b/src/apps/experimental/features/session/hooks/useServerConnectionResultHandler.ts
@@ -1,0 +1,49 @@
+import { useCallback } from 'react';
+import { ConnectionState } from 'lib/jellyfin-apiclient';
+import globalize from 'lib/globalize';
+import Dashboard from 'utils/dashboard';
+
+export function useServerConnectionResultHandler () {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const handleResult = useCallback((result: any) => {
+        async function handleResultAsync() {
+            if (result.State === ConnectionState.SignedIn) {
+                const apiClient = result.ApiClient;
+
+                Dashboard.onServerChanged(apiClient.getCurrentUserId(), apiClient.accessToken(), apiClient);
+                await Dashboard.navigate('home');
+            }
+
+            if (result.State === ConnectionState.ServerSignIn) {
+                const path = result.SystemInfo.StartupWizardCompleted ?
+                    `login?serverid=${result.Servers[0].Id}` :
+                    '/wizard/start';
+
+                await Dashboard.navigate(path, false);
+            }
+
+            if (result.State === ConnectionState.ServerSelection) {
+                await Dashboard.navigate('selectserver', false);
+            }
+
+            if (result.State === ConnectionState.ServerUpdateNeeded) {
+                Dashboard.alert({
+                    message: globalize.translate('ServerUpdateNeeded', '<a href="https://github.com/jellyfin/jellyfin">https://github.com/jellyfin/jellyfin</a>')
+                });
+            }
+
+            if (result.State === ConnectionState.Unavailable) {
+                Dashboard.alert({
+                    message: globalize.translate('MessageUnableToConnectToServer'),
+                    title: globalize.translate('HeaderConnectionFailure')
+                });
+            }
+        }
+
+        handleResultAsync().catch(err => {
+            console.log('[useServerConnectionResultHandler] Failed while handling result', err);
+        });
+    }, []);
+
+    return handleResult;
+}

--- a/src/apps/experimental/routes/addserver/index.tsx
+++ b/src/apps/experimental/routes/addserver/index.tsx
@@ -1,0 +1,18 @@
+import React, { type FC } from 'react';
+import Page from 'components/Page';
+import AddServerForm from 'apps/experimental/features/session/components/AddServerForm';
+
+const AddServer: FC = () => {
+    return (
+        <Page
+            id='addserver'
+            className='mainAnimatedPage standalonePage'
+        >
+            <div className='padded-left padded-right padded-bottom-page'>
+                <AddServerForm />
+            </div>
+        </Page>
+    );
+};
+
+export default AddServer;

--- a/src/apps/experimental/routes/asyncRoutes/index.ts
+++ b/src/apps/experimental/routes/asyncRoutes/index.ts
@@ -1,1 +1,2 @@
 export * from './user';
+export * from './public';

--- a/src/apps/experimental/routes/asyncRoutes/public.ts
+++ b/src/apps/experimental/routes/asyncRoutes/public.ts
@@ -1,0 +1,6 @@
+import { AsyncRoute } from 'components/router/AsyncRoute';
+import { AppType } from 'constants/appType';
+
+export const ASYNC_PUBLIC_ROUTES: AsyncRoute[] = [
+    { path: 'addserver', type: AppType.Experimental }
+];

--- a/src/apps/experimental/routes/legacyRoutes/public.ts
+++ b/src/apps/experimental/routes/legacyRoutes/public.ts
@@ -2,13 +2,6 @@ import { LegacyRoute } from '../../../../components/router/LegacyRoute';
 
 export const LEGACY_PUBLIC_ROUTES: LegacyRoute[] = [
     {
-        path: 'addserver',
-        pageProps: {
-            controller: 'session/addServer/index',
-            view: 'session/addServer/index.html'
-        }
-    },
-    {
         path: 'selectserver',
         pageProps: {
             controller: 'session/selectServer/index',

--- a/src/apps/experimental/routes/routes.tsx
+++ b/src/apps/experimental/routes/routes.tsx
@@ -7,7 +7,7 @@ import { toViewManagerPageRoute } from 'components/router/LegacyRoute';
 import ErrorBoundary from 'components/router/ErrorBoundary';
 import FallbackRoute from 'components/router/FallbackRoute';
 
-import { ASYNC_USER_ROUTES } from './asyncRoutes';
+import { ASYNC_PUBLIC_ROUTES, ASYNC_USER_ROUTES } from './asyncRoutes';
 import { LEGACY_PUBLIC_ROUTES, LEGACY_USER_ROUTES } from './legacyRoutes';
 import VideoPage from './video';
 
@@ -38,6 +38,7 @@ export const EXPERIMENTAL_APP_ROUTES: RouteObject[] = [
                 /* Public routes */
                 element: <ConnectionRequired level='public' />,
                 children: [
+                    ...ASYNC_PUBLIC_ROUTES.map(toAsyncPageRoute),
                     ...LEGACY_PUBLIC_ROUTES.map(toViewManagerPageRoute),
 
                     /* Fallback route for invalid paths */


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

### Changes
<!--
Describe your changes here in 1-5 sentences.
Please include before/after screenshots of any UI changes.
-->

- Implements `AddServer` page in experimental app with React. The view is a one-to-one mapping from the existing one.
- Adds `useServerConnectionResultHandler` hook that could be reused in the SelectServer page.

<img width="3240" height="1000" alt="image" src="https://github.com/user-attachments/assets/55412131-a0f3-4561-b585-3bf67446ca3a" />

### Issues
<!--
Tag any issues that this PR solves here.
ex. Fixes #
-->

### Code assistance
<!--
If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance.
-->

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
