### PR TITLE
Add polish to library toolbar and menus design

### DIFF
--- a/src/apps/experimental/components/library/ItemsView.tsx
+++ b/src/apps/experimental/components/library/ItemsView.tsx
@@ -4,6 +4,8 @@ import { ImageType } from '@jellyfin/sdk/lib/generated-client/models/image-type'
 import { ItemSortBy } from '@jellyfin/sdk/lib/generated-client/models/item-sort-by';
 import Box from '@mui/material/Box';
 import ButtonGroup from '@mui/material/ButtonGroup';
+import Chip from '@mui/material/Chip';
+import Stack from '@mui/material/Stack';
 import type { Theme } from '@mui/material/styles';
 import Toolbar from '@mui/material/Toolbar';
 import useMediaQuery from '@mui/material/useMediaQuery';
@@ -22,11 +24,13 @@ import ItemsContainer from 'elements/emby-itemscontainer/ItemsContainer';
 import NoItemsMessage from 'components/common/NoItemsMessage';
 import Lists from 'components/listview/List/Lists';
 import Cards from 'components/cardbuilder/Card/Cards';
+import { useItem } from 'hooks/useItem';
+import { useUserSettings } from 'hooks/useUserSettings';
+import globalize from 'lib/globalize';
 import { LibraryTab } from 'types/libraryTab';
 import { type LibraryViewSettings, type ParentId, ViewMode } from 'types/library';
 import type { CardOptions } from 'types/cardOptions';
 import type { ListOptions } from 'types/listOptions';
-import { useItem } from 'hooks/useItem';
 
 import OffsetAppBar from '../OffsetAppBar';
 
