### PR TITLE
Replace deprecated UserDto.HasConfiguredPassword with HasPassword

### DIFF
--- a/src/components/dashboard/users/UserPasswordForm.tsx
+++ b/src/components/dashboard/users/UserPasswordForm.tsx
@@ -32,7 +32,7 @@ const UserPasswordForm: FunctionComponent<IProps> = ({ user }: IProps) => {
 
         (await libraryMenu).setTitle(user.Name);
 
-        if (user.HasConfiguredPassword) {
+        if (user.HasPassword) {
             if (!user.Policy?.IsAdministrator) {
                 (page.querySelector('#btnResetPassword') as HTMLDivElement).classList.remove('hide');
             }
@@ -93,7 +93,7 @@ const UserPasswordForm: FunctionComponent<IProps> = ({ user }: IProps) => {
 
             if ((page.querySelector('#fldCurrentPassword') as HTMLDivElement).classList.contains('hide')) {
                 // Firefox does not respect autocomplete=off, so clear it if the field is supposed to be hidden (and blank)
-                // This should only happen when user.HasConfiguredPassword is false, but this information is not passed on
+                // This should only happen when user.HasPassword is false, but this information is not passed on
                 currentPassword = '';
             }
 


### PR DESCRIPTION
### Changes

`UserPasswordForm` was reading `user.HasConfiguredPassword` to decide whether to show the "current password" and "reset password" fields. That property is marked `@deprecated` in the Jellyfin TypeScript SDK's `UserDto` model. The non-deprecated sibling `HasPassword` (defined just above on the same model) carries the same boolean signal — whether the account currently has a password set — so I switched the read to `user.HasPassword` and updated the inline comment that referenced the old name.

```diff
-        if (user.HasConfiguredPassword) {
+        if (user.HasPassword) {
             ...
-                // This should only happen when user.HasConfiguredPassword is false, but this information is not passed on
+                // This should only happen when user.HasPassword is false, but this information is not passed on
```

### Issues

None directly. This resolves the `@typescript-eslint/no-deprecated` warning reported by `npm run lint` for `src/components/dashboard/users/UserPasswordForm.tsx:35`.

### Code assistance

Used Claude (LLM) to scan the SDK's UserDto model for the non-deprecated successor of HasConfiguredPassword and to confirm the semantics line up with how the form uses the value (decide whether to render password-change fields).

---

* [x] I have read and followed the contributing guidelines.
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a substantive review of another web PR.
