### PR TITLE
chore: fix comment typos

### DIFF
--- a/src/components/htmlMediaHelper.js
+++ b/src/components/htmlMediaHelper.js
@@ -54,7 +54,7 @@ export function enableHlsJsPlayer(runTimeTicks, mediaType) {
     }
 
     if (canPlayNativeHls()) {
-        // Android Webview's native HLS has performance and compatiblity issues
+        // Android Webview's native HLS has performance and compatibility issues
         if (browser.android && (mediaType === 'Audio' || mediaType === 'Video')) {
             return true;
         }

--- a/src/components/itemContextMenu.js
+++ b/src/components/itemContextMenu.js
@@ -131,7 +131,7 @@ export async function getCommands(options) {
     }
 
     if (!browser.tv) {
-        // Multiselect is currrently only ran on long clicks of card components
+        // Multiselect is currently only ran on long clicks of card components
         // This disables Select on any context menu not originating from a card i.e songs
         if (options.positionTo && (dom.parentWithClass(options.positionTo, 'card') !== null)) {
             commands.push({
@@ -192,7 +192,7 @@ export async function getCommands(options) {
             });
         }
 
-        // Books are promoted to major download Button and therefor excluded in the context menu
+        // Books are promoted to major download Button and therefore excluded in the context menu
         if (item.CanDownload && item.Type !== 'Book') {
             commands.push({
                 name: globalize.translate('Download'),

--- a/src/components/scrollManager.js
+++ b/src/components/scrollManager.js
@@ -52,7 +52,7 @@ try {
      * Returns value clamped by range [min, max].
      *
      * @param {number} value - Clamped value.
-     * @param {number} min - Begining of range.
+     * @param {number} min - Beginning of range.
      * @param {number} max - Ending of range.
      * @return {number} Clamped value.
      */
@@ -69,9 +69,9 @@ function clamp(value, min, max) {
      * Returns the required delta to fit range 1 into range 2.
      * In case of range 1 is bigger than range 2 returns delta to fit most out of range part.
      *
-     * @param {number} begin1 - Begining of range 1.
+     * @param {number} begin1 - Beginning of range 1.
      * @param {number} end1 - Ending of range 1.
-     * @param {number} begin2 - Begining of range 2.
+     * @param {number} begin2 - Beginning of range 2.
      * @param {number} end2 - Ending of range 2.
      * @return {number} Delta: <0 move range1 to the left, >0 - to the right.
      */
@@ -176,8 +176,8 @@ class DocumentScroller {
 
     /**
          * Returns attribute value.
-         * @param {string} attributeName - Attibute name.
-         * @return {string} Attibute value.
+         * @param {string} attributeName - Attribute name.
+         * @return {string} Attribute value.
          */
     getAttribute(attributeName) {
         return document.body.getAttribute(attributeName);

--- a/src/plugins/syncPlay/core/PlaybackCore.js
+++ b/src/plugins/syncPlay/core/PlaybackCore.js
@@ -218,7 +218,7 @@ class PlaybackCore {
                         // During seek, playback is paused.
                         // FIXME: check range instead of fixed value for ticks.
                         if (isPlaying || currentPositionTicks !== command.PositionTicks) {
-                            // Account for player imperfections, we got half a second of tollerance we can play with
+                            // Account for player imperfections, we got half a second of tolerance we can play with
                             // (the server tollerates a range of values when client reports that is ready).
                             const rangeWidth = 100; // In milliseconds.
                             // eslint-disable-next-line sonarjs/pseudo-random

--- a/src/plugins/syncPlay/core/QueueCore.js
+++ b/src/plugins/syncPlay/core/QueueCore.js
@@ -219,7 +219,7 @@ class QueueCore {
             // Prefer playback commands as they're more frequent (and also because playback position is PlaybackCore's concern).
             startPositionTicks = this.manager.getPlaybackCore().estimateCurrentTicks(playbackCommand.PositionTicks, playbackCommand.When);
         } else {
-            // A PlayQueueUpdate is emited only on queue changes so it's less reliable for playback position syncing.
+            // A PlayQueueUpdate is emitted only on queue changes so it's less reliable for playback position syncing.
             const oldStartPositionTicks = this.getStartPositionTicks();
             const lastQueueUpdateDate = this.getLastUpdate();
             startPositionTicks = this.manager.getPlaybackCore().estimateCurrentTicks(oldStartPositionTicks, lastQueueUpdateDate);

--- a/src/plugins/syncPlay/core/players/GenericPlayer.js
+++ b/src/plugins/syncPlay/core/players/GenericPlayer.js
@@ -32,7 +32,7 @@ class GenericPlayer {
     }
 
     /**
-     * Binds to the player's events. Overriden.
+     * Binds to the player's events. Overridden.
      */
     localBindToPlayer() {
         throw new Error('Override this method!');
@@ -51,7 +51,7 @@ class GenericPlayer {
     }
 
     /**
-     * Removes the bindings from the player's events. Overriden.
+     * Removes the bindings from the player's events. Overridden.
      */
     localUnbindFromPlayer() {
         throw new Error('Override this method!');

--- a/src/plugins/syncPlay/ui/playbackPermissionManager.js
+++ b/src/plugins/syncPlay/ui/playbackPermissionManager.js
@@ -33,7 +33,7 @@ function destroyTestMediaElement (elem) {
 class PlaybackPermissionManager {
     /**
      * Tests playback permission. Grabs the permission when called inside a click event (or any other valid user interaction).
-     * @returns {Promise} Promise that resolves succesfully if playback permission is allowed.
+     * @returns {Promise} Promise that resolves successfully if playback permission is allowed.
      */
     check () {
         if (appHost.supports(AppFeature.HtmlAudioAutoplay)) {

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -28,7 +28,7 @@ export function toDecimalString(value: number, locale: string): string {
 }
 
 /**
- * Gets the value of a number formatted as a perentage.
+ * Gets the value of a number formatted as a percentage.
  * @param {number} value The value as a number.
  * @param {string} locale The locale to use for formatting (i.e. en-us).
  * @returns {string} The value formatted as a percentage.


### PR DESCRIPTION
## Summary

Pure comment/JSDoc typo fixes detected by codespell. No identifiers or strings touched, so nothing to verify behaviorally.

| File | Line(s) | Fix |
|---|---|---|
| `src/components/htmlMediaHelper.js` | 57 | compatiblity → compatibility |
| `src/components/itemContextMenu.js` | 134 | currrently → currently |
| `src/components/itemContextMenu.js` | 195 | therefor → therefore |
| `src/components/scrollManager.js` | 55, 72, 74 | Begining → Beginning |
| `src/components/scrollManager.js` | 179, 180 | Attibute → Attribute |
| `src/plugins/syncPlay/core/PlaybackCore.js` | 221 | tollerance → tolerance |
| `src/plugins/syncPlay/core/QueueCore.js` | 222 | emited → emitted |
| `src/plugins/syncPlay/core/players/GenericPlayer.js` | 35, 54 | Overriden → Overridden |
| `src/plugins/syncPlay/ui/playbackPermissionManager.js` | 36 | succesfully → successfully |
| `src/utils/number.ts` | 31 | perentage → percentage |