### PR TITLE
Replace deprecated DOMImplementation.hasFeature in scroller

### DIFF
--- a/src/lib/scroller/index.js
+++ b/src/lib/scroller/index.js
@@ -73,7 +73,7 @@ function within(number, num1, num2) {
 // Other global values
 const dragMouseEvents = ['mousemove', 'mouseup'];
 const dragTouchEvents = ['touchmove', 'touchend'];
-const wheelEvent = (document.implementation.hasFeature('Event.wheel', '3.0') ? 'wheel' : 'mousewheel');
+const wheelEvent = ('onwheel' in document.documentElement ? 'wheel' : 'mousewheel');
 const interactiveElements = ['INPUT', 'SELECT', 'TEXTAREA'];
 
 const scrollerFactory = function (frame, options) {


### PR DESCRIPTION
### Changes

The `wheelEvent` constant in `src/lib/scroller/index.js` was using `document.implementation.hasFeature('Event.wheel', '3.0')` to pick between the modern `wheel` event and the legacy `mousewheel` event. That API has been deprecated since DOM Level 4 and modern browsers always make it return `true`, so the legacy fallback was effectively dead code.

I replaced the check with `'onwheel' in document.documentElement`, which is the standard feature-detection pattern for events and actually returns `false` on browsers that genuinely don't support the `wheel` event. Behavior on modern browsers is unchanged; older user agents that don't expose `onwheel` now correctly fall back to `mousewheel`.

```diff
-const wheelEvent = (document.implementation.hasFeature('Event.wheel', '3.0') ? 'wheel' : 'mousewheel');
+const wheelEvent = ('onwheel' in document.documentElement ? 'wheel' : 'mousewheel');
```

### Issues

None directly. This resolves the `@typescript-eslint/no-deprecated` warning reported by `npm run lint` for `src/lib/scroller/index.js:76`.

### Code assistance

Used Claude (LLM) to scan the project for deprecated APIs flagged by ESLint and to verify that `'onwheel' in document.documentElement` is the safe replacement for `hasFeature` given the project's `browserslist`.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A%22merge+conflict%22+-label%3Astale+-author%3A%40me).