### PR TITLE
Fix homescreen settings for mixed libraries 

### DIFF
--- a/src/components/homeScreenSettings/homeScreenSettings.js
+++ b/src/components/homeScreenSettings/homeScreenSettings.js
@@ -318,7 +318,7 @@ function getPerLibrarySettingsHtml(item, user, userSettings) {
 
         const userValue = userSettings.get(`landing-${idForLanding}`);
 
-        html += getLandingScreenOptionsHtml(item.CollectionType, userValue);
+        html += getLandingScreenOptionsHtml(collectionType, userValue);
 
         html += '</select>';
         html += '</div>';


### PR DESCRIPTION
### Changes

Accidentally dropped this in https://github.com/jellyfin/jellyfin-web/pull/7821 during merge.

- Use const `collectionType` instead of item.CollectionType

### Issues

Needed to be able to set the default homescreen settings for a Mixed Library.

### Code assistance
N/A

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
