### PR TITLE
Fix dashboard user save error handling

### DIFF
--- a/src/apps/dashboard/features/users/components/Profile.test.tsx
+++ b/src/apps/dashboard/features/users/components/Profile.test.tsx
@@ -1,0 +1,509 @@
+import React, { type InputHTMLAttributes } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync } from 'react-dom';
+import { createRoot, type Root } from 'react-dom/client';
+import type { SyncPlayUserAccessType, UserDto } from '@jellyfin/sdk/lib/generated-client';
+
+import Profile from './Profile';
+
+const PASSWORD_RESET_PROVIDER_ID = [ 'sso', 'provider' ].join('-');
+
+function cloneUserDto<T>(value: T): T {
+    return JSON.parse(JSON.stringify(value)) as T;
+}
+
+const mocks = vi.hoisted(() => ({
+    navigate: vi.fn(),
+    loadingShow: vi.fn(),
+    loadingHide: vi.fn(),
+    setTitle: vi.fn(),
+    updateUserMutate: vi.fn(),
+    updateUserPolicyMutate: vi.fn(),
+    toastOnClose: undefined as undefined | ((event: Event, reason: string) => void),
+    authProvidersResponse: {
+        data: [
+            { Id: 'auth', Name: 'Default' }
+        ],
+        isSuccess: true
+    },
+    passwordResetProvidersResponse: {
+        data: [
+            { Id: 'reset', Name: 'Default' }
+        ],
+        isSuccess: true
+    },
+    mediaFoldersResponse: {
+        data: {
+            Items: [
+                { Id: 'folder-1', Name: 'Movies' }
+            ]
+        },
+        isSuccess: true
+    },
+    channelsResponse: {
+        data: {
+            Items: [
+                { Id: 'channel-1', Name: 'News' }
+            ]
+        },
+        isSuccess: true
+    },
+    networkConfigResponse: {
+        data: {
+            EnableRemoteAccess: true
+        },
+        isSuccess: true
+    }
+}));
+
+vi.mock('react-router-dom', () => ({
+    useNavigate: () => mocks.navigate
+}));
+
+vi.mock('lib/globalize', () => ({
+    default: {
+        translate: (key: string) => key
+    }
+}));
+
+vi.mock('components/loading/loading', () => ({
+    default: {
+        show: mocks.loadingShow,
+        hide: mocks.loadingHide
+    }
+}));
+
+vi.mock('elements/emby-input/Input', () => ({
+    default: ({ id, type = 'text', required = false, min, step, inputMode, pattern }: {
+        id: string;
+        type?: string;
+        required?: boolean;
+        min?: number | string;
+        step?: number | string;
+        inputMode?: InputHTMLAttributes<HTMLInputElement>['inputMode'];
+        pattern?: string;
+    }) => (
+        <input id={id} type={type} required={required} min={min} step={step} inputMode={inputMode} pattern={pattern} />
+    )
+}));
+
+vi.mock('elements/emby-button/Button', () => ({
+    default: ({ id, type = 'button', className, title }: { id?: string; type?: 'button' | 'submit'; className?: string; title: string }) => (
+        <button id={id} type={type} className={className}>{title}</button>
+    )
+}));
+
+vi.mock('elements/emby-button/LinkButton', () => ({
+    default: ({ children, href, className }: React.PropsWithChildren<{ href?: string; className?: string }>) => (
+        <a href={href} className={className}>{children}</a>
+    )
+}));
+
+vi.mock('elements/CheckBoxElement', () => ({
+    default: ({
+        className,
+        itemId,
+        itemName,
+        labelClassName,
+        itemCheckedAttribute
+    }: {
+        className?: string;
+        itemId?: string;
+        itemName?: string | null;
+        labelClassName?: string;
+        itemCheckedAttribute?: string;
+    }) => (
+        <label className={labelClassName}>
+            <input
+                type='checkbox'
+                className={className}
+                data-id={itemId}
+                defaultChecked={itemCheckedAttribute === ' checked="checked"'}
+            />
+            <span>{itemName}</span>
+        </label>
+    )
+}));
+
+vi.mock('elements/SelectElement', () => ({
+    default: ({ id }: { id: string }) => (
+        <select id={id} defaultValue=''>
+            <option value=''>default</option>
+            <option value='None'>None</option>
+            <option value='CreateAndJoinGroups'>CreateAndJoinGroups</option>
+        </select>
+    )
+}));
+
+vi.mock('apps/dashboard/components/Toast', () => ({
+    default: ({ open, message, onClose }: { open?: boolean; message?: string; onClose?: (event: Event, reason: string) => void }) => {
+        mocks.toastOnClose = onClose;
+
+        return open ? (
+            <div data-testid='toast'>
+                <span data-testid='toast-message'>{message}</span>
+                <button
+                    type='button'
+                    data-testid='toast-close'
+                >
+                    close
+                </button>
+            </div>
+        ) : null;
+    }
+}));
+
+vi.mock('scripts/libraryMenu', () => ({
+    default: {
+        setTitle: mocks.setTitle
+    }
+}));
+
+vi.mock('apps/dashboard/features/users/api/useAuthProviders', () => ({
+    useAuthProviders: () => mocks.authProvidersResponse
+}));
+
+vi.mock('apps/dashboard/features/users/api/usePasswordResetProviders', () => ({
+    usePasswordResetProviders: () => mocks.passwordResetProvidersResponse
+}));
+
+vi.mock('apps/dashboard/features/users/api/useLibraryMediaFolders', () => ({
+    useLibraryMediaFolders: () => mocks.mediaFoldersResponse
+}));
+
+vi.mock('apps/dashboard/features/users/api/useChannels', () => ({
+    useChannels: () => mocks.channelsResponse
+}));
+
+vi.mock('apps/dashboard/features/users/api/useNetworkConfig', () => ({
+    useNetworkConfig: () => mocks.networkConfigResponse
+}));
+
+vi.mock('apps/dashboard/features/users/api/useUpdateUser', () => ({
+    useUpdateUser: () => ({
+        mutate: mocks.updateUserMutate
+    })
+}));
+
+vi.mock('apps/dashboard/features/users/api/useUpdateUserPolicy', () => ({
+    useUpdateUserPolicy: () => ({
+        mutate: mocks.updateUserPolicyMutate
+    })
+}));
+
+describe('Profile', () => {
+    let container: HTMLDivElement;
+    let root: Root;
+    let historyBackSpy: ReturnType<typeof vi.spyOn>;
+
+    const createUserDto = (): UserDto => ({
+        Id: 'user-1',
+        Name: 'Existing User',
+        Policy: {
+            AuthenticationProviderId: '',
+            PasswordResetProviderId: '',
+            SyncPlayAccess: 'None' as SyncPlayUserAccessType
+        }
+    });
+
+    const flushEffects = async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+        await new Promise(resolve => setTimeout(resolve, 0));
+    };
+
+    const waitUntil = async (assertion: () => void) => {
+        let lastError: unknown;
+
+        for (let attempt = 0; attempt < 10; attempt++) {
+            try {
+                assertion();
+                return;
+            } catch (error) {
+                lastError = error;
+                await flushEffects();
+            }
+        }
+
+        throw lastError;
+    };
+
+    const renderPage = async (userOverride = createUserDto()) => {
+        flushSync(() => {
+            root = createRoot(container);
+            root.render(<Profile userDto={cloneUserDto(userOverride)} />);
+        });
+
+        await flushEffects();
+    };
+
+    const submitForm = async () => {
+        const form = container.querySelector('.editUserProfileForm');
+
+        if (!(form instanceof HTMLFormElement)) {
+            throw new Error('Expected edit user form to be rendered');
+        }
+
+        flushSync(() => {
+            form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+        });
+
+        await flushEffects();
+    };
+
+    const changeCheckbox = async (selector: string, checked: boolean) => {
+        const checkbox = container.querySelector(selector);
+
+        if (!(checkbox instanceof HTMLInputElement)) {
+            throw new Error(`Expected checkbox ${selector} to exist`);
+        }
+
+        checkbox.checked = checked;
+        flushSync(() => {
+            checkbox.dispatchEvent(new Event('change', { bubbles: true }));
+        });
+
+        await flushEffects();
+        return checkbox;
+    };
+
+    const clickButton = async (selector: string) => {
+        const button = container.querySelector(selector);
+
+        if (!(button instanceof HTMLButtonElement)) {
+            throw new Error(`Expected button ${selector} to exist`);
+        }
+
+        flushSync(() => {
+            button.click();
+        });
+
+        await flushEffects();
+    };
+
+    const dismissToast = async () => {
+        flushSync(() => {
+            mocks.toastOnClose?.(new Event('close'), 'clickaway');
+        });
+
+        await flushEffects();
+    };
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        document.body.appendChild(container);
+        historyBackSpy = vi.spyOn(window.history, 'back').mockImplementation(() => undefined);
+        mocks.toastOnClose = undefined;
+
+        mocks.authProvidersResponse.data = [
+            { Id: 'auth', Name: 'Default' }
+        ];
+        mocks.authProvidersResponse.isSuccess = true;
+        mocks.passwordResetProvidersResponse.data = [
+            { Id: 'reset', Name: 'Default' }
+        ];
+        mocks.passwordResetProvidersResponse.isSuccess = true;
+        mocks.mediaFoldersResponse.data.Items = [
+            { Id: 'folder-1', Name: 'Movies' }
+        ];
+        mocks.mediaFoldersResponse.isSuccess = true;
+        mocks.channelsResponse.data.Items = [
+            { Id: 'channel-1', Name: 'News' }
+        ];
+        mocks.channelsResponse.isSuccess = true;
+        mocks.networkConfigResponse.data.EnableRemoteAccess = true;
+        mocks.networkConfigResponse.isSuccess = true;
+    });
+
+    afterEach(async () => {
+        if (root) {
+            flushSync(() => {
+                root.unmount();
+            });
+        }
+
+        container.remove();
+        historyBackSpy.mockRestore();
+        vi.clearAllMocks();
+    });
+
+    it('renders the loaded profile state, access lists, and interactive toggles', async () => {
+        mocks.authProvidersResponse.data = [
+            { Id: 'auth', Name: 'Default' },
+            { Id: 'ldap', Name: 'LDAP' }
+        ];
+        mocks.passwordResetProvidersResponse.data = [
+            { Id: 'reset', Name: 'Default' },
+            { Id: 'sso', Name: 'SSO' }
+        ];
+        mocks.networkConfigResponse.data.EnableRemoteAccess = false;
+
+        const userDto = createUserDto();
+        userDto.Name = 'Disabled User';
+        userDto.Policy = {
+            AuthenticationProviderId: 'ldap',
+            PasswordResetProviderId: PASSWORD_RESET_PROVIDER_ID,
+            SyncPlayAccess: 'CreateAndJoinGroups' as SyncPlayUserAccessType,
+            IsDisabled: true,
+            EnableRemoteAccess: false,
+            EnableContentDeletionFromFolders: ['folder-1', 'channel-1'],
+            RemoteClientBitrateLimit: 4250000,
+            LoginAttemptsBeforeLockout: 5,
+            MaxActiveSessions: 3
+        };
+
+        await renderPage(userDto);
+
+        await waitUntil(() => {
+            expect(mocks.setTitle).toHaveBeenCalledWith('Disabled User');
+            expect(container.querySelectorAll('.deleteAccess .chkFolder')).toHaveLength(2);
+        });
+
+        expect(mocks.loadingHide).toHaveBeenCalled();
+        expect(container.querySelector('.fldSelectLoginProvider')?.classList.contains('hide')).toBe(false);
+        expect(container.querySelector('.fldSelectPasswordResetProvider')?.classList.contains('hide')).toBe(false);
+        expect(container.querySelector('.fldRemoteAccess')?.classList.contains('hide')).toBe(true);
+        expect(container.querySelector('.disabledUserBanner')?.classList.contains('hide')).toBe(false);
+        expect((container.querySelector('#txtUserName') as HTMLInputElement).value).toBe('Disabled User');
+        expect((container.querySelector('#txtRemoteClientBitrateLimit') as HTMLInputElement).value).toBe('4.25');
+        expect((container.querySelector('#txtLoginAttemptsBeforeLockout') as HTMLInputElement).value).toBe('5');
+        expect((container.querySelector('#txtMaxActiveSessions') as HTMLInputElement).value).toBe('3');
+        await changeCheckbox('.chkEnableDeleteAllFolders', true);
+        expect(container.querySelector('.deleteAccess')?.classList.contains('hide')).toBe(true);
+
+        await changeCheckbox('.chkEnableDeleteAllFolders', false);
+        expect(container.querySelector('.deleteAccess')?.classList.contains('hide')).toBe(false);
+
+        await clickButton('#btnCancel');
+        expect(historyBackSpy).toHaveBeenCalledOnce();
+    });
+
+    it('hides loading and shows the server validation message when updating a user fails', async () => {
+        mocks.updateUserMutate.mockImplementation((params, options) => {
+            expect(params.userDto.Name).toBe('test / test');
+
+            options?.onError?.({
+                response: {
+                    data: 'Usernames can contain unicode symbols, numbers (0-9), dashes (-), underscores (_), apostrophes (\'), and periods (.)'
+                }
+            });
+        });
+
+        await renderPage();
+
+        mocks.loadingShow.mockClear();
+        mocks.loadingHide.mockClear();
+
+        (container.querySelector('#txtUserName') as HTMLInputElement).value = 'test / test';
+
+        await submitForm();
+
+        expect(mocks.loadingShow).toHaveBeenCalledOnce();
+        expect(mocks.loadingHide).toHaveBeenCalledOnce();
+        expect(container.querySelector('[data-testid="toast-message"]')?.textContent).toContain('Usernames can contain unicode symbols');
+        expect(mocks.updateUserPolicyMutate).not.toHaveBeenCalled();
+        expect(mocks.navigate).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the default error message when the update failure has no message', async () => {
+        mocks.updateUserMutate.mockImplementation((_params, options) => {
+            options?.onError?.({});
+        });
+
+        await renderPage();
+
+        mocks.loadingShow.mockClear();
+        mocks.loadingHide.mockClear();
+
+        await submitForm();
+
+        expect(mocks.loadingHide).toHaveBeenCalledOnce();
+        expect(container.querySelector('[data-testid="toast-message"]')?.textContent).toBe('ErrorDefault');
+    });
+
+    it('closes the error toast when dismissed', async () => {
+        mocks.updateUserMutate.mockImplementation((_params, options) => {
+            options?.onError?.({});
+        });
+
+        await renderPage();
+        await submitForm();
+        await dismissToast();
+
+        expect(container.querySelector('[data-testid="toast"]')).toBeNull();
+    });
+
+    it('hides loading and shows the nested policy update error message', async () => {
+        mocks.updateUserMutate.mockImplementation((_params, options) => {
+            options?.onSuccess?.({}, { userId: 'user-1', userDto: cloneUserDto(createUserDto()) }, undefined);
+        });
+
+        mocks.updateUserPolicyMutate.mockImplementation((_params, options) => {
+            options?.onError?.(new Error('Policy update failed'));
+        });
+
+        await renderPage();
+
+        mocks.loadingShow.mockClear();
+        mocks.loadingHide.mockClear();
+
+        (container.querySelector('#txtUserName') as HTMLInputElement).value = 'valid-name';
+
+        await submitForm();
+
+        expect(mocks.updateUserMutate).toHaveBeenCalledOnce();
+        expect(mocks.updateUserPolicyMutate).toHaveBeenCalledOnce();
+        expect(mocks.loadingHide).toHaveBeenCalledOnce();
+        expect(container.querySelector('[data-testid="toast-message"]')?.textContent).toContain('Policy update failed');
+        expect(mocks.navigate).not.toHaveBeenCalled();
+    });
+
+    it('submits the edited user policy and navigates with a saved toast on success', async () => {
+        mocks.updateUserMutate.mockImplementation((params, options) => {
+            expect(params.userId).toBe('user-1');
+            expect(params.userDto.Name).toBe('Updated Name');
+            expect(params.userDto.Policy.EnableRemoteAccess).toBe(true);
+            expect(params.userDto.Policy.EnableContentDeletion).toBe(false);
+            expect(params.userDto.Policy.EnableContentDeletionFromFolders).toEqual(['folder-1', 'channel-1']);
+            expect(params.userDto.Policy.RemoteClientBitrateLimit).toBe(3500000);
+            expect(params.userDto.Policy.LoginAttemptsBeforeLockout).toBe(7);
+            expect(params.userDto.Policy.MaxActiveSessions).toBe(9);
+            expect(params.userDto.Policy.SyncPlayAccess).toBe('CreateAndJoinGroups');
+
+            options?.onSuccess?.({}, params, undefined);
+        });
+
+        mocks.updateUserPolicyMutate.mockImplementation((params, options) => {
+            expect(params.userId).toBe('user-1');
+            expect(params.userPolicy.EnableContentDeletionFromFolders).toEqual(['folder-1', 'channel-1']);
+            options?.onSuccess?.();
+        });
+
+        await renderPage();
+
+        await waitUntil(() => {
+            expect(container.querySelectorAll('.deleteAccess .chkFolder')).toHaveLength(2);
+        });
+
+        mocks.loadingShow.mockClear();
+        mocks.loadingHide.mockClear();
+
+        (container.querySelector('#txtUserName') as HTMLInputElement).value = '  Updated Name  ';
+        (container.querySelector('#txtRemoteClientBitrateLimit') as HTMLInputElement).value = '3.5';
+        (container.querySelector('#txtLoginAttemptsBeforeLockout') as HTMLInputElement).value = '7';
+        (container.querySelector('#txtMaxActiveSessions') as HTMLInputElement).value = '9';
+        (container.querySelector('#selectSyncPlayAccess') as HTMLSelectElement).value = 'CreateAndJoinGroups';
+        (container.querySelector('.chkRemoteAccess') as HTMLInputElement).checked = true;
+        (container.querySelectorAll('.deleteAccess .chkFolder')[0] as HTMLInputElement).checked = true;
+        (container.querySelectorAll('.deleteAccess .chkFolder')[1] as HTMLInputElement).checked = true;
+
+        await submitForm();
+
+        expect(mocks.updateUserMutate).toHaveBeenCalledOnce();
+        expect(mocks.updateUserPolicyMutate).toHaveBeenCalledOnce();
+        expect(mocks.loadingHide).toHaveBeenCalledOnce();
+        expect(mocks.navigate).toHaveBeenCalledWith('/dashboard/users', {
+            state: { openSavedToast: true }
+        });
+    });
+});

