### PR TITLE
Fix queued theme videos lose aspect-ratio

### DIFF
--- a/src/components/themeMediaPlayer.js
+++ b/src/components/themeMediaPlayer.js
@@ -33,6 +33,7 @@ function playThemeMedia(items, ownerId) {
 
         currentThemeItems.forEach((i) => {
             i.playOptions = {
+                aspectRatio: 'cover',
                 fullscreen: false,
                 enableRemotePlayers: false
             };


### PR DESCRIPTION
### Changes
Queued theme videos now keep the aspect-ratio cover after switching to the next one.

### Issues
Fixes #7860

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
