### PR TITLE
Allow common link-protocol schemes in the login disclaimer

### DIFF
--- a/src/apps/legacy/controllers/session/login/index.js
+++ b/src/apps/legacy/controllers/session/login/index.js
@@ -1,4 +1,4 @@
-import DOMPurify from 'dompurify';
+import createDOMPurify from 'dompurify';
 import markdownIt from 'markdown-it';
 
 import { AppFeature } from 'constants/appFeature';
@@ -21,6 +21,13 @@ import baseAlert from 'components/alert';
 import { getDefaultBackgroundClass } from 'components/cardbuilder/utils/builder';
 
 import './login.scss';
+
+// Own instance so the schemes stay scoped: DOMPurify's defaults + matrix, tg, whatsapp, signal, irc(s).
+const domPurify = createDOMPurify();
+domPurify.setConfig({
+    // eslint-disable-next-line @typescript-eslint/naming-convention, sonarjs/regex-complexity -- DOMPurify config option; extends its default regex
+    ALLOWED_URI_REGEXP: /^(?:(?:https?|ftps?|mailto|tel|callto|cid|xmpp|matrix|tg|whatsapp|signal|ircs?):|[^a-z]|[a-z+.-]+(?:[^-a-z+.:]|$))/i
+});
 
 const enableFocusTransform = !browser.slow && !browser.edge;
 
@@ -297,7 +304,7 @@ export default function (view, params) {
             const loginDisclaimer = view.querySelector('.loginDisclaimer');
 
             // eslint-disable-next-line sonarjs/disabled-auto-escaping
-            loginDisclaimer.innerHTML = DOMPurify.sanitize(markdownIt({ html: true }).render(options.LoginDisclaimer || ''));
+            loginDisclaimer.innerHTML = domPurify.sanitize(markdownIt({ html: true }).render(options.LoginDisclaimer || ''));
 
             for (const elem of loginDisclaimer.querySelectorAll('a')) {
                 elem.rel = 'noopener noreferrer';

--- a/src/apps/legacy/controllers/session/login/index.js
+++ b/src/apps/legacy/controllers/session/login/index.js
@@ -22,11 +22,10 @@ import { getDefaultBackgroundClass } from 'components/cardbuilder/utils/builder'
 
 import './login.scss';
 
-// Own instance so the schemes stay scoped: DOMPurify's defaults + matrix, tg, whatsapp, signal, irc(s).
 const domPurify = createDOMPurify();
 domPurify.setConfig({
-    // eslint-disable-next-line @typescript-eslint/naming-convention, sonarjs/regex-complexity -- DOMPurify config option; extends its default regex
-    ALLOWED_URI_REGEXP: /^(?:(?:https?|ftps?|mailto|tel|callto|cid|xmpp|matrix|tg|whatsapp|signal|ircs?):|[^a-z]|[a-z+.-]+(?:[^-a-z+.:]|$))/i
+    // eslint-disable-next-line @typescript-eslint/naming-convention, sonarjs/regex-complexity -- DOMPurify config option; customizes its default regex
+    ALLOWED_URI_REGEXP: /^(?:(?:https?|mailto|tel|callto|cid|xmpp|matrix|tg|whatsapp|signal|ircs?):|[^a-z]|[a-z+.-]+(?:[^-a-z+.:]|$))/i
 });
 
 const enableFocusTransform = !browser.slow && !browser.edge;


### PR DESCRIPTION
### Changes
The login page renders the admin-configured login disclaimer through `markdown-it` and `DOMPurify` with no options. DOMPurify allowed-URI regex only accepts `http(s)`, `ftp(s)`, `mailto`, `tel`, `callto`, `cid`, and `xmpp`, so anchors using `matrix:`, `tg:`, `whatsapp:`, `signal:`, `irc:`, or `ircs:` don't work.
 
This extracts the sanitize pipeline into a small helper and pass an `ALLOWED_URI_REGEXP` that mirrors `DOMPurify`'s default with those six schemes added. `javascript:`, `data:`, `vbscript:`, and `file:` remain blocked.

The disclaimer is admin-only configuration and existing post-sanitize code already sets `rel=noopener noreferrer` and `target=_blank` on every link, so the additional schemes do not widen the attack surface beyond opening an external app.

### Testing
I manually tested by using this in the login disclaimer:

```md
Contact us:

 - [Matrix](matrix:r/jellyfin:matrix.org)
 - [Telegram](tg:resolve?domain=jellyfin)
 - [WhatsApp](whatsapp://send?phone=12345)
 - [Signal](signal:+12345)
 - [IRC](irc://irc.libera.chat/jellyfin)
 - [Email](mailto:test@example.com)
```

And then logging out and seeing the actual HTML generated on the login page.

Before the fix:
```html
<div class="loginDisclaimer"><p>Contact us:</p>
<ul>
<li><a rel="noopener noreferrer" target="_blank" class="button-link emby-button" is="emby-linkbutton">Matrix</a></li>
<li><a rel="noopener noreferrer" target="_blank" class="button-link emby-button" is="emby-linkbutton">Telegram</a></li>
<li><a rel="noopener noreferrer" target="_blank" class="button-link emby-button" is="emby-linkbutton">WhatsApp</a></li>
<li><a rel="noopener noreferrer" target="_blank" class="button-link emby-button" is="emby-linkbutton">Signal</a></li>
<li><a rel="noopener noreferrer" target="_blank" class="button-link emby-button" is="emby-linkbutton">IRC</a></li>
<li><a href="mailto:test@example.com" rel="noopener noreferrer" target="_blank" class="button-link emby-button" is="emby-linkbutton">Email</a></li>
</ul>
</div>
```

After the fix:
```html
<div class="loginDisclaimer"><p>Contact us:</p>
<ul>
<li><a href="matrix:r/jellyfin:matrix.org" rel="noopener noreferrer" target="_blank" class="button-link emby-button" is="emby-linkbutton">Matrix</a></li>
<li><a href="tg:resolve?domain=jellyfin" rel="noopener noreferrer" target="_blank" class="button-link emby-button" is="emby-linkbutton">Telegram</a></li>
<li><a href="whatsapp://send?phone=12345" rel="noopener noreferrer" target="_blank" class="button-link emby-button" is="emby-linkbutton">WhatsApp</a></li>
<li><a href="signal:+12345" rel="noopener noreferrer" target="_blank" class="button-link emby-button" is="emby-linkbutton">Signal</a></li>
<li><a href="irc://irc.libera.chat/jellyfin" rel="noopener noreferrer" target="_blank" class="button-link emby-button" is="emby-linkbutton">IRC</a></li>
<li><a href="mailto:test@example.com" rel="noopener noreferrer" target="_blank" class="button-link emby-button" is="emby-linkbutton">Email</a></li>
</ul>
</div>
```

### Issues
Fixes #7958

### Code assistance
The regex (and accompanying code comment) was generated by an LLM

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
