### PR TITLE
Show aired date for home videos

### DIFF
--- a/src/components/mediainfo/mediainfo.js
+++ b/src/components/mediainfo/mediainfo.js
@@ -129,7 +129,7 @@ export function getMediaInfoHtml(item, options = {}) {
         }
     }
 
-    if ((item.Type === 'Episode' || item.MediaType === 'Photo')
+    if ((item.Type === 'Episode' || item.Type === 'Video' || item.MediaType === 'Photo')
             && options.originalAirDate !== false
             && item.PremiereDate
     ) {
@@ -245,7 +245,7 @@ export function getMediaInfoHtml(item, options = {}) {
         }
     }
 
-    if (options.year !== false && item.Type !== 'Series' && item.Type !== 'Episode' && item.Type !== 'Person'
+    if (options.year !== false && item.Type !== 'Series' && item.Type !== 'Episode' && item.Type !== 'Video' && item.Type !== 'Person'
             && item.MediaType !== 'Photo' && item.Type !== 'Program' && item.Type !== 'Season'
     ) {
         if (item.ProductionYear) {

--- a/src/components/mediainfo/usePrimaryMediaInfo.tsx
+++ b/src/components/mediainfo/usePrimaryMediaInfo.tsx
@@ -70,6 +70,7 @@ function addOriginalAirDateInfo(
     if (
         showOriginalAirDateInfo
         && (itemType === ItemKind.Episode
+            || itemType === ItemKind.Video
             || itemMediaType === ItemMediaKind.Photo)
         && itemPremiereDate
     ) {
@@ -310,6 +311,7 @@ function addYearInfo(
         showYearInfo
         && itemType !== ItemKind.Series
         && itemType !== ItemKind.Episode
+        && itemType !== ItemKind.Video
         && itemType !== ItemKind.Person
         && itemMediaType !== ItemMediaKind.Photo
         && itemType !== ItemKind.Program


### PR DESCRIPTION
### Changes

Home videos in a "Home Videos and Photos" library now display their aired/recording date in the media info, matching how photos already display their capture date. The server already populates `PremiereDate` for home videos from the embedded container creation date (via ffprobe in `FFProbeVideoInfo`), but the web client only rendered it for `Episode` and `Photo` items, so home videos (`Type === 'Video'`) showed no date at all. This adds `Video` to the original-air-date condition and excludes it from the year-info path so the full date is shown instead of a duplicate year line. Movies (`Movie`) and music videos (`MusicVideo`) are unaffected, and the date only renders when a `PremiereDate` is present (so extras/loose video files without a date are a no-op).

### Issues
<!-- none -->

### Code assistance

This change was developed with the assistance of an LLM (Claude / Claude Code): it was used to trace the display logic across the web client and server (`usePrimaryMediaInfo.tsx`, `mediainfo.js`, `FFProbeVideoInfo`, `MovieResolver`), confirm that home videos resolve to `BaseItemKind.Video` distinct from movies, and implement the two-line condition changes. The changes were verified with `tsc --noEmit` and `eslint` (both clean).

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
