### PR TITLE
Fix branding page crash in loader

### DIFF
--- a/src/apps/dashboard/routes/branding/index.tsx
+++ b/src/apps/dashboard/routes/branding/index.tsx
@@ -60,9 +60,12 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     };
 };
 
-export const loader = () => {
+export const loader = async () => {
+    const api = ServerConnections.getCurrentApi();
+    if (!api) return {};
+
     return queryClient.ensureQueryData(
-        getBrandingOptionsQuery(ServerConnections.getCurrentApi()));
+        getBrandingOptionsQuery(api));
 };
 
 export const Component = () => {


### PR DESCRIPTION
### Changes
Fixes a crash on the branding page that can happen if the page loads before the api instance is available

### Issues
Fixes #7889

### Code assistance
Zed autocomplete

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
