### PR TITLE
Disable known broken fMP4 HLS container on Firefox 149

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -839,6 +839,12 @@ export default function (options) {
         enableFmp4Hls = false;
     }
 
+    // fMP4 in Firefox 149 is largely broken due to bad moof::traf::tfdt handling
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=2026875
+    if (browser.firefox && browser.versionMajor == 149) {
+        enableFmp4Hls = false;
+    }
+
     if (canPlayHls() && browser.enableHlsAudio !== false) {
         profile.TranscodingProfiles.push({
             Container: enableFmp4Hls ? 'mp4' : 'ts',


### PR DESCRIPTION
Only this major version 149 will not receive a fix, and it seems that some Linux distributions ship this buggy version by default.

https://bugzilla.mozilla.org/show_bug.cgi?id=2026875

### Changes
- Disable known broken fMP4 HLS container on Firefox 149

### Issues
- https://github.com/jellyfin/jellyfin-web/issues/7405#issuecomment-4347841565

### Code assistance

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
