### PR TITLE
Remove repository prefix for pages deployment on push workflow

### DIFF
--- a/.github/workflows/__deploy.yml
+++ b/.github/workflows/__deploy.yml
@@ -48,7 +48,7 @@ jobs:
     name: CloudFlare Pages 📃
     runs-on: ubuntu-latest
     environment:
-      name: ${{ inputs.branch == 'jellyfin/jellyfin-web/master' && 'Production' || 'Preview' }}
+      name: ${{ inputs.branch == github.event.repository.default_branch && 'Production' || 'Preview' }}
       url: ${{ steps.cf.outputs.deployment-url }}
     outputs:
       url: ${{ steps.cf.outputs.deployment-url }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -51,7 +51,7 @@ jobs:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
     with:
-      branch: ${{ format('{0}/{1}', github.repository, github.ref_name) }}
+      branch: ${{ github.ref_name }}
       commit: ${{ github.sha }}
       workflow_run_id: ${{ github.run_id }}
       comment: false


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

### Changes

Cloudflare pages checks the branch name on push to match a configured branch name in their settings to determine whether it is the default branch or not. We must use "master" without the "jellyfin/jellyfin-web/" prefix for it to work. Otherwise it will never deploy to https://jellyfin-web.pages.dev. I looked into changing the value on Cloudflare's side but their dashboard isn't working and IIRC they check if it is an existing branch (which is not the case with the prefix applied).

Update the push workflow to always use the branch name without repository prefix, this shouldn't hurt because the deployment on push only runs on upstream anyway.

Additionally change the deploy workflow to set the environment based on github.event.repository.default_branch (which is set to "master").

### Issues
<!--
Tag any issues that this PR solves here.
ex. Fixes #
-->

### Code assistance
<!--
If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance.
-->

None

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [ ] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
