### PR TITLE
Chore: When viewing a movie, the page title changes to reflect the name of the movie

### DIFF
--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -552,7 +552,7 @@ function renderHeaderBackdrop(page, item, apiClient) {
 function reloadFromItem(instance, page, params, item, user) {
     const apiClient = ServerConnections.getApiClient(item.ServerId);
 
-    libraryMenu.setTitle('');
+    libraryMenu.setTitle(item.Name);
     unmount(instance);
 
     // Start rendering the artwork first
@@ -2047,7 +2047,7 @@ export default function (view, params) {
 
             if (e.detail.isRestored) {
                 if (currentItem) {
-                    libraryMenu.setTitle('');
+                    libraryMenu.setTitle(currentItem.Name);
                     renderTrackSelections(page, self, currentItem, true);
                     renderBackdrop(page, currentItem);
                 }
@@ -2065,6 +2065,7 @@ export default function (view, params) {
             Events.off(apiClient, 'message', onWebSocketMessage);
             Events.off(playbackManager, 'playerchange', onPlayerChange);
             libraryMenu.setTransparentMenu(false);
+            libraryMenu.setTitle('');
         });
         view.addEventListener('viewdestroy', function () {
             unmount(self);


### PR DESCRIPTION
When the user selects a movie, the title of the page does not change. When having mutiple tabs open for different movies, the user only sees 'Jellyfin'. Fixed it to reflect the name of the movie.

### Changes
1. Before making changes to the page title:
<img width="1008" height="461" alt="3" src="https://github.com/user-attachments/assets/27cc566b-1549-4ed4-bea4-bb95e701722a" />
2. After making changes to the page title:
<img width="1007" height="475" alt="2" src="https://github.com/user-attachments/assets/bad4d95d-b9a9-456c-b490-99ace91fc0c3" />

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
