### PR TITLE
Update item cards in place after a metadata refresh

### DIFF
--- a/src/apps/experimental/components/library/ItemsView.tsx
+++ b/src/apps/experimental/components/library/ItemsView.tsx
@@ -8,7 +8,7 @@ import type { Theme } from '@mui/material/styles';
 import Toolbar from '@mui/material/Toolbar';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import classNames from 'classnames';
-import React, { type FC, useCallback } from 'react';
+import React, { type FC, useCallback, useEffect } from 'react';
 
 import { CardShape } from 'components/cardbuilder/utils/shape';
 import { ItemAction } from 'constants/itemAction';
@@ -97,6 +97,17 @@ const ItemsView: FC<ItemsViewProps> = ({
         libraryViewSettings
     );
     const { data: item } = useItem(parentId || undefined);
+
+    // Card images are lazy-loaded (react-lazy-load-image-component) and only
+    // load on a scroll/resize visibility check. When items change in place —
+    // e.g. after a metadata-refresh refetch — no scroll occurs, so freshly
+    // mounted images would wait until the next user scroll. Nudge the lazy
+    // loader once the new cards have committed.
+    useEffect(() => {
+        if (!itemsResult?.Items?.length) return;
+        const raf = requestAnimationFrame(() => window.dispatchEvent(new Event('scroll')));
+        return () => cancelAnimationFrame(raf);
+    }, [itemsResult?.Items]);
 
     const getListOptions = useCallback(() => {
         const listOptions: ListOptions = {

--- a/src/components/itemContextMenu.js
+++ b/src/components/itemContextMenu.js
@@ -16,6 +16,8 @@ import itemHelper, { canEditPlaylist } from './itemHelper';
 import { playbackManager } from './playback/playbackmanager';
 import toast from './toast/toast';
 import * as userSettings from '../scripts/settings/userSettings';
+import Events from '../utils/events';
+import serverNotifications from '../scripts/serverNotifications';
 
 /** Item types that support downloading all children. */
 const DOWNLOAD_ALL_TYPES = [
@@ -750,12 +752,40 @@ function deleteItem(apiClient, item) {
 }
 
 function refresh(apiClient, item) {
-    import('./refreshdialog/refreshdialog').then(({ default: RefreshDialog }) => {
-        new RefreshDialog({
-            itemIds: [item.Id],
-            serverId: apiClient.serverInfo().Id,
-            mode: item.Type === 'CollectionFolder' ? 'scan' : null
-        }).show();
+    const userId = apiClient.getCurrentUserId();
+    const itemId = item.Id;
+    // Snapshot the item's Etag before the refresh runs so we can detect when
+    // the server has actually committed the change.
+    apiClient.getItem(userId, itemId).then((base) => {
+        const baseEtag = base?.Etag;
+        import('./refreshdialog/refreshdialog').then(({ default: RefreshDialog }) => {
+            new RefreshDialog({
+                itemIds: [itemId],
+                serverId: apiClient.serverInfo().Id,
+                mode: item.Type === 'CollectionFolder' ? 'scan' : null
+            }).show().then(() => {
+                // The server processes the refresh asynchronously and only
+                // broadcasts LibraryChanged on a coalescing timer (up to ~30s).
+                // Poll just this item until its Etag changes, then re-emit
+                // LibraryChanged locally so views showing it re-fetch promptly.
+                // If nothing changed within the budget, the view is already
+                // correct and the eventual batched event remains the fallback.
+                let tries = 0;
+                const check = () => {
+                    apiClient.getItem(userId, itemId).then((fresh) => {
+                        if (fresh?.Etag && fresh.Etag !== baseEtag) {
+                            Events.trigger(serverNotifications, 'LibraryChanged',
+                                [apiClient, { ItemsUpdated: [itemId] }]);
+                        } else if (tries++ < 5) {
+                            setTimeout(check, 1000);
+                        }
+                    }, () => {
+                        if (tries++ < 5) setTimeout(check, 1000);
+                    });
+                };
+                setTimeout(check, 1000);
+            });
+        });
     });
 }
 

--- a/src/elements/emby-itemscontainer/ItemsContainer.tsx
+++ b/src/elements/emby-itemscontainer/ItemsContainer.tsx
@@ -228,6 +228,17 @@ const ItemsContainer: FC<PropsWithChildren<ItemsContainerProps>> = ({
                 return;
             }
 
+            // Items whose metadata/images changed in place (e.g. a "Refresh
+            // metadata" action completing server-side) arrive in ItemsUpdated,
+            // not Added/Removed. Reload if one is currently rendered here, so
+            // the card repaints without the user navigating away and back.
+            const itemsUpdated = data.ItemsUpdated ?? [];
+            const container = itemsContainerRef.current;
+            if (container && itemsUpdated.some((id) => container.querySelector(`[data-id="${id}"]`))) {
+                notifyRefreshNeeded(true);
+                return;
+            }
+
             const itemsAdded = data.ItemsAdded ?? [];
             const itemsRemoved = data.ItemsRemoved ?? [];
             if (!itemsAdded.length && !itemsRemoved.length) {

--- a/src/elements/emby-itemscontainer/emby-itemscontainer.js
+++ b/src/elements/emby-itemscontainer/emby-itemscontainer.js
@@ -225,6 +225,16 @@ function onLibraryChanged(e, apiClient, data) {
         return;
     }
 
+    // Items whose metadata/images changed in place (e.g. a "Refresh metadata"
+    // action completing server-side) arrive in ItemsUpdated, not Added/Removed.
+    // Repaint if one of them is currently rendered in this container, so the
+    // card updates without the user navigating away and back.
+    const itemsUpdated = data.ItemsUpdated || [];
+    if (itemsUpdated.some((id) => itemsContainer.querySelector(`[data-id="${id}"]`))) {
+        itemsContainer.notifyRefreshNeeded(true);
+        return;
+    }
+
     const itemsAdded = data.ItemsAdded || [];
     const itemsRemoved = data.ItemsRemoved || [];
     if (!itemsAdded.length && !itemsRemoved.length) {


### PR DESCRIPTION
Item containers reacted only to `ItemsAdded`/`ItemsRemoved` from
`LibraryChanged` and ignored `ItemsUpdated`, so a card whose metadata or
image changed in place — e.g. via a "Refresh metadata" action — was not
repainted until the user navigated away and back.

This reacts to `ItemsUpdated` for items currently displayed, in both the
React `ItemsContainer` and the legacy `emby-itemscontainer`, and nudges
the lazy image loader after items change so refreshed artwork loads
without a manual scroll. The card updates when the server broadcasts the
change, within its `LibraryChanged` coalescing window.
