### PR TITLE
Handle media element errors before playback starts

### DIFF
--- a/src/components/htmlMediaHelper.js
+++ b/src/components/htmlMediaHelper.js
@@ -195,27 +195,60 @@ function onSuccessfulPlay(elem, onErrorFn) {
     elem.addEventListener('error', onErrorFn);
 }
 
-export function playWithPromise(elem, onErrorFn) {
+function getMediaElementError(elem) {
+    return elem.error || new Error('Media element error');
+}
+
+function isIgnoredPlayError(err) {
+    const errorName = (err?.name || '').toLowerCase();
+
+    // safari uses aborterror
+    return errorName === 'notallowederror'
+        || errorName === 'aborterror';
+}
+
+function playElement(elem) {
     try {
-        return elem.play()
-            .catch((e) => {
-                const errorName = (e.name || '').toLowerCase();
-                // safari uses aborterror
-                if (errorName === 'notallowederror'
-                        || errorName === 'aborterror') {
-                    // swallow this error because the user can still click the play button on the video element
+        return Promise.resolve(elem.play())
+            .catch((err) => {
+                if (isIgnoredPlayError(err)) {
+                    // swallow this error because the user can still click the play button on the media element
                     return Promise.resolve();
                 }
-                return Promise.reject(e);
-            })
-            .then(() => {
-                onSuccessfulPlay(elem, onErrorFn);
-                return Promise.resolve();
+
+                throw err;
             });
     } catch (err) {
         console.error('error calling video.play: ' + err);
-        return Promise.reject();
+        throw err;
     }
+}
+
+export function playWithPromise(elem, onErrorFn, options = {}) {
+    let cleanupStartupError;
+
+    const startupErrorPromise = new Promise((resolve, reject) => {
+        const onStartupError = () => reject(getMediaElementError(elem));
+
+        cleanupStartupError = () => {
+            elem.removeEventListener('error', onStartupError);
+        };
+
+        elem.addEventListener('error', onStartupError);
+    });
+
+    const playPromise = Promise.resolve()
+        .then(options.beforePlay)
+        .then(() => playElement(elem));
+
+    return Promise.race([playPromise, startupErrorPromise])
+        .then(() => {
+            cleanupStartupError();
+            onSuccessfulPlay(elem, onErrorFn);
+        }, (err) => {
+            cleanupStartupError();
+            throw err;
+        });
 }
 
 export function destroyCastPlayer(instance) {

--- a/src/plugins/htmlAudioPlayer/plugin.js
+++ b/src/plugins/htmlAudioPlayer/plugin.js
@@ -108,6 +108,28 @@ class HtmlAudioPlayer {
             return setCurrentSrc(elem, options);
         };
 
+        function applySrcBeforePlay(elem, val, options) {
+            return htmlMediaHelper.applySrc(elem, val, options).then(function () {
+                self._currentSrc = val;
+            });
+        }
+
+        async function playWithNativePlayer(elem, val, options) {
+            elem.autoplay = true;
+
+            const includeCorsCredentials = await getIncludeCorsCredentials();
+            if (includeCorsCredentials) {
+                // Safari will not send cookies without this
+                elem.crossOrigin = 'use-credentials';
+            }
+
+            return htmlMediaHelper.playWithPromise(elem, onError, {
+                beforePlay: function () {
+                    return applySrcBeforePlay(elem, val, options);
+                }
+            });
+        }
+
         function setCurrentSrc(elem, options) {
             unBindEvents(elem);
             bindEvents(elem);
@@ -185,20 +207,8 @@ class HtmlAudioPlayer {
                         self._currentSrc = val;
                     });
                 });
-            }, async () => {
-                elem.autoplay = true;
-
-                const includeCorsCredentials = await getIncludeCorsCredentials();
-                if (includeCorsCredentials) {
-                    // Safari will not send cookies without this
-                    elem.crossOrigin = 'use-credentials';
-                }
-
-                return htmlMediaHelper.applySrc(elem, val, options).then(function () {
-                    self._currentSrc = val;
-
-                    return htmlMediaHelper.playWithPromise(elem, onError);
-                });
+            }, function () {
+                return playWithNativePlayer(elem, val, options);
             });
         }
 

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -545,10 +545,10 @@ export class HtmlVideoPlayer {
                 elem.crossOrigin = 'use-credentials';
             }
 
-            return applySrc(elem, val, options).then(() => {
-                this.#currentSrc = val;
-
-                return playWithPromise(elem, this.onError);
+            return playWithPromise(elem, this.onError, {
+                beforePlay: () => applySrc(elem, val, options).then(() => {
+                    this.#currentSrc = val;
+                })
             });
         }
     }

--- a/src/utils/mediaError.ts
+++ b/src/utils/mediaError.ts
@@ -1,11 +1,21 @@
 import { MediaError } from 'types/mediaError';
 
 /**
- * Maps a DOMException name to an equivalent {@link MediaError}.
+ * Maps a playback exception or HTML media error to an equivalent {@link MediaError}.
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMException#error_names
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/MediaError/code
  */
-export function getMediaError(e?: DOMException): MediaError {
-    if (e?.name === 'NotSupportedError') return MediaError.MEDIA_NOT_SUPPORTED;
+export function getMediaError(err?: { code?: number; name?: string }): MediaError {
+    switch (err?.code) {
+        case 2:
+            return MediaError.NETWORK_ERROR;
+        case 3:
+            return MediaError.MEDIA_DECODE_ERROR;
+        case 4:
+            return MediaError.MEDIA_NOT_SUPPORTED;
+    }
+
+    if (err?.name === 'NotSupportedError') return MediaError.MEDIA_NOT_SUPPORTED;
     return MediaError.PLAYER_ERROR;
 }


### PR DESCRIPTION
### Changes
Handle media element errors that happen during playback startup, before `play()` resolves.

DirectPlay can fail after the source is assigned but before Jellyfin Web has attached the normal media error listener. In that case the `<video>` element may already expose `MediaError.code`, but the error never reaches the existing playback error path.

This change listens for startup media errors inside `playWithPromise` and rejects the startup play promise instead of calling the normal media error handler directly. That keeps startup failures on existing `playbackmanager` handling for clearing startup state and retrying with transcoding or showing the playback error.

### Issues
Fixes #7912. Related to #7651.

### Code assistance
None.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
