### PR TITLE
Fix books not displaying in genre lists

### DIFF
--- a/src/controllers/list.js
+++ b/src/controllers/list.js
@@ -315,7 +315,7 @@ function getItems(instance, params, item, sortBy, startIndex, limit) {
         } else if (item.CollectionType === CollectionType.Tvshows) {
             query.IncludeItemTypes = 'Series';
         } else if (item.Type === 'Genre') {
-            query.IncludeItemTypes = 'Movie,Series,Video';
+            query.IncludeItemTypes = 'Audiobook,Book,Movie,Series,Video';
         } else if (item.Type === 'Person') {
             query.IncludeItemTypes = params.type;
         }


### PR DESCRIPTION
### Changes
A [genres tab](https://github.com/jellyfin/jellyfin-web/pull/7354) was added for books/audiobooks, but we didn't update the genre list type to include them. 

Add type `Audiobook` and `Book` to the genre list types

### Issues
<!--
Tag any issues that this PR solves here.
ex. Fixes #
-->
No issues reported

### Code assistance
N/A

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
