### PR TITLE
Promote delete to top-level action and fix post-delete UI refresh

### DIFF
--- a/src/components/common/DeleteIconButton.tsx
+++ b/src/components/common/DeleteIconButton.tsx
@@ -1,0 +1,24 @@
+import React, { type FC } from 'react';
+import IconButton from '@mui/material/IconButton';
+import DeleteIcon from '@mui/icons-material/Delete';
+
+import { ItemAction } from 'constants/itemAction';
+import globalize from 'lib/globalize';
+
+interface DeleteIconButtonProps {
+    className?: string;
+}
+
+const DeleteIconButton: FC<DeleteIconButtonProps> = ({ className }) => {
+    return (
+        <IconButton
+            className={className}
+            data-action={ItemAction.Delete}
+            title={globalize.translate('Delete')}
+        >
+            <DeleteIcon />
+        </IconButton>
+    );
+};
+
+export default DeleteIconButton;

--- a/src/components/listview/List/ListViewUserDataButtons.tsx
+++ b/src/components/listview/List/ListViewUserDataButtons.tsx
@@ -7,6 +7,7 @@ import FavoriteButton from 'elements/emby-ratingbutton/FavoriteButton';
 import PlaylistAddIconButton from '../../common/PlaylistAddIconButton';
 import InfoIconButton from '../../common/InfoIconButton';
 import RightIconButtons from '../../common/RightIconButtons';
+import DeleteIconButton from '../../common/DeleteIconButton';
 import MoreVertIconButton from '../../common/MoreVertIconButton';
 
 import type { ItemDto } from 'types/base/models/item-dto';
@@ -74,6 +75,10 @@ const ListViewUserDataButtons: FC<ListViewUserDataButtonsProps> = ({
                         />
                     )}
                 </>
