### PR TITLE
Replace deprecated DOMException.code with name in user profile

### DIFF
--- a/src/apps/stable/routes/user/userprofile.tsx
+++ b/src/apps/stable/routes/user/userprofile.tsx
@@ -15,6 +15,7 @@ import UserPasswordForm from 'components/dashboard/users/UserPasswordForm';
 import Page from 'components/Page';
 import Loading from 'components/loading/LoadingComponent';
 import Button from 'elements/emby-button/Button';
+import { DOMExceptionName } from 'types/domExceptionName';
 
 const UserProfile: FunctionComponent = () => {
     const [ searchParams ] = useSearchParams();
@@ -77,11 +78,11 @@ const UserProfile: FunctionComponent = () => {
 
         const onFileReaderError = (evt: ProgressEvent<FileReader>) => {
             loading.hide();
-            switch (evt.target?.error?.code) {
-                case DOMException.NOT_FOUND_ERR:
+            switch (evt.target?.error?.name) {
+                case DOMExceptionName.NotFoundError:
                     toast(globalize.translate('FileNotFound'));
                     break;
-                case DOMException.ABORT_ERR:
+                case DOMExceptionName.AbortError:
                     onFileReaderAbort();
                     break;
                 default:

--- a/src/types/domExceptionName.ts
+++ b/src/types/domExceptionName.ts
@@ -1,0 +1,14 @@
+/**
+ * Standardized DOMException name strings.
+ *
+ * Use these instead of the deprecated numeric DOMException codes
+ * (e.g. DOMException.NOT_FOUND_ERR) when matching against
+ * DOMException.name.
+ *
+ * @see https://developer.mozilla.org/docs/Web/API/DOMException#error_names
+ */
+export enum DOMExceptionName {
+    AbortError = 'AbortError',
+    NotFoundError = 'NotFoundError',
+    NotSupportedError = 'NotSupportedError'
+}

--- a/src/types/domExceptionName.ts
+++ b/src/types/domExceptionName.ts
@@ -9,6 +9,9 @@
  */
 export enum DOMExceptionName {
     AbortError = 'AbortError',
+    EncodingError = 'EncodingError',
     NotFoundError = 'NotFoundError',
-    NotSupportedError = 'NotSupportedError'
+    NotReadableError = 'NotReadableError',
+    NotSupportedError = 'NotSupportedError',
+    SecurityError = 'SecurityError'
 }

--- a/src/utils/mediaError.test.ts
+++ b/src/utils/mediaError.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { MediaError } from 'types/mediaError';
+import { getMediaError } from './mediaError';
+
+describe('getMediaError', () => {
+    it('returns MEDIA_NOT_SUPPORTED for a NotSupportedError DOMException', () => {
+        const e = new DOMException('codec not supported', 'NotSupportedError');
+        expect(getMediaError(e)).toBe(MediaError.MEDIA_NOT_SUPPORTED);
+    });
+
+    it('returns PLAYER_ERROR for any other DOMException', () => {
+        const e = new DOMException('aborted', 'AbortError');
+        expect(getMediaError(e)).toBe(MediaError.PLAYER_ERROR);
+    });
+
+    it('returns PLAYER_ERROR when no error is passed', () => {
+        expect(getMediaError()).toBe(MediaError.PLAYER_ERROR);
+    });
+});

--- a/src/utils/mediaError.ts
+++ b/src/utils/mediaError.ts
@@ -1,3 +1,4 @@
+import { DOMExceptionName } from 'types/domExceptionName';
 import { MediaError } from 'types/mediaError';
 
 /**
@@ -6,6 +7,6 @@ import { MediaError } from 'types/mediaError';
  * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMException#error_names
  */
 export function getMediaError(e?: DOMException): MediaError {
-    if (e?.name === 'NotSupportedError') return MediaError.MEDIA_NOT_SUPPORTED;
+    if (e?.name === DOMExceptionName.NotSupportedError) return MediaError.MEDIA_NOT_SUPPORTED;
     return MediaError.PLAYER_ERROR;
 }


### PR DESCRIPTION
### Changes

DOMException's numeric `code` property is deprecated in the Web platform spec; the string `name` field is the modern equivalent. This PR switches the user-profile FileReader error handler from `error.code` to `error.name` and introduces a small `DOMExceptionName` enum under `src/types/` so callsites do not rely on magic strings or on the deprecated numeric constants.

The enum is also adopted in `src/utils/mediaError.ts`, which previously matched against the literal `'NotSupportedError'`.

```diff
-            switch (evt.target?.error?.code) {
-                case DOMException.NOT_FOUND_ERR:
+            switch (evt.target?.error?.name) {
+                case DOMExceptionName.NotFoundError:
                     toast(globalize.translate('FileNotFound'));
                     break;
-                case DOMException.ABORT_ERR:
+                case DOMExceptionName.AbortError:
                     onFileReaderAbort();
```

The enum currently covers the FileReader-related error names (`AbortError`, `EncodingError`, `NotFoundError`, `NotReadableError`, `SecurityError`) and `NotSupportedError` used by `mediaError.ts`. New callsites can extend it as needed.

A small `mediaError.test.ts` is included to lock in the existing `getMediaError` behaviour now that it depends on the shared enum.

### Issues

None — cleanup of deprecated `DOMException.code` flagged by ESLint. A previous attempt (#5256) was closed without follow-up; the reviewer there asked for a centralized enum in `src/types`, which this PR provides.

### Code assistance

Used Claude (LLM) to assist with the code changes and the writing of this PR description.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A%22merge+conflict%22+-label%3Astale+-author%3A%40me).