### PR TITLE
Use tanstack query for user settings

### DIFF
--- a/src/components/displaySettings/displaySettings.js
+++ b/src/components/displaySettings/displaySettings.js
@@ -1,6 +1,11 @@
 import escapeHtml from 'escape-html';
 
 import { AppFeature } from 'constants/appFeature';
+import { getUserQuery } from 'hooks/api/useUser';
+import { ServerConnections } from 'lib/jellyfin-apiclient';
+import { toApi } from 'utils/jellyfin-apiclient/compat';
+import { queryClient } from 'utils/query/queryClient';
+
 import browser from '../../scripts/browser';
 import layoutManager from '../layoutManager';
 import { pluginManager } from '../pluginManager';
@@ -8,17 +13,18 @@ import { appHost } from '../apphost';
 import focusManager from '../focusManager';
 import datetime from '../../scripts/datetime';
 import globalize from '../../lib/globalize';
-import { ServerConnections } from 'lib/jellyfin-apiclient';
 import loading from '../loading/loading';
 import skinManager from '../../scripts/themeManager';
 import { PluginType } from '../../types/plugin.ts';
 import Events from '../../utils/events.ts';
+import toast from '../toast/toast';
+
+import template from './displaySettings.template.html';
+
 import '../../elements/emby-select/emby-select';
 import '../../elements/emby-checkbox/emby-checkbox';
 import '../../elements/emby-button/emby-button';
 import '../../elements/emby-textarea/emby-textarea';
