### PR TITLE
Make Played and Unplayed filters mutually exclusive for the Modern view

### DIFF
--- a/src/apps/experimental/components/library/filter/FiltersStatus.tsx
+++ b/src/apps/experimental/components/library/filter/FiltersStatus.tsx
@@ -15,6 +15,11 @@ const defaultFiltersOptions = [
     { label: 'ContinueWatching', value: ItemFilter.IsResumable }
 ];
 
+const mutuallyExclusiveFilters: Partial<Record<ItemFilter, ItemFilter>> = {
+    [ItemFilter.IsPlayed]: ItemFilter.IsUnplayed,
+    [ItemFilter.IsUnplayed]: ItemFilter.IsPlayed
+};
+
 interface FiltersStatusProps {
     viewType: LibraryTab;
     libraryViewSettings: LibraryViewSettings;
@@ -39,10 +44,11 @@ const FiltersStatus: FC<FiltersStatusProps> = ({
             event.preventDefault();
             const value = event.target.value as ItemFilter;
             const existingStatus = libraryViewSettings?.Filters?.Status ?? [];
+            const exclusiveFilter = mutuallyExclusiveFilters[value];
 
             const updatedStatus = existingStatus.includes(value) ?
                 existingStatus.filter((filter) => filter !== value) :
-                [...existingStatus, value];
+                [...existingStatus.filter((filter) => filter !== exclusiveFilter), value];
 
             setLibraryViewSettings((prevState) => ({
                 ...prevState,


### PR DESCRIPTION
Selecting both Played and Unplayed filters causes a Bad Request ([#16398](https://github.com/jellyfin/jellyfin/pull/16398))

### Changes
Makes the Played and Unplayed filters mutually exclusive for the modern view. The PR does not touch the legacy filters.

### Issues
Fixes: https://github.com/jellyfin/jellyfin/issues/16297

### Code assistance
N/A

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
