### PR TITLE
Remove deprecated UserDto password property usages

### DIFF
--- a/src/components/dashboard/users/UserPasswordForm.tsx
+++ b/src/components/dashboard/users/UserPasswordForm.tsx
@@ -32,15 +32,13 @@ const UserPasswordForm: FunctionComponent<IProps> = ({ user }: IProps) => {
 
         (await libraryMenu).setTitle(user.Name);
 
-        if (user.HasConfiguredPassword) {
-            if (!user.Policy?.IsAdministrator) {
-                (page.querySelector('#btnResetPassword') as HTMLDivElement).classList.remove('hide');
-            }
-            (page.querySelector('#fldCurrentPassword') as HTMLDivElement).classList.remove('hide');
-        } else {
-            (page.querySelector('#btnResetPassword') as HTMLDivElement).classList.add('hide');
-            (page.querySelector('#fldCurrentPassword') as HTMLDivElement).classList.add('hide');
+        // user.HasConfiguredPassword always returns true since the server fix in
+        // jellyfin/jellyfin#14950 (it used to leak whether another user was passwordless),
+        // so we just show the current-password field and the reset button for non-admins.
+        if (!user.Policy?.IsAdministrator) {
+            (page.querySelector('#btnResetPassword') as HTMLDivElement).classList.remove('hide');
         }
+        (page.querySelector('#fldCurrentPassword') as HTMLDivElement).classList.remove('hide');
 
         const canChangePassword = loggedInUser?.Policy?.IsAdministrator || user.Policy.EnableUserPreferenceAccess;
         (page.querySelector('.passwordSection') as HTMLDivElement).classList.toggle('hide', !canChangePassword);
@@ -88,14 +86,8 @@ const UserPasswordForm: FunctionComponent<IProps> = ({ user }: IProps) => {
                 return;
             }
 
-            let currentPassword = (page.querySelector('#txtCurrentPassword') as HTMLInputElement).value;
+            const currentPassword = (page.querySelector('#txtCurrentPassword') as HTMLInputElement).value;
             const newPassword = (page.querySelector('#txtNewPassword') as HTMLInputElement).value;
-
-            if ((page.querySelector('#fldCurrentPassword') as HTMLDivElement).classList.contains('hide')) {
-                // Firefox does not respect autocomplete=off, so clear it if the field is supposed to be hidden (and blank)
-                // This should only happen when user.HasConfiguredPassword is false, but this information is not passed on
-                currentPassword = '';
-            }
 
             window.ApiClient.updateUserPassword(user.Id, currentPassword, newPassword).then(function () {
                 loading.hide();

--- a/src/controllers/session/login/index.js
+++ b/src/controllers/session/login/index.js
@@ -156,7 +156,7 @@ function loadUserList(context, apiClient, users) {
         html += '<div class="' + cardBoxCssClass + '">';
         html += '<div class="cardScalable">';
         html += '<div class="cardPadder cardPadder-square"></div>';
-        html += `<div class="cardContent" data-haspw="${user.HasPassword}" data-username="${user.Name}" data-userid="${user.Id}">`;
+        html += `<div class="cardContent" data-username="${user.Name}" data-userid="${user.Id}">`;
         let imgUrl;
 
         if (user.PrimaryImageTag) {
@@ -226,13 +226,10 @@ export default function (view, params) {
             const context = view;
             const id = cardContent.getAttribute('data-userid');
             const name = cardContent.getAttribute('data-username');
-            const haspw = cardContent.getAttribute('data-haspw');
 
             if (id === 'manual') {
                 context.querySelector('#txtManualName').value = '';
                 showManualForm(context, true);
-            } else if (haspw == 'false') {
-                authenticateUserByName(context, getApiClient(), getTargetUrl(), name, '');
             } else {
                 context.querySelector('#txtManualName').value = name;
                 context.querySelector('#txtManualPassword').value = '';


### PR DESCRIPTION
### Changes

`UserDto.HasConfiguredPassword`, `UserDto.HasPassword` and `UserDto.HasConfiguredEasyPassword` are all marked `@deprecated` in the Jellyfin SDK and now always return `true` since jellyfin/jellyfin#14950 (the booleans used to leak whether another user had no password set, which is the security issue that PR fixed).

Two places in jellyfin-web still referenced these properties; both reduce to dead code now that the values are constant:

1. **`src/components/dashboard/users/UserPasswordForm.tsx`** had an `if (user.HasConfiguredPassword) { ... } else { ... }` block. The `else` branch (which hid the current-password field and the reset button) was never reached. I removed the conditional and kept the formerly-`then` logic. I also removed the Firefox-autocomplete workaround that was guarded on `#fldCurrentPassword` being hidden, because nothing hides it anymore.

2. **`src/controllers/session/login/index.js`** generated a `data-haspw="${user.HasPassword}"` attribute on each user card and used it to skip the manual password form for users with no password (`else if (haspw == 'false') { authenticateUserByName(..., '') }`). That is precisely the path the server fix #14950 closed off, so I removed the attribute, its read, and the branch.

Net change: `-19 / +8`.

### Issues

Resolves the `@typescript-eslint/no-deprecated` warning at `src/components/dashboard/users/UserPasswordForm.tsx:35`. Also removes all remaining references to the three deprecated `UserDto` password booleans (`HasConfiguredPassword`, `HasPassword`, `HasConfiguredEasyPassword`) from jellyfin-web.

Closes #7901.

### Code assistance

Used Claude (LLM) to assist with the code changes and the writing of this PR description.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A%22merge+conflict%22+-label%3Astale+-author%3A%40me).