### PR TITLE
Fix display of 0 (zero) ratings.

### DIFF
--- a/src/components/mediainfo/PrimaryMediaInfo.tsx
+++ b/src/components/mediainfo/PrimaryMediaInfo.tsx
@@ -86,7 +86,7 @@ const PrimaryMediaInfo: FC<PrimaryMediaInfoProps> = ({
         <Box className={cssClass}>
             {miscInfo.map((info, index) => renderMediaInfo(info, index))}
 
-            {showStarRatingInfo && CommunityRating && (
+            {showStarRatingInfo && CommunityRating != null && (
                 <StarIcons
                     className={infoclass}
                     communityRating={CommunityRating}
@@ -97,7 +97,7 @@ const PrimaryMediaInfo: FC<PrimaryMediaInfoProps> = ({
                 <CaptionMediaInfo className={infoclass} />
             )}
 
-            {showCriticRatingInfo && CriticRating && (
+            {showCriticRatingInfo && CriticRating != null && (
                 <CriticRatingMediaInfo
                     className={infoclass}
                     criticRating={CriticRating}


### PR DESCRIPTION
While not common, it is possible for media to get a 0 rating. This should still be shown to the user but 0 is falsy, so it remained hidden.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

### Changes
Check if ratings are not null instead of a simple truthy check on the ratings value.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
