### PR TITLE
Reload item data on version change and use correct parts on playback

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -2117,7 +2117,7 @@ export class PlaybackManager {
             // Prepare the list of items
             items = await translateItemsForPlayback(items, options);
             // Add any additional parts for movies or episodes
-            items = await getAdditionalParts(items);
+            items = await getAdditionalParts(items, options.mediaSourceId, options.startIndex || 0);
             // Adjust the start index for additional parts added to the queue
             if (options.startIndex) {
                 let adjustedStartIndex = 0;
@@ -2269,15 +2269,22 @@ export class PlaybackManager {
             return player.play(options);
         }
 
-        const getAdditionalParts = async (items) => {
-            const getItemAndParts = async function (item) {
+        const getAdditionalParts = async (items, mediaSourceId, startIndex) => {
+            const getItemAndParts = async function (item, isStartItem) {
                 if (
                     item.PartCount && item.PartCount > 1
                     && [ BaseItemKind.Episode, BaseItemKind.Movie ].includes(item.Type)
                 ) {
                     const client = ServerConnections.getApiClient(item.ServerId);
                     const user = await client.getCurrentUser();
-                    const additionalParts = await client.getAdditionalVideoParts(user.Id, item.Id);
+                    // When the user picked an alternate version, that version's MediaSourceId
+                    // equals its own BaseItem.Id, so use it to fetch the alternate's own
+                    // additional parts instead of the primary's - otherwise the primary's
+                    // stack parts would queue after the alternate finishes.
+                    const idForParts = (isStartItem && mediaSourceId && mediaSourceId !== item.Id) ?
+                        mediaSourceId :
+                        item.Id;
+                    const additionalParts = await client.getAdditionalVideoParts(user.Id, idForParts);
                     if (additionalParts.Items.length) {
                         return [ item, ...additionalParts.Items ];
                     }
@@ -2285,7 +2292,7 @@ export class PlaybackManager {
                 return [ item ];
             };
 
-            return Promise.all(items.map(getItemAndParts));
+            return Promise.all(items.map((item, index) => getItemAndParts(item, index === (startIndex || 0))));
         };
 
         function playWithIntros(items, options) {

--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -2039,6 +2039,7 @@ export default function (view, params) {
             renderAudioSelections(view, self._currentPlaybackMediaSources);
             renderSubtitleSelections(view, self._currentPlaybackMediaSources);
             updateMiscInfo();
+            refreshSelectedVersion();
         });
         view.addEventListener('viewshow', function (e) {
             const page = this;
@@ -2081,6 +2082,38 @@ export default function (view, params) {
             // patch currentItem (primary item) with details from the selected MediaSource:
             ...currentItem,
             ...selectedMediaSource
+        });
+    }
+
+    // When the user picks an alternate version, fetch that Video item's own DTO
+    // and refresh the play/user-data buttons so resume position, watched state, and
+    // stack-part count reflect the selected version rather than the primary's.
+    function refreshSelectedVersion() {
+        const selectedId = view.querySelector('.selectSource').value;
+        if (!selectedId || !currentItem || selectedId === currentItem.Id) {
+            reloadPlayButtons(view, currentItem);
+            reloadUserDataButtons(view, currentItem);
+            return;
+        }
+
+        const apiClient = ServerConnections.getApiClient(currentItem.ServerId);
+        apiClient.getItem(apiClient.getCurrentUserId(), selectedId).then(function (altItem) {
+            if (view.querySelector('.selectSource').value !== selectedId) {
+                return;
+            }
+            // Keep primary's shared metadata (overview, cast, etc.) and override the
+            // fields that are intrinsic to the playback target (UserData, runtime, parts).
+            const merged = {
+                ...currentItem,
+                UserData: altItem.UserData,
+                RunTimeTicks: altItem.RunTimeTicks,
+                PartCount: altItem.PartCount,
+                MediaStreams: altItem.MediaStreams
+            };
+            reloadPlayButtons(view, merged);
+            reloadUserDataButtons(view, merged);
+        }).catch(function (err) {
+            console.error('failed to load alternate version item', err);
         });
     }
 

--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -1,6 +1,7 @@
 import { BaseItemKind } from '@jellyfin/sdk/lib/generated-client/models/base-item-kind';
 import { PersonKind } from '@jellyfin/sdk/lib/generated-client/models/person-kind';
 import { getLibraryApi } from '@jellyfin/sdk/lib/utils/api/library-api';
+import { getUserLibraryApi } from '@jellyfin/sdk/lib/utils/api/user-library-api';
 import { intervalToDuration } from 'date-fns';
 import DOMPurify from 'dompurify';
 import escapeHtml from 'escape-html';
@@ -2097,7 +2098,11 @@ export default function (view, params) {
         }
 
         const apiClient = ServerConnections.getApiClient(currentItem.ServerId);
-        apiClient.getItem(apiClient.getCurrentUserId(), selectedId).then(function (altItem) {
+        const api = toApi(apiClient);
+        getUserLibraryApi(api).getItem({
+            userId: apiClient.getCurrentUserId(),
+            itemId: selectedId
+        }).then(function ({ data: altItem }) {
             if (view.querySelector('.selectSource').value !== selectedId) {
                 return;
             }


### PR DESCRIPTION
When having multiple versions and a multipart main version, changing vesion will play partX of the main version after completion.

Somewhat related to jellyfin/jellyfin#16828 but also necessary without it.

### Changes
* Reload item data on version change
* Load the current version's parts on playback

### Code assistance
Guidance provided by Claude Opus 4.7 via Claude Code

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
