### PR TITLE
Replace deprecated Navigator.platform and appVersion in browser.js

### DIFF
--- a/src/scripts/browser.js
+++ b/src/scripts/browser.js
@@ -76,8 +76,11 @@ function hasKeyboard(browser) {
 }
 
 function iOSversion() {
-    // MacIntel: Apple iPad Pro 11 iOS 13.1
-    if (/iP(hone|od|ad)|MacIntel/.test(navigator.platform)) {
+    // Macintosh: Apple iPad Pro 11 iOS 13.1 (desktop-mode UA still says Macintosh).
+    // We test the user-agent string here because navigator.platform and
+    // navigator.appVersion are deprecated and not in the modern Web platform spec.
+    const userAgent = navigator.userAgent;
+    if (/iP(hone|od|ad)|Macintosh/.test(userAgent)) {
         const tests = [
             // Original test for getting full iOS version number in iOS 2.0+
             /OS (\d+)_(\d+)_?(\d+)?/,
@@ -85,7 +88,7 @@ function iOSversion() {
             /Version\/(\d+)/
         ];
         for (const test of tests) {
-            const matches = RegExp(test).exec(navigator.appVersion);
+            const matches = new RegExp(test).exec(userAgent);
             if (matches) {
                 return [
                     parseInt(matches[1], 10),


### PR DESCRIPTION
### Changes

`navigator.platform` and `navigator.appVersion` are deprecated. They were used in `iOSversion()` in `src/scripts/browser.js` for Apple device detection. I replaced both with `navigator.userAgent`. The regex `MacIntel` becomes `Macintosh` because that is what shows up in the UA string for an iPad Pro in desktop mode (same device behavior, different string). The other regexes (`OS x_y_z`, `Version/x`) do not change — `appVersion` is just `userAgent` without the `Mozilla/` prefix, so they keep matching.

```diff
 function iOSversion() {
-    // MacIntel: Apple iPad Pro 11 iOS 13.1
-    if (/iP(hone|od|ad)|MacIntel/.test(navigator.platform)) {
+    // Macintosh: Apple iPad Pro 11 iOS 13.1 (desktop-mode UA still says Macintosh).
+    // We test the user-agent string here because navigator.platform and
+    // navigator.appVersion are deprecated and not in the modern Web platform spec.
+    const userAgent = navigator.userAgent;
+    if (/iP(hone|od|ad)|Macintosh/.test(userAgent)) {
         const tests = [
             /OS (\d+)_(\d+)_?(\d+)?/,
             /Version\/(\d+)/
         ];
         for (const test of tests) {
-            const matches = RegExp(test).exec(navigator.appVersion);
+            const matches = RegExp(test).exec(userAgent);
```

### Issues

None — `npm run lint` cleanup (`@typescript-eslint/no-deprecated`).

### Code assistance

Used Claude (LLM) to assist with the code changes and the writing of this PR description.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A%22merge+conflict%22+-label%3Astale+-author%3A%40me).