### PR TITLE
Disable touch switcher on experimental and disable scroll buttons on touch devices

### DIFF
--- a/src/components/maintabsmanager.js
+++ b/src/components/maintabsmanager.js
@@ -1,5 +1,6 @@
 import dom from '../utils/dom';
 import browser from '../scripts/browser';
+import layoutManager from './layoutManager';
 import Events from '../utils/events.ts';
 import '../elements/emby-tabs/emby-tabs';
 import '../elements/emby-button/emby-button';
@@ -46,7 +47,7 @@ function allowSwipe(target) {
 }
 
 function configureSwipeTabs(view, currentElement) {
-    if (!browser.touch) {
+    if (!browser.touch || layoutManager.experimental) {
         return;
     }
 

--- a/src/elements/emby-scroller/Scroller.tsx
+++ b/src/elements/emby-scroller/Scroller.tsx
@@ -158,7 +158,7 @@ const Scroller: FC<PropsWithChildren<ScrollerProps>> = ({
             return;
         }
 
-        const enableScrollButtons = layoutManager.desktop && isHorizontalEnabled && isScrollButtonsEnabled;
+        const enableScrollButtons = layoutManager.desktop && !browser.touch && isHorizontalEnabled && isScrollButtonsEnabled;
 
         const options = {
             horizontal: isHorizontalEnabled,

--- a/src/elements/emby-scroller/emby-scroller.js
+++ b/src/elements/emby-scroller/emby-scroller.js
@@ -116,7 +116,7 @@ ScrollerPrototype.attachedCallback = function () {
     }
 
     const scrollFrame = this;
-    const enableScrollButtons = layoutManager.desktop && horizontal && this.getAttribute('data-scrollbuttons') !== 'false';
+    const enableScrollButtons = layoutManager.desktop && !browser.touch && horizontal && this.getAttribute('data-scrollbuttons') !== 'false';
 
     const options = {
         horizontal: horizontal,


### PR DESCRIPTION
On the old layout we had `Home` and `Favorite` tabs on the main screen which you could switch between with swiping on touch devices. These tabs do not exist in that constellation on the experimental layout, leading to unintended switches when you swiped on the main screen.
iPads are considered desktop devices by Apple, so the trigger for disabling the scroll buttons on non-desktop does not trigger, leading to weird usability issues. IMO the deciding factor should be touch device and not mobile device.

### Changes
* Disable scroll buttons on touch devices
* Disable tab switcher on experimental layout

### Code assistance
None

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
