### PR TITLE
fix: properly advertise PlaybackOrder

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -2172,7 +2172,9 @@ export class PlaybackManager {
                 state.PlayState.IsMuted = player.isMuted();
                 state.PlayState.IsPaused = player.paused();
                 state.PlayState.RepeatMode = self.getRepeatMode(player);
-                state.PlayState.ShuffleMode = self.getQueueShuffleMode(player);
+                const shuffleMode = self.getQueueShuffleMode(player);
+                state.PlayState.ShuffleMode = shuffleMode;
+                state.PlayState.PlaybackOrder = shuffleMode === 'Shuffle' ? 'Shuffle' : 'Default';
                 state.PlayState.MaxStreamingBitrate = self.getMaxStreamingBitrate(player);
 
                 state.PlayState.PositionTicks = getCurrentTicks(player);


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

### Changes
Made it so that `PlayState.PlaybackOrder` is set to the correct value when we toggle shuffle on or off. Currently, it'd always default to `Default`.
Rationale: The `Sessions` API endpoint returns a `SessionInfoDto` object with a `PlayStateInfo` member in which there's the `PlayBackOrder`. As far as I can tell it's the only way to tell if a client is in shuffle mode or sorted and that info wasn't being reported to the server
https://typescript-sdk.jellyfin.org/interfaces/generated-client.SessionInfoDto.html#playstate

### Issues
<!--
Tag any issues that this PR solves here.
ex. Fixes #
-->

### Code assistance
N/A

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
