### PR TITLE
Add .jellyignore toggle for per-library file filtering

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -105,6 +105,7 @@
 - [johnnyg](https://github.com/johnnyg)
 - [lmaotrigine](https://github.com/lmaotrigine)
 - [bjorntp](https://github.com/bjorntp)
+- [Rani-Wehbe](https://github.com/Rani-Wehbe)
 
 ## Emby Contributors
 

--- a/src/components/libraryoptionseditor/libraryoptionseditor.js
+++ b/src/components/libraryoptionseditor/libraryoptionseditor.js
@@ -626,6 +626,7 @@ export function getLibraryOptions(parent) {
         EnableArchiveMediaFiles: false,
         EnablePhotos: parent.querySelector('.chkEnablePhotos').checked,
         EnableRealtimeMonitor: parent.querySelector('.chkEnableRealtimeMonitor').checked,
+        EnableJellyignore: parent.querySelector('.chkEnableJellyignore').checked,
         EnableLUFSScan: parent.querySelector('.chkEnableLUFSScan').checked,
         ExtractTrickplayImagesDuringLibraryScan: parent.querySelector('.chkExtractTrickplayDuringLibraryScan').checked,
         SaveTrickplayWithMedia: parent.querySelector('.chkSaveTrickplayLocally').checked,
@@ -699,6 +700,7 @@ export function setLibraryOptions(parent, options) {
     parent.querySelector('.chkEnabled').checked = options.Enabled;
     parent.querySelector('.chkEnablePhotos').checked = options.EnablePhotos;
     parent.querySelector('.chkEnableRealtimeMonitor').checked = options.EnableRealtimeMonitor;
+    parent.querySelector('.chkEnableJellyignore').checked = options.EnableJellyignore;
     parent.querySelector('.chkEnableLUFSScan').checked = options.EnableLUFSScan;
     parent.querySelector('.chkExtractTrickplayDuringLibraryScan').checked = options.ExtractTrickplayImagesDuringLibraryScan;
     parent.querySelector('.chkExtractTrickplayImages').checked = options.EnableTrickplayImageExtraction;

--- a/src/components/libraryoptionseditor/libraryoptionseditor.template.html
+++ b/src/components/libraryoptionseditor/libraryoptionseditor.template.html
@@ -63,6 +63,14 @@
     <div class="fieldDescription checkboxFieldDescription">${LabelEnableRealtimeMonitorHelp}</div>
 </div>
 
+<div class="checkboxContainer checkboxContainer-withDescription chkEnableJellyignoreContainer advanced">
+    <label>
+        <input type="checkbox" is="emby-checkbox" class="chkEnableJellyignore" checked />
+        <span>${LabelEnableJellyignore}</span>
+    </label>
+    <div class="fieldDescription checkboxFieldDescription">${LabelEnableJellyignoreHelp}</div>
+</div>
+
 <div class="checkboxContainer checkboxContainer-withDescription chkEnableLUFSScanContainer advanced">
     <label>
         <input type="checkbox" is="emby-checkbox" class="chkEnableLUFSScan" checked />

--- a/src/strings/en-gb.json
+++ b/src/strings/en-gb.json
@@ -842,6 +842,8 @@
     "LabelEpisodeNumber": "Episode number",
     "LabelEnableRealtimeMonitorHelp": "Changes to files will be processed immediately on supported file systems.",
     "LabelEnableRealtimeMonitor": "Enable real time monitoring",
+    "LabelEnableJellyignore": "Enable .jellyignore support",
+    "LabelEnableJellyignoreHelp": "Allow .jellyignore files in library folders to exclude files and folders from scanning using glob patterns.",
     "LabelDynamicExternalId": "{0} Id",
     "LabelDropShadow": "Drop shadow",
     "LabelDropImageHere": "Drop image here, or click to browse.",

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -739,6 +739,8 @@
     "LabelEnablePlugin": "Enable plugin",
     "LabelEnableRealtimeMonitor": "Enable real time monitoring",
     "LabelEnableRealtimeMonitorHelp": "Changes to files will be processed immediately on supported file systems.",
+    "LabelEnableJellyignore": "Enable .jellyignore support",
+    "LabelEnableJellyignoreHelp": "Allow .jellyignore files in library folders to exclude files and folders from scanning using glob patterns.",
     "LabelEncoderPreset": "Encoding preset",
     "LabelEndDate": "End date",
     "LabelEpisodeNumber": "Episode number",


### PR DESCRIPTION
## Summary
- Add EnableJellyignore checkbox in library options editor to control per-library .jellyignore support
- Allow administrators to enable/disable .jellyignore filtering on a per-library basis
- Add localization strings for en-US and en-GB

## Related Issue
Complements jellyfin/jellyfin#16705 for backend .jellyignore implementation

## Testing
- Verify checkbox appears in library settings
- Confirm EnableJellyignore property is read/written to the virtual folders request to the backend
- Tested with backend implementation 