### PR TITLE
Only show Play All button when items are present

### DIFF
--- a/src/apps/experimental/components/library/ItemsView.tsx
+++ b/src/apps/experimental/components/library/ItemsView.tsx
@@ -294,7 +294,7 @@ const ItemsView: FC<ItemsViewProps> = ({
                                 <ButtonGroup
                                     variant='contained'
                                 >
-                                    {isBtnPlayAllEnabled && (
+                                    {isBtnPlayAllEnabled && totalRecordCount > 0 && (
                                         <PlayAllButton
                                             item={item}
                                             items={items}


### PR DESCRIPTION
### Changes
Only show the **Play All** button when items are available. This prevents it from appearing in empty tabs, such as the Home Videos and Photos libraries, where attempting playback would result in an error.


### Issues
 N/A

### Code assistance
N/A

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