+            )}
+
+            {item.CanDelete && listOptions.enableDeleteButton && (
+                <DeleteIconButton className='listItemButton' />
             )}
 
             {listOptions.moreButton !== false && (

--- a/src/components/listview/listview.js
+++ b/src/components/listview/listview.js
@@ -477,6 +477,10 @@ export function getListViewHtml(options) {
                 }
             }
 
+            if (item.CanDelete && options.enableDeleteButton) {
+                html += `<button is="paper-icon-button-light" class="listItemButton itemAction" data-action="${ItemAction.Delete}" title="${globalize.translate('Delete')}"><span class="material-icons delete" aria-hidden="true"></span></button>`;
+            }
+
             if (options.moreButton !== false) {
                 html += `<button is="paper-icon-button-light" class="listItemButton itemAction" data-action="${ItemAction.Menu}" title="${globalize.translate('ButtonMore')}"><span class="material-icons more_vert" aria-hidden="true"></span></button>`;
             }

--- a/src/components/shortcuts.js
+++ b/src/components/shortcuts.js
@@ -171,7 +171,13 @@ function showContextMenu(card, options = {}) {
             .then(result => {
                 if (result.command === 'playallfromhere' || result.command === 'queueallfromhere') {
                     executeAction(card, options.positionTo, result.command);
-                } else if (result.updated || result.deleted) {
+                } else if (result.deleted) {
+                    const itemsContainerForMenu = dom.parentWithAttribute(card, 'is', 'emby-itemscontainer')
+                        || options.itemsContainer;
+                    const row = card.closest('.listItem') || card.closest('.card');
+                    if (row) row.remove();
+                    if (itemsContainerForMenu) itemsContainerForMenu.notifyRefreshNeeded(true);
+                } else if (result.updated) {
                     notifyRefreshNeeded(card, options.itemsContainer);
                 }
             })
@@ -329,15 +335,19 @@ function executeAction(card, target, action) {
         case ItemAction.AddToPlaylist:
             getItem(target).then(addToPlaylist);
             break;
-        case ItemAction.Delete:
+        case ItemAction.Delete: {
+            const itemsContainerForDelete = dom.parentWithAttribute(card, 'is', 'emby-itemscontainer');
             getItem(card).then(itemToDelete => {
                 import('../scripts/deleteHelper').then(({ deleteItem }) => {
                     deleteItem({ item: itemToDelete, navigate: false }).then(() => {
-                        notifyRefreshNeeded(card);
+                        const row = card.closest('.listItem') || card.closest('.card');
+                        if (row) row.remove();
+                        if (itemsContainerForDelete) itemsContainerForDelete.notifyRefreshNeeded(true);
                     }).catch(() => { /* user cancelled or error already shown */ });
                 });
             });
             break;
+        }
         case ItemAction.Custom: {
             const customAction = target.getAttribute('data-customaction');
 

--- a/src/components/shortcuts.js
+++ b/src/components/shortcuts.js
@@ -329,6 +329,15 @@ function executeAction(card, target, action) {
         case ItemAction.AddToPlaylist:
             getItem(target).then(addToPlaylist);
             break;
+        case ItemAction.Delete:
+            getItem(card).then(itemToDelete => {
+                import('../scripts/deleteHelper').then(({ deleteItem }) => {
+                    deleteItem({ item: itemToDelete, navigate: false }).then(() => {
+                        notifyRefreshNeeded(card);
+                    }).catch(() => { /* user cancelled or error already shown */ });
+                });
+            });
+            break;
         case ItemAction.Custom: {
             const customAction = target.getAttribute('data-customaction');
 

--- a/src/constants/itemAction.ts
+++ b/src/constants/itemAction.ts
@@ -28,6 +28,8 @@ export enum ItemAction {
     Queue = 'queue',
     /** Queue the Item and all subsequent Items. */
     QueueAllFromHere = 'queueallfromhere',
+    /** Delete the Item. */
+    Delete = 'delete',
     /** Record the Item. */
     Record = 'record',
     /** Resume playback of the Item. */

--- a/src/controllers/itemDetails/index.html
+++ b/src/controllers/itemDetails/index.html
@@ -76,6 +76,12 @@
                         </div>
                     </button>
 
+                    <button is="emby-button" type="button" class="button-flat btnDeleteItem hide detailButton" title="${Delete}">
+                        <div class="detailButton-content">
+                            <span class="material-icons detailButton-icon delete" aria-hidden="true"></span>
+                        </div>
+                    </button>
+
                     <button is="emby-button" type="button" class="button-flat btnSplitVersions hide detailButton" title="${ButtonSplit}">
                         <div class="detailButton-content">
                             <span class="material-icons detailButton-icon call_split" aria-hidden="true"></span>

--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -1407,6 +1407,9 @@ function renderChildren(page, item) {
         }
         childrenItemsContainer.innerHTML = html;
         imageLoader.lazyChildren(childrenItemsContainer);
+        childrenItemsContainer.notifyRefreshNeeded = function () {
+            renderChildren(page, item);
+        };
         if (item.Type == 'BoxSet') {
             const collectionItemTypes = [{
                 name: globalize.translate('Movies'),
@@ -1963,7 +1966,9 @@ export default function (view, params) {
     }
 
     function onDeleteItemClick() {
-        deleteHelper.deleteItem({ item: currentItem, navigate: true });
+        deleteHelper.deleteItem({ item: currentItem, navigate: true }).catch(() => {
+            // user cancelled or error already shown by deleteHelper
+        });
     }
 
     function onMoreCommandsClick() {

--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -29,6 +29,7 @@ import { ItemAction } from 'constants/itemAction';
 import globalize from 'lib/globalize';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
 import browser from 'scripts/browser';
+import deleteHelper from 'scripts/deleteHelper';
 import datetime from 'scripts/datetime';
 import dom from 'utils/dom';
 import { renderComponent } from 'utils/reactUtils';
@@ -595,6 +596,8 @@ function reloadFromItem(instance, page, params, item, user) {
     } else {
         page.querySelector('.btnSplitVersions').classList.add('hide');
     }
+
+    hideAll(page, 'btnDeleteItem', item.CanDelete === true);
 
     itemContextMenu.getCommands(getContextMenuOptions(item, user)).then(commands => {
         if (commands.length) {
@@ -1368,6 +1371,7 @@ function renderChildren(page, item) {
                     enableOverview: true,
                     enablePlayedButton: !layoutManager.mobile,
                     infoButton: !layoutManager.mobile,
+                    enableDeleteButton: true,
                     imageSize: 'large',
                     enableSideMediaInfo: false,
                     highlight: false,
@@ -1958,6 +1962,10 @@ export default function (view, params) {
         }]);
     }
 
+    function onDeleteItemClick() {
+        deleteHelper.deleteItem({ item: currentItem, navigate: true });
+    }
+
     function onMoreCommandsClick() {
         const button = this;
         let selectedItem = view.querySelector('.selectSource').value || currentItem.Id;
@@ -2030,6 +2038,7 @@ export default function (view, params) {
         view.querySelector('.btnSplitVersions').addEventListener('click', function () {
             splitVersions(self, view, apiClient, params);
         });
+        bindAll(view, '.btnDeleteItem', 'click', onDeleteItemClick);
         bindAll(view, '.btnMoreCommands', 'click', onMoreCommandsClick);
         view.querySelector('.selectSource').addEventListener('change', function () {
             renderVideoSelections(view, self._currentPlaybackMediaSources);

--- a/src/types/listOptions.ts
+++ b/src/types/listOptions.ts
@@ -40,6 +40,7 @@ export interface ListOptions extends TextLineOpts {
     }[];
     enablePlayedButton?: boolean;
     enableRatingButton?: boolean;
+    enableDeleteButton?: boolean;
     smallIcon?: boolean;
     sortBy?: ItemSortBy;
 }


### PR DESCRIPTION
### Changes

Delete was previously only accessible through the More (...) overflow menu,
requiring several extra clicks for a very common activity.
This brings it up into the primary action row alongside
Info, Mark Played, and Favorites, conditioned on `item.CanDelete` so it
only appears where the user has permission. Delete remains available in
the More menu as well, both paths exist.

Covers the Season episode list (both the legacy list view and the React
`ListViewUserDataButtons` path) and the item detail page (movies, episodes,
etc.). 

Added `ItemAction.Delete` to the `ItemAction` enum and `enableDeleteButton` 
to `ListOptions`, following the existing opt-in pattern
used by `enablePlayedButton`, `enableRatingButton`, etc. 

Added a `DeleteIconButton` React component following the `InfoIconButton` /
`MoreVertIconButton` pattern.

This also fixes how deleted items required a manual refresh to go away. 
The deleted item now disappears immediately on confirmation
regardless of which delete path was used. 

Wires `notifyRefreshNeeded` on the season episode container to re-call 
`renderChildren` on the API matching the pattern used by collection containers.

Suppresses an unhandled promise rejection when the user cancels the
confirmation dialog.

### Issues

N/A

### Code assistance

I used Claude Code to assist with this implementation to ensure I didn't
miss anything upstream or break compatibility with existing patterns
outside of the specific changes I was working on.

---

- [X] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
- [X] I have tested these changes.
- [X] I have verified that this is not duplicating changes in an existing PR.
- [X] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).