### PR TITLE
fix: subtitle position ignored in native VTT renderer

### DIFF
--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1490,10 +1490,23 @@ export class HtmlVideoPlayer {
             const subtitleAppearance = userSettings.getSubtitleAppearanceSettings();
             const cueLine = parseInt(subtitleAppearance.verticalPosition, 10);
 
+            const assTagToPosition = {
+                '{\\an7}': { line: 10, position: 20 },
+                '{\\an8}': { line: 10 },
+                '{\\an9}': { line: 10, position: 80 },
+                '{\\an4}': { line: 50, position: 20 },
+                '{\\an5}': { line: 50 },
+                '{\\an6}': { line: 50, position: 80 },
+                '{\\an1}': { position: 20 },
+                '{\\an2}': {},
+                '{\\an3}': { position: 80 }
+            };
+
             // add some cues to show the text
             // in safari, the cues need to be added before setting the track mode to showing
             for (const trackEvent of data.TrackEvents) {
                 const TrackCue = window.VTTCue || window.TextTrackCue;
+                const assMatch = trackEvent.Text.match(/\{\\an\d\}/i);
                 const text = normalizeTrackEventText(trackEvent.Text, false);
                 const cue = new TrackCue(trackEvent.StartPositionTicks / 10000000, trackEvent.EndPositionTicks / 10000000, text);
 
@@ -1505,7 +1518,19 @@ export class HtmlVideoPlayer {
                         cue.line = cueLine;
                     }
                 }
-
+                if (assMatch) {
+                    const cuePosition = assTagToPosition[assMatch[0].toLowerCase()];
+                    if (cuePosition) {
+                        if (cuePosition.line !== undefined) {
+                            cue.line = cuePosition.line;
+                            cue.snapToLines = false;
+                        }
+                        if (cuePosition.position !== undefined) {
+                            cue.position = cuePosition.position;
+                            cue.positionAlign = 'center';
+                        }
+                    }
+                }
                 trackElement.addCue(cue);
             }
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

### Changes

VTT subtitles with position (e.g. line:10%) and SRT files with ASS position tags (e.g. {\an8}) always rendered at the bottom of the screen. normalizeTrackEventText() was stripping all ASS tags before creating the VTTCue, discarding position info. The fix reads the position tag before normalization, translates it to valid VTTCue properties using a lookup table, then strips the tag from the cue text.

Note: only applies to the native browser renderer im still investigating the custom one.


### Issues
<!--
Tag any issues that this PR solves here.
ex. Fixes #
-->

### Code assistance
Claude (Anthropic) was used for codebase explanation and debugging 
guidance. English is not my first language - this PR body was written 
by me in Spanish first and corrected for grammar only.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
