### PR TITLE
Use innerHTML instead of replaceChildren to empty div

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -71,6 +71,13 @@ export default tseslint.config(
             'no-redeclare': 'off',
             '@typescript-eslint/no-redeclare': ['error', { builtinGlobals: false }],
             'no-restricted-globals': ['error'].concat(restrictedGlobals),
+            'no-restricted-properties': [
+                'error',
+                {
+                    property: 'replaceChildren',
+                    message: 'replaceChildren is not supported in all target browsers'
+                }
+            ],
             'no-return-assign': 'error',
             'no-return-await': 'error',
             'no-sequences': ['error', { 'allowInParentheses': false }],

--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -983,7 +983,7 @@ function renderDetails(page, instance, item, apiClient, context) {
     const itemDetailsGroup = page.querySelector('.itemDetailsGroup');
 
     if (itemDetailsGroup) {
-        itemDetailsGroup.replaceChildren();
+        itemDetailsGroup.innerHTML = '';
 
         const metadataTypes = [
             PersonKind.Author,


### PR DESCRIPTION
### Changes
The itemDetails page is using `Element.replaceChildren` since #7656. Older browsers don't support this ([caniuse](https://caniuse.com/mdn-api_element_replacechildren)) resulting in an exception that prevents the page from properly loading. This PR changes the usage of `replaceChildren` with an `.innerHTML = ''` as the purpose is to clear all children of the `itemDetailsGroup` div.

### Issues
<!--
Tag any issues that this PR solves here.
ex. Fixes #
-->
N/A

### Code assistance
<!--
If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance.
-->
None

---

* [X] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [X] I have tested these changes.
* [X] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
