### PR TITLE
Implement studio search

### DIFF
--- a/src/apps/stable/features/search/api/useSearchItems.ts
+++ b/src/apps/stable/features/search/api/useSearchItems.ts
@@ -2,10 +2,12 @@ import { BaseItemKind } from '@jellyfin/sdk/lib/generated-client/models/base-ite
 import type { BaseItemDto } from '@jellyfin/sdk/lib/generated-client/models/base-item-dto';
 import { CollectionType } from '@jellyfin/sdk/lib/generated-client/models/collection-type';
 import { useQuery } from '@tanstack/react-query';
+import { CardShape } from 'components/cardbuilder/utils/shape';
 import { useApi } from '../../../../../hooks/useApi';
 import { addSection, getCardOptionsFromType, getItemTypesFromCollectionType, getTitleFromType, isLivetv, isMovies, isMusic, isTVShows, sortSections } from '../utils/search';
 import { useArtistsSearch } from './useArtistsSearch';
 import { usePeopleSearch } from './usePeopleSearch';
+import { useStudiosSearch } from './useStudiosSearch';
 import { useVideoSearch } from './useVideoSearch';
 import { Section } from '../types';
 import { useLiveTvSearch } from './useLiveTvSearch';
@@ -20,6 +22,7 @@ export const useSearchItems = (
 ) => {
     const { data: artists, isPending: isArtistsPending } = useArtistsSearch(parentId, collectionType, searchTerm);
     const { data: people, isPending: isPeoplePending } = usePeopleSearch(parentId, collectionType, searchTerm);
+    const { data: studios, isPending: isStudiosPending } = useStudiosSearch(parentId, collectionType, searchTerm);
     const { data: videos, isPending: isVideosPending } = useVideoSearch(parentId, collectionType, searchTerm);
     const { data: programs, isPending: isProgramsPending } = useProgramsSearch(parentId, collectionType, searchTerm);
     const { data: liveTvSections, isPending: isLiveTvPending } = useLiveTvSearch(parentId, collectionType, searchTerm);
@@ -28,6 +31,7 @@ export const useSearchItems = (
 
     const isArtistsEnabled = !isArtistsPending || (collectionType && !isMusic(collectionType));
     const isPeopleEnabled = !isPeoplePending || (collectionType && !isMovies(collectionType) && !isTVShows(collectionType));
+    const isStudiosEnabled = !isStudiosPending || (collectionType && !isMovies(collectionType) && !isTVShows(collectionType));
     const isVideosEnabled = !isVideosPending || collectionType;
     const isProgramsEnabled = !isProgramsPending || collectionType;
     const isLiveTvEnabled = !isLiveTvPending || !collectionType || !isLivetv(collectionType);
@@ -51,6 +55,10 @@ export const useSearchItems = (
 
             addSection(sections, 'People', people?.Items, {
                 coverImage: true
+            });
+
+            addSection(sections, 'Studios', studios?.Items, {
+                shape: CardShape.SquareOverflow
             });
 
             addSection(sections, 'HeaderVideos', videos?.Items, {
@@ -91,6 +99,7 @@ export const useSearchItems = (
             && !!userId
             && !!isArtistsEnabled
             && !!isPeopleEnabled
+            && !!isStudiosEnabled
             && !!isVideosEnabled
             && !!isLiveTvEnabled
             && !!isProgramsEnabled

--- a/src/apps/stable/features/search/api/useStudiosSearch.ts
+++ b/src/apps/stable/features/search/api/useStudiosSearch.ts
@@ -1,0 +1,51 @@
+import { Api } from '@jellyfin/sdk';
+import { CollectionType } from '@jellyfin/sdk/lib/generated-client/models/collection-type';
+import { StudiosApiGetStudiosRequest } from '@jellyfin/sdk/lib/generated-client/api/studios-api';
+import { getStudiosApi } from '@jellyfin/sdk/lib/utils/api/studios-api';
+import { useQuery } from '@tanstack/react-query';
+import { AxiosRequestConfig } from 'axios';
+import { useApi } from 'hooks/useApi';
+import { QUERY_OPTIONS } from '../constants/queryOptions';
+import { isMovies, isTVShows } from '../utils/search';
+
+const fetchStudios = async (
+    api: Api,
+    userId: string,
+    params?: StudiosApiGetStudiosRequest,
+    options?: AxiosRequestConfig
+) => {
+    const response = await getStudiosApi(api).getStudios(
+        {
+            ...QUERY_OPTIONS,
+            userId,
+            ...params
+        },
+        options
+    );
+    return response.data;
+};
+
+export const useStudiosSearch = (
+    parentId?: string,
+    collectionType?: CollectionType,
+    searchTerm?: string
+) => {
+    const { api, user } = useApi();
+    const userId = user?.Id;
+
+    const isStudiosEnabled = (!collectionType || isMovies(collectionType) || isTVShows(collectionType));
+
+    return useQuery({
+        queryKey: ['Search', 'Studios', collectionType, parentId, searchTerm],
+        queryFn: ({ signal }) => fetchStudios(
+            api!,
+            userId!,
+            {
+                parentId,
+                searchTerm
+            },
+            { signal }
+        ),
+        enabled: !!api && !!userId && isStudiosEnabled
+    });
+};

--- a/src/apps/stable/features/search/constants/sectionSortOrder.ts
+++ b/src/apps/stable/features/search/constants/sectionSortOrder.ts
@@ -3,6 +3,7 @@ export const SEARCH_SECTIONS_SORT_ORDER = [
     'Shows',
     'Episodes',
     'People',
+    'Studios',
     'Playlists',
     'Artists',
     'Albums',


### PR DESCRIPTION
Searching by studio is a nice thing imo. This does look not that great due to a lot of studio logos missing in our current artwork repo though.

### Changes
* Add a search query for Studios

### Code assistance
None

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
