### PR TITLE
Pass an explicit comparator to sort() in MusicAlbum artist comparison

### DIFF
--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -1308,7 +1308,11 @@ function renderChildren(page, item) {
         if (item.Type == 'MusicAlbum') {
             let showArtist = false;
             for (const track of result.Items) {
-                const compareIds = (a, b) => a.localeCompare(b);
+                const compareIds = (a, b) => {
+                    if (a < b) return -1;
+                    if (a > b) return 1;
+                    return 0;
+                };
                 if (!isEqual(track.ArtistItems.map(x => x.Id).sort(compareIds), track.AlbumArtists.map(x => x.Id).sort(compareIds))) {
                     showArtist = true;
                     break;

--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -1308,7 +1308,8 @@ function renderChildren(page, item) {
         if (item.Type == 'MusicAlbum') {
             let showArtist = false;
             for (const track of result.Items) {
-                if (!isEqual(track.ArtistItems.map(x => x.Id).sort(), track.AlbumArtists.map(x => x.Id).sort())) {
+                const compareIds = (a, b) => a.localeCompare(b);
+                if (!isEqual(track.ArtistItems.map(x => x.Id).sort(compareIds), track.AlbumArtists.map(x => x.Id).sort(compareIds))) {
                     showArtist = true;
                     break;
                 }


### PR DESCRIPTION
### Changes

In `src/controllers/itemDetails/index.js`, when rendering a MusicAlbum's track list, the code compares each track's `ArtistItems` and `AlbumArtists` ID lists by sorting both and checking equality. Both `.sort()` calls were called without a comparator, which ESLint (`sonarjs/no-alphabetical-sort`) flags: relying on the default sort is ambiguous because it converts elements to strings and compares UTF-16 code units.

The IDs are already strings (Jellyfin item IDs are ASCII-hex), so the default sort happens to do the right thing — but it is not obvious. I pulled the comparator into a small local function and passed it to both `.sort()` calls, so the intent is explicit and ESLint is happy:

```js
const compareIds = (a, b) => {
    if (a < b) return -1;
    if (a > b) return 1;
    return 0;
};
```

A nested-ternary form (`a < b ? -1 : a > b ? 1 : 0`) was rejected by the project's `no-nested-ternary` rule. `String.prototype.localeCompare` would also work but is locale-aware and slower than necessary for opaque ASCII identifiers. Behavior is unchanged for the IDs Jellyfin produces.

### Issues

None directly. This resolves the two `sonarjs/no-alphabetical-sort` warnings reported by `npm run lint` for `src/controllers/itemDetails/index.js:1311`.

### Code assistance

Used Claude (LLM) to assist with the code changes and the writing of this PR description.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A%22merge+conflict%22+-label%3Astale+-author%3A%40me).