### PR TITLE
Reload scroller on data receive

### DIFF
--- a/src/apps/stable/features/search/components/SearchResultsRow.tsx
+++ b/src/apps/stable/features/search/components/SearchResultsRow.tsx
@@ -30,6 +30,9 @@ const SearchResultsRow: FC<SearchResultsRowProps> = ({ title, items = [], cardOp
             itemsContainer: element.current?.querySelector('.itemsContainer'),
             ...cardOptions
         });
+
+        const scrollerEl = element.current?.querySelector('[is="emby-scroller"]') as (HTMLDivElement & { scroller?: { reload: () => void } }) | null;
+        scrollerEl?.scroller?.reload();
     }, [cardOptions, items]);
 
     return (


### PR DESCRIPTION
The scroller is created via `dangerouslySetInnerHTML` with an empty itemsContainer. emby-scroller's `attachedCallback` runs synchronously, measures the (empty) slidee, caches the size, and never re-measures since the frame element's width doesn't change when cards are added later in useEffect. That stale size:
- caps pos.end, so slideTo clamps the scroll position too early
- is what emby-scrollbuttons reads via `getScrollSize()` to decide if there's overflow, so scrollWidth <= scrollSize + 20 was true and the chevrons stayed hidden in certain cases

### Changes
* Reload scroller when necessary


### Code Assistance
none

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
