### PR TITLE
Fix keyboard in old browsers

### DIFF
--- a/src/lib/legacy/keyboardEvent.js
+++ b/src/lib/legacy/keyboardEvent.js
@@ -1,6 +1,8 @@
 /**
  * Polyfill for KeyboardEvent
  * - Constructor.
+ * - 'code' property.
+ * - 'key' property.
  */
 
 (function (window) {
@@ -41,5 +43,70 @@
 
         KeyboardEvent.prototype = KeyboardEventOriginal.prototype;
         window.KeyboardEvent = KeyboardEvent;
+    }
+
+    if (!('code' in KeyboardEvent.prototype)) {
+        /**
+         * Key code mapping.
+         */
+        const KeyCodes = {
+            13: 'Enter',
+            19: 'Pause',
+            27: 'Escape',
+            32: 'Space',
+            37: 'ArrowLeft',
+            38: 'ArrowUp',
+            39: 'ArrowRight',
+            40: 'ArrowDown'
+        };
+
+        // Add [a..z]
+        for (let i = 65; i <= 90; i++) {
+            KeyCodes[i] = `Key${String.fromCharCode(i)}`;
+        }
+
+        // Add [0..9]
+        for (let i = 48; i <= 57; i++) {
+            KeyCodes[i] = `Digit${String.fromCharCode(i)}`;
+        }
+
+        Object.defineProperty(KeyboardEvent.prototype, 'code', {
+            get: function () {
+                return KeyCodes[this.keyCode] || '';
+            },
+            enumerable: true,
+            configurable: true
+        });
+    }
+
+    if (!('key' in KeyboardEvent.prototype)) {
+        /**
+         * Key mapping.
+         */
+        const Keys = {
+            13: 'Enter',
+            19: 'Pause',
+            27: 'Escape',
+            32: 'Space',
+            37: 'ArrowLeft',
+            38: 'ArrowUp',
+            39: 'ArrowRight',
+            40: 'ArrowDown'
+        };
+
+        // Add [a..z]
+        for (let i = 65; i <= 90; i++) {
+            const c = String.fromCharCode(i);
+            Keys[i] = [c.toLowerCase(), c.toUpperCase()];
+        }
+
+        Object.defineProperty(KeyboardEvent.prototype, 'key', {
+            get: function () {
+                const key = Keys[this.keyCode] || '';
+                return Array.isArray(key) ? key[+this.shiftKey] : key;
+            },
+            enumerable: true,
+            configurable: true
+        });
     }
 }(window));

--- a/src/lib/legacy/keyboardEvent.js
+++ b/src/lib/legacy/keyboardEvent.js
@@ -54,10 +54,19 @@
             19: 'Pause',
             27: 'Escape',
             32: 'Space',
+            33: 'PageUp',
+            34: 'PageDown',
+            35: 'End',
+            36: 'Home',
             37: 'ArrowLeft',
             38: 'ArrowUp',
             39: 'ArrowRight',
-            40: 'ArrowDown'
+            40: 'ArrowDown',
+            45: 'Insert',
+            46: 'Delete',
+            110: 'NumpadDecimal',
+            188: 'Comma',
+            190: 'Period'
         };
 
         // Add [a..z]
