### PR TITLE
feat: respect subtitle position in native VTT cues

### DIFF
--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1490,10 +1490,23 @@ export class HtmlVideoPlayer {
             const subtitleAppearance = userSettings.getSubtitleAppearanceSettings();
             const cueLine = parseInt(subtitleAppearance.verticalPosition, 10);
 
+            const assTagToPosition = {
+                '{\\an7}': { line: 10, position: 20 },
+                '{\\an8}': { line: 10 },
+                '{\\an9}': { line: 10, position: 80 },
+                '{\\an4}': { line: 50, position: 20 },
+                '{\\an5}': { line: 50 },
+                '{\\an6}': { line: 50, position: 80 },
+                '{\\an1}': { position: 20 },
+                '{\\an2}': {},
+                '{\\an3}': { position: 80 }
+            };
+
             // add some cues to show the text
             // in safari, the cues need to be added before setting the track mode to showing
             for (const trackEvent of data.TrackEvents) {
                 const TrackCue = window.VTTCue || window.TextTrackCue;
+                const assMatch = trackEvent.Text.match(/\{\\an\d\}/i);
                 const text = normalizeTrackEventText(trackEvent.Text, false);
                 const cue = new TrackCue(trackEvent.StartPositionTicks / 10000000, trackEvent.EndPositionTicks / 10000000, text);
 
@@ -1505,7 +1518,19 @@ export class HtmlVideoPlayer {
                         cue.line = cueLine;
                     }
                 }
-
+                if (assMatch) {
+                    const cuePosition = assTagToPosition[assMatch[0].toLowerCase()];
+                    if (cuePosition) {
+                        if (cuePosition.line !== undefined) {
+                            cue.line = cuePosition.line;
+                            cue.snapToLines = false;
+                        }
+                        if (cuePosition.position !== undefined) {
+                            cue.position = cuePosition.position;
+                            cue.positionAlign = 'center';
+                        }
+                    }
+                }
                 trackElement.addCue(cue);
             }
 


### PR DESCRIPTION
### Summary

When Jellyfin serves external subtitles (VTT, SRT) through its JSON 
TrackEvents API, the server converts VTT position properties (e.g. 
`line:10%`) into ASS alignment tags (e.g. `{\an8}`) in the `Text` field 
of each TrackEvent.

Previously, `normalizeTrackEventText()` stripped all ASS tags before 
the VTTCue was created, discarding position information entirely. 
This caused all subtitles to render at the default bottom-center 
position regardless of what the original file specified.

### Changes

- Added an `assTagToPosition` lookup table mapping ASS alignment tags 
  to their corresponding VTTCue `line` and `position` values
- In `renderTracksEvents()`, the ASS tag is now read from the original 
  `TrackEvent.Text` before normalization
- The extracted position is applied to `cue.line`, `cue.snapToLines`, 
  `cue.position` and `cue.positionAlign` as appropriate

### Issues

### Code assistance

### Screenshot
<img width="1366" height="768" alt="Captura desde 2026-05-05 23-20-41" src="https://github.com/user-attachments/assets/e9c062e9-959b-42aa-8626-7e9ec22e695d" />
