### PR TITLE
Add error handling for user creation with alert on failure

### DIFF
--- a/src/apps/dashboard/routes/users/add.tsx
+++ b/src/apps/dashboard/routes/users/add.tsx
@@ -125,6 +125,7 @@ const UserNew = () => {
                 Name: (page.querySelector('#txtUsername') as HTMLInputElement).value,
                 Password: (page.querySelector('#txtPassword') as HTMLInputElement).value
             };
+
             createUser.mutate({ createUserByName: userInput }, {
                 onSuccess: (response) => {
                     const user = response.data;
@@ -167,6 +168,14 @@ const UserNew = () => {
                             setIsErrorToastOpen(true);
                         }
                     });
+                },
+                onError: (response) => { //catch failure
+                    if (response?.message) {
+                        alert(`${response.message}: Failed to create user. Please check for special characters.`); //return API failure message if exists
+                    } else {
+                        alert('Failed to create user. Please check for special characters.'); //default failure message
+                    }
+                    loading.hide();
                 }
             });
         };


### PR DESCRIPTION
### Changes
<!--
Very simple check for API result on user creation. Provide error message if present, default if not. 
-->

### Issues
<!--
Issue-7857
-->

### Code assistance
<!--
Just used for commit title
-->

---

* [Y ] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [ Y] I have tested these changes.
* [ Y] I have verified that this is not duplicating changes in an existing PR.
* [ Y] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