@@ -68,6 +77,11 @@
         // Add [0..9]
         for (let i = 48; i <= 57; i++) {
             KeyCodes[i] = `Digit${String.fromCharCode(i)}`;
+        }
+
+        // Add numpad [0..9]
+        for (let i = 0; i <= 9; i++) {
+            KeyCodes[i + 96] = `Numpad${i}`;
         }
 
         Object.defineProperty(KeyboardEvent.prototype, 'code', {
@@ -88,10 +102,40 @@
             19: 'Pause',
             27: 'Escape',
             32: 'Space',
+            33: 'PageUp',
+            34: 'PageDown',
+            35: 'End',
+            36: 'Home',
             37: 'ArrowLeft',
             38: 'ArrowUp',
             39: 'ArrowRight',
-            40: 'ArrowDown'
+            40: 'ArrowDown',
+            45: 'Insert',
+            46: 'Delete',
+            48: ['0', ')'],
+            49: ['1', '!'],
+            50: ['2', '@'],
+            51: ['3', '#'],
+            52: ['4', '$'],
+            53: ['5', '%'],
+            54: ['6', '^'],
+            55: ['7', '&'],
+            56: ['8', '*'],
+            57: ['9', '('],
+            // Numpad+Shift is usually ignored or replaced with a direct key code (Insert, End, ArrowRight, ...)
+            96: ['0', 'Insert'],
+            97: ['1', 'End'],
+            98: ['2', 'ArrowDown'],
+            99: ['3', 'PageDown'],
+            100: ['4', 'ArrowLeft'],
+            101: ['5', ''],
+            102: ['6', 'ArrowRight'],
+            103: ['7', 'Home'],
+            104: ['8', 'ArrowUp'],
+            105: ['9', 'PageUp'],
+            110: ['.', 'Delete'],
+            188: [',', '<'],
+            190: ['.', '>']
         };
 
         // Add [a..z]

--- a/src/lib/legacy/keyboardEvent.js
+++ b/src/lib/legacy/keyboardEvent.js
@@ -21,9 +21,8 @@
 
             event.view = options.view || document.defaultView;
 
-            event.key = options.key || options.keyIdentifier || '';
+            // Don't populate 'key' and 'code' with dummy values
             event.keyCode = options.keyCode || 0;
-            event.code = options.code || '';
             event.charCode = options.charCode || 0;
             event.char = options.char || '';
             event.which = options.which || 0;

--- a/src/scripts/keyboardNavigation.js
+++ b/src/scripts/keyboardNavigation.js
@@ -102,17 +102,22 @@ const InteractiveElements = ['INPUT', 'TEXTAREA'];
  */
 const NonInteractiveInputElements = ['button', 'checkbox', 'color', 'file', 'hidden', 'image', 'radio', 'reset', 'submit'];
 
-let hasFieldKey = false;
+let hasFieldCode = false;
 try {
-    hasFieldKey = 'key' in new KeyboardEvent('keydown');
+    hasFieldCode = 'code' in new KeyboardEvent('keydown');
 } catch (e) {
-    console.error("error checking 'key' field", e);
+    console.error("error checking 'code' field", e);
 }
 
-if (!hasFieldKey) {
+if (!hasFieldCode) {
     // Add [a..z]
     for (let i = 65; i <= 90; i++) {
-        KeyNames[i] = String.fromCharCode(i).toLowerCase();
+        KeyNames[i] = `Key${String.fromCharCode(i)}`;
+    }
+
+    // Add [0..9]
+    for (let i = 48; i <= 57; i++) {
+        KeyNames[i] = `Digit${String.fromCharCode(i)}`;
     }
 }
 
@@ -123,8 +128,8 @@ if (!hasFieldKey) {
  * @return {string} Key name.
  */
 export function getKeyName(event) {
-    const key = KeyNames[event.keyCode] || event.key;
-    return KeyAliases[key] || event.code;
+    const key = KeyNames[event.keyCode] || event.code || '';
+    return KeyAliases[key] || key;
 }
 
 /**

--- a/src/scripts/keyboardNavigation.js
+++ b/src/scripts/keyboardNavigation.js
@@ -12,15 +12,6 @@ import appSettings from './settings/appSettings';
  * Key name mapping.
  */
 const KeyNames = {
-    13: 'Enter',
-    19: 'Pause',
-    27: 'Escape',
-    32: 'Space',
-    37: 'ArrowLeft',
-    38: 'ArrowUp',
-    39: 'ArrowRight',
-    40: 'ArrowDown',
-
     // UWP WebView section start --
     // Navigation Up/Down/Left/Right is part of TVJS directionalnavigation-1.0.0.0.js
     // Unsure what this is used for. Media remote?
@@ -101,25 +92,6 @@ const InteractiveElements = ['INPUT', 'TEXTAREA'];
  * Types of INPUT element for which navigation shouldn't be constrained.
  */
 const NonInteractiveInputElements = ['button', 'checkbox', 'color', 'file', 'hidden', 'image', 'radio', 'reset', 'submit'];
-
-let hasFieldCode = false;
-try {
-    hasFieldCode = 'code' in new KeyboardEvent('keydown');
-} catch (e) {
-    console.error("error checking 'code' field", e);
-}
-
-if (!hasFieldCode) {
-    // Add [a..z]
-    for (let i = 65; i <= 90; i++) {
-        KeyNames[i] = `Key${String.fromCharCode(i)}`;
-    }
-
-    // Add [0..9]
-    for (let i = 48; i <= 57; i++) {
-        KeyNames[i] = `Digit${String.fromCharCode(i)}`;
-    }
-}
 
 /**
  * Returns key name from event.


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

### Changes
<!--
Describe your changes here in 1-5 sentences.
Please include before/after screenshots of any UI changes.
-->
- Fix the check for the presence of the `KeyboardEvent.key|code` property.
- Fix the `KeyboardEvent.code` fallback.
- Add `KeyboardEvent.key` and `KeyboardEvent.code` polyfills.

Technically, the issue is fixed by 1st and 2nd commits.

We could use the [`keyboardevent-key-polyfill`](https://www.npmjs.com/package/keyboardevent-key-polyfill?ref=pkgstats.com) module for the `key` property, but now we need the `code` property.

### Issues
<!--
Tag any issues that this PR solves here.
ex. Fixes #
-->
Regressions #4632
The check for the presence of the `KeyboardEvent.key` property is broken.
Regressions #7398
`KeyboardEvent.code` is `undefined` in old browsers (https://github.com/jellyfin/jellyfin-web/pull/7398#discussion_r3232719068). This caused navigation to stop working.

### Code assistance
<!--
If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance.
-->
None.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
