### PR TITLE
Handle SetPlaybackRate command and expose it from sessionPlayer

### DIFF
--- a/src/plugins/sessionPlayer/plugin.js
+++ b/src/plugins/sessionPlayer/plugin.js
@@ -513,6 +513,12 @@ class SessionPlayer {
         return state.AudioStreamIndex;
     }
 
+    getPlaybackRate() {
+        let state = this.lastPlayerData || {};
+        state = state.PlayState || {};
+        return state.PlaybackRate;
+    }
+
     playTrailers(item) {
         sendCommandByName(this, 'PlayTrailers', {
             ItemId: item.Id

--- a/src/scripts/serverNotifications.js
+++ b/src/scripts/serverNotifications.js
@@ -105,6 +105,10 @@ function processGeneralCommand(cmd, apiClient) {
             notifyApp();
             playbackManager.setSubtitleStreamIndex(parseInt(cmd.Arguments.Index, 10));
             break;
+        case 'SetPlaybackRate':
+            notifyApp();
+            playbackManager.setPlaybackRate(parseFloat(cmd.Arguments.PlaybackRate));
+            break;
         case 'ToggleFullscreen':
             inputManager.handleCommand('togglefullscreen');
             return;


### PR DESCRIPTION
### Changes
- Added `SetPlaybackRate` command to change the PlaybackRate-

### Code assistance
Claude Code was used to find where the changes should be added.

### Related branches/PRs
- https://github.com/AirplanegoBrr/jellyfin/tree/feat/playback-speed-session-state
- https://github.com/jellyfin/jellyfin/pull/16875

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
