### PR TITLE
Encode auth params when creating ApiClients

### DIFF
--- a/src/lib/jellyfin-apiclient/ServerConnections.js
+++ b/src/lib/jellyfin-apiclient/ServerConnections.js
@@ -1,14 +1,15 @@
-import { Credentials, ApiClient } from 'jellyfin-apiclient';
+import { Credentials } from 'jellyfin-apiclient';
 
 import { appHost } from 'components/apphost';
 import appSettings from 'scripts/settings/appSettings';
 import { setUserInfo } from 'scripts/settings/userSettings';
+import { detectBitrate } from 'utils/bitrateTest';
 import Dashboard from 'utils/dashboard';
-import Events from 'utils/events.ts';
+import Events from 'utils/events';
 import { toApi } from 'utils/jellyfin-apiclient/compat';
+import { createApiClient } from 'utils/jellyfin-apiclient/createApiClient';
 
 import ConnectionManager from './connectionManager';
-import { detectBitrate } from 'utils/bitrateTest';
 
 const normalizeImageOptions = options => {
     if (!options.quality && (options.maxWidth || options.width || options.maxHeight || options.height || options.fillWidth || options.fillHeight)) {
@@ -57,7 +58,7 @@ class ServerConnections extends ConnectionManager {
     initApiClient(server) {
         console.debug('creating ApiClient singleton');
 
-        const apiClient = new ApiClient(
+        const apiClient = createApiClient(
             server,
             appHost.appName(),
             appHost.appVersion(),
@@ -98,7 +99,7 @@ class ServerConnections extends ConnectionManager {
 
     /**
      * Gets the ApiClient that is currently connected.
-     * @returns {ApiClient|undefined} apiClient
+     * @returns {import('jellyfin-apiclient').ApiClient|undefined} apiClient
      */
     currentApiClient() {
         let apiClient = this.getLocalApiClient();

--- a/src/lib/jellyfin-apiclient/connectionManager.js
+++ b/src/lib/jellyfin-apiclient/connectionManager.js
@@ -1,7 +1,6 @@
 import { AUTHORIZATION_HEADER } from '@jellyfin/sdk/lib/constants';
 import { getAuthorizationHeader } from '@jellyfin/sdk/lib/utils';
 import { MINIMUM_VERSION } from '@jellyfin/sdk/lib/versions';
-import { ApiClient } from 'jellyfin-apiclient';
 
 import events from 'utils/events';
 import { ajax } from 'utils/fetch';
@@ -756,7 +755,7 @@ export default class ConnectionManager {
     /**
      * Gets the ApiClient for a given BaseItem or ServerId.
      * @param {import('@jellyfin/sdk/lib/generated-client').BaseItemDto | string | undefined} item
-     * @returns {ApiClient}
+     * @returns {import('jellyfin-apiclient').ApiClient}
      */
     getApiClient(item) {
         if (!item) {

--- a/src/lib/jellyfin-apiclient/connectionManager.js
+++ b/src/lib/jellyfin-apiclient/connectionManager.js
@@ -5,6 +5,7 @@ import { ApiClient } from 'jellyfin-apiclient';
 
 import events from 'utils/events';
 import { ajax } from 'utils/fetch';
+import { createApiClient } from 'utils/jellyfin-apiclient/createApiClient';
 import { equalsIgnoreCase } from 'utils/string';
 import { compareVersions } from 'utils/versions';
 
@@ -137,7 +138,7 @@ export default class ConnectionManager {
             let apiClient = self.getApiClient(server.Id);
 
             if (!apiClient) {
-                apiClient = new ApiClient(serverUrl, appName, appVersion, deviceName, deviceId);
+                apiClient = createApiClient(serverUrl, appName, appVersion, deviceName, deviceId);
 
                 self._apiClients.push(apiClient);
 

--- a/src/utils/jellyfin-apiclient/compat.ts
+++ b/src/utils/jellyfin-apiclient/compat.ts
@@ -1,6 +1,8 @@
 import { Api, Jellyfin } from '@jellyfin/sdk';
 import { ApiClient } from 'jellyfin-apiclient';
 
+import { safeDecodeURIComponent } from 'utils/url';
+
 /**
  * Returns an SDK Api instance using the same parameters as the provided ApiClient.
  * @param {ApiClient} apiClient The (legacy) ApiClient.
@@ -8,13 +10,15 @@ import { ApiClient } from 'jellyfin-apiclient';
  */
 export const toApi = (apiClient: ApiClient): Api => {
     return (new Jellyfin({
+        // The SDK encodes these values when creating the authorization header,
+        // so we need to decode them here to avoid double encoding.
         clientInfo: {
-            name: apiClient.appName(),
-            version: apiClient.appVersion()
+            name: safeDecodeURIComponent(apiClient.appName()),
+            version: safeDecodeURIComponent(apiClient.appVersion())
         },
         deviceInfo: {
-            name: apiClient.deviceName(),
-            id: apiClient.deviceId()
+            name: safeDecodeURIComponent(apiClient.deviceName()),
+            id: safeDecodeURIComponent(apiClient.deviceId())
         }
     })).createApi(
         apiClient.serverAddress(),

--- a/src/utils/jellyfin-apiclient/createApiClient.ts
+++ b/src/utils/jellyfin-apiclient/createApiClient.ts
@@ -1,0 +1,27 @@
+import { ApiClient } from 'jellyfin-apiclient';
+
+import { safeDecodeURIComponent } from 'utils/url';
+
+/**
+ * Encodes a value for use as a parameter when creating the ApiClient.
+ * Ensuring that it is properly decoded before encoding to avoid double-encoding issues.
+ * (In case a webview passes an already encoded value for example.)
+ */
+const encodeParam = (value: string) => encodeURIComponent(safeDecodeURIComponent(value));
+
+/** Creates a new ApiClient instance with the provided parameters, encoding them as needed. */
+export function createApiClient(
+    serverUrl: string,
+    appName: string,
+    appVersion: string,
+    deviceName: string,
+    deviceId: string
+) {
+    return new ApiClient(
+        serverUrl,
+        encodeParam(appName),
+        encodeParam(appVersion),
+        encodeParam(deviceName),
+        encodeParam(deviceId)
+    );
+}

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { getLocationSearch } from './url';
+import { getLocationSearch, safeDecodeURIComponent } from './url';
 
 const mockLocation = (urlString: string) => {
     const url = new URL(urlString);
@@ -55,5 +55,15 @@ describe('getLocationSearch', () => {
                 search: ''
             });
         expect(getLocationSearch()).toBe('?foo');
+    });
+});
+
+describe('safeDecodeURIComponent', () => {
+    it('Should decode a properly encoded URI component', () => {
+        expect(safeDecodeURIComponent(encodeURIComponent('Hello, World!'))).toBe('Hello, World!');
+    });
+
+    it('Should return the original value if decoding fails', () => {
+        expect(safeDecodeURIComponent('Hello, World!%')).toBe('Hello, World!%');
     });
 });

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -38,3 +38,18 @@ export const getParameterByName = (name: string, url?: string | null | undefined
 
     return new URLSearchParams(url).get(name) || '';
 };
+
+/**
+ * Safely decodes a URI component, returning the original value if decoding fails.
+ * This is useful for handling cases where the value may or may not be encoded.
+ * @param value The value to decode.
+ * @returns The decoded value.
+ */
+export const safeDecodeURIComponent = (value: string) => {
+    try {
+        return decodeURIComponent(value);
+    } catch {
+        // If decoding fails, return the original value, this can happen for values that are not encoded.
+        return value;
+    }
+};


### PR DESCRIPTION
### Changes
Fixes our handling of client and device details to ensure they are properly encoded in the legacy ApiClient and not double encoded in the TS SDK Api

### Issues
Fixes https://github.com/jellyfin/jellyfin-web/issues/7930

### Code assistance
Zed autocomplete

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