-import toast from '../toast/toast';
-import template from './displaySettings.template.html';
 
 function fillThemes(select, selectedTheme) {
     skinManager.getThemes().then(themes => {
@@ -233,7 +239,7 @@ class DisplaySettings {
         embed(options, this);
     }
 
-    loadData(autoFocus) {
+    async loadData(autoFocus) {
         const self = this;
         const context = self.options.element;
 
@@ -243,15 +249,14 @@ class DisplaySettings {
         const apiClient = ServerConnections.getApiClient(self.options.serverId);
         const userSettings = self.options.userSettings;
 
-        return apiClient.getUser(userId).then(user => {
-            return userSettings.setUserInfo(userId, apiClient).then(() => {
-                self.dataLoaded = true;
-                loadForm(context, user, userSettings);
-                if (autoFocus) {
-                    focusManager.autoFocus(context);
-                }
-            });
-        });
+        const user = await queryClient.fetchQuery(getUserQuery(toApi(apiClient), { userId }));
+        await userSettings.setUserInfo(userId, apiClient);
+
+        self.dataLoaded = true;
+        loadForm(context, user, userSettings);
+        if (autoFocus) {
+            focusManager.autoFocus(context);
+        }
     }
 
     submit() {

--- a/src/hooks/api/useDisplayPreferences.ts
+++ b/src/hooks/api/useDisplayPreferences.ts
@@ -1,0 +1,36 @@
+import type { Api } from '@jellyfin/sdk/lib/api';
+import { DisplayPreferencesApiGetDisplayPreferencesRequest } from '@jellyfin/sdk/lib/generated-client/api/display-preferences-api';
+import { getDisplayPreferencesApi } from '@jellyfin/sdk/lib/utils/api/display-preferences-api';
+import { queryOptions, useQuery } from '@tanstack/react-query';
+import type { AxiosRequestConfig } from 'axios';
+
+import { useApi } from 'hooks/useApi';
+
+const fetchDisplayPreferences = async (
+    api: Api,
+    params: DisplayPreferencesApiGetDisplayPreferencesRequest,
+    options?: AxiosRequestConfig
+) => {
+    const response = await getDisplayPreferencesApi(api)
+        .getDisplayPreferences(params, options);
+    return response.data;
+};
+
+export const getDisplayPreferencesQuery = (
+    api?: Api,
+    params?: DisplayPreferencesApiGetDisplayPreferencesRequest
+) => queryOptions({
+    queryKey: [ 'User', params?.userId, 'DisplayPreferences', params?.displayPreferencesId, params?.client ],
+    queryFn: ({ signal }) => fetchDisplayPreferences(api!, params!, { signal }),
+    enabled: !!api && !!params
+});
+
+export const useDisplayPreferences = (
+    params: DisplayPreferencesApiGetDisplayPreferencesRequest
+) => {
+    const { api, user } = useApi();
+    return useQuery(getDisplayPreferencesQuery(api, {
+        ...params,
+        userId: params?.userId || user?.Id
+    }));
+};

--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -1,12 +1,22 @@
-import Events from '../../utils/events.ts';
-import { toBoolean } from '../../utils/string.ts';
+import { getDisplayPreferencesQuery } from 'hooks/api/useDisplayPreferences';
+import { getUserQuery } from 'hooks/api/useUser';
+import { QUERY_KEY } from 'hooks/useUsers';
+import Events from 'utils/events';
+import { toApi } from 'utils/jellyfin-apiclient/compat';
+import { queryClient } from 'utils/query/queryClient';
+import { toBoolean } from 'utils/string';
+
 import browser from '../browser';
 import appSettings from './appSettings';
+
+const DISPLAY_PREFERENCES_ID = 'usersettings';
+// TODO: We should really update the client ID at some point
+const CLIENT_ID = 'emby';
 
 function onSaveTimeout() {
     const self = this;
     self.saveTimeout = null;
-    self.currentApiClient.updateDisplayPreferences('usersettings', self.displayPrefs, self.currentUserId, 'emby');
+    self.currentApiClient.updateDisplayPreferences(DISPLAY_PREFERENCES_ID, self.displayPrefs, self.currentUserId, CLIENT_ID);
 }
 
 function saveServerPreferences(instance) {
@@ -49,8 +59,8 @@ const defaultComicsPlayerSettings = {
 export class UserSettings {
     /**
      * Bind UserSettings instance to user.
-     * @param {string} - User identifier.
-     * @param {Object} - ApiClient instance.
+     * @param {string|undefined} userId - User identifier.
+     * @param {import('jellyfin-apiclient').ApiClient} apiClient - ApiClient instance.
      */
     setUserInfo(userId, apiClient) {
         if (this.saveTimeout) {
@@ -67,10 +77,19 @@ export class UserSettings {
 
         const self = this;
 
-        return apiClient.getDisplayPreferences('usersettings', userId, 'emby').then(function (result) {
-            result.CustomPrefs = result.CustomPrefs || {};
-            self.displayPrefs = result;
-        });
+        return queryClient
+            .fetchQuery(getDisplayPreferencesQuery(
+                toApi(apiClient),
+                {
+                    displayPreferencesId: DISPLAY_PREFERENCES_ID,
+                    client: CLIENT_ID,
+                    userId
+                }
+            ))
+            .then(result => {
+                result.CustomPrefs = result.CustomPrefs || {};
+                self.displayPrefs = result;
+            });
     }
 
     // FIXME: 'appSettings.set' doesn't return any value
@@ -120,12 +139,18 @@ export class UserSettings {
     serverConfig(config) {
         const apiClient = this.currentApiClient;
         if (config) {
-            return apiClient.updateUserConfiguration(this.currentUserId, config);
+            return apiClient
+                .updateUserConfiguration(this.currentUserId, config)
+                .then(() => {
+                    queryClient.invalidateQueries({
+                        queryKey: [ QUERY_KEY, this.currentUserId ]
+                    });
+                });
         }
 
-        return apiClient.getUser(this.currentUserId).then(function (user) {
-            return user.Configuration;
-        });
+        return queryClient
+            .fetchQuery(getUserQuery(toApi(apiClient), { userId: this.currentUserId }))
+            .then(user => user.Configuration);
     }
 
     /**


### PR DESCRIPTION
### Changes
Migrate user setting API requests to tanstack query

### Issues
N/A

### Code assistance
VS Code autocomplete

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
