### PR TITLE
Fix layout mode for library routing

### DIFF
--- a/src/RootAppRouter.tsx
+++ b/src/RootAppRouter.tsx
@@ -13,16 +13,14 @@ import { STABLE_APP_ROUTES } from 'apps/stable/routes/routes';
 import { WIZARD_APP_ROUTES } from 'apps/wizard/routes/routes';
 import AppHeader from 'components/AppHeader';
 import Backdrop from 'components/Backdrop';
-import { SETTING_KEY as LAYOUT_SETTING_KEY } from 'components/layoutManager';
+import layoutManager from 'components/layoutManager';
 import BangRedirect from 'components/router/BangRedirect';
 import { createRouterHistory } from 'components/router/routerHistory';
 import { LayoutMode } from 'constants/layoutMode';
-import browser from 'scripts/browser';
 import appTheme from 'themes';
 import { ThemeStorageManager } from 'themes/themeStorageManager';
 
-const layoutMode = browser.tv ? LayoutMode.Tv : localStorage.getItem(LAYOUT_SETTING_KEY);
-const isExperimentalLayout = !layoutMode || layoutMode === LayoutMode.Experimental;
+const isExperimentalLayout = layoutManager.layout === LayoutMode.Experimental;
 
 const router = createHashRouter([
     {

--- a/src/components/layoutManager.js
+++ b/src/components/layoutManager.js
@@ -23,6 +23,14 @@ class LayoutManager {
     desktop = false;
     experimental = false;
 
+    get layout() {
+        if (this.tv) return LayoutMode.Tv;
+        if (this.experimental) return LayoutMode.Experimental;
+        if (this.mobile) return LayoutMode.Mobile;
+        if (this.desktop) return LayoutMode.Desktop;
+        return LayoutMode.Experimental;
+    }
+
     setLayout(layout = '', save = true) {
         const layoutValue = (!layout || layout === LayoutMode.Auto) ? '' : layout;
 

--- a/src/components/router/appRouter.js
+++ b/src/components/router/appRouter.js
@@ -409,7 +409,12 @@ class AppRouter {
             const isExperimentalLayout = layoutManager.layout === LayoutMode.Experimental;
 
             if (isExperimentalLayout && item.CollectionType == CollectionType.Books) {
-                return `#/books?topParentId=${item.Id}`;
+                url = `#/books?topParentId=${item.Id}&collectionType=${item.CollectionType}`;
+
+                if (options?.section === 'latest') {
+                    url += '&tab=3';
+                }
+                return url;
             }
 
             if (item.CollectionType == CollectionType.Movies) {

--- a/src/components/router/appRouter.js
+++ b/src/components/router/appRouter.js
@@ -406,9 +406,9 @@ class AppRouter {
         }
 
         if (context !== 'folders' && !itemHelper.isLocalItem(item)) {
-            const layoutMode = layoutManager.layout;
+            const isExperimentalLayout = layoutManager.layout === LayoutMode.Experimental;
 
-            if (layoutMode === LayoutMode.Experimental && item.CollectionType == CollectionType.Books) {
+            if (isExperimentalLayout && item.CollectionType == CollectionType.Books) {
                 return `#/books?topParentId=${item.Id}`;
             }
 
@@ -442,11 +442,11 @@ class AppRouter {
                 return url;
             }
 
-            if (layoutMode === LayoutMode.Experimental && item.CollectionType == CollectionType.Homevideos) {
+            if (isExperimentalLayout && item.CollectionType == CollectionType.Homevideos) {
                 return '#/homevideos?topParentId=' + item.Id;
             }
 
-            if (layoutMode === LayoutMode.Experimental && item.CollectionType == CollectionType.Musicvideos) {
+            if (isExperimentalLayout && item.CollectionType == CollectionType.Musicvideos) {
                 url = `#/musicvideos?topParentId=${item.Id}&collectionType=${item.CollectionType}`;
 
                 if (options?.section === 'latest') {
@@ -455,15 +455,15 @@ class AppRouter {
                 return url;
             }
 
-            if (layoutMode === LayoutMode.Experimental && item.CollectionType == CollectionType.Boxsets) {
+            if (isExperimentalLayout && item.CollectionType == CollectionType.Boxsets) {
                 return `#/boxsets?topParentId=${item.Id}&collectionType=${item.CollectionType}`;
             }
 
-            if (layoutMode === LayoutMode.Experimental && item.CollectionType == CollectionType.Playlists) {
+            if (isExperimentalLayout && item.CollectionType == CollectionType.Playlists) {
                 return `#/playlists?topParentId=${item.Id}&collectionType=${item.CollectionType}`;
             }
 
-            if (layoutMode === LayoutMode.Experimental && item.CollectionType == null && item.Type === 'CollectionFolder') {
+            if (isExperimentalLayout && item.CollectionType == null && item.Type === 'CollectionFolder') {
                 url = `#/mixed?topParentId=${item.Id}&collectionType=mixed`;
 
                 if (options?.section === 'latest') {

--- a/src/components/router/appRouter.js
+++ b/src/components/router/appRouter.js
@@ -6,6 +6,7 @@ import itemHelper from '../itemHelper';
 import loading from '../loading/loading';
 import alert from '../alert';
 
+import layoutManager from 'components/layoutManager';
 import { LayoutMode } from 'constants/layoutMode';
 import { getItemQuery } from 'hooks/useItem';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
@@ -405,7 +406,7 @@ class AppRouter {
         }
 
         if (context !== 'folders' && !itemHelper.isLocalItem(item)) {
-            const layoutMode = localStorage.getItem('layout') || LayoutMode.Experimental;
+            const layoutMode = layoutManager.tv ? LayoutMode.Tv : (layoutManager.getSavedLayout() || LayoutMode.Experimental);
 
             if (layoutMode === LayoutMode.Experimental && item.CollectionType == CollectionType.Books) {
                 return `#/books?topParentId=${item.Id}`;

--- a/src/components/router/appRouter.js
+++ b/src/components/router/appRouter.js
@@ -406,7 +406,7 @@ class AppRouter {
         }
 
         if (context !== 'folders' && !itemHelper.isLocalItem(item)) {
-            const layoutMode = layoutManager.tv ? LayoutMode.Tv : (layoutManager.getSavedLayout() || LayoutMode.Experimental);
+            const layoutMode = layoutManager.layout;
 
             if (layoutMode === LayoutMode.Experimental && item.CollectionType == CollectionType.Books) {
                 return `#/books?topParentId=${item.Id}`;


### PR DESCRIPTION
### Changes
Add a layout getter to LayoutManager to get the current layout mode, and use it in AppRouter and RootAppRouter instead of reading from localStorage directly. Fixes "page not found" errors on TVs when using auto mode.

Misc.
Add url for recently added tab for Book Collections

### Issues
Fixes: #7945

### Code assistance
N/A

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
