### PR TITLE
fix: prevent screensaver from activating during photo browsing

### DIFF
--- a/src/scripts/screensavermanager.js
+++ b/src/scripts/screensavermanager.js
@@ -23,7 +23,7 @@ function getFunctionalEventIdleTime() {
 
 Events.on(playbackManager, 'playbackstop', function (_e, stopInfo) {
     const state = stopInfo.state;
-    if (state.NowPlayingItem && state.NowPlayingItem.MediaType == 'Video') {
+    if (state.NowPlayingItem) {
         lastFunctionalEvent = new Date().getTime();
     }
 });
@@ -123,7 +123,8 @@ function ScreenSaverManager() {
             return;
         }
 
-        if (playbackManager.isPlayingVideo() && !playbackManager.paused()) {
+        if (playbackManager.isPlayingVideo() && !playbackManager.paused()
+                || playbackManager.isPlayingMediaType('Photo')) {
             return;
         }
 


### PR DESCRIPTION
## Summary

Hey! I ran into the screensaver popping up while I was browsing through my photo library, which was pretty annoying. After digging into `screensavermanager.js` I found the root cause — the screensaver idle tracking was only considering video playback, so photo browsing was essentially invisible to it.

This PR fixes it with two small changes:

Resolves #7873

## What's Changed

### 1. Broadened the `playbackstop` handler (line 26)

The handler was only resetting `lastFunctionalEvent` when a **Video** stopped playing. Now it resets for any media type, so when a photo slideshow ends, the screensaver timer gets properly pushed back.

```diff
- if (state.NowPlayingItem && state.NowPlayingItem.MediaType == 'Video') {
+ if (state.NowPlayingItem) {
```

### 2. Added photo playback check to the interval guard (line 126-127)

The interval function that decides when to show the screensaver only checked `isPlayingVideo()`. Added a check for `isPlayingMediaType('Photo')` so the screensaver stays hidden during active photo browsing. The photo player/slideshow doesn't have a "paused" concept, so we just check if it's active.

```diff
- if (playbackManager.isPlayingVideo() && !playbackManager.paused()) {
+ if (playbackManager.isPlayingVideo() && !playbackManager.paused()
+         || playbackManager.isPlayingMediaType('Photo')) {
```

## Testing Notes

- Photo browsing should no longer trigger the screensaver
- Video playback behavior is unchanged (the video path still works the same)
- Normal idle screensaver still activates when nothing is playing

Let me know if anything needs adjusting!
