### PR TITLE
Start a library scan when adding folders to a library

### DIFF
--- a/src/apps/dashboard/features/libraries/components/LibraryCard.tsx
+++ b/src/apps/dashboard/features/libraries/components/LibraryCard.tsx
@@ -106,7 +106,8 @@ const LibraryCard = ({ virtualFolder }: LibraryCardProps) => {
         setIsMenuOpen(false);
 
         const mediaLibraryEditor = new MediaLibraryEditor({
-            library: virtualFolder
+            library: virtualFolder,
+            refresh: true
         }) as Promise<boolean>;
 
         void mediaLibraryEditor.then((hasChanges: boolean) => {


### PR DESCRIPTION
When adding  folders to a library for them to be scanned, we need to trigger a scan.

### Changes
* Force a refresh when adding folders to a library

### Issues
Fixes #7801

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
