### PR TITLE
Move bitrate detection to web

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -32,6 +32,7 @@ import { MediaError } from 'types/mediaError';
 import { getMediaError } from 'utils/mediaError';
 import { toApi } from 'utils/jellyfin-apiclient/compat';
 import { bindSkipSegment } from './skipsegment.ts';
+import * as bitrateTest from 'utils/bitrateTest';
 
 const UNLIMITED_ITEMS = -1;
 
@@ -1406,7 +1407,7 @@ export class PlaybackManager {
                 let promise;
                 if (options.enableAutomaticBitrateDetection) {
                     appSettings.enableAutomaticBitrateDetection(endpointInfo.IsInNetwork, mediaType, true);
-                    promise = apiClient.detectBitrate(true);
+                    promise = bitrateTest.detectBitrate(toApi(apiClient), true);
                 } else {
                     appSettings.enableAutomaticBitrateDetection(endpointInfo.IsInNetwork, mediaType, false);
                     promise = Promise.resolve(options.maxBitrate);
@@ -2583,10 +2584,11 @@ export class PlaybackManager {
                     return apiClient.getEndpointInfo()
                         .then((endpointInfo) => {
                             if ((mediaType === 'Video' || mediaType === 'Audio') && appSettings.enableAutomaticBitrateDetection(endpointInfo.IsInNetwork, mediaType)) {
-                                return apiClient.detectBitrate().then((bitrate) => {
-                                    appSettings.maxStreamingBitrate(endpointInfo.IsInNetwork, mediaType, bitrate);
-                                    return bitrate;
-                                });
+                                return bitrateTest.detectBitrate(toApi(apiClient))
+                                    .then((bitrate) => {
+                                        appSettings.maxStreamingBitrate(endpointInfo.IsInNetwork, mediaType, bitrate);
+                                        return bitrate;
+                                    });
                             }
 
                             return Promise.reject(new Error('skip bitrate detection'));

--- a/src/lib/jellyfin-apiclient/ServerConnections.js
+++ b/src/lib/jellyfin-apiclient/ServerConnections.js
@@ -8,6 +8,7 @@ import Events from 'utils/events.ts';
 import { toApi } from 'utils/jellyfin-apiclient/compat';
 
 import ConnectionManager from './connectionManager';
+import { detectBitrate } from 'utils/bitrateTest';
 
 const normalizeImageOptions = options => {
     if (!options.quality && (options.maxWidth || options.width || options.maxHeight || options.height || options.fillWidth || options.fillHeight)) {
@@ -139,6 +140,7 @@ class ServerConnections extends ConnectionManager {
     onLocalUserSignedIn(user) {
         const apiClient = this.getApiClient(user.ServerId);
         this.setLocalApiClient(apiClient);
+        setTimeout(() => detectBitrate(toApi(apiClient), true), 6000);
         return setUserInfo(user.Id, apiClient).then(() => {
             if (window.NativeShell && typeof window.NativeShell.onLocalUserSignedIn === 'function') {
                 return window.NativeShell.onLocalUserSignedIn(user, apiClient.accessToken());

--- a/src/lib/jellyfin-apiclient/connectionManager.js
+++ b/src/lib/jellyfin-apiclient/connectionManager.js
@@ -189,8 +189,8 @@ export default class ConnectionManager {
             credentialProvider.addOrUpdateServer(credentials.Servers, server);
             credentialProvider.credentials(credentials);
 
-            // set this now before updating server info, otherwise it won't be set in time
-            apiClient.enableAutomaticBitrateDetection = options.enableAutomaticBitrateDetection;
+            // Disable the legacy apiclient's bitrate detection as this feature is now upstreamed.
+            apiClient.enableAutomaticBitrateDetection = false;
 
             apiClient.serverInfo(server);
             apiClient.setAuthenticationInfo(result.AccessToken, result.User.Id);
@@ -203,7 +203,7 @@ export default class ConnectionManager {
             if (options.reportCapabilities !== false) {
                 apiClient.reportCapabilities(capabilities);
             }
-            apiClient.enableAutomaticBitrateDetection = options.enableAutomaticBitrateDetection;
+            apiClient.enableAutomaticBitrateDetection = false;
 
             if (options.enableWebSocket !== false) {
                 console.log('calling apiClient.ensureWebSocket');
@@ -602,8 +602,8 @@ export default class ConnectionManager {
 
             result.Servers.push(server);
 
-            // set this now before updating server info, otherwise it won't be set in time
-            result.ApiClient.enableAutomaticBitrateDetection = options.enableAutomaticBitrateDetection;
+            // Disable the legacy apiclient's bitrate detection as this feature is now upstreamed.
+            result.ApiClient.enableAutomaticBitrateDetection = false;
 
             result.ApiClient.updateServerInfo(server, serverUrl);
             result.ApiClient.setAuthenticationInfo(server.AccessToken, server.UserId);

--- a/src/utils/bitrateTest.ts
+++ b/src/utils/bitrateTest.ts
@@ -145,6 +145,7 @@ const detectBitrateInternal = (api: Api, tests: BitrateTest[], index: number, cu
     const test = tests[index];
 
     return getDownloadSpeed(api, test.bytes).then(
+        // eslint-disable-next-line sonarjs/function-return-type
         (bitrate) => {
             if (bitrate < test.threshold) {
                 return normalizeReturnBitrate(bitrate);

--- a/src/utils/bitrateTest.ts
+++ b/src/utils/bitrateTest.ts
@@ -147,7 +147,7 @@ const detectBitrateInternal = (api: Api, tests: BitrateTest[], index: number, cu
     return getDownloadSpeed(api, test.bytes).then(
         (bitrate) => {
             if (bitrate < test.threshold) {
-                return Promise.resolve(normalizeReturnBitrate(bitrate));
+                return normalizeReturnBitrate(bitrate);
             } else {
                 return detectBitrateInternal(api, tests, index + 1, bitrate);
             }

--- a/src/utils/bitrateTest.ts
+++ b/src/utils/bitrateTest.ts
@@ -182,13 +182,14 @@ const detectBitrateWithEndpointInfo = (api: Api, endpointInfo: EndPointInfo) => 
         0,
         undefined
     ).then(result => {
+        const bitrateInMbps = (result / 1048576).toFixed(2);
+        console.debug(`[bitratetest] bitrate detected as ${bitrateInMbps} Mbps`);
         if (endpointInfo.IsInNetwork) {
             result = Math.max(result || 0, LAN_BITRATE);
 
             lastDetectedBitrate = result;
             lastDetectedBitrateTime = Date.now();
         }
-        console.debug(`[bitratetest] bitrate detected as ${Math.round(result / 1048576)} Mbps`);
         return result;
     });
 };

--- a/src/utils/bitrateTest.ts
+++ b/src/utils/bitrateTest.ts
@@ -1,0 +1,223 @@
+import { Api } from '@jellyfin/sdk';
+import type { EndPointInfo } from '@jellyfin/sdk/lib/generated-client/models/end-point-info';
+import { getSystemApi } from '@jellyfin/sdk/lib/utils/api/system-api';
+
+/** Maximum bitrate (Int32) */
+const MAX_BITRATE = 2147483647;
+/** Approximate LAN bitrate */
+const LAN_BITRATE = 140000000;
+/** Bitrate test timeout in milliseconds */
+const BITRATETEST_TIMEOUT = 5000;
+/** Bitrate cache time in milliseconds */
+const BITRATE_CACHE_DURATION = 3600000;
+
+let lastDetectedBitrate: number;
+let lastDetectedBitrateTime: number;
+let pendingBitrateDetection: Promise<number> | null = null;
+
+interface BitrateTest {
+    bytes: number;
+    threshold: number;
+}
+
+/** Gets a normalized maximum downlink speed (only supported on certain browsers) */
+const getMaxBandwidth = () => {
+    const connection = (navigator as unknown as { connection: { downlinkMax: number } }).connection;
+    if (connection) {
+        let max = connection.downlinkMax;
+        if (max && max > 0 && max < Number.POSITIVE_INFINITY) {
+            max /= 8;
+            max *= 1000000;
+            max *= 0.7;
+            return max;
+        }
+    }
+
+    return null;
+};
+
+/**
+ * Perform a download speed test
+ * @param {Api} api The Api client
+ * @param {number} bytes The bytes to download
+ * @returns {number} Download speed in bits per second
+ */
+const getDownloadSpeed = (api: Api, bytes: number) => {
+    return new Promise<number>((resolve, reject) => {
+        const url = api.basePath + '/Playback/BitrateTest?' + new URLSearchParams({
+            Size: bytes.toString()
+        });
+
+        const xhr = new XMLHttpRequest;
+
+        xhr.open('GET', url, true);
+
+        xhr.responseType = 'blob';
+        xhr.timeout = BITRATETEST_TIMEOUT;
+
+        const headers = {
+            'Cache-Control': 'no-cache, no-store',
+            'Authorization': api.authorizationHeader
+        };
+
+        for (const key in headers) {
+            xhr.setRequestHeader(key, headers[key as keyof typeof headers]);
+        }
+
+        let startTime: number;
+
+        xhr.onreadystatechange = () => {
+            if (xhr.readyState == XMLHttpRequest.HEADERS_RECEIVED) {
+                startTime = performance.now();
+            }
+        };
+
+        xhr.onload = () => {
+            if (xhr.status < 400) {
+                const responseTimeSeconds = (performance.now() - startTime) * 1e-3;
+                const bytesLoaded = xhr.response.size;
+                const bytesPerSecond = bytesLoaded / responseTimeSeconds;
+                const bitrate = Math.round(bytesPerSecond * 8);
+
+                console.debug(`[bitratetest] ${bytesLoaded} bytes loaded (${bytes} requested) in ${responseTimeSeconds} seconds -> ${bitrate} bps`);
+
+                resolve(bitrate);
+            } else {
+                reject(new Error(`[bitratetest] failed with ${xhr.status} status`));
+            }
+        };
+
+        xhr.onabort = () => {
+            reject(new Error('[bitratetest] abort'));
+        };
+
+        xhr.onerror = () => {
+            reject(new Error('[bitratetest] error'));
+        };
+
+        xhr.ontimeout = () => {
+            reject(new Error('[bitratetest] timeout'));
+        };
+
+        xhr.send(null);
+    });
+};
+
+/**
+ * Normalizes the bitrate value by reducing it by 30% (to account for network overhead)
+ * and limits the value by MAX_BITRATE
+ * @param bitrate The bitrate to normalize
+ * @returns {number} Normalized bitrate
+ */
+const normalizeReturnBitrate = (bitrate: number) => {
+    if (!bitrate) {
+        if (lastDetectedBitrate) {
+            return lastDetectedBitrate;
+        }
+    }
+
+    let result = Math.min(Math.round(bitrate * 0.7), MAX_BITRATE);
+
+    const maxRate = getMaxBandwidth();
+    if (maxRate) {
+        result = Math.min(result, maxRate);
+    }
+
+    lastDetectedBitrate = result;
+    lastDetectedBitrateTime = Date.now();
+
+    return result;
+};
+
+/**
+ *
+ * @param {Api} api The Api client
+ * @param {BitrateTest[]} tests The tests to perform
+ * @param {number} index Current test index
+ * @param {number | undefined} currentBitrate Current bitrate
+ * @returns {number} Normalized bitrate
+ */
+const detectBitrateInternal = (api: Api, tests: BitrateTest[], index: number, currentBitrate: number | undefined): Promise<number> => {
+    if (index >= tests.length) {
+        return Promise.resolve(normalizeReturnBitrate(currentBitrate || 0));
+    }
+
+    const test = tests[index];
+
+    return getDownloadSpeed(api, test.bytes).then(
+        (bitrate) => {
+            if (bitrate < test.threshold) {
+                return Promise.resolve(normalizeReturnBitrate(bitrate));
+            } else {
+                return detectBitrateInternal(api, tests, index + 1, bitrate);
+            }
+        },
+        () => normalizeReturnBitrate(currentBitrate || 0)
+    );
+};
+
+/**
+ * Detects the bitrate using a series of tests
+ * @param {Api} api The api client
+ * @param {EndPointInfo} endpointInfo Endpoint info for special handling on local networks
+ * @returns {number} Normalized bitrate
+ */
+const detectBitrateWithEndpointInfo = (api: Api, endpointInfo: EndPointInfo) => {
+    return detectBitrateInternal(
+        api,
+        [
+            {
+                bytes: 500000,
+                threshold: 500000
+            },
+            {
+                bytes: 1000000,
+                threshold: 20000000
+            },
+            {
+                bytes: 3000000,
+                threshold: 50000000
+            }
+        ],
+        0,
+        undefined
+    ).then(result => {
+        if (endpointInfo.IsInNetwork) {
+            result = Math.max(result || 0, LAN_BITRATE);
+
+            lastDetectedBitrate = result;
+            lastDetectedBitrateTime = Date.now();
+        }
+        console.debug(`[bitratetest] bitrate detected as ${Math.round(result / 1048576)} Mbps`);
+        return result;
+    });
+};
+
+/**
+ * Detects the bitrate on the current device
+ * @param {Api} api The Api client
+ * @param {boolean} force Ignore the cached bitrate and force a re-detection
+ * @returns {number} The detected bitrate
+ */
+export const detectBitrate = (api: Api, force: boolean) => {
+    if (!force
+        && lastDetectedBitrate
+        && Date.now() - (lastDetectedBitrateTime || 0) <= BITRATE_CACHE_DURATION) {
+        return Promise.resolve(lastDetectedBitrate);
+    }
+
+    if (pendingBitrateDetection) {
+        return pendingBitrateDetection;
+    }
+
+    pendingBitrateDetection = getSystemApi(api)
+        .getEndpointInfo()
+        .then(
+            (response) => detectBitrateWithEndpointInfo(api, response.data),
+            () => detectBitrateWithEndpointInfo(api, {})
+        ).finally(() => {
+            pendingBitrateDetection = null;
+        });
+
+    return pendingBitrateDetection;
+};


### PR DESCRIPTION
Moves the bitrate detection logic from the legacy apiclient to web. No change in detection behavior is made, other than an additional guard to prevent more than one test from running at the same time.

Moving the bitrate detection behavior to web paves the way to eventually revising how the bitrate calculation behavior is done

### Changes
Move bitrate detection to web

### Issues
N/A

### Code assistance
None

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
