### PR TITLE
web: preserve Edge HEVC HDR playback when TrueHD is unsupported

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -275,6 +275,32 @@ function supportsDolbyVision(options) {
     );
 }
 
+function supportsHdr10DoViFallbackHevc(videoTestElement, options) {
+    return browser.edgeChromium
+        && browser.windows
+        && !supportsDolbyVision(options)
+        && supportsHdr10(options)
+        && canPlayHevc(videoTestElement, options);
+}
+
+function supportsTrueHdPlayback(options) {
+    if (options.supportsTrueHd) {
+        return true;
+    }
+
+    // Plain browsers cannot reliably signal whether a TrueHD track will be decoded as
+    // TrueHD or silently fall back to the embedded AC-3 core. Keep the manual override
+    // for native shells, but do not advertise TrueHD for the standalone web client.
+    return appSettings.enableTrueHd() && !!window.NativeShell;
+}
+
+function prefersProgressiveHevcTranscode(videoTestElement, options) {
+    return browser.edgeChromium
+        && browser.windows
+        && canPlayHevc(videoTestElement, options)
+        && supportsHdr10(options);
+}
+
 function supportedDolbyVisionProfilesHevc(videoTestElement) {
     if (browser.xboxOne) return [5, 8];
 
@@ -627,7 +653,7 @@ export default function (options) {
         videoAudioCodecs.push('pcm_s24le');
     }
 
-    if (appSettings.enableTrueHd() || options.supportsTrueHd) {
+    if (supportsTrueHdPlayback(options)) {
         videoAudioCodecs.push('truehd');
     }
 
@@ -894,6 +920,19 @@ export default function (options) {
             MaxAudioChannels: physicalAudioChannels.toString()
         });
     });
