### PR TITLE
Decouple gamepadtokey repeat rate from framerate

### DIFF
--- a/src/scripts/gamepadtokey.js
+++ b/src/scripts/gamepadtokey.js
@@ -170,17 +170,29 @@ _ButtonPressedState.setdPadRight = function (newPressedState) {
     _dPadRightPressed = newPressedState;
 };
 
-const times = {};
+const delayTimes = {};
 
-function throttle(key) {
-    const time = times[key] || 0;
+function delay(key) {
+    const time = delayTimes[key] || 0;
     const now = new Date().getTime();
 
     return (now - time) >= 200;
 }
 
+function resetDelay(key) {
+    delayTimes[key] = new Date().getTime();
+}
+
+const throttleTimes = {};
+
+function throttle(key) {
+    const time = throttleTimes[key] || delayTimes[key];
+    const now = new Date().getTime();
+    return (now - time) >= 33;
+}
+
 function resetThrottle(key) {
-    times[key] = new Date().getTime();
+    throttleTimes[key] = new Date().getTime();
 }
 
 const isElectron = navigator.userAgent.toLowerCase().indexOf('electron') !== -1;
@@ -225,16 +237,17 @@ function raiseKeyEvent(oldPressedState, newPressedState, key, keyCode, enableRep
         // always fire if this is the initial down press
         if (oldPressedState === false) {
             fire = true;
-            resetThrottle(key);
+            resetDelay(key);
         } else if (enableRepeatKeyDown) {
-            fire = throttle(key);
+            fire = delay(key) && throttle(key);
         }
 
         if (fire && keyCode) {
             newPressedEvent = raiseEvent('keydown', key, keyCode);
+            resetThrottle(key);
         }
     } else if (newPressedState === false && oldPressedState === true) {
-        resetThrottle(key);
+        resetDelay(key);
 
         // button up
         if (keyCode) {

--- a/src/scripts/gamepadtokey.js
+++ b/src/scripts/gamepadtokey.js
@@ -356,18 +356,16 @@ function runInputLoop() {
             }
         }
     }
-    // Schedule the next one
-    inputLoopTimer = requestAnimationFrame(runInputLoop);
 }
 
 function startInputLoop() {
     if (!inputLoopTimer) {
-        runInputLoop();
+        inputLoopTimer = setInterval(runInputLoop, 15);
     }
 }
 
 function stopInputLoop() {
-    cancelAnimationFrame(inputLoopTimer);
+    clearInterval(inputLoopTimer);
     inputLoopTimer = undefined;
 }
 

--- a/src/scripts/gamepadtokey.js
+++ b/src/scripts/gamepadtokey.js
@@ -170,29 +170,22 @@ _ButtonPressedState.setdPadRight = function (newPressedState) {
     _dPadRightPressed = newPressedState;
 };
 
-const delayTimes = {};
-
-function delay(key) {
-    const time = delayTimes[key] || 0;
-    const now = new Date().getTime();
-
-    return (now - time) >= 200;
-}
-
-function resetDelay(key) {
-    delayTimes[key] = new Date().getTime();
-}
-
-const throttleTimes = {};
+const keydownCounter = {};
+const times = {};
 
 function throttle(key) {
-    const time = throttleTimes[key] || delayTimes[key];
+    const time = times[key] || 0;
     const now = new Date().getTime();
-    return (now - time) >= 33;
+
+    if (keydownCounter[key] === 1) {
+        return (now - time) >= 200;
+    } else {
+        return (now - time) >= 40;
+    }
 }
 
 function resetThrottle(key) {
-    throttleTimes[key] = new Date().getTime();
+    times[key] = new Date().getTime();
 }
 
 const isElectron = navigator.userAgent.toLowerCase().indexOf('electron') !== -1;
@@ -237,18 +230,17 @@ function raiseKeyEvent(oldPressedState, newPressedState, key, keyCode, enableRep
         // always fire if this is the initial down press
         if (oldPressedState === false) {
             fire = true;
-            resetDelay(key);
+            keydownCounter[key] = 0;
         } else if (enableRepeatKeyDown) {
-            fire = delay(key) && throttle(key);
+            fire = throttle(key);
         }
 
         if (fire && keyCode) {
             newPressedEvent = raiseEvent('keydown', key, keyCode);
+            keydownCounter[key]++;
             resetThrottle(key);
         }
     } else if (newPressedState === false && oldPressedState === true) {
-        resetDelay(key);
-
         // button up
         if (keyCode) {
             newPressedEvent = raiseEvent('keyup', key, keyCode);
@@ -360,7 +352,7 @@ function runInputLoop() {
 
 function startInputLoop() {
     if (!inputLoopTimer) {
-        inputLoopTimer = setInterval(runInputLoop, 15);
+        inputLoopTimer = setInterval(runInputLoop, 20);
     }
 }
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

### Changes
<!--
Describe your changes here in 1-5 sentences.
Please include before/after screenshots of any UI changes.
-->
Changes the throttle function to prevent repeated keydown events from firing too fast, and rename the existing function to delay. I set the repeat rate to 30hz, as that felt closest to how fast the page moves on keyboard on Windows (maybe should be configurable?).
Also moves the timer away from triggering on vsync, meaning input delay should be consistent across refresh rates.

### Issues
<!--
Tag any issues that this PR solves here.
ex. Fixes #
-->
Might fix part of #7834 

### Code assistance
<!--
If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance.
-->
The Duckduckgo AI summary for keyboard repeat rate suggested that the two parts were called delay and throttle, and they felt good enough as names. No other AI was used.

---

* [X] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [X] I have tested these changes.
* [X] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
