### PR TITLE
Fix drawer display version

### DIFF
--- a/src/apps/experimental/components/drawers/DrawerHeaderLink.tsx
+++ b/src/apps/experimental/components/drawers/DrawerHeaderLink.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 
 import { useSystemInfo } from 'hooks/useSystemInfo';
 import ListItemLink from 'components/ListItemLink';
+import { getDisplayVersion } from 'utils/versions';
 
 import appIcon from '@jellyfin/ux-web/icon-transparent.png';
 
@@ -22,7 +23,7 @@ const DrawerHeaderLink = () => {
             </ListItemIcon>
             <ListItemText
                 primary={systemInfo?.ServerName || 'Jellyfin'}
-                secondary={systemInfo?.Version}
+                secondary={getDisplayVersion(systemInfo?.Version)}
                 slotProps={{
                     primary: { variant: 'h6' }
                 }}


### PR DESCRIPTION
### Changes
Use the display version utility for the drawer header also so "12.0.0" is properly displayed as "12.0"

### Issues
N/A

### Code assistance
Zed autocomplete

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
