### PR TITLE
Fix dashboard material table layout

### DIFF
--- a/src/apps/dashboard/AppLayout.tsx
+++ b/src/apps/dashboard/AppLayout.tsx
@@ -52,7 +52,8 @@ export const Component: FC = () => {
             <Box
                 sx={{
                     display: 'flex',
-                    flexDirection: 'column'
+                    flexDirection: 'column',
+                    height: '100%'
                 }}
             >
                 <StrictMode>
@@ -103,6 +104,7 @@ export const Component: FC = () => {
                     sx={{
                         position: 'relative',
                         width: '100%',
+                        minHeight: 0,
                         flexGrow: 1
                     }}
                 >


### PR DESCRIPTION
### Changes
Fixes the dashboard layout so pages using material-react-table render again after the app bar/layout CSS changes in #7965.

The API Keys page was only showing the page header/description. After this change, the table toolbar, columns, empty state, and pagination render correctly again.

### Issues
Fixes #7974

### Code assistance
I used Codex for help narrowing down the layout issue.

### Testing
- npm run build:check
- npm run lint -- src/apps/dashboard/AppLayout.tsx
- npm run build:development
- Tested locally with Jellyfin Server unstable/12.0 in Docker and verified the API Keys dashboard page renders the material table.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Ainvalid+-label%3Astale+-author%3A%40me).