### PR TITLE
Fix playback issues in the home videos and photos library videos tab

### DIFF
--- a/src/apps/experimental/components/library/ItemsView.tsx
+++ b/src/apps/experimental/components/library/ItemsView.tsx
@@ -294,11 +294,12 @@ const ItemsView: FC<ItemsViewProps> = ({
                                 <ButtonGroup
                                     variant='contained'
                                 >
-                                    {isBtnPlayAllEnabled && (
+                                    {isBtnPlayAllEnabled && totalRecordCount > 0 && (
                                         <PlayAllButton
                                             item={item}
                                             items={items}
                                             viewType={viewType}
+                                            collectionType={collectionType}
                                             hasFilters={hasFilters}
                                             isTextVisible={isSmallScreen}
                                             libraryViewSettings={libraryViewSettings}
@@ -310,6 +311,7 @@ const ItemsView: FC<ItemsViewProps> = ({
                                             item={item}
                                             items={items}
                                             viewType={viewType}
+                                            collectionType={collectionType}
                                             hasFilters={hasFilters}
                                             isTextVisible={isSmallScreen && !isBtnPlayAllEnabled}
                                             libraryViewSettings={libraryViewSettings}

--- a/src/apps/experimental/components/library/PlayAllButton.tsx
+++ b/src/apps/experimental/components/library/PlayAllButton.tsx
@@ -27,7 +27,10 @@ const PlayAllButton: FC<PlayAllButtonProps> = ({
     libraryViewSettings
 }) => {
     const play = useCallback(() => {
-        if (item && !hasFilters) {
+        // For the Homevideos library Videos tab, pass items directly to playback since
+        // the playback manager hardcodes MediaTypes: 'Photo' for the Homevideos library
+        // which would exclude videos from the queue
+        if (item && !hasFilters && viewType !== LibraryTab.Videos) {
             playbackManager.play({
                 items: [item],
                 autoplay: true,

--- a/src/apps/experimental/components/library/PlayAllButton.tsx
+++ b/src/apps/experimental/components/library/PlayAllButton.tsx
@@ -8,11 +8,13 @@ import { getFiltersQuery } from 'utils/items';
 import { LibraryViewSettings } from 'types/library';
 import { LibraryTab } from 'types/libraryTab';
 import type { ItemDto } from 'types/base/models/item-dto';
+import { CollectionType } from '@jellyfin/sdk/lib/generated-client/models/collection-type';
 
 interface PlayAllButtonProps {
     item: ItemDto | undefined
     items: ItemDto[]
     viewType: LibraryTab
+    collectionType: CollectionType | undefined
     hasFilters: boolean
     isTextVisible: boolean
     libraryViewSettings: LibraryViewSettings
@@ -22,6 +24,7 @@ const PlayAllButton: FC<PlayAllButtonProps> = ({
     item,
     items,
     viewType,
+    collectionType,
     hasFilters,
     isTextVisible,
     libraryViewSettings
@@ -30,7 +33,7 @@ const PlayAllButton: FC<PlayAllButtonProps> = ({
         // For the Homevideos library Videos tab, pass items directly to playback since
         // the playback manager hardcodes MediaTypes: 'Photo' for the Homevideos library
         // which would exclude videos from the queue
-        if (item && !hasFilters && viewType !== LibraryTab.Videos) {
+        if (item && !hasFilters && !(viewType === LibraryTab.Videos && collectionType === CollectionType.Homevideos)) {
             playbackManager.play({
                 items: [item],
                 autoplay: true,
@@ -55,7 +58,7 @@ const PlayAllButton: FC<PlayAllButtonProps> = ({
                 console.error('[PlayAllButton] failed to play', err);
             });
         }
-    }, [hasFilters, item, items, libraryViewSettings, viewType]);
+    }, [collectionType, hasFilters, item, items, libraryViewSettings, viewType]);
 
     return (
         <Button

--- a/src/apps/experimental/components/library/ShuffleButton.tsx
+++ b/src/apps/experimental/components/library/ShuffleButton.tsx
@@ -28,7 +28,10 @@ const ShuffleButton: FC<ShuffleButtonProps> = ({
     libraryViewSettings
 }) => {
     const shuffle = useCallback(() => {
-        if (item && !hasFilters) {
+        // For the Homevideos library Videos tab, pass items directly to playback since
+        // the playback manager hardcodes MediaTypes: 'Photo' for the Homevideos library
+        // which would exclude videos from the queue
+        if (item && !hasFilters && viewType !== LibraryTab.Videos) {
             playbackManager.shuffle(item);
         } else {
             playbackManager.play({

--- a/src/apps/experimental/components/library/ShuffleButton.tsx
+++ b/src/apps/experimental/components/library/ShuffleButton.tsx
@@ -9,11 +9,13 @@ import { getFiltersQuery } from 'utils/items';
 import { LibraryViewSettings } from 'types/library';
 import { LibraryTab } from 'types/libraryTab';
 import type { ItemDto } from 'types/base/models/item-dto';
+import { CollectionType } from '@jellyfin/sdk/lib/generated-client/models/collection-type';
 
 interface ShuffleButtonProps {
     item: ItemDto | undefined
     items: ItemDto[]
     viewType: LibraryTab
+    collectionType: CollectionType | undefined
     hasFilters: boolean
     isTextVisible: boolean
     libraryViewSettings: LibraryViewSettings
@@ -23,6 +25,7 @@ const ShuffleButton: FC<ShuffleButtonProps> = ({
     item,
     items,
     viewType,
+    collectionType,
     hasFilters,
     isTextVisible,
     libraryViewSettings
@@ -31,7 +34,7 @@ const ShuffleButton: FC<ShuffleButtonProps> = ({
         // For the Homevideos library Videos tab, pass items directly to playback since
         // the playback manager hardcodes MediaTypes: 'Photo' for the Homevideos library
         // which would exclude videos from the queue
-        if (item && !hasFilters && viewType !== LibraryTab.Videos) {
+        if (item && !hasFilters && !(viewType === LibraryTab.Videos && collectionType === CollectionType.Homevideos)) {
             playbackManager.shuffle(item);
         } else {
             playbackManager.play({
@@ -46,7 +49,7 @@ const ShuffleButton: FC<ShuffleButtonProps> = ({
                 console.error('[ShuffleButton] failed to play', err);
             });
         }
-    }, [hasFilters, item, items, libraryViewSettings, viewType]);
+    }, [collectionType, hasFilters, item, items, libraryViewSettings, viewType]);
 
     return (
         <Button


### PR DESCRIPTION
When clicking Play All or Shuffle on the Videos tab in a Home Videos and Photos library, only photos would play if present. If there are only videos, it would result in a playback error. This is because the playback manager hardcodes MediaTypes: 'Photo'  for the  Home Videos and Photos library.

### Changes
For the Home Videos and Photos library Videos tab `PlayAllButton` and `ShuffleButton`, pass the filtered `items` array directly to the playback manager instead of the parent folder item.

### Issues
None yet reported for the new layout

### Code assistance
N/A
---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