--- a/src/apps/dashboard/features/users/components/Profile.test.tsx
+++ b/src/apps/dashboard/features/users/components/Profile.test.tsx
@@ -5,12 +5,17 @@ import { createRoot, type Root } from 'react-dom/client';
 import type { SyncPlayUserAccessType, UserDto } from '@jellyfin/sdk/lib/generated-client';
 
 import Profile from './Profile';
+import {
+    changeCheckbox,
+    clickButton,
+    cloneJson,
+    dismissToast as dismissToastUtil,
+    dispatchFormSubmit,
+    flushEffects,
+    waitUntil
+} from '../testUtils';
 
 const PASSWORD_RESET_PROVIDER_ID = [ 'sso', 'provider' ].join('-');
-
-function cloneUserDto<T>(value: T): T {
-    return JSON.parse(JSON.stringify(value)) as T;
-}
 
 const mocks = vi.hoisted(() => ({
     navigate: vi.fn(),
@@ -206,87 +211,17 @@ describe('Profile', () => {
         }
     });
 
-    const flushEffects = async () => {
-        await Promise.resolve();
-        await Promise.resolve();
-        await new Promise(resolve => setTimeout(resolve, 0));
-    };
-
-    const waitUntil = async (assertion: () => void) => {
-        let lastError: unknown;
-
-        for (let attempt = 0; attempt < 10; attempt++) {
-            try {
-                assertion();
-                return;
-            } catch (error) {
-                lastError = error;
-                await flushEffects();
-            }
-        }
-
-        throw lastError;
-    };
-
     const renderPage = async (userOverride = createUserDto()) => {
         flushSync(() => {
             root = createRoot(container);
-            root.render(<Profile userDto={cloneUserDto(userOverride)} />);
-        });
-
-        await flushEffects();
-    };
-
-    const submitForm = async () => {
-        const form = container.querySelector('.editUserProfileForm');
-
-        if (!(form instanceof HTMLFormElement)) {
-            throw new Error('Expected edit user form to be rendered');
-        }
-
-        flushSync(() => {
-            form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
-        });
-
-        await flushEffects();
-    };
-
-    const changeCheckbox = async (selector: string, checked: boolean) => {
-        const checkbox = container.querySelector(selector);
-
-        if (!(checkbox instanceof HTMLInputElement)) {
-            throw new Error(`Expected checkbox ${selector} to exist`);
-        }
-
-        checkbox.checked = checked;
-        flushSync(() => {
-            checkbox.dispatchEvent(new Event('change', { bubbles: true }));
-        });
-
-        await flushEffects();
-        return checkbox;
-    };
-
-    const clickButton = async (selector: string) => {
-        const button = container.querySelector(selector);
-
-        if (!(button instanceof HTMLButtonElement)) {
-            throw new Error(`Expected button ${selector} to exist`);
-        }
-
-        flushSync(() => {
-            button.click();
+            root.render(<Profile userDto={cloneJson(userOverride)} />);
         });
 
         await flushEffects();
     };
 
     const dismissToast = async () => {
-        flushSync(() => {
-            mocks.toastOnClose?.(new Event('close'), 'clickaway');
-        });
-
-        await flushEffects();
+        await dismissToastUtil(mocks.toastOnClose);
     };
 
     beforeEach(() => {
@@ -368,13 +303,13 @@ describe('Profile', () => {
         expect((container.querySelector('#txtRemoteClientBitrateLimit') as HTMLInputElement).value).toBe('4.25');
         expect((container.querySelector('#txtLoginAttemptsBeforeLockout') as HTMLInputElement).value).toBe('5');
         expect((container.querySelector('#txtMaxActiveSessions') as HTMLInputElement).value).toBe('3');
-        await changeCheckbox('.chkEnableDeleteAllFolders', true);
+        await changeCheckbox(container, '.chkEnableDeleteAllFolders', true);
         expect(container.querySelector('.deleteAccess')?.classList.contains('hide')).toBe(true);
 
-        await changeCheckbox('.chkEnableDeleteAllFolders', false);
+        await changeCheckbox(container, '.chkEnableDeleteAllFolders', false);
         expect(container.querySelector('.deleteAccess')?.classList.contains('hide')).toBe(false);
 
-        await clickButton('#btnCancel');
+        await clickButton(container, '#btnCancel');
         expect(historyBackSpy).toHaveBeenCalledOnce();
     });
 
@@ -396,7 +331,7 @@ describe('Profile', () => {
 
         (container.querySelector('#txtUserName') as HTMLInputElement).value = 'test / test';
 
-        await submitForm();
+        await dispatchFormSubmit(container, '.editUserProfileForm');
 
         expect(mocks.loadingShow).toHaveBeenCalledOnce();
         expect(mocks.loadingHide).toHaveBeenCalledOnce();
@@ -415,7 +350,7 @@ describe('Profile', () => {
         mocks.loadingShow.mockClear();
         mocks.loadingHide.mockClear();
 
-        await submitForm();
+        await dispatchFormSubmit(container, '.editUserProfileForm');
 
         expect(mocks.loadingHide).toHaveBeenCalledOnce();
         expect(container.querySelector('[data-testid="toast-message"]')?.textContent).toBe('ErrorDefault');
@@ -427,7 +362,7 @@ describe('Profile', () => {
         });
 
         await renderPage();
-        await submitForm();
+        await dispatchFormSubmit(container, '.editUserProfileForm');
         await dismissToast();
 
         expect(container.querySelector('[data-testid="toast"]')).toBeNull();
@@ -435,7 +370,7 @@ describe('Profile', () => {
 
     it('hides loading and shows the nested policy update error message', async () => {
         mocks.updateUserMutate.mockImplementation((_params, options) => {
-            options?.onSuccess?.({}, { userId: 'user-1', userDto: cloneUserDto(createUserDto()) }, undefined);
+            options?.onSuccess?.({}, { userId: 'user-1', userDto: cloneJson(createUserDto()) }, undefined);
         });
 
         mocks.updateUserPolicyMutate.mockImplementation((_params, options) => {
@@ -449,7 +384,7 @@ describe('Profile', () => {
 
         (container.querySelector('#txtUserName') as HTMLInputElement).value = 'valid-name';
 
-        await submitForm();
+        await dispatchFormSubmit(container, '.editUserProfileForm');
 
         expect(mocks.updateUserMutate).toHaveBeenCalledOnce();
         expect(mocks.updateUserPolicyMutate).toHaveBeenCalledOnce();
@@ -497,7 +432,7 @@ describe('Profile', () => {
         (container.querySelectorAll('.deleteAccess .chkFolder')[0] as HTMLInputElement).checked = true;
         (container.querySelectorAll('.deleteAccess .chkFolder')[1] as HTMLInputElement).checked = true;
 
-        await submitForm();
+        await dispatchFormSubmit(container, '.editUserProfileForm');
 
         expect(mocks.updateUserMutate).toHaveBeenCalledOnce();
         expect(mocks.updateUserPolicyMutate).toHaveBeenCalledOnce();

--- a/src/apps/dashboard/features/users/components/Profile.tsx
+++ b/src/apps/dashboard/features/users/components/Profile.tsx
@@ -10,6 +10,7 @@ import LinkButton from 'elements/emby-button/LinkButton';
 import Input from 'elements/emby-input/Input';
 import loading from 'components/loading/loading';
 import SelectElement from 'elements/SelectElement';
+import Toast from 'apps/dashboard/components/Toast';
 import { useAuthProviders } from 'apps/dashboard/features/users/api/useAuthProviders';
 import { usePasswordResetProviders } from 'apps/dashboard/features/users/api/usePasswordResetProviders';
 import { useLibraryMediaFolders } from 'apps/dashboard/features/users/api/useLibraryMediaFolders';
@@ -17,6 +18,7 @@ import { useChannels } from 'apps/dashboard/features/users/api/useChannels';
 import { useUpdateUser } from 'apps/dashboard/features/users/api/useUpdateUser';
 import { useUpdateUserPolicy } from 'apps/dashboard/features/users/api/useUpdateUserPolicy';
 import { useNetworkConfig } from 'apps/dashboard/features/users/api/useNetworkConfig';
+import { getMutationErrorMessage } from '../errorMessage';
 
 interface ProfileProps {
     userDto: UserDto;
@@ -35,6 +37,8 @@ const Profile = ({ userDto }: ProfileProps) => {
     const navigate = useNavigate();
     const [ deleteFoldersAccess, setDeleteFoldersAccess ] = useState<ResetProvider[]>([]);
     const libraryMenu = useMemo(async () => ((await import('scripts/libraryMenu')).default), []);
+    const [ errorMessage, setErrorMessage ] = useState(globalize.translate('ErrorDefault'));
+    const [ isErrorToastOpen, setIsErrorToastOpen ] = useState(false);
 
     const [ authenticationProviderId, setAuthenticationProviderId ] = useState('');
     const [ passwordResetProviderId, setPasswordResetProviderId ] = useState('');
@@ -54,6 +58,35 @@ const Profile = ({ userDto }: ProfileProps) => {
         const evt = new Event('change', { bubbles: false, cancelable: true });
         select.dispatchEvent(evt);
     };
+
+    const handleToastClose = useCallback(() => {
+        setIsErrorToastOpen(false);
+    }, []);
+
+    const showErrorToast = useCallback((error?: unknown) => {
+        loading.hide();
+        setErrorMessage(getMutationErrorMessage(error) || globalize.translate('ErrorDefault'));
+        setIsErrorToastOpen(true);
+    }, []);
+
+    const navigateToUsers = useCallback(() => {
+        loading.hide();
+        navigate('/dashboard/users', {
+            state: { openSavedToast: true }
+        });
+    }, [navigate]);
+
+    const submitUpdatedUserPolicy = useCallback((user: UserDto) => {
+        if (user.Id) {
+            updateUserPolicy.mutate({
+                userId: user.Id,
+                userPolicy: user.Policy || { PasswordResetProviderId: '', AuthenticationProviderId: '' }
+            }, {
+                onSuccess: navigateToUsers,
+                onError: showErrorToast
+            });
+        }
+    }, [updateUserPolicy, navigateToUsers, showErrorToast]);
 
     const loadAuthProviders = useCallback((page: HTMLDivElement, user: UserDto, providers: NameIdPair[]) => {
         const fldSelectLoginProvider = page.querySelector('.fldSelectLoginProvider') as HTMLDivElement;
@@ -240,22 +273,11 @@ const Profile = ({ userDto }: ProfileProps) => {
             user.Policy.EnableContentDeletionFromFolders = user.Policy.EnableContentDeletion ? [] : getCheckedElementDataIds(page.querySelectorAll('.chkFolder'));
             user.Policy.SyncPlayAccess = (page.querySelector('#selectSyncPlayAccess') as HTMLSelectElement).value as SyncPlayUserAccessType;
 
+            const handleUpdateUserSuccess = submitUpdatedUserPolicy.bind(null, user);
+
             updateUser.mutate({ userId: user.Id, userDto: user }, {
-                onSuccess: () => {
-                    if (user.Id) {
-                        updateUserPolicy.mutate({
-                            userId: user.Id,
-                            userPolicy: user.Policy || { PasswordResetProviderId: '', AuthenticationProviderId: '' }
-                        }, {
-                            onSuccess: () => {
-                                loading.hide();
-                                navigate('/dashboard/users', {
-                                    state: { openSavedToast: true }
-                                });
-                            }
-                        });
-                    }
-                }
+                onSuccess: handleUpdateUserSuccess,
+                onError: showErrorToast
             });
         };
 
@@ -284,7 +306,7 @@ const Profile = ({ userDto }: ProfileProps) => {
             (page.querySelector('.editUserProfileForm') as HTMLFormElement).removeEventListener('submit', onSubmit);
             (page.querySelector('#btnCancel') as HTMLButtonElement).removeEventListener('click', onBtnCancelClick);
         };
-    }, [updateUser, userDto, updateUserPolicy, navigate]);
+    }, [updateUser, userDto, showErrorToast, submitUpdatedUserPolicy]);
 
     const optionLoginProvider = authProviders?.map((provider) => {
         const selected = provider.Id === authenticationProviderId || authProviders.length < 2 ? ' selected' : '';
@@ -306,6 +328,11 @@ const Profile = ({ userDto }: ProfileProps) => {
 
     return (
         <div ref={element}>
+            <Toast
+                open={isErrorToastOpen}
+                onClose={handleToastClose}
+                message={errorMessage}
+            />
             <div
                 className='lnkEditUserPreferencesContainer'
                 style={{ paddingBottom: '1em' }}

--- a/src/apps/dashboard/features/users/errorMessage.test.ts
+++ b/src/apps/dashboard/features/users/errorMessage.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { getMutationErrorMessage } from './errorMessage';
+
+describe('getMutationErrorMessage', () => {
+    it('extracts nested response messages', () => {
+        expect(getMutationErrorMessage({ response: { data: { message: 'Invalid username' } } })).toBe('Invalid username');
+        expect(getMutationErrorMessage({ response: { data: { Message: 'Uppercase message' } } })).toBe('Uppercase message');
+    });
+
+    it('extracts error instances and trims strings', () => {
+        expect(getMutationErrorMessage(new Error('  Boom  '))).toBe('Boom');
+        expect(getMutationErrorMessage({ error: { title: 'Bad request' } })).toBe('Bad request');
+    });
+
+    it('returns undefined for unsupported, empty, or overly deep values', () => {
+        expect(getMutationErrorMessage('   ')).toBeUndefined();
+        expect(getMutationErrorMessage(42)).toBeUndefined();
+        expect(getMutationErrorMessage({ response: { data: { response: { data: { message: 'too deep' } } } } })).toBeUndefined();
+    });
+});

--- a/src/apps/dashboard/features/users/errorMessage.ts
+++ b/src/apps/dashboard/features/users/errorMessage.ts
@@ -1,0 +1,33 @@
+function getErrorString(value: unknown, depth = 0): string | undefined {
+    if (depth > 3 || value == null) {
+        return undefined;
+    }
+
+    if (typeof value === 'string') {
+        const trimmedValue = value.trim();
+        return trimmedValue || undefined;
+    }
+
+    if (value instanceof Error) {
+        return getErrorString(value.message, depth + 1);
+    }
+
+    if (typeof value === 'object') {
+        const record = value as Record<string, unknown>;
+
+        return getErrorString(record.message, depth + 1)
+            ?? getErrorString(record.Message, depth + 1)
+            ?? getErrorString(record.title, depth + 1)
+            ?? getErrorString(record.Title, depth + 1)
+            ?? getErrorString(record.error, depth + 1)
+            ?? getErrorString(record.Error, depth + 1)
+            ?? getErrorString(record.data, depth + 1)
+            ?? getErrorString(record.response, depth + 1);
+    }
+
+    return undefined;
+}
+
+export function getMutationErrorMessage(error: unknown): string | undefined {
+    return getErrorString(error);
+}

--- a/src/apps/dashboard/features/users/testUtils.ts
+++ b/src/apps/dashboard/features/users/testUtils.ts
@@ -1,0 +1,79 @@
+import { flushSync } from 'react-dom';
+
+export async function flushEffects() {
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+export async function waitUntil(assertion: () => void) {
+    let lastError: unknown;
+
+    for (let attempt = 0; attempt < 10; attempt++) {
+        try {
+            assertion();
+            return;
+        } catch (error) {
+            lastError = error;
+            await flushEffects();
+        }
+    }
+
+    throw lastError;
+}
+
+export async function dispatchFormSubmit(container: ParentNode, selector: string) {
+    const form = container.querySelector(selector);
+
+    if (!(form instanceof HTMLFormElement)) {
+        throw new Error(`Expected form ${selector} to be rendered`);
+    }
+
+    flushSync(() => {
+        form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    });
+
+    await flushEffects();
+}
+
+export async function changeCheckbox(container: ParentNode, selector: string, checked: boolean) {
+    const checkbox = container.querySelector(selector);
+
+    if (!(checkbox instanceof HTMLInputElement)) {
+        throw new Error(`Expected checkbox ${selector} to exist`);
+    }
+
+    checkbox.checked = checked;
+    flushSync(() => {
+        checkbox.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    await flushEffects();
+    return checkbox;
+}
+
+export async function clickButton(container: ParentNode, selector: string) {
+    const button = container.querySelector(selector);
+
+    if (!(button instanceof HTMLButtonElement)) {
+        throw new Error(`Expected button ${selector} to exist`);
+    }
+
+    flushSync(() => {
+        button.click();
+    });
+
+    await flushEffects();
+}
+
+export async function dismissToast(onClose?: (event: Event, reason: string) => void) {
+    flushSync(() => {
+        onClose?.(new Event('close'), 'clickaway');
+    });
+
+    await flushEffects();
+}
+
+export function cloneJson<T>(value: T): T {
+    return JSON.parse(JSON.stringify(value)) as T;
+}

--- a/src/apps/dashboard/features/users/testUtils.ts
+++ b/src/apps/dashboard/features/users/testUtils.ts
@@ -26,7 +26,7 @@ export async function dispatchFormSubmit(container: ParentNode, selector: string
     const form = container.querySelector(selector);
 
     if (!(form instanceof HTMLFormElement)) {
-        throw new Error(`Expected form ${selector} to be rendered`);
+        throw new TypeError(`Expected form ${selector} to be rendered`);
     }
 
     flushSync(() => {
@@ -40,7 +40,7 @@ export async function changeCheckbox(container: ParentNode, selector: string, ch
     const checkbox = container.querySelector(selector);
 
     if (!(checkbox instanceof HTMLInputElement)) {
-        throw new Error(`Expected checkbox ${selector} to exist`);
+        throw new TypeError(`Expected checkbox ${selector} to exist`);
     }
 
     checkbox.checked = checked;
@@ -56,7 +56,7 @@ export async function clickButton(container: ParentNode, selector: string) {
     const button = container.querySelector(selector);
 
     if (!(button instanceof HTMLButtonElement)) {
-        throw new Error(`Expected button ${selector} to exist`);
+        throw new TypeError(`Expected button ${selector} to exist`);
     }
 
     flushSync(() => {

--- a/src/apps/dashboard/routes/users/add.test.tsx
+++ b/src/apps/dashboard/routes/users/add.test.tsx
@@ -4,6 +4,14 @@ import { flushSync } from 'react-dom';
 import { createRoot, type Root } from 'react-dom/client';
 
 import UserNew from './add';
+import {
+    changeCheckbox,
+    clickButton,
+    dismissToast as dismissToastUtil,
+    dispatchFormSubmit,
+    flushEffects,
+    waitUntil
+} from '../../features/users/testUtils';
 
 const TEST_PASSWORD = [ 'test', 'passphrase' ].join('-');
 
@@ -151,28 +159,6 @@ describe('UserNew', () => {
     let root: Root;
     let historyBackSpy: ReturnType<typeof vi.spyOn>;
 
-    const flushEffects = async () => {
-        await Promise.resolve();
-        await Promise.resolve();
-        await new Promise(resolve => setTimeout(resolve, 0));
-    };
-
-    const waitUntil = async (assertion: () => void) => {
-        let lastError: unknown;
-
-        for (let attempt = 0; attempt < 10; attempt++) {
-            try {
-                assertion();
-                return;
-            } catch (error) {
-                lastError = error;
-                await flushEffects();
-            }
-        }
-
-        throw lastError;
-    };
-
     const renderPage = async () => {
         flushSync(() => {
             root = createRoot(container);
@@ -182,56 +168,8 @@ describe('UserNew', () => {
         await flushEffects();
     };
 
-    const submitForm = async () => {
-        const form = container.querySelector('.newUserProfileForm');
-
-        if (!(form instanceof HTMLFormElement)) {
-            throw new Error('Expected new user form to be rendered');
-        }
-
-        flushSync(() => {
-            form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
-        });
-
-        await flushEffects();
-    };
-
-    const changeCheckbox = async (selector: string, checked: boolean) => {
-        const checkbox = container.querySelector(selector);
-
-        if (!(checkbox instanceof HTMLInputElement)) {
-            throw new Error(`Expected checkbox ${selector} to exist`);
-        }
-
-        checkbox.checked = checked;
-        flushSync(() => {
-            checkbox.dispatchEvent(new Event('change', { bubbles: true }));
-        });
-
-        await flushEffects();
-        return checkbox;
-    };
-
-    const clickButton = async (selector: string) => {
-        const button = container.querySelector(selector);
-
-        if (!(button instanceof HTMLButtonElement)) {
-            throw new Error(`Expected button ${selector} to exist`);
-        }
-
-        flushSync(() => {
-            button.click();
-        });
-
-        await flushEffects();
-    };
-
     const dismissToast = async () => {
-        flushSync(() => {
-            mocks.toastOnClose?.(new Event('close'), 'clickaway');
-        });
-
-        await flushEffects();
+        await dismissToastUtil(mocks.toastOnClose);
     };
 
     beforeEach(() => {
@@ -274,19 +212,19 @@ describe('UserNew', () => {
         expect(mocks.loadingHide).toHaveBeenCalledOnce();
         expect(container.querySelector('.channelAccessContainer')?.classList.contains('hide')).toBe(false);
 
-        await changeCheckbox('.chkEnableAllChannels', true);
+        await changeCheckbox(container, '.chkEnableAllChannels', true);
         expect(container.querySelector('.channelAccessListContainer')?.classList.contains('hide')).toBe(true);
 
-        await changeCheckbox('.chkEnableAllChannels', false);
+        await changeCheckbox(container, '.chkEnableAllChannels', false);
         expect(container.querySelector('.channelAccessListContainer')?.classList.contains('hide')).toBe(false);
 
-        await changeCheckbox('.chkEnableAllFolders', true);
+        await changeCheckbox(container, '.chkEnableAllFolders', true);
         expect(container.querySelector('.folderAccessListContainer')?.classList.contains('hide')).toBe(true);
 
-        await changeCheckbox('.chkEnableAllFolders', false);
+        await changeCheckbox(container, '.chkEnableAllFolders', false);
         expect(container.querySelector('.folderAccessListContainer')?.classList.contains('hide')).toBe(false);
 
-        await clickButton('#btnCancel');
+        await clickButton(container, '#btnCancel');
 
         expect(historyBackSpy).toHaveBeenCalledOnce();
     });
@@ -326,7 +264,7 @@ describe('UserNew', () => {
         (container.querySelector('#txtUsername') as HTMLInputElement).value = 'test / test';
         (container.querySelector('#txtPassword') as HTMLInputElement).value = TEST_PASSWORD;
 
-        await submitForm();
+        await dispatchFormSubmit(container, '.newUserProfileForm');
 
         expect(mocks.loadingShow).toHaveBeenCalledOnce();
         expect(mocks.loadingHide).toHaveBeenCalledOnce();
@@ -347,7 +285,7 @@ describe('UserNew', () => {
 
         (container.querySelector('#txtUsername') as HTMLInputElement).value = 'valid-name';
 
-        await submitForm();
+        await dispatchFormSubmit(container, '.newUserProfileForm');
 
         expect(mocks.loadingHide).toHaveBeenCalledOnce();
         expect(container.querySelector('[data-testid="toast-message"]')?.textContent).toBe('ErrorDefault');
@@ -359,7 +297,7 @@ describe('UserNew', () => {
         });
 
         await renderPage();
-        await submitForm();
+        await dispatchFormSubmit(container, '.newUserProfileForm');
 
         await dismissToast();
 
@@ -388,7 +326,7 @@ describe('UserNew', () => {
         (container.querySelector('#txtUsername') as HTMLInputElement).value = 'valid-name';
         (container.querySelector('#txtPassword') as HTMLInputElement).value = TEST_PASSWORD;
 
-        await submitForm();
+        await dispatchFormSubmit(container, '.newUserProfileForm');
 
         expect(mocks.createUserMutate).toHaveBeenCalledOnce();
         expect(mocks.updateUserPolicyMutate).toHaveBeenCalledOnce();
@@ -432,7 +370,7 @@ describe('UserNew', () => {
         (container.querySelector('.chkFolder') as HTMLInputElement).checked = true;
         (container.querySelector('.chkChannel') as HTMLInputElement).checked = true;
 
-        await submitForm();
+        await dispatchFormSubmit(container, '.newUserProfileForm');
 
         expect(mocks.navigate).toHaveBeenCalledWith('/dashboard/users/user-1/profile');
     });
@@ -465,10 +403,10 @@ describe('UserNew', () => {
 
         (container.querySelector('#txtUsername') as HTMLInputElement).value = 'valid-name';
         (container.querySelector('#txtPassword') as HTMLInputElement).value = TEST_PASSWORD;
-        await changeCheckbox('.chkEnableAllFolders', true);
-        await changeCheckbox('.chkEnableAllChannels', true);
+        await changeCheckbox(container, '.chkEnableAllFolders', true);
+        await changeCheckbox(container, '.chkEnableAllChannels', true);
 
-        await submitForm();
+        await dispatchFormSubmit(container, '.newUserProfileForm');
 
         expect(mocks.createUserMutate).toHaveBeenCalledOnce();
         expect(mocks.updateUserPolicyMutate).toHaveBeenCalledOnce();

--- a/src/apps/dashboard/routes/users/add.test.tsx
+++ b/src/apps/dashboard/routes/users/add.test.tsx
@@ -1,0 +1,477 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync } from 'react-dom';
+import { createRoot, type Root } from 'react-dom/client';
+
+import UserNew from './add';
+
+const TEST_PASSWORD = [ 'test', 'passphrase' ].join('-');
+
+const mocks = vi.hoisted(() => ({
+    navigate: vi.fn(),
+    loadingShow: vi.fn(),
+    loadingHide: vi.fn(),
+    createUserMutate: vi.fn(),
+    updateUserPolicyMutate: vi.fn(),
+    toastOnClose: undefined as undefined | ((event: Event, reason: string) => void),
+    mediaFoldersResponse: {
+        data: {
+            Items: [
+                { Id: 'folder-1', Name: 'Movies' }
+            ]
+        },
+        isSuccess: true
+    },
+    channelsResponse: {
+        data: {
+            Items: [
+                { Id: 'channel-1', Name: 'News' }
+            ]
+        },
+        isSuccess: true
+    }
+}));
+
+vi.mock('react-router-dom', () => ({
+    useNavigate: () => mocks.navigate
+}));
+
+vi.mock('../../../../lib/globalize', () => ({
+    default: {
+        translate: (key: string) => key
+    }
+}));
+
+vi.mock('../../../../components/loading/loading', () => ({
+    default: {
+        show: mocks.loadingShow,
+        hide: mocks.loadingHide
+    }
+}));
+
+vi.mock('../../../../components/Page', () => ({
+    default: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => <div {...props}>{children}</div>
+}));
+
+vi.mock('../../../../elements/SectionTitleContainer', () => ({
+    default: ({ title }: { title: string }) => <div>{title}</div>
+}));
+
+vi.mock('../../../../elements/emby-input/Input', () => ({
+    default: ({ id, type = 'text', required = false }: { id: string; type?: string; required?: boolean }) => (
+        <input id={id} type={type} required={required} />
+    )
+}));
+
+vi.mock('../../../../elements/emby-button/Button', () => ({
+    default: ({ id, type = 'button', className, title }: { id?: string; type?: 'button' | 'submit'; className?: string; title: string }) => (
+        <button id={id} type={type} className={className}>{title}</button>
+    )
+}));
+
+vi.mock('../../../../components/dashboard/users/AccessContainer', () => ({
+    default: ({
+        children,
+        containerClassName,
+        checkBoxClassName,
+        listContainerClassName,
+        accessClassName
+    }: React.PropsWithChildren<{
+        containerClassName: string;
+        checkBoxClassName: string;
+        listContainerClassName: string;
+        accessClassName: string;
+    }>) => (
+        <div className={containerClassName}>
+            <input type='checkbox' className={checkBoxClassName} />
+            <div className={listContainerClassName}>
+                <div className={accessClassName}>{children}</div>
+            </div>
+        </div>
+    )
+}));
+
+vi.mock('../../../../elements/CheckBoxElement', () => ({
+    default: ({
+        className,
+        itemId,
+        itemName
+    }: {
+        className?: string;
+        itemId?: string;
+        itemName?: string | null;
+    }) => (
+        <label>
+            <input type='checkbox' className={className} data-id={itemId} />
+            <span>{itemName}</span>
+        </label>
+    )
+}));
+
+vi.mock('apps/dashboard/components/Toast', () => ({
+    default: ({ open, message, onClose }: { open?: boolean; message?: string; onClose?: (event: Event, reason: string) => void }) => {
+        mocks.toastOnClose = onClose;
+
+        return open ? (
+            <div data-testid='toast'>
+                <span data-testid='toast-message'>{message}</span>
+                <button
+                    type='button'
+                    data-testid='toast-close'
+                >
+                    close
+                </button>
+            </div>
+        ) : null;
+    }
+}));
+
+vi.mock('apps/dashboard/features/users/api/useLibraryMediaFolders', () => ({
+    useLibraryMediaFolders: () => mocks.mediaFoldersResponse
+}));
+
+vi.mock('apps/dashboard/features/users/api/useChannels', () => ({
+    useChannels: () => mocks.channelsResponse
+}));
+
+vi.mock('apps/dashboard/features/users/api/useCreateUser', () => ({
+    useCreateUser: () => ({
+        mutate: mocks.createUserMutate
+    })
+}));
+
+vi.mock('apps/dashboard/features/users/api/useUpdateUserPolicy', () => ({
+    useUpdateUserPolicy: () => ({
+        mutate: mocks.updateUserPolicyMutate
+    })
+}));
+
+describe('UserNew', () => {
+    let container: HTMLDivElement;
+    let root: Root;
+    let historyBackSpy: ReturnType<typeof vi.spyOn>;
+
+    const flushEffects = async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+        await new Promise(resolve => setTimeout(resolve, 0));
+    };
+
+    const waitUntil = async (assertion: () => void) => {
+        let lastError: unknown;
+
+        for (let attempt = 0; attempt < 10; attempt++) {
+            try {
+                assertion();
+                return;
+            } catch (error) {
+                lastError = error;
+                await flushEffects();
+            }
+        }
+
+        throw lastError;
+    };
+
+    const renderPage = async () => {
+        flushSync(() => {
+            root = createRoot(container);
+            root.render(<UserNew />);
+        });
+
+        await flushEffects();
+    };
+
+    const submitForm = async () => {
+        const form = container.querySelector('.newUserProfileForm');
+
+        if (!(form instanceof HTMLFormElement)) {
+            throw new Error('Expected new user form to be rendered');
+        }
+
+        flushSync(() => {
+            form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+        });
+
+        await flushEffects();
+    };
+
+    const changeCheckbox = async (selector: string, checked: boolean) => {
+        const checkbox = container.querySelector(selector);
+
+        if (!(checkbox instanceof HTMLInputElement)) {
+            throw new Error(`Expected checkbox ${selector} to exist`);
+        }
+
+        checkbox.checked = checked;
+        flushSync(() => {
+            checkbox.dispatchEvent(new Event('change', { bubbles: true }));
+        });
+
+        await flushEffects();
+        return checkbox;
+    };
+
+    const clickButton = async (selector: string) => {
+        const button = container.querySelector(selector);
+
+        if (!(button instanceof HTMLButtonElement)) {
+            throw new Error(`Expected button ${selector} to exist`);
+        }
+
+        flushSync(() => {
+            button.click();
+        });
+
+        await flushEffects();
+    };
+
+    const dismissToast = async () => {
+        flushSync(() => {
+            mocks.toastOnClose?.(new Event('close'), 'clickaway');
+        });
+
+        await flushEffects();
+    };
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        document.body.appendChild(container);
+        historyBackSpy = vi.spyOn(window.history, 'back').mockImplementation(() => undefined);
+        mocks.toastOnClose = undefined;
+
+        mocks.mediaFoldersResponse.isSuccess = true;
+        mocks.mediaFoldersResponse.data.Items = [
+            { Id: 'folder-1', Name: 'Movies' }
+        ];
+        mocks.channelsResponse.isSuccess = true;
+        mocks.channelsResponse.data.Items = [
+            { Id: 'channel-1', Name: 'News' }
+        ];
+    });
+
+    afterEach(async () => {
+        if (root) {
+            flushSync(() => {
+                root.unmount();
+            });
+        }
+
+        container.remove();
+        historyBackSpy.mockRestore();
+        vi.clearAllMocks();
+    });
+
+    it('loads the access lists, toggles the list visibility, and supports cancel navigation', async () => {
+        await renderPage();
+
+        await waitUntil(() => {
+            expect(container.querySelectorAll('.chkFolder')).toHaveLength(1);
+            expect(container.querySelectorAll('.chkChannel')).toHaveLength(1);
+        });
+
+        expect(mocks.loadingShow).toHaveBeenCalledOnce();
+        expect(mocks.loadingHide).toHaveBeenCalledOnce();
+        expect(container.querySelector('.channelAccessContainer')?.classList.contains('hide')).toBe(false);
+
+        await changeCheckbox('.chkEnableAllChannels', true);
+        expect(container.querySelector('.channelAccessListContainer')?.classList.contains('hide')).toBe(true);
+
+        await changeCheckbox('.chkEnableAllChannels', false);
+        expect(container.querySelector('.channelAccessListContainer')?.classList.contains('hide')).toBe(false);
+
+        await changeCheckbox('.chkEnableAllFolders', true);
+        expect(container.querySelector('.folderAccessListContainer')?.classList.contains('hide')).toBe(true);
+
+        await changeCheckbox('.chkEnableAllFolders', false);
+        expect(container.querySelector('.folderAccessListContainer')?.classList.contains('hide')).toBe(false);
+
+        await clickButton('#btnCancel');
+
+        expect(historyBackSpy).toHaveBeenCalledOnce();
+    });
+
+    it('keeps the channel access section hidden when there are no channels', async () => {
+        mocks.channelsResponse.data.Items = [];
+
+        await renderPage();
+
+        expect(container.querySelector('.channelAccessContainer')?.classList.contains('hide')).toBe(true);
+        expect(container.querySelectorAll('.chkChannel')).toHaveLength(0);
+    });
+
+    it('hides loading and shows the server validation message when creating a user fails', async () => {
+        mocks.createUserMutate.mockImplementation((params, options) => {
+            expect(params).toEqual({
+                createUserByName: {
+                    Name: 'test / test',
+                    Password: TEST_PASSWORD
+                }
+            });
+
+            options?.onError?.({
+                response: {
+                    data: {
+                        message: 'Usernames can contain unicode symbols, numbers (0-9), dashes (-), underscores (_), apostrophes (\'), and periods (.)'
+                    }
+                }
+            });
+        });
+
+        await renderPage();
+
+        mocks.loadingShow.mockClear();
+        mocks.loadingHide.mockClear();
+
+        (container.querySelector('#txtUsername') as HTMLInputElement).value = 'test / test';
+        (container.querySelector('#txtPassword') as HTMLInputElement).value = TEST_PASSWORD;
+
+        await submitForm();
+
+        expect(mocks.loadingShow).toHaveBeenCalledOnce();
+        expect(mocks.loadingHide).toHaveBeenCalledOnce();
+        expect(container.querySelector('[data-testid="toast-message"]')?.textContent).toContain('Usernames can contain unicode symbols');
+        expect(mocks.updateUserPolicyMutate).not.toHaveBeenCalled();
+        expect(mocks.navigate).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the default error message when the create failure has no message', async () => {
+        mocks.createUserMutate.mockImplementation((_params, options) => {
+            options?.onError?.({});
+        });
+
+        await renderPage();
+
+        mocks.loadingShow.mockClear();
+        mocks.loadingHide.mockClear();
+
+        (container.querySelector('#txtUsername') as HTMLInputElement).value = 'valid-name';
+
+        await submitForm();
+
+        expect(mocks.loadingHide).toHaveBeenCalledOnce();
+        expect(container.querySelector('[data-testid="toast-message"]')?.textContent).toBe('ErrorDefault');
+    });
+
+    it('closes the error toast when dismissed', async () => {
+        mocks.createUserMutate.mockImplementation((_params, options) => {
+            options?.onError?.({});
+        });
+
+        await renderPage();
+        await submitForm();
+
+        await dismissToast();
+
+        expect(container.querySelector('[data-testid="toast"]')).toBeNull();
+    });
+
+    it('hides loading and shows the nested policy update error message', async () => {
+        mocks.createUserMutate.mockImplementation((_params, options) => {
+            options?.onSuccess?.({
+                data: {
+                    Id: 'user-1',
+                    Policy: {}
+                }
+            });
+        });
+
+        mocks.updateUserPolicyMutate.mockImplementation((_params, options) => {
+            options?.onError?.(new Error('Policy update failed'));
+        });
+
+        await renderPage();
+
+        mocks.loadingShow.mockClear();
+        mocks.loadingHide.mockClear();
+
+        (container.querySelector('#txtUsername') as HTMLInputElement).value = 'valid-name';
+        (container.querySelector('#txtPassword') as HTMLInputElement).value = TEST_PASSWORD;
+
+        await submitForm();
+
+        expect(mocks.createUserMutate).toHaveBeenCalledOnce();
+        expect(mocks.updateUserPolicyMutate).toHaveBeenCalledOnce();
+        expect(mocks.loadingHide).toHaveBeenCalledOnce();
+        expect(container.querySelector('[data-testid="toast-message"]')?.textContent).toContain('Policy update failed');
+        expect(mocks.navigate).not.toHaveBeenCalled();
+    });
+
+    it('submits individually selected folder and channel access ids', async () => {
+        mocks.createUserMutate.mockImplementation((_params, options) => {
+            options?.onSuccess?.({
+                data: {
+                    Id: 'user-1',
+                    Policy: {}
+                }
+            });
+        });
+
+        mocks.updateUserPolicyMutate.mockImplementation((params, options) => {
+            expect(params).toEqual({
+                userId: 'user-1',
+                userPolicy: {
+                    EnableAllFolders: false,
+                    EnabledFolders: ['folder-1'],
+                    EnableAllChannels: false,
+                    EnabledChannels: ['channel-1']
+                }
+            });
+
+            options?.onSuccess?.();
+        });
+
+        await renderPage();
+        await waitUntil(() => {
+            expect(container.querySelectorAll('.chkFolder')).toHaveLength(1);
+            expect(container.querySelectorAll('.chkChannel')).toHaveLength(1);
+        });
+
+        (container.querySelector('#txtUsername') as HTMLInputElement).value = 'valid-name';
+        (container.querySelector('#txtPassword') as HTMLInputElement).value = TEST_PASSWORD;
+        (container.querySelector('.chkFolder') as HTMLInputElement).checked = true;
+        (container.querySelector('.chkChannel') as HTMLInputElement).checked = true;
+
+        await submitForm();
+
+        expect(mocks.navigate).toHaveBeenCalledWith('/dashboard/users/user-1/profile');
+    });
+
+    it('submits full-access policy updates and navigates on success', async () => {
+        mocks.createUserMutate.mockImplementation((_params, options) => {
+            options?.onSuccess?.({
+                data: {
+                    Id: 'user-1',
+                    Policy: {}
+                }
+            });
+        });
+
+        mocks.updateUserPolicyMutate.mockImplementation((params, options) => {
+            expect(params).toEqual({
+                userId: 'user-1',
+                userPolicy: {
+                    EnableAllFolders: true,
+                    EnabledFolders: [],
+                    EnableAllChannels: true,
+                    EnabledChannels: []
+                }
+            });
+
+            options?.onSuccess?.();
+        });
+
+        await renderPage();
+
+        (container.querySelector('#txtUsername') as HTMLInputElement).value = 'valid-name';
+        (container.querySelector('#txtPassword') as HTMLInputElement).value = TEST_PASSWORD;
+        await changeCheckbox('.chkEnableAllFolders', true);
+        await changeCheckbox('.chkEnableAllChannels', true);
+
+        await submitForm();
+
+        expect(mocks.createUserMutate).toHaveBeenCalledOnce();
+        expect(mocks.updateUserPolicyMutate).toHaveBeenCalledOnce();
+        expect(mocks.navigate).toHaveBeenCalledWith('/dashboard/users/user-1/profile');
+    });
+});

--- a/src/apps/dashboard/routes/users/add.tsx
+++ b/src/apps/dashboard/routes/users/add.tsx
@@ -23,9 +23,11 @@ type ItemsArr = {
     Id?: string;
 };
 
-const getCheckedElementDataIds = (elements: NodeListOf<Element>) => (
-    Array.prototype.filter.call(elements, e => e.checked)
-        .map(e => e.getAttribute('data-id'))
+const getCheckedElementDataIds = (elements: NodeListOf<HTMLInputElement>) => (
+    Array.from(elements)
+        .filter(e => e.checked)
+        .map(e => e.dataset.id)
+        .filter((id): id is string => !!id)
 );
 
 const UserNew = () => {

--- a/src/apps/dashboard/routes/users/add.tsx
+++ b/src/apps/dashboard/routes/users/add.tsx
@@ -10,6 +10,7 @@ import AccessContainer from '../../../../components/dashboard/users/AccessContai
 import CheckBoxElement from '../../../../elements/CheckBoxElement';
 import Page from '../../../../components/Page';
 import Toast from 'apps/dashboard/components/Toast';
+import { getMutationErrorMessage } from 'apps/dashboard/features/users/errorMessage';
 
 import { useLibraryMediaFolders } from 'apps/dashboard/features/users/api/useLibraryMediaFolders';
 import { useChannels } from 'apps/dashboard/features/users/api/useChannels';
@@ -22,16 +23,38 @@ type ItemsArr = {
     Id?: string;
 };
 
+const getCheckedElementDataIds = (elements: NodeListOf<Element>) => (
+    Array.prototype.filter.call(elements, e => e.checked)
+        .map(e => e.getAttribute('data-id'))
+);
+
 const UserNew = () => {
     const navigate = useNavigate();
     const [ channelsItems, setChannelsItems ] = useState<ItemsArr[]>([]);
     const [ mediaFoldersItems, setMediaFoldersItems ] = useState<ItemsArr[]>([]);
+    const [ errorMessage, setErrorMessage ] = useState(globalize.translate('ErrorDefault'));
     const [ isErrorToastOpen, setIsErrorToastOpen ] = useState(false);
     const element = useRef<HTMLDivElement>(null);
 
     const handleToastClose = useCallback(() => {
         setIsErrorToastOpen(false);
     }, []);
+
+    const showErrorToast = useCallback((error?: unknown) => {
+        loading.hide();
+        setErrorMessage(getMutationErrorMessage(error) || globalize.translate('ErrorDefault'));
+        setIsErrorToastOpen(true);
+    }, []);
+
+    const navigateToUserProfile = useCallback((userId: string) => {
+        navigate(`/dashboard/users/${userId}/profile`);
+    }, [navigate]);
+
+    const handleUpdateUserPolicyError = useCallback((error?: unknown) => {
+        console.error('[usernew] failed to update user policy');
+        showErrorToast(error);
+    }, [showErrorToast]);
+
     const { data: mediaFolders, isSuccess: isMediaFoldersSuccess } = useLibraryMediaFolders();
     const { data: channels, isSuccess: isChannelsSuccess } = useChannels();
 
@@ -125,6 +148,7 @@ const UserNew = () => {
                 Name: (page.querySelector('#txtUsername') as HTMLInputElement).value,
                 Password: (page.querySelector('#txtPassword') as HTMLInputElement).value
             };
+
             createUser.mutate({ createUserByName: userInput }, {
                 onSuccess: (response) => {
                     const user = response.data;
@@ -137,37 +161,27 @@ const UserNew = () => {
                     user.Policy.EnabledFolders = [];
 
                     if (!user.Policy.EnableAllFolders) {
-                        user.Policy.EnabledFolders = Array.prototype.filter.call(page.querySelectorAll('.chkFolder'), function (i) {
-                            return i.checked;
-                        }).map(function (i) {
-                            return i.getAttribute('data-id');
-                        });
+                        user.Policy.EnabledFolders = getCheckedElementDataIds(page.querySelectorAll('.chkFolder'));
                     }
 
                     user.Policy.EnableAllChannels = (page.querySelector('.chkEnableAllChannels') as HTMLInputElement).checked;
                     user.Policy.EnabledChannels = [];
 
                     if (!user.Policy.EnableAllChannels) {
-                        user.Policy.EnabledChannels = Array.prototype.filter.call(page.querySelectorAll('.chkChannel'), function (i) {
-                            return i.checked;
-                        }).map(function (i) {
-                            return i.getAttribute('data-id');
-                        });
+                        user.Policy.EnabledChannels = getCheckedElementDataIds(page.querySelectorAll('.chkChannel'));
                     }
+
+                    const handleUpdateUserPolicySuccess = navigateToUserProfile.bind(null, user.Id);
 
                     updateUserPolicy.mutate({
                         userId: user.Id,
                         userPolicy: user.Policy
                     }, {
-                        onSuccess: () => {
-                            navigate(`/dashboard/users/${user.Id}/profile`);
-                        },
-                        onError: () => {
-                            console.error('[usernew] failed to update user policy');
-                            setIsErrorToastOpen(true);
-                        }
+                        onSuccess: handleUpdateUserPolicySuccess,
+                        onError: handleUpdateUserPolicyError
                     });
-                }
+                },
+                onError: showErrorToast
             });
         };
 
@@ -204,7 +218,7 @@ const UserNew = () => {
             (page.querySelector('.newUserProfileForm') as HTMLFormElement).removeEventListener('submit', onSubmit);
             (page.querySelector('#btnCancel') as HTMLButtonElement).removeEventListener('click', onCancelClick);
         };
-    }, [loadUser, createUser, updateUserPolicy, navigate]);
+    }, [loadUser, createUser, updateUserPolicy, navigateToUserProfile, showErrorToast, handleUpdateUserPolicyError]);
 
     return (
         <Page
@@ -214,7 +228,7 @@ const UserNew = () => {
             <Toast
                 open={isErrorToastOpen}
                 onClose={handleToastClose}
-                message={globalize.translate('ErrorDefault')}
+                message={errorMessage}
             />
             <div ref={element} className='content-primary'>
                 <div className='verticalSection'>


### PR DESCRIPTION
## Summary
- clear the loading overlay when dashboard user create, update, or policy-save requests fail
- surface server validation messages in both the new-user and profile flows instead of falling back to an endless spinner or generic toast
- add deep regression tests for success, failure, fallback, dismissal, and access-selection behavior across both forms

## Testing
- npx tsc --noEmit --pretty false
- npx eslint src/apps/dashboard/routes/users/add.tsx src/apps/dashboard/features/users/components/Profile.tsx src/apps/dashboard/features/users/errorMessage.ts src/apps/dashboard/routes/users/add.test.tsx src/apps/dashboard/features/users/components/Profile.test.tsx src/apps/dashboard/features/users/errorMessage.test.ts
- npx vitest run \"src/apps/dashboard/routes/users/add.test.tsx\" \"src/apps/dashboard/features/users/components/Profile.test.tsx\" \"src/apps/dashboard/features/users/errorMessage.test.ts\" --config vite.config.ts --reporter verbose --testTimeout 10000 --hookTimeout 10000