### PR TITLE
Add Collections and playlist tab to all libraries

### DIFF
--- a/src/apps/experimental/features/libraries/constants/libraryRoutes.ts
+++ b/src/apps/experimental/features/libraries/constants/libraryRoutes.ts
@@ -124,6 +124,11 @@ export const LibraryRoutes: LibraryRoute[] = [
                 index: 4,
                 label: 'Genres',
                 view: LibraryTab.Genres
+            },
+            {
+                index: 5,
+                label: 'Playlists',
+                view: LibraryTab.Playlists
             }
         ]
     },
@@ -206,6 +211,11 @@ export const LibraryRoutes: LibraryRoute[] = [
                 index: 6,
                 label: 'Collections',
                 view: LibraryTab.Collections
+            },
+            {
+                index: 7,
+                label: 'Playlists',
+                view: LibraryTab.Playlists
             }
         ]
     },

--- a/src/apps/experimental/features/libraries/constants/libraryRoutes.ts
+++ b/src/apps/experimental/features/libraries/constants/libraryRoutes.ts
@@ -201,6 +201,11 @@ export const LibraryRoutes: LibraryRoute[] = [
                 index: 5,
                 label: 'Episodes',
                 view: LibraryTab.Episodes
+            },
+            {
+                index: 6,
+                label: 'Collections',
+                view: LibraryTab.Collections
             }
         ]
     },

--- a/src/apps/experimental/features/libraries/constants/libraryRoutes.ts
+++ b/src/apps/experimental/features/libraries/constants/libraryRoutes.ts
@@ -170,6 +170,11 @@ export const LibraryRoutes: LibraryRoute[] = [
                 index: 6,
                 label: 'Genres',
                 view: LibraryTab.Genres
+            },
+            {
+                index: 7,
+                label: 'Collections',
+                view: LibraryTab.Collections
             }
         ]
     },
@@ -263,6 +268,11 @@ export const LibraryRoutes: LibraryRoute[] = [
                 index: 2,
                 label: 'HeaderVideos',
                 view: LibraryTab.MusicVideos
+            },
+            {
+                index: 3,
+                label: 'Playlists',
+                view: LibraryTab.Playlists
             }
         ]
     },
@@ -300,6 +310,16 @@ export const LibraryRoutes: LibraryRoute[] = [
                 index: 2,
                 label: 'HeaderMedia',
                 view: LibraryTab.Mixed
+            },
+            {
+                index: 3,
+                label: 'Collections',
+                view: LibraryTab.Collections
+            },
+            {
+                index: 4,
+                label: 'Playlists',
+                view: LibraryTab.Playlists
             }
         ]
     }

--- a/src/apps/experimental/routes/mixed/index.tsx
+++ b/src/apps/experimental/routes/mixed/index.tsx
@@ -29,10 +29,29 @@ const mixedTabContent: LibraryTabContent = {
     itemType: [BaseItemKind.Movie, BaseItemKind.Series]
 };
 