+
+    if (prefersProgressiveHevcTranscode(videoTestElement, options) && hlsInFmp4VideoAudioCodecs.length) {
+        profile.TranscodingProfiles.push({
+            Container: 'mp4',
+            Type: 'Video',
+            AudioCodec: hlsInFmp4VideoAudioCodecs.join(','),
+            VideoCodec: 'hevc',
+            Context: 'Streaming',
+            Protocol: 'http',
+            MaxAudioChannels: physicalAudioChannels.toString(),
+            BreakOnNonKeyFrames: false
+        });
+    }
 
     if (canPlayHls() && options.enableHls !== false) {
         const enableLimitedSegmentLength = userSettings.limitSegmentLength();
@@ -1211,6 +1250,11 @@ export default function (options) {
     let av1VideoRangeTypes = 'SDR';
 
     const isWebOsWithoutDolbyVision = browser.web0s && !supportsDolbyVision(options);
+    const supportsHdr10HevcDoviFallbacks =
+        browser.tizenVersion >= 3
+        || browser.vidaa
+        || isWebOsWithoutDolbyVision
+        || supportsHdr10DoViFallbackHevc(videoTestElement, options);
 
     if (browser.tizenVersion >= 3 || isWebOsWithoutDolbyVision) {
         hevcVideoRangeTypes += '|DOVIWithSDR';
@@ -1222,14 +1266,21 @@ export default function (options) {
         vp9VideoRangeTypes += '|HDR10|HDR10Plus';
         av1VideoRangeTypes += '|HDR10|HDR10Plus';
 
-        if (browser.tizenVersion >= 3 || browser.vidaa || isWebOsWithoutDolbyVision) {
+        if (supportsHdr10HevcDoviFallbacks) {
             // Tizen TV does not support Dolby Vision at all, but it can safely play the HDR fallback.
             // LG TVs that don't support Dolby Vision still can play the HDR fallback without issues.
+            // Edge on Windows can also use the HDR10-compatible fallback when the browser already
+            // reports HEVC Main 10 + HDR10 support through the platform decoder path.
             // Advertising the support so that the server doesn't have to remux.
-            hevcVideoRangeTypes += '|DOVIWithHDR10|DOVIWithHDR10Plus|DOVIWithEL|DOVIWithELHDR10Plus|DOVIInvalid';
+            hevcVideoRangeTypes += '|DOVIWithHDR10|DOVIWithHDR10Plus|DOVIWithEL|DOVIWithELHDR10Plus';
+            if (browser.tizenVersion >= 3 || browser.vidaa || isWebOsWithoutDolbyVision) {
+                hevcVideoRangeTypes += '|DOVIInvalid';
+            }
             // Although no official tools exist to create AV1+DV files yet, some of our users managed to use community tools to create such files.
             // These files should also be playable on Tizen TVs.
-            av1VideoRangeTypes += '|DOVIWithHDR10|DOVIWithHDR10Plus|DOVIWithEL|DOVIWithELHDR10Plus|DOVIInvalid';
+            if (browser.tizenVersion >= 3 || browser.vidaa || isWebOsWithoutDolbyVision) {
+                av1VideoRangeTypes += '|DOVIWithHDR10|DOVIWithHDR10Plus|DOVIWithEL|DOVIWithELHDR10Plus|DOVIInvalid';
+            }
         }
     }
 

--- a/src/scripts/browserDeviceProfile.test.ts
+++ b/src/scripts/browserDeviceProfile.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+type VideoDirectPlayProfile = {
+    Type?: string;
+    Container?: string;
+    AudioCodec?: string;
+};
+
+type VideoTranscodingProfile = {
+    Type?: string;
+    Container?: string;
+    Protocol?: string;
+    VideoCodec?: string;
+    AudioCodec?: string;
+};
+
+type BrowserDeviceProfile = {
+    DirectPlayProfiles: VideoDirectPlayProfile[];
+    TranscodingProfiles?: VideoTranscodingProfile[];
+};
+
+vi.mock('./browser', () => ({
+    default: {
+        edgeChromium: true,
+        windows: true,
+        versionMajor: 142
+    }
+}));
+
+vi.mock('./settings/appSettings', () => ({
+    default: {
+        enableDts: () => false,
+        enableTrueHd: () => true,
+        alwaysRemuxFlac: () => false,
+        alwaysRemuxMp3: () => false,
+        disableVbrAudio: () => false,
+        enableHi10p: () => false,
+        get: () => null
+    }
+}));
+
+vi.mock('./settings/userSettings', () => ({
+    allowedAudioChannels: () => '0',
+    preferFmp4HlsContainer: () => true,
+    limitSegmentLength: () => false
+}));
+
+function mockCanPlayType(type: string) {
+    if (
+        type.includes('video/mp4')
+        || type.includes('video/x-matroska')
+        || type.includes('video/mkv')
+        || type.includes('application/x-mpegURL')
+        || type.includes('application/vnd.apple.mpegURL')
+        || type.includes('audio/mp4; codecs="ac-3"')
+        || type.includes('audio/mp4; codecs="ec-3"')
+        || type.includes('audio/ogg; codecs="opus"')
+        || type.startsWith('audio/flac')
+        || type.startsWith('audio/alac')
+    ) {
+        return 'probably';
+    }
+
+    return '';
+}
+
+describe('browserDeviceProfile', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('does not advertise truehd for plain Edge browser playback', async () => {
+        vi.spyOn(HTMLMediaElement.prototype, 'canPlayType').mockImplementation(mockCanPlayType);
+
+        const { default: buildDeviceProfile } = await import('./browserDeviceProfile');
+        const profile = buildDeviceProfile({}) as BrowserDeviceProfile;
+        const directPlayProfiles = profile.DirectPlayProfiles;
+        const videoProfiles = directPlayProfiles.filter((directPlayProfile) => directPlayProfile.Type === 'Video');
+
+        expect(videoProfiles.some((directPlayProfile) => (directPlayProfile.AudioCodec || '').split(',').includes('truehd'))).toBe(false);
+    });
+
+    it('keeps truehd available when explicitly reported by the host', async () => {
+        vi.spyOn(HTMLMediaElement.prototype, 'canPlayType').mockImplementation(mockCanPlayType);
+
+        const { default: buildDeviceProfile } = await import('./browserDeviceProfile');
+        const profile = buildDeviceProfile({ supportsTrueHd: true }) as BrowserDeviceProfile;
+        const directPlayProfiles = profile.DirectPlayProfiles;
+        const mkvProfile = directPlayProfiles.find((directPlayProfile) => directPlayProfile.Type === 'Video' && directPlayProfile.Container === 'mkv');
+
+        expect(mkvProfile?.AudioCodec?.split(',') ?? []).toContain('truehd');
+    });
+
+    it('prefers progressive hevc video transcode on Edge Windows HDR clients', async () => {
+        vi.spyOn(HTMLMediaElement.prototype, 'canPlayType').mockImplementation(mockCanPlayType);
+
+        const { default: buildDeviceProfile } = await import('./browserDeviceProfile');
+        const profile = buildDeviceProfile({}) as BrowserDeviceProfile;
+        const transcodingProfiles = profile.TranscodingProfiles || [];
+        const httpHevcProfile = transcodingProfiles.find((transcodingProfile) => transcodingProfile.Type === 'Video'
+            && transcodingProfile.Protocol === 'http'
+            && transcodingProfile.Container === 'mp4'
+            && transcodingProfile.VideoCodec === 'hevc');
+
+        expect(httpHevcProfile?.AudioCodec?.split(',') ?? []).toContain('aac');
+    });
+});


### PR DESCRIPTION
This PR was AI generated. However, it's quite simple, and fixes a real issue so I think it deserves a pass.

### Changes

Adjust Edge on Windows playback profiling for HDR-capable HEVC media so HDR10-compatible Dolby Vision files are not rejected purely on `VideoRangeType`, and so unsupported `TrueHD` audio does not push playback onto a poor browser fallback path. Plain Jellyfin Web clients no longer advertise `TrueHD` support blindly, and Edge/Windows now prefers a progressive HTTP HEVC path with audio transcoding when only the audio is unsupported. The browser-only `TrueHD` toggle is also hidden because it no longer affects standalone web playback after this change. Regression coverage was added for the Edge/Windows HDR device profile and the HEVC + DoVi/HDR10 + TrueHD playback cases.

### Issues

Fixes the Edge/Windows HDR playback issue where HEVC Main 10 Dolby Vision/HDR10 media was either fully transcoded to H.264 due to `VideoRangeTypeNotSupported` or routed through a lower-quality browser playback path when `TrueHD` audio was present.

### Code assistance

Code assistance was used for repository search, compatibility-path debugging, identifying the Jellyfin Web and server decision points involved in playback selection, and drafting the targeted profile/test changes. All resulting code paths, test fixtures, and local Docker builds were then verified manually.

Before:
Color banding when TrueHD turned off. Wrong audio track when TrueHD turned on
<img width="436" height="548" alt="before" src="https://github.com/user-attachments/assets/d09d6886-f9a2-451a-8cc4-193c53959556" />

After:
No color banding and correct audio track plays with DoVi 7.6 and DoVi 8.1
<img width="611" height="537" alt="image" src="https://github.com/user-attachments/assets/ea55c5c3-671f-4421-be4a-3a9b9d0e9754" />
And Dovi 8.1
<img width="604" height="549" alt="image" src="https://github.com/user-attachments/assets/8eec0d61-534f-4346-bf2b-b6c0b76edafe" />

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [ ] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
