### PR TITLE
Fix serverId missing in Cast card links in Details page

### DIFF
--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -866,7 +866,9 @@ function buildCard(index, item, apiClient, options) {
     } else {
         const cardImageContainerAriaLabelAttribute = ` aria-label="${escapeHtml(item.Name)}" role="img"`;
 
-        const url = appRouter.getRouteUrl(item);
+        const url = appRouter.getRouteUrl(item, {
+            serverId: options.serverId
+        });
         // Don't use the IMG tag with safari because it puts a white border around it
         cardImageContainerOpen = imgUrl ? ('<a href="' + url + '" data-action="' + action + '" class="' + cardImageContainerClasses + ' ' + cardContentClass + ' itemAction lazy" data-src="' + imgUrl + '" ' + blurhashAttrib + cardImageContainerAriaLabelAttribute + '>') : ('<a href="' + url + '" data-action="' + action + '" class="' + cardImageContainerClasses + ' ' + cardContentClass + ' itemAction"' + cardImageContainerAriaLabelAttribute + '>');
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

### Changes
<!--
Describe your changes here in 1-5 sentences.
Please include before/after screenshots of any UI changes.
-->

Currently the links in cards from the cast section of the details page have the server id missing. 

In the Card Builder, the id isn't present in the item objects, but it is in options. This change passes the value to `appRouter.getRouteUrl` to get the correct url.

**Before**
<img width="1308" height="814" alt="image" src="https://github.com/user-attachments/assets/4f3545a8-6a34-4b13-b7ff-bb04bda0e639" />


**After**
<img width="1524" height="1060" alt="image" src="https://github.com/user-attachments/assets/207d15d4-4631-47a6-9ead-5a48ac12147f" />


### Issues
<!--
Tag any issues that this PR solves here.
ex. Fixes #
-->

Fixes #7854 

### Code assistance
<!--
If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance.
-->

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
