### PR TITLE
Fix image upload spinner on failure

### DIFF
--- a/src/components/imageUploader/imageUploader.js
+++ b/src/components/imageUploader/imageUploader.js
@@ -109,6 +109,9 @@ function onSubmit(e) {
         loading.hide();
         hasChanges = true;
         dialogHelper.close(dlg);
+    }).catch(() => {
+        loading.hide();
+        toast(globalize.translate('ImageUploadFailed'));
     });
 
     e.preventDefault();


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

### Changes
<!--
Describe your changes here in 1-5 sentences.
Please include before/after screenshots of any UI changes.
-->
This change handles the image upload failure path. When an image upload fails, it will now hide the loading spinner and shows the existing image upload failure message instead of leaving the upload dialog in a loading state. The successful upload path is unchanged.


Before:
<img width="2554" height="1271" alt="image" src="https://github.com/user-attachments/assets/49ce9ed4-5eb7-4676-a4e4-3c16eb543d29" />

After:
<img width="2552" height="1275" alt="image" src="https://github.com/user-attachments/assets/179a3cf1-17b1-4555-a996-c5f292fd3fa7" />


### Issues
<!--
Tag any issues that this PR solves here.
ex. Fixes #
-->
Fixes #7865

### Code assistance
<!--
If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance.
-->
None
---

* [X] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [X] I have tested these changes.
* [X] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