+const collectionsTabContent: LibraryTabContent = {
+    viewType: LibraryTab.Collections,
+    collectionType: null,
+    isBtnNewCollectionEnabled: true,
+    itemType: [BaseItemKind.BoxSet],
+    noItemsMessage: 'MessageNoCollectionsAvailable'
+};
+
+const playlistsTabContent: LibraryTabContent = {
+    viewType: LibraryTab.Playlists,
+    isBtnFilterEnabled: false,
+    isBtnGridListEnabled: false,
+    isBtnNewPlaylistEnabled: true,
+    isAlphabetPickerEnabled: false,
+    itemType: [BaseItemKind.Playlist]
+};
+
 const mixedTabMapping: LibraryTabMapping = {
     0: foldersTabContent,
     1: suggestionsTabContent,
-    2: mixedTabContent
+    2: mixedTabContent,
+    3: collectionsTabContent,
+    4: playlistsTabContent
 };
 
 const Mixed: FC = () => {

--- a/src/apps/experimental/routes/movies/index.tsx
+++ b/src/apps/experimental/routes/movies/index.tsx
@@ -42,12 +42,22 @@ const genresTabContent: LibraryTabContent = {
     itemType: [BaseItemKind.Movie]
 };
 
+const playlistsTabContent: LibraryTabContent = {
+    viewType: LibraryTab.Playlists,
+    isBtnFilterEnabled: false,
+    isBtnGridListEnabled: false,
+    isBtnNewPlaylistEnabled: true,
+    isAlphabetPickerEnabled: false,
+    itemType: [BaseItemKind.Playlist]
+};
+
 const moviesTabMapping: LibraryTabMapping = {
     0: moviesTabContent,
     1: suggestionsTabContent,
     2: favoritesTabContent,
     3: collectionsTabContent,
-    4: genresTabContent
+    4: genresTabContent,
+    5: playlistsTabContent
 };
 
 const Movies: FC = () => {

--- a/src/apps/experimental/routes/music/index.tsx
+++ b/src/apps/experimental/routes/music/index.tsx
@@ -80,10 +80,7 @@ const Music: FC = () => {
             <PageTabContent
                 key={`${currentTab.viewType} - ${libraryId}`}
                 currentTab={currentTab}
-                parentId={
-                    // Playlists exist outside of the scope of the library
-                    currentTab.viewType === LibraryTab.Playlists ? undefined : libraryId
-                }
+                parentId={libraryId}
             />
         </Page>
     );

--- a/src/apps/experimental/routes/music/index.tsx
+++ b/src/apps/experimental/routes/music/index.tsx
@@ -57,6 +57,14 @@ const genresTabContent: LibraryTabContent = {
     itemType: [BaseItemKind.MusicAlbum]
 };
 
+const collectionsTabContent: LibraryTabContent = {
+    viewType: LibraryTab.Collections,
+    collectionType: CollectionType.Music,
+    isBtnNewCollectionEnabled: true,
+    itemType: [BaseItemKind.BoxSet],
+    noItemsMessage: 'MessageNoCollectionsAvailable'
+};
+
 const musicTabMapping: LibraryTabMapping = {
     0: albumsTabContent,
     1: suggestionsTabContent,
@@ -64,7 +72,8 @@ const musicTabMapping: LibraryTabMapping = {
     3: artistsTabContent,
     4: playlistsTabContent,
     5: songsTabContent,
-    6: genresTabContent
+    6: genresTabContent,
+    7: collectionsTabContent
 };
 
 const Music: FC = () => {

--- a/src/apps/experimental/routes/musicvideos/index.tsx
+++ b/src/apps/experimental/routes/musicvideos/index.tsx
@@ -30,10 +30,20 @@ const musicVideosTabContent: LibraryTabContent = {
     itemType: [BaseItemKind.MusicVideo]
 };
 
+const playlistsTabContent: LibraryTabContent = {
+    viewType: LibraryTab.Playlists,
+    isBtnFilterEnabled: false,
+    isBtnGridListEnabled: false,
+    isBtnNewPlaylistEnabled: true,
+    isAlphabetPickerEnabled: false,
+    itemType: [BaseItemKind.Playlist]
+};
+
 const musicVideosTabMapping: LibraryTabMapping = {
     0: foldersTabContent,
     1: suggestionsTabContent,
-    2: musicVideosTabContent
+    2: musicVideosTabContent,
+    3: playlistsTabContent
 };
 
 const MusicVideos: FC = () => {

--- a/src/apps/experimental/routes/shows/index.tsx
+++ b/src/apps/experimental/routes/shows/index.tsx
@@ -56,6 +56,15 @@ const collectionsTabContent: LibraryTabContent = {
     noItemsMessage: 'MessageNoCollectionsAvailable'
 };
 
+const playlistsTabContent: LibraryTabContent = {
+    viewType: LibraryTab.Playlists,
+    isBtnFilterEnabled: false,
+    isBtnGridListEnabled: false,
+    isBtnNewPlaylistEnabled: true,
+    isAlphabetPickerEnabled: false,
+    itemType: [BaseItemKind.Playlist]
+};
+
 const tvShowsTabMapping: LibraryTabMapping = {
     0: seriesTabContent,
     1: suggestionsTabContent,
@@ -63,7 +72,8 @@ const tvShowsTabMapping: LibraryTabMapping = {
     3: genresTabContent,
     4: networksTabContent,
     5: episodesTabContent,
-    6: collectionsTabContent
+    6: collectionsTabContent,
+    7: playlistsTabContent
 };
 
 const Shows: FC = () => {

--- a/src/apps/experimental/routes/shows/index.tsx
+++ b/src/apps/experimental/routes/shows/index.tsx
@@ -48,13 +48,22 @@ const genresTabContent: LibraryTabContent = {
     collectionType: CollectionType.Tvshows
 };
 
+const collectionsTabContent: LibraryTabContent = {
+    viewType: LibraryTab.Collections,
+    collectionType: CollectionType.Tvshows,
+    isBtnNewCollectionEnabled: true,
+    itemType: [BaseItemKind.BoxSet],
+    noItemsMessage: 'MessageNoCollectionsAvailable'
+};
+
 const tvShowsTabMapping: LibraryTabMapping = {
     0: seriesTabContent,
     1: suggestionsTabContent,
     2: upcomingTabContent,
     3: genresTabContent,
     4: networksTabContent,
-    5: episodesTabContent
+    5: episodesTabContent,
+    6: collectionsTabContent
 };
 
 const Shows: FC = () => {

--- a/src/components/homeScreenSettings/homeScreenSettings.js
+++ b/src/components/homeScreenSettings/homeScreenSettings.js
@@ -73,6 +73,10 @@ function getLandingScreenOptions(type) {
             {
                 name: globalize.translate('Genres'),
                 value: LibraryTab.Genres
+            },
+            {
+                name: globalize.translate('Playlists'),
+                value: LibraryTab.Playlists
             }
         );
     } else if (type === 'tvshows') {
@@ -101,6 +105,14 @@ function getLandingScreenOptions(type) {
             {
                 name: globalize.translate('Episodes'),
                 value: LibraryTab.Episodes
+            },
+            {
+                name: globalize.translate('Collections'),
+                value: LibraryTab.Collections
+            },
+            {
+                name: globalize.translate('Playlists'),
+                value: LibraryTab.Playlists
             }
         );
     } else if (type === 'music') {

--- a/src/components/homeScreenSettings/homeScreenSettings.js
+++ b/src/components/homeScreenSettings/homeScreenSettings.js
@@ -67,12 +67,12 @@ function getLandingScreenOptions(type) {
                 value: LibraryTab.Favorites
             },
             {
-                name: globalize.translate('Collections'),
-                value: LibraryTab.Collections
-            },
-            {
                 name: globalize.translate('Genres'),
                 value: LibraryTab.Genres
+            },
+            {
+                name: globalize.translate('Collections'),
+                value: LibraryTab.Collections
             },
             {
                 name: globalize.translate('Playlists'),
@@ -95,16 +95,16 @@ function getLandingScreenOptions(type) {
                 value: LibraryTab.Upcoming
             },
             {
-                name: globalize.translate('Genres'),
-                value: LibraryTab.Genres
-            },
-            {
                 name: globalize.translate('TabNetworks'),
                 value: LibraryTab.Networks
             },
             {
                 name: globalize.translate('Episodes'),
                 value: LibraryTab.Episodes
+            },
+            {
+                name: globalize.translate('Genres'),
+                value: LibraryTab.Genres
             },
             {
                 name: globalize.translate('Collections'),
@@ -135,16 +135,20 @@ function getLandingScreenOptions(type) {
                 value: LibraryTab.Artists
             },
             {
-                name: globalize.translate('Playlists'),
-                value: LibraryTab.Playlists
-            },
-            {
                 name: globalize.translate('Songs'),
                 value: LibraryTab.Songs
             },
             {
                 name: globalize.translate('Genres'),
                 value: LibraryTab.Genres
+            },
+            {
+                name: globalize.translate('Collections'),
+                value: LibraryTab.Collections
+            },
+            {
+                name: globalize.translate('Playlists'),
+                value: LibraryTab.Playlists
             }
         );
     } else if (type === 'livetv') {
@@ -209,6 +213,10 @@ function getLandingScreenOptions(type) {
             {
                 name: globalize.translate('HeaderVideos'),
                 value: LibraryTab.MusicVideos
+            },
+            {
+                name: globalize.translate('Playlists'),
+                value: LibraryTab.Playlists
             }
         );
     } else if (type === 'mixed') {
@@ -225,6 +233,14 @@ function getLandingScreenOptions(type) {
             {
                 name: globalize.translate('HeaderMedia'),
                 value: LibraryTab.Mixed
+            },
+            {
+                name: globalize.translate('Collections'),
+                value: LibraryTab.Collections
+            },
+            {
+                name: globalize.translate('Playlists'),
+                value: LibraryTab.Playlists
             }
         );
     }


### PR DESCRIPTION
Needs jellyfin/jellyfin#16882 and jellyfin/jellyfin/pull/16893 so the query correctly filters

### Changes
Adds the collection and playlist tabs to all library types

### Issues
Collections and Playlists are either global or only on movies right now, I don't see a reason why it should not also be there on the other library types because we can add any item type to both of them.

### Code assistance
None

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
