### PR TITLE
fix cardImage data-src set to "undefined"

### DIFF
--- a/src/components/cardbuilder/cardImage.ts
+++ b/src/components/cardbuilder/cardImage.ts
@@ -66,7 +66,7 @@ export function buildCardImage(
             <div
                 class="cardImageContainer coveredImage cardContent lazy"
                 style="cursor: default;"
-                data-src="${imgUrl}"
+                data-src="${imgUrl || ''}"
                 ${blurhashAttrib}
             ></div>
         </div>


### PR DESCRIPTION
### Changes
Prevents making a request to `/undefined` when fetching the image via the attribute.

### Issues
<!--
Tag any issues that this PR solves here.
ex. Fixes #
-->

### Code assistance
<!--
If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance.
-->

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