@@ -230,6 +234,23 @@ const ItemsView: FC<ItemsViewProps> = ({
     );
     const hasSortName = libraryViewSettings.SortBy !== ItemSortBy.Random;
 
+    // Pagination
+    const startIndex = libraryViewSettings.StartIndex ?? 0;
+    const { libraryPageSize: paginationLimit } = useUserSettings();
+    const paginationStart = totalRecordCount ? startIndex + 1 : 0;
+    const paginationEnd = paginationLimit ?
+        Math.min(startIndex + paginationLimit, totalRecordCount) :
+        totalRecordCount;
+    /** True if the data is larger than the page limit */
+    const isPaginationRequired = paginationLimit > 0 && paginationLimit < totalRecordCount;
+
+    let itemCountDisplay = '\u2219'; // Bullet "operator" character as a loading indicator
+    if (!isPending) {
+        itemCountDisplay = isPaginationRequired ?
+            globalize.translate('ListPaging', paginationStart, paginationEnd, totalRecordCount) :
+            totalRecordCount;
+    }
+
     const itemsContainerClass = classNames(
         'padded-left padded-right padded-right-withalphapicker',
         libraryViewSettings.ViewMode === ViewMode.ListView ?
@@ -259,53 +280,7 @@ const ItemsView: FC<ItemsViewProps> = ({
                         alignItems: 'center'
                     }}
                 >
-                    <Box
-                        sx={{ marginRight: 1 }}
-                    >
-                        <LibraryViewMenu />
-                    </Box>
-
-                    <Box
-                        sx={{
-                            flexGrow: {
-                                xs: 1,
-                                sm: 0
-                            },
-                            marginRight: 1
-                        }}
-                    >
-                        <ButtonGroup
-                            color='inherit'
-                            variant='text'
-                        >
-                            {isBtnFilterEnabled && (
-                                <FilterButton
-                                    parentId={parentId}
-                                    itemType={itemType}
-                                    viewType={viewType}
-                                    hasFilters={hasFilters}
-                                    libraryViewSettings={libraryViewSettings}
-                                    setLibraryViewSettings={setLibraryViewSettings}
-                                />
-                            )}
-
-                            {isBtnSortEnabled && (
-                                <SortButton
-                                    viewType={viewType}
-                                    libraryViewSettings={libraryViewSettings}
-                                    setLibraryViewSettings={setLibraryViewSettings}
-                                />
-                            )}
-
-                            {isBtnGridListEnabled && (
-                                <ViewSettingsButton
-                                    viewType={viewType}
-                                    libraryViewSettings={libraryViewSettings}
-                                    setLibraryViewSettings={setLibraryViewSettings}
-                                />
-                            )}
-                        </ButtonGroup>
-                    </Box>
+                    <LibraryViewMenu />
 
                     <Box
                         sx={{
@@ -314,7 +289,8 @@ const ItemsView: FC<ItemsViewProps> = ({
                                 xs: 1,
                                 sm: 0
                             },
-                            justifyContent: 'flex-end'
+                            justifyContent: 'flex-end',
+                            marginLeft: 1
                         }}
                     >
                         {!isPending && (
@@ -360,30 +336,77 @@ const ItemsView: FC<ItemsViewProps> = ({
                         )}
                     </Box>
 
-                    <Box
+                    <Stack
+                        direction='row'
+                        spacing={1}
                         sx={{
-                            display: 'flex',
-                            justifyContent: 'end',
+                            justifyContent: {
+                                xs: 'auto',
+                                sm: 'end'
+                            },
                             flexBasis: {
                                 xs: '100%',
                                 sm: 'auto'
                             },
                             flexGrow: 1,
-                            marginTop: {
-                                xs: 0.5,
-                                sm: 0
-                            }
+                            marginTop: 0.5,
+                            marginBottom: 0.5
                         }}
                     >
-                        {!isPending && isPaginationEnabled && (
+                        <Box
+                            sx={{
+                                display: 'flex',
+                                flexGrow: {
+                                    xs: 1,
+                                    sm: 0
+                                }
+                            }}
+                        >
+                            <Chip label={itemCountDisplay} />
+                        </Box>
+
+                        <ButtonGroup
+                            color='inherit'
+                            variant='text'
+                        >
+                            {isBtnFilterEnabled && (
+                                <FilterButton
+                                    parentId={parentId}
+                                    itemType={itemType}
+                                    viewType={viewType}
+                                    hasFilters={hasFilters}
+                                    libraryViewSettings={libraryViewSettings}
+                                    setLibraryViewSettings={setLibraryViewSettings}
+                                />
+                            )}
+
+                            {isBtnSortEnabled && (
+                                <SortButton
+                                    viewType={viewType}
+                                    libraryViewSettings={libraryViewSettings}
+                                    setLibraryViewSettings={setLibraryViewSettings}
+                                />
+                            )}
+
+                            {isBtnGridListEnabled && (
+                                <ViewSettingsButton
+                                    viewType={viewType}
+                                    libraryViewSettings={libraryViewSettings}
+                                    setLibraryViewSettings={setLibraryViewSettings}
+                                />
+                            )}
+                        </ButtonGroup>
+
+                        {!isPending && isPaginationEnabled && isPaginationRequired && (
                             <Pagination
-                                totalRecordCount={totalRecordCount}
-                                libraryViewSettings={libraryViewSettings}
-                                isPlaceholderData={isPlaceholderData}
                                 setLibraryViewSettings={setLibraryViewSettings}
+                                index={startIndex}
+                                pageSize={paginationLimit}
+                                total={totalRecordCount}
+                                disabled={isPlaceholderData}
                             />
                         )}
-                    </Box>
+                    </Stack>
                 </Toolbar>
             </OffsetAppBar>
 

--- a/src/apps/experimental/components/library/ItemsView.tsx
+++ b/src/apps/experimental/components/library/ItemsView.tsx
@@ -356,6 +356,7 @@ const ItemsView: FC<ItemsViewProps> = ({
                         <Box
                             sx={{
                                 display: 'flex',
+                                alignItems: 'center',
                                 flexGrow: {
                                     xs: 1,
                                     sm: 0

--- a/src/apps/experimental/components/library/ItemsView.tsx
+++ b/src/apps/experimental/components/library/ItemsView.tsx
@@ -397,13 +397,13 @@ const ItemsView: FC<ItemsViewProps> = ({
                             )}
                         </ButtonGroup>
 
-                        {!isPending && isPaginationEnabled && (
+                        {isPaginationEnabled && (
                             <Pagination
                                 setLibraryViewSettings={setLibraryViewSettings}
                                 index={startIndex}
                                 pageSize={paginationLimit}
                                 total={totalRecordCount}
-                                disabled={!isPaginationRequired || isPlaceholderData}
+                                disabled={isPending || !isPaginationRequired || isPlaceholderData}
                             />
                         )}
                     </Stack>

--- a/src/apps/experimental/components/library/ItemsView.tsx
+++ b/src/apps/experimental/components/library/ItemsView.tsx
@@ -397,13 +397,13 @@ const ItemsView: FC<ItemsViewProps> = ({
                             )}
                         </ButtonGroup>
 
-                        {!isPending && isPaginationEnabled && isPaginationRequired && (
+                        {!isPending && isPaginationEnabled && (
                             <Pagination
                                 setLibraryViewSettings={setLibraryViewSettings}
                                 index={startIndex}
                                 pageSize={paginationLimit}
                                 total={totalRecordCount}
-                                disabled={isPlaceholderData}
+                                disabled={!isPaginationRequired || isPlaceholderData}
                             />
                         )}
                     </Stack>

--- a/src/apps/experimental/components/library/LibraryViewMenu.tsx
+++ b/src/apps/experimental/components/library/LibraryViewMenu.tsx
@@ -3,6 +3,7 @@ import ArrowDropDown from '@mui/icons-material/ArrowDropDown';
 import Button from '@mui/material/Button/Button';
 import Menu from '@mui/material/Menu/Menu';
 import MenuItem from '@mui/material/MenuItem/MenuItem';
+import Typography from '@mui/material/Typography';
 import React, { FC, useCallback, useState } from 'react';
 import { useLocation, useSearchParams } from 'react-router-dom';
 
@@ -44,7 +45,9 @@ const LibraryViewMenu: FC = () => {
                 aria-haspopup='true'
                 onClick={onMenuButtonClick}
             >
-                {globalize.translate(currentTab.label)}
+                <Typography variant='h2' component='span'>
+                    {globalize.translate(currentTab.label)}
+                </Typography>
             </Button>
 
             <Menu

--- a/src/apps/experimental/components/library/Pagination.tsx
+++ b/src/apps/experimental/components/library/Pagination.tsx
@@ -1,142 +1,64 @@
 import React, { FC, useCallback } from 'react';
 import NavigateBeforeIcon from '@mui/icons-material/NavigateBefore';
 import NavigateNextIcon from '@mui/icons-material/NavigateNext';
-import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import ButtonGroup from '@mui/material/ButtonGroup';
-import Stack from '@mui/material/Stack';
-import type { Theme } from '@mui/material/styles';
-import Typography from '@mui/material/Typography';
-import useMediaQuery from '@mui/material/useMediaQuery';
 
 import globalize from 'lib/globalize';
-import * as userSettings from 'scripts/settings/userSettings';
-import { LibraryViewSettings } from 'types/library';
+import type { LibraryViewSettings } from 'types/library';
 
 interface PaginationProps {
-    libraryViewSettings: LibraryViewSettings;
-    setLibraryViewSettings: React.Dispatch<React.SetStateAction<LibraryViewSettings>>;
-    totalRecordCount: number;
-    isPlaceholderData: boolean
+    setLibraryViewSettings: React.Dispatch<React.SetStateAction<LibraryViewSettings>>
+    index: number
+    pageSize: number
+    total: number
+    disabled?: boolean
 }
 
 const Pagination: FC<PaginationProps> = ({
-    libraryViewSettings,
     setLibraryViewSettings,
-    totalRecordCount,
-    isPlaceholderData
+    index,
+    pageSize,
+    total,
+    disabled
 }) => {
-    const isSmallScreen = useMediaQuery((t: Theme) => t.breakpoints.up('sm'));
-
-    const limit = userSettings.libraryPageSize(undefined);
-    const startIndex = libraryViewSettings.StartIndex ?? 0;
-    const recordsStart = totalRecordCount ? startIndex + 1 : 0;
-    const recordsEnd = limit ?
-        Math.min(startIndex + limit, totalRecordCount) :
-        totalRecordCount;
-    const showControls = limit > 0 && limit < totalRecordCount;
-
     const onNextPageClick = useCallback(() => {
-        const newIndex = startIndex + limit;
         setLibraryViewSettings((prevState) => ({
             ...prevState,
-            StartIndex: newIndex
+            StartIndex: index + pageSize
         }));
         window.scrollTo(0, 0);
-    }, [limit, setLibraryViewSettings, startIndex]);
+    }, [index, pageSize, setLibraryViewSettings]);
 
     const onPreviousPageClick = useCallback(() => {
-        const newIndex = Math.max(0, startIndex - limit);
         setLibraryViewSettings((prevState) => ({
             ...prevState,
-            StartIndex: newIndex
+            StartIndex: Math.max(0, index - pageSize)
         }));
         window.scrollTo(0, 0);
-    }, [limit, setLibraryViewSettings, startIndex]);
+    }, [index, pageSize, setLibraryViewSettings]);
 
     return (
-        <Stack
-            direction='row'
-            spacing={0.5}
-            sx={{
-                alignItems: 'center',
-                flexGrow: {
-                    xs: 1,
-                    sm: 0
-                },
-                marginLeft: {
-                    xs: 0,
-                    sm: 0.5
-                }
-            }}
+        <ButtonGroup
+            color='inherit'
+            variant='text'
         >
-            {!isSmallScreen && (
-                <Button
-                    color='inherit'
-                    variant='text'
-                    title={globalize.translate('Previous')}
-                    disabled={!showControls || startIndex == 0 || isPlaceholderData}
-                    onClick={onPreviousPageClick}
-                >
-                    <NavigateBeforeIcon />
-                </Button>
-            )}
-
-            <Box
-                sx={{
-                    display: 'flex',
-                    flexGrow: 1,
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    marginLeft: 1,
-                    marginRight: 1
-                }}
+            <Button
+                title={globalize.translate('Previous')}
+                disabled={disabled || index == 0}
+                onClick={onPreviousPageClick}
             >
-                <Typography variant='body2'>
-                    {globalize.translate(
-                        'ListPaging',
-                        recordsStart,
-                        recordsEnd,
-                        totalRecordCount
-                    )}
-                </Typography>
-            </Box>
+                <NavigateBeforeIcon />
+            </Button>
 
-            {isSmallScreen && (
-                <ButtonGroup
-                    color='inherit'
-                    variant='text'
-                >
-                    <Button
-                        title={globalize.translate('Previous')}
-                        disabled={!showControls || startIndex == 0 || isPlaceholderData}
-                        onClick={onPreviousPageClick}
-                    >
-                        <NavigateBeforeIcon />
-                    </Button>
-
-                    <Button
-                        title={globalize.translate('Next')}
-                        disabled={!showControls || startIndex + limit >= totalRecordCount || isPlaceholderData }
-                        onClick={onNextPageClick}
-                    >
-                        <NavigateNextIcon />
-                    </Button>
-                </ButtonGroup>
-            )}
-
-            {!isSmallScreen && (
-                <Button
-                    color='inherit'
-                    variant='text'
-                    title={globalize.translate('Next')}
-                    disabled={!showControls || startIndex + limit >= totalRecordCount || isPlaceholderData }
-                    onClick={onNextPageClick}
-                >
-                    <NavigateNextIcon />
-                </Button>
-            )}
-        </Stack>
+            <Button
+                title={globalize.translate('Next')}
+                disabled={disabled || index + pageSize >= total}
+                onClick={onNextPageClick}
+            >
+                <NavigateNextIcon />
+            </Button>
+        </ButtonGroup>
     );
 };
 

--- a/src/apps/experimental/components/library/Pagination.tsx
+++ b/src/apps/experimental/components/library/Pagination.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useCallback } from 'react';
-import ArrowBackIcon from '@mui/icons-material/ArrowBack';
-import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import NavigateBeforeIcon from '@mui/icons-material/NavigateBefore';
+import NavigateNextIcon from '@mui/icons-material/NavigateNext';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import ButtonGroup from '@mui/material/ButtonGroup';
@@ -78,7 +78,7 @@ const Pagination: FC<PaginationProps> = ({
                     disabled={!showControls || startIndex == 0 || isPlaceholderData}
                     onClick={onPreviousPageClick}
                 >
-                    <ArrowBackIcon />
+                    <NavigateBeforeIcon />
                 </Button>
             )}
 
@@ -112,7 +112,7 @@ const Pagination: FC<PaginationProps> = ({
                         disabled={!showControls || startIndex == 0 || isPlaceholderData}
                         onClick={onPreviousPageClick}
                     >
-                        <ArrowBackIcon />
+                        <NavigateBeforeIcon />
                     </Button>
 
                     <Button
@@ -120,7 +120,7 @@ const Pagination: FC<PaginationProps> = ({
                         disabled={!showControls || startIndex + limit >= totalRecordCount || isPlaceholderData }
                         onClick={onNextPageClick}
                     >
-                        <ArrowForwardIcon />
+                        <NavigateNextIcon />
                     </Button>
                 </ButtonGroup>
             )}
@@ -133,7 +133,7 @@ const Pagination: FC<PaginationProps> = ({
                     disabled={!showControls || startIndex + limit >= totalRecordCount || isPlaceholderData }
                     onClick={onNextPageClick}
                 >
-                    <ArrowForwardIcon />
+                    <NavigateNextIcon />
                 </Button>
             )}
         </Stack>

--- a/src/apps/experimental/components/library/SortButton.tsx
+++ b/src/apps/experimental/components/library/SortButton.tsx
@@ -1,15 +1,15 @@
 import { ItemSortBy } from '@jellyfin/sdk/lib/generated-client/models/item-sort-by';
 import { SortOrder } from '@jellyfin/sdk/lib/generated-client/models/sort-order';
 import React, { FC, useCallback } from 'react';
-import Button from '@mui/material/Button';
-import MenuItem from '@mui/material/MenuItem';
-import Popover from '@mui/material/Popover';
-import Typography from '@mui/material/Typography';
-import Divider from '@mui/material/Divider';
-import InputLabel from '@mui/material/InputLabel';
-import FormControl from '@mui/material/FormControl';
-import Select, { SelectChangeEvent } from '@mui/material/Select';
+import ArrowDownward from '@mui/icons-material/ArrowDownward';
+import ArrowUpward from '@mui/icons-material/ArrowUpward';
 import SortByAlphaIcon from '@mui/icons-material/SortByAlpha';
+import Button from '@mui/material/Button';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import MenuItem from '@mui/material/MenuItem';
+import MenuList from '@mui/material/MenuList';
+import Popover from '@mui/material/Popover';
 
 import globalize from 'lib/globalize';
 import { LibraryViewSettings } from 'types/library';
@@ -158,11 +158,6 @@ const getSortMenuOptions = (viewType: LibraryTab): SortOption[] => {
     return sortOptionsMapping[viewType] || [];
 };
 
-const sortOrderMenuOptions = [
-    { label: 'Ascending', value: SortOrder.Ascending },
-    { label: 'Descending', value: SortOrder.Descending }
-];
-
 interface SortButtonProps {
     viewType: LibraryTab;
     libraryViewSettings: LibraryViewSettings;
@@ -179,6 +174,7 @@ const SortButton: FC<SortButtonProps> = ({
     const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
     const open = Boolean(anchorEl);
     const id = open ? 'sort-popover' : undefined;
+    const sortMenuOptions = getSortMenuOptions(viewType);
 
     const handleClick = useCallback((event: React.MouseEvent<HTMLElement>) => {
         setAnchorEl(event.currentTarget);
@@ -188,20 +184,25 @@ const SortButton: FC<SortButtonProps> = ({
         setAnchorEl(null);
     }, []);
 
-    const onSelectChange = useCallback(
-        (event: SelectChangeEvent) => {
-            const name = event.target.name;
+    const onMenuItemClick = useCallback(
+        (sortBy: ItemSortBy) => {
+            setLibraryViewSettings((prevState) => {
+                let sortOrder: SortOrder = SortOrder.Ascending;
+                // If the user clicks the currently selected sort option, toggle the sort order
+                if (prevState.SortBy === sortBy) {
+                    sortOrder = prevState.SortOrder === SortOrder.Ascending ? SortOrder.Descending : SortOrder.Ascending;
+                }
 
-            setLibraryViewSettings((prevState) => ({
-                ...prevState,
-                StartIndex: 0,
-                [name]: event.target.value
-            }));
+                return {
+                    ...prevState,
+                    StartIndex: 0,
+                    SortBy: sortBy,
+                    SortOrder: sortOrder
+                };
+            });
         },
         [setLibraryViewSettings]
     );
-
-    const sortMenuOptions = getSortMenuOptions(viewType);
 
     return (
         <>
@@ -229,58 +230,29 @@ const SortButton: FC<SortButtonProps> = ({
                     '& .MuiFormControl-root': { m: 1, width: 200 }
                 }}
             >
-                <FormControl fullWidth>
-                    <InputLabel id='select-sort-label'>
-                        <Typography component='span'>
-                            {globalize.translate('LabelSortBy')}
-                        </Typography>
-                    </InputLabel>
-                    <Select
-                        labelId='select-sort-label'
-                        id='selectSortBy'
-                        value={libraryViewSettings.SortBy}
-                        label={globalize.translate('LabelSortBy')}
-                        name='SortBy'
-                        onChange={onSelectChange}
-                    >
-                        {sortMenuOptions
-                            .map((option) => (
-                                <MenuItem
-                                    key={option.value}
-                                    value={option.value}
-                                >
-                                    <Typography component='span'>
-                                        {globalize.translate(option.label)}
-                                    </Typography>
-                                </MenuItem>
-                            ))}
-                    </Select>
-                </FormControl>
-
-                <Divider />
-                <FormControl fullWidth>
-                    <InputLabel id='select-sortorder-label'>
-                        <Typography component='span'>
-                            {globalize.translate('LabelSortOrder')}
-                        </Typography>
-                    </InputLabel>
-                    <Select
-                        labelId='select-sortorder-label'
-                        id='selectSortOrder'
-                        value={libraryViewSettings.SortOrder}
-                        label={globalize.translate('LabelSortOrder')}
-                        name='SortOrder'
-                        onChange={onSelectChange}
-                    >
-                        {sortOrderMenuOptions.map((option) => (
-                            <MenuItem key={option.value} value={option.value}>
-                                <Typography component='span'>
+                <MenuList>
+                    {sortMenuOptions
+                        .map((option) => (
+                            <MenuItem
+                                key={option.value}
+                                // eslint-disable-next-line react/jsx-no-bind
+                                onClick={() => onMenuItemClick(option.value)}
+                            >
+                                <ListItemText>
                                     {globalize.translate(option.label)}
-                                </Typography>
+                                </ListItemText>
+                                <ListItemIcon sx={{ justifyContent: 'flex-end' }}>
+                                    {libraryViewSettings.SortBy === option.value && (
+                                        libraryViewSettings.SortOrder === SortOrder.Ascending ? (
+                                            <ArrowUpward fontSize='small' />
+                                        ) : (
+                                            <ArrowDownward fontSize='small' />
+                                        ))
+                                    }
+                                </ListItemIcon>
                             </MenuItem>
                         ))}
-                    </Select>
-                </FormControl>
+                </MenuList>
             </Popover>
         </>
     );

--- a/src/apps/experimental/components/library/ViewSettingsButton.tsx
+++ b/src/apps/experimental/components/library/ViewSettingsButton.tsx
@@ -17,7 +17,6 @@ import MenuItem from '@mui/material/MenuItem';
 import MenuList from '@mui/material/MenuList';
 import Popover from '@mui/material/Popover';
 import Switch from '@mui/material/Switch';
-import Typography from '@mui/material/Typography';
 
 import globalize from 'lib/globalize';
 import { LibraryViewSettings, ViewMode } from 'types/library';
@@ -184,9 +183,9 @@ const ViewSettingsButton: FC<ViewSettingsButtonProps> = ({
                                         <ListItemIcon>
                                             {libraryViewSettings.ImageType === imageType.value && <Check fontSize='small' />}
                                         </ListItemIcon>
-                                        <Typography component='span'>
+                                        <ListItemText>
                                             {globalize.translate(imageType.label)}
-                                        </Typography>
+                                        </ListItemText>
                                     </MenuItem>
                                 ))}
                             </MenuList>

--- a/src/apps/experimental/components/library/ViewSettingsButton.tsx
+++ b/src/apps/experimental/components/library/ViewSettingsButton.tsx
@@ -1,21 +1,22 @@
 import { ImageType } from '@jellyfin/sdk/lib/generated-client/models/image-type';
-import React, { FC, useCallback } from 'react';
+import React, { type FC, useCallback, useState } from 'react';
 
 import Check from '@mui/icons-material/Check';
-import MoreVert from '@mui/icons-material/MoreVert';
+import Settings from '@mui/icons-material/Settings';
+import ViewListIcon from '@mui/icons-material/ViewList';
+import ViewModuleIcon from '@mui/icons-material/ViewModule';
 import Button from '@mui/material/Button';
-import Checkbox from '@mui/material/Checkbox';
+import Collapse from '@mui/material/Collapse';
 import Divider from '@mui/material/Divider';
-import FormControl from '@mui/material/FormControl';
 import FormControlLabel from '@mui/material/FormControlLabel';
-import FormGroup from '@mui/material/FormGroup';
-import InputLabel from '@mui/material/InputLabel';
+import IconButton from '@mui/material/IconButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
+import ListSubheader from '@mui/material/ListSubheader';
 import MenuItem from '@mui/material/MenuItem';
 import MenuList from '@mui/material/MenuList';
 import Popover from '@mui/material/Popover';
-import Select, { SelectChangeEvent } from '@mui/material/Select';
+import Switch from '@mui/material/Switch';
 import Typography from '@mui/material/Typography';
 
 import globalize from 'lib/globalize';
@@ -50,7 +51,8 @@ const ViewSettingsButton: FC<ViewSettingsButtonProps> = ({
     libraryViewSettings,
     setLibraryViewSettings
 }) => {
-    const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+    const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+    const [isSettingsOpen, setIsSettingsOpen] = useState(false);
     const open = Boolean(anchorEl);
     const id = open ? 'selectview-popover' : undefined;
 
@@ -60,6 +62,7 @@ const ViewSettingsButton: FC<ViewSettingsButtonProps> = ({
 
     const handleClose = useCallback(() => {
         setAnchorEl(null);
+        setIsSettingsOpen(false);
     }, []);
 
     const handleChange = useCallback(
@@ -79,6 +82,7 @@ const ViewSettingsButton: FC<ViewSettingsButtonProps> = ({
             ...prevState,
             ViewMode: ViewMode.GridView
         }));
+        setIsSettingsOpen(false);
     }, [ setLibraryViewSettings ]);
 
     const onListViewClick = useCallback(() => {
@@ -86,17 +90,20 @@ const ViewSettingsButton: FC<ViewSettingsButtonProps> = ({
             ...prevState,
             ViewMode: ViewMode.ListView
         }));
-    }, [ setLibraryViewSettings ]);
+        setIsSettingsOpen(false);
+    }, [setLibraryViewSettings]);
 
-    const onSelectChange = useCallback(
-        (event: SelectChangeEvent) => {
-            setLibraryViewSettings((prevState) => ({
-                ...prevState,
-                ImageType: event.target.value as ImageType
-            }));
-        },
-        [setLibraryViewSettings]
-    );
+    const onSettingsClick = useCallback((e: React.MouseEvent<HTMLButtonElement>) => {
+        e.stopPropagation();
+        setIsSettingsOpen(prev => !prev);
+    }, []);
+
+    const setImageType = useCallback((imageType: ImageType) => {
+        setLibraryViewSettings((prevState) => ({
+            ...prevState,
+            ImageType: imageType
+        }));
+    }, [setLibraryViewSettings]);
 
     const isGridView = libraryViewSettings.ViewMode === ViewMode.GridView;
     const isImageTypeVisible = !IMAGE_TYPE_EXCLUDED_VIEWS.includes(viewType);
@@ -108,8 +115,9 @@ const ViewSettingsButton: FC<ViewSettingsButtonProps> = ({
                 aria-describedby={id}
                 onClick={handleClick}
             >
-                <MoreVert />
+                {isGridView ? <ViewModuleIcon /> : <ViewListIcon />}
             </Button>
+
             <Popover
                 id={id}
                 open={open}
@@ -128,97 +136,130 @@ const ViewSettingsButton: FC<ViewSettingsButtonProps> = ({
                 }}
             >
                 <MenuList>
-
                     <MenuItem
                         onClick={onGridViewClick}
                     >
-                        {isGridView && (
-                            <ListItemIcon><Check /></ListItemIcon>
-                        )}
-                        <ListItemText inset={!isGridView}>
+                        <ListItemIcon>
+                            {isGridView ? <Check fontSize='small' /> : null}
+                        </ListItemIcon>
+                        <ListItemText>
                             {globalize.translate('GridView')}
                         </ListItemText>
+                        <IconButton
+                            onClick={onSettingsClick}
+                            size='small'
+                            sx={{
+                                ml: 2
+                            }}
+                        >
+                            <Settings fontSize='small' />
+                        </IconButton>
                     </MenuItem>
+
+                    <Collapse
+                        in={isSettingsOpen}
+                        timeout='auto'
+                        unmountOnExit
+                    >
+                        {isImageTypeVisible && (
+                            <MenuList
+                                subheader={
+                                    <ListSubheader
+                                        disableSticky
+                                        sx={{
+                                            lineHeight: '36px'
+                                        }}
+                                    >
+                                        {globalize.translate('LabelImageType')}
+                                    </ListSubheader>
+                                }
+                                dense
+                            >
+                                {imageTypesOptions.map((imageType) => (
+                                    <MenuItem
+                                        key={imageType.value}
+                                        // eslint-disable-next-line react/jsx-no-bind
+                                        onClick={() => setImageType(imageType.value)}
+                                    >
+                                        <ListItemIcon>
+                                            {libraryViewSettings.ImageType === imageType.value && <Check fontSize='small' />}
+                                        </ListItemIcon>
+                                        <Typography component='span'>
+                                            {globalize.translate(imageType.label)}
+                                        </Typography>
+                                    </MenuItem>
+                                ))}
+                            </MenuList>
+                        )}
+
+                        <MenuList
+                            subheader={
+                                <ListSubheader
+                                    disableSticky
+                                    sx={{
+                                        lineHeight: '36px'
+                                    }}
+                                >
+                                    {globalize.translate('CardSettings')}
+                                </ListSubheader>
+                            }
+                            dense
+                        >
+                            <MenuItem>
+                                <FormControlLabel
+                                    control={
+                                        <Switch
+                                            size='small'
+                                            checked={libraryViewSettings.ShowTitle}
+                                            onChange={handleChange}
+                                            name='ShowTitle'
+                                        />
+                                    }
+                                    label={globalize.translate('ShowTitle')}
+                                />
+                            </MenuItem>
+                            {isImageTypeVisible && (
+                                <MenuItem>
+                                    <FormControlLabel
+                                        control={
+                                            <Switch
+                                                size='small'
+                                                checked={libraryViewSettings.ShowYear}
+                                                onChange={handleChange}
+                                                name='ShowYear'
+                                            />
+                                        }
+                                        label={globalize.translate('ShowYear')}
+                                    />
+                                </MenuItem>
+                            )}
+                            <MenuItem>
+                                <FormControlLabel
+                                    control={
+                                        <Switch
+                                            size='small'
+                                            checked={libraryViewSettings.CardLayout}
+                                            onChange={handleChange}
+                                            name='CardLayout'
+                                        />
+                                    }
+                                    label={globalize.translate('EnableCardLayout')}
+                                />
+                            </MenuItem>
+                        </MenuList>
+                        <Divider />
+                    </Collapse>
+
                     <MenuItem
                         onClick={onListViewClick}
                     >
-                        {!isGridView && (
-                            <ListItemIcon><Check /></ListItemIcon>
-                        )}
-                        <ListItemText inset={isGridView}>
+                        <ListItemIcon>
+                            {isGridView ? null : <Check fontSize='small' />}
+                        </ListItemIcon>
+                        <ListItemText>
                             {globalize.translate('ListView')}
                         </ListItemText>
                     </MenuItem>
-
-                    {isGridView && (
-                        <>
-                            <Divider />
-                            {isImageTypeVisible && (
-                                <>
-                                    <FormControl>
-                                        <InputLabel>
-                                            <Typography component='span'>
-                                                {globalize.translate('LabelImageType')}
-                                            </Typography>
-                                        </InputLabel>
-                                        <Select
-                                            value={libraryViewSettings.ImageType}
-                                            label={globalize.translate('LabelImageType')}
-                                            onChange={onSelectChange}
-                                        >
-                                            {imageTypesOptions.map((imageType) => (
-                                                <MenuItem
-                                                    key={imageType.value}
-                                                    value={imageType.value}
-                                                >
-                                                    <Typography component='span'>
-                                                        {globalize.translate(imageType.label)}
-                                                    </Typography>
-                                                </MenuItem>
-                                            ))}
-                                        </Select>
-                                    </FormControl>
-                                    <Divider />
-                                </>
-                            )}
-                            <FormControl>
-                                <FormGroup>
-                                    <FormControlLabel
-                                        control={
-                                            <Checkbox
-                                                checked={libraryViewSettings.ShowTitle}
-                                                onChange={handleChange}
-                                                name='ShowTitle'
-                                            />
-                                        }
-                                        label={globalize.translate('ShowTitle')}
-                                    />
-                                    {isImageTypeVisible && (
-                                        <FormControlLabel
-                                            control={
-                                                <Checkbox
-                                                    checked={libraryViewSettings.ShowYear}
-                                                    onChange={handleChange}
-                                                    name='ShowYear'
-                                                />
-                                            }
-                                            label={globalize.translate('ShowYear')}
-                                        />
-                                    )}
-                                    <FormControlLabel
-                                        control={
-                                            <Checkbox
-                                                checked={libraryViewSettings.CardLayout}
-                                                onChange={handleChange}
-                                                name='CardLayout'
-                                            />
-                                        }
-                                        label={globalize.translate('EnableCardLayout')}
-                                    />
-                                </FormGroup>
-                            </FormControl>
-                        </>
-                    )}
                 </MenuList>
             </Popover>
         </>

--- a/src/hooks/useUserSettings.tsx
+++ b/src/hooks/useUserSettings.tsx
@@ -13,6 +13,8 @@ interface UserSettings {
     dashboardTheme?: string
     dateTimeLocale?: string
     language?: string
+    /** The number of items to display per page in the library */
+    libraryPageSize: number
 }
 
 // NOTE: This is an incomplete list of only the settings that are currently being used
@@ -25,11 +27,16 @@ const UserSettingField = {
     DashboardTheme: 'dashboardTheme',
     // Locale settings
     DateTimeLocale: 'datetimelocale',
-    Language: 'language'
+    Language: 'language',
+    // Library settings
+    LibraryPageSize: 'libraryPageSize'
 };
 
+const DEFAULT_LIBRARY_PAGE_SIZE = 100;
+
 const UserSettingsContext = createContext<UserSettings>({
-    disableCustomCss: false
+    disableCustomCss: false,
+    libraryPageSize: DEFAULT_LIBRARY_PAGE_SIZE
 });
 
 export const useUserSettings = () => useContext(UserSettingsContext);
@@ -41,6 +48,7 @@ export const UserSettingsProvider: FC<PropsWithChildren<unknown>> = ({ children 
     const [ dashboardTheme, setDashboardTheme ] = useState<string>();
     const [ dateTimeLocale, setDateTimeLocale ] = useState<string>();
     const [ language, setLanguage ] = useState<string | undefined>(FALLBACK_CULTURE);
+    const [ libraryPageSize, setLibraryPageSize ] = useState<number>(DEFAULT_LIBRARY_PAGE_SIZE);
 
     const { user } = useApi();
 
@@ -50,14 +58,16 @@ export const UserSettingsProvider: FC<PropsWithChildren<unknown>> = ({ children 
         theme,
         dashboardTheme,
         dateTimeLocale,
-        locale: language
+        locale: language,
+        libraryPageSize
     }), [
         customCss,
         disableCustomCss,
         theme,
         dashboardTheme,
         dateTimeLocale,
-        language
+        language,
+        libraryPageSize
     ]);
 
     // Update the values of the user settings
@@ -68,6 +78,7 @@ export const UserSettingsProvider: FC<PropsWithChildren<unknown>> = ({ children 
         setDashboardTheme(userSettings.dashboardTheme());
         setDateTimeLocale(userSettings.dateTimeLocale());
         setLanguage(userSettings.language());
+        setLibraryPageSize(userSettings.libraryPageSize() ?? DEFAULT_LIBRARY_PAGE_SIZE);
     }, []);
 
     const onUserSettingsChange = useCallback((_e: Event, name?: string) => {

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -155,6 +155,7 @@
     "Bwdif": "Bob Weaver DeInterlacing Filter (BWDIF)",
     "CancelRecording": "Cancel recording",
     "CancelSeries": "Cancel series",
+    "CardSettings": "Card settings",
     "Casual": "Casual",
     "Categories": "Categories",
     "ChangingMetadataImageSettingsNewContent": "Changes to metadata or artwork downloading settings will only apply to new content added to your library. To apply the changes to existing titles, you'll need to refresh their metadata manually.",


### PR DESCRIPTION
### Changes
* Increase the size of the library view selector
* Update pagination icons
* Redesign sort and view setting menus
* Update layout of buttons
* Use chip for item counts

<img width="1229" height="64" alt="Screenshot 2026-05-15 at 17-37-11 Jellyfin Edge" src="https://github.com/user-attachments/assets/c7be7cb8-592c-4850-a4b4-ea3c822016cb" />
<img width="235" height="478" alt="Screenshot 2026-05-15 at 17-49-01 Jellyfin Edge" src="https://github.com/user-attachments/assets/4dfb8dca-f75c-4dba-a266-3d65c042b8d2" />
<img width="199" height="403" alt="Screenshot 2026-05-15 at 17-49-14 Jellyfin Edge" src="https://github.com/user-attachments/assets/8900a7b1-102d-4ab9-bc50-5332c2080aa0" />


### Issues
N/A

### Code assistance
Zed autocomplete

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
