### PR TITLE
Remove deprecated VideoPlaybackQuality.corruptedVideoFrames

### DIFF
--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -2194,15 +2194,10 @@ export class HtmlVideoPlayer {
         if (mediaElement.getVideoPlaybackQuality) {
             const playbackQuality = mediaElement.getVideoPlaybackQuality();
             const droppedVideoFrames = playbackQuality.droppedVideoFrames || 0;
-            const corruptedVideoFrames = playbackQuality.corruptedVideoFrames || 0;
-
-            const qualityInfos = [];
-            qualityInfos.push(droppedVideoFrames);
-            qualityInfos.push(corruptedVideoFrames);
 
             videoCategory.stats.push({
                 label: globalize.translate('LabelPlaybackQuality'),
-                value: qualityInfos.join(' / ')
+                value: String(droppedVideoFrames)
             });
         }
 

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1905,5 +1905,5 @@
     "LabelProgressAndSpeed": "Progress / speed",
     "LabelReasons": "Reasons",
     "LabelPlayerSizes": "Player sizes",
-    "LabelPlaybackQuality": "Frame dropped / corrupted"
+    "LabelPlaybackQuality": "Frames dropped"
 }


### PR DESCRIPTION
### Changes

`HtmlVideoPlayer` was reading both `droppedVideoFrames` and `corruptedVideoFrames` from `mediaElement.getVideoPlaybackQuality()` and joining them with " / " under the **Frame dropped / corrupted** label in the playback stats overlay. `VideoPlaybackQuality.corruptedVideoFrames` has been removed from the W3C Media Capabilities spec — current Chrome / Firefox / Safari no longer expose it, so the value was always falling back to `0` and the overlay was permanently showing `X / 0`.

I removed the `corruptedVideoFrames` lookup and the now-superfluous `qualityInfos` array, and updated the English label from `Frame dropped / corrupted` to `Frames dropped` so it matches what is actually shown.

```diff
-            const corruptedVideoFrames = playbackQuality.corruptedVideoFrames || 0;
-
-            const qualityInfos = [];
-            qualityInfos.push(droppedVideoFrames);
-            qualityInfos.push(corruptedVideoFrames);
-
             videoCategory.stats.push({
                 label: globalize.translate('LabelPlaybackQuality'),
-                value: qualityInfos.join(' / ')
+                value: String(droppedVideoFrames)
             });
```

### i18n note

The EN label is updated because the previous value referred to the now-removed `corruptedVideoFrames` field. The translation key (`LabelPlaybackQuality`) is left unchanged so existing translations are not lost. Other locales will be marked outdated in Weblate on the next sync, which is the expected workflow when an EN source string changes.

### Issues

None directly. This resolves the `@typescript-eslint/no-deprecated` warning reported by `npm run lint` for `src/plugins/htmlVideoPlayer/plugin.js:2197`.

### Code assistance

Used Claude (LLM) to assist with the code changes and the writing of this PR description.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A%22merge+conflict%22+-label%3Astale+-author%3A%40me).