### PR TITLE
Fix navigation with game controllers

### DIFF
--- a/src/scripts/keyboardNavigation.js
+++ b/src/scripts/keyboardNavigation.js
@@ -13,13 +13,12 @@ import appSettings from './settings/appSettings';
  */
 const KeyNames = {
     13: 'Enter',
-    19: 'Pause',
     27: 'Escape',
-    32: 'Space',
     37: 'ArrowLeft',
     38: 'ArrowUp',
     39: 'ArrowRight',
     40: 'ArrowDown',
+
     // UWP WebView section start --
     // Navigation Up/Down/Left/Right is part of TVJS directionalnavigation-1.0.0.0.js
     // Unsure what this is used for. Media remote?

--- a/src/scripts/keyboardNavigation.js
+++ b/src/scripts/keyboardNavigation.js
@@ -12,6 +12,14 @@ import appSettings from './settings/appSettings';
  * Key name mapping.
  */
 const KeyNames = {
+    13: 'Enter',
+    19: 'Pause',
+    27: 'Escape',
+    32: 'Space',
+    37: 'ArrowLeft',
+    38: 'ArrowUp',
+    39: 'ArrowRight',
+    40: 'ArrowDown',
     // UWP WebView section start --
     // Navigation Up/Down/Left/Right is part of TVJS directionalnavigation-1.0.0.0.js
     // Unsure what this is used for. Media remote?


### PR DESCRIPTION
### Changes
Various changes in keyboard navigation broke controller navigation. This fixes it by bringing back the KeyNames which are used by controllers.

<img width="275" height="122" alt="image" src="https://github.com/user-attachments/assets/05e9ed5d-cffa-4400-9cc6-d822e3f73f5d" />


<img width="329" height="91" alt="image" src="https://github.com/user-attachments/assets/cd932c47-85e9-4fad-ad35-218a02f8e7ca" />


### Issues
Fixes #7973

### Code assistance
Clanker told me how to turn on controller navigation in browser cuz I couldn't find it :clown_face: 

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
