### PR TITLE
Hide Group Versions for unsupported item types

### DIFF
--- a/src/components/multiSelect/multiSelect.js
+++ b/src/components/multiSelect/multiSelect.js
@@ -1,3 +1,4 @@
+import { BaseItemKind } from '@jellyfin/sdk/lib/generated-client/models/base-item-kind';
 import { AppFeature } from 'constants/appFeature';
 import browser from '../../scripts/browser';
 import { appHost } from '../apphost';
@@ -204,10 +205,10 @@ function showMenuForSelectedItems(e) {
             }
 
             const includeTypes = [
-                'Movie',
-                'Episode',
-                'MusicVideo',
-                'Video'
+                BaseItemKind.Movie,
+                BaseItemKind.Episode,
+                BaseItemKind.MusicVideo,
+                BaseItemKind.Video
             ];
 
             if (user.Policy.IsAdministrator && includeTypes.includes(firstItem.Type)) {

--- a/src/components/multiSelect/multiSelect.js
+++ b/src/components/multiSelect/multiSelect.js
@@ -203,7 +203,14 @@ function showMenuForSelectedItems(e) {
                 // Disabled because there is no callback for this item
             }
 
-            if (user.Policy.IsAdministrator) {
+            const includeTypes = [
+                'Movie',
+                'Episode',
+                'MusicVideo',
+                'Video'
+            ];
+
+            if (user.Policy.IsAdministrator && includeTypes.includes(firstItem.Type)) {
                 menuItems.push({
                     name: globalize.translate('GroupVersions'),
                     id: 'groupvideos',


### PR DESCRIPTION
Jellyfin doesn't support merging of every item type, but the web allows anything that can be selected to be merged.

### Changes
Limit Group Versions to supported item types:
```
BaseItemKind.Movie,
BaseItemKind.Episode,
BaseItemKind.MusicVideo,
BaseItemKind.Video
```
### Issues
Fixes [#13755](https://github.com/jellyfin/jellyfin/issues/13755)

### Code assistance
N/A

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
