### PR TITLE
Fix blurry card images on high-DPI displays

### DIFF
--- a/src/apps/dashboard/features/libraries/components/LibraryCard.tsx
+++ b/src/apps/dashboard/features/libraries/components/LibraryCard.tsx
@@ -44,9 +44,10 @@ const LibraryCard = ({ virtualFolder }: LibraryCardProps) => {
 
     const imageUrl = useMemo(() => {
         if (virtualFolder.PrimaryImageItemId && virtualFolder.ItemId && api) {
+            const dpr = window?.devicePixelRatio || 1;
             return getImageApi(api)
                 .getItemImageUrlById(virtualFolder.ItemId, ImageType.Primary, {
-                    maxWidth: Math.round(dom.getScreenWidth() * 0.40)
+                    maxWidth: Math.round(dom.getScreenWidth() * dpr * 0.40)
                 });
         }
     }, [ api, virtualFolder ]);

--- a/src/components/cardbuilder/Card/cardHelper.ts
+++ b/src/components/cardbuilder/Card/cardHelper.ts
@@ -29,7 +29,8 @@ export function getCardLogoUrl(
     let imgType;
     let imgTag;
     let itemId;
-    const logoHeight = 40;
+    const dpr = window?.devicePixelRatio || 1;
+    const logoHeight = Math.round(40 * dpr);
 
     if (cardOptions.showChannelLogo && item.ChannelPrimaryImageTag) {
         imgType = ImageType.Primary;

--- a/src/components/cardbuilder/utils/url.ts
+++ b/src/components/cardbuilder/utils/url.ts
@@ -147,13 +147,15 @@ export function getCardImageUrl({
             height = width / uiAspect;
         }
 
+        const dpr = window?.devicePixelRatio || 1;
+
         imgUrl = getImageApi(api).getItemImageUrlById(
             itemId,
             imgType,
             {
                 // Dimensions must be rounded or the API will reject the request
-                fillHeight: height ? Math.round(height) : undefined,
-                fillWidth: width ? Math.round(width) : undefined,
+                fillHeight: height ? Math.round(height * dpr) : undefined,
+                fillWidth: width ? Math.round(width * dpr) : undefined,
                 quality: 96,
                 tag: imgTag
             }

--- a/src/components/listview/List/listHelper.ts
+++ b/src/components/listview/List/listHelper.ts
@@ -93,8 +93,10 @@ export function getImageUrl(
 ) {
     let imgTag;
     let itemId;
-    const fillWidth = size;
-    const fillHeight = size;
+    const dpr = window.devicePixelRatio || 1;
+    const scaledSize = size ? Math.round(size * dpr) : undefined;
+    const fillWidth = scaledSize;
+    const fillHeight = scaledSize;
     const imgType = ImageType.Primary;
 
     if (item.ImageTags?.Primary) {
@@ -137,8 +139,10 @@ export function getChannelImageUrl(
 ) {
     let imgTag;
     let itemId;
-    const fillWidth = size;
-    const fillHeight = size;
+    const dpr = window.devicePixelRatio || 1;
+    const scaledSize = size ? Math.round(size * dpr) : undefined;
+    const fillWidth = scaledSize;
+    const fillHeight = scaledSize;
 
     if (item.ChannelId && item.ChannelPrimaryImageTag) {
         imgTag = item.ChannelPrimaryImageTag;


### PR DESCRIPTION
I was trying out Jellyfin Unstable 10.12 (2026050514) and noticed that all image cards were suddenly blurry compared to my main server that's still on 10.10.7.
Specifically, the URLs used for images were halved compared to those used on 10.10.7.

Looking through the git history, I identified 8924ea487df6ade72ce0e5a7b49b9b4a37f01ae5 as a possible cause. With the help of Claude Sonnet 4.6, I found the reason and a potential fix for this issue. Running the fixed Jellyfin Web locally confirms the images are sharp again. However, I'm unsure if the location I am (well, Claude is) applying the fix to is optimal, so please take it with a grain of salt and modify the PR if necessary.

### Changes
`getItemImageUrlById` does not apply device pixel ratio scaling, unlike the legacy `apiClient.getScaledImageUrl` which multiplied dimensions by `window.devicePixelRatio` automatically. Scale the fill dimensions explicitly to restore full-resolution images on HiDPI screens.

### Code assistance
I used Claude Sonnet to find the cause after noticing this bug on my own test server. See above for more details.

---

* [X] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [X] I have tested these changes.
* [X] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
