### PR TITLE
Don't suppress up-next prompt when the OSD is visible

### DIFF
--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -656,7 +656,10 @@ export default function (view) {
     }
 
     function showComingUpNextIfNeeded(player, currentItem, currentTimeTicks, runtimeTicks) {
-        if (runtimeTicks && currentTimeTicks && !comingUpNextDisplayed && !currentVisibleMenu && currentItem.Type === 'Episode' && userSettings.enableNextVideoInfoOverlay()) {
+        // The auto-shown OSD sets currentVisibleMenu='osd'; treat it as
+        // non-blocking so a hovering pointer doesn't suppress the prompt.
+        const blockingMenu = currentVisibleMenu && currentVisibleMenu !== 'osd';
+        if (runtimeTicks && currentTimeTicks && !comingUpNextDisplayed && !blockingMenu && currentItem.Type === 'Episode' && userSettings.enableNextVideoInfoOverlay()) {
             let showAtSecondsLeft = 30;
             if (runtimeTicks >= 50 * TICKS_PER_MINUTE) {
                 showAtSecondsLeft = 40;
@@ -680,8 +683,11 @@ export default function (view) {
 
     function showComingUpNext(player) {
         import('../../../components/upnextdialog/upnextdialog').then(({ default: UpNextDialog }) => {
-            if (!(currentVisibleMenu || currentUpNextDialog)) {
-                currentVisibleMenu = 'upnext';
+            const blockingMenu = currentVisibleMenu && currentVisibleMenu !== 'osd';
+            if (!blockingMenu && !currentUpNextDialog) {
+                // Preserve currentVisibleMenu='osd' so the OSD's hide timer
+                // can still tear itself down via hideMainOsdControls.
+                if (!currentVisibleMenu) currentVisibleMenu = 'upnext';
                 comingUpNextDisplayed = true;
                 playbackManager.nextItem(player).then(function (nextItem) {
                     currentUpNextDialog = new UpNextDialog({


### PR DESCRIPTION
## Summary

The end-of-episode \"Up Next\" prompt is silently suppressed whenever the user's pointer is active.

\`showComingUpNextIfNeeded()\` and \`showComingUpNext()\` (\`src/controllers/playback/video/index.js\`) both gate on \`!currentVisibleMenu\`. But that same flag is set to \`'osd'\` whenever the on-screen controls are visible (\`showMainOsdControls\`, line ~343). So any pointer movement during the last ~30s of an episode triggers \`showOsd()\` → sets \`currentVisibleMenu = 'osd'\` → the prompt's gate fails → no prompt.

Net effect: the user only sees the prompt if their cursor happens to be perfectly idle at the right moment.

## Fix

Treat the auto-shown OSD as non-blocking so the prompt overlays it (matching Netflix/Plex/YouTube). Real menus (audio, subs, settings) still suppress it. \`currentVisibleMenu\` is left as \`'osd'\` when the prompt opens on top so \`hideMainOsdControls\`' tear-down path still runs once the OSD hide timer fires.

## Test plan

- [ ] Hover the player during the last 30s of an episode → up-next prompt appears
- [ ] Move pointer once it's visible — OSD shows/hides on its 3s timer as before
- [ ] Open a real menu (audio/subs/settings) near end of episode → prompt does NOT appear, as expected