### PR TITLE
Add password field visibility toggle

### DIFF
--- a/src/elements/emby-input/Input.tsx
+++ b/src/elements/emby-input/Input.tsx
@@ -19,11 +19,12 @@ interface InputProps
 }
 
 const Input = forwardRef<HTMLInputElement, InputProps>(
-    ({ id, label, className, onBlur, onFocus, ...props }, ref) => {
+    ({ id, label, className, onBlur, onFocus, type, ...props }, ref) => {
         const [isFocused, setIsFocused] = useState(false);
+        const [passwordVisible, setPasswordVisible] = useState(false);
 
         const onBlurInternal = useCallback(
-            (e: React.FocusEvent<HTMLInputElement, Element>) => {
+            (e: React.FocusEvent<HTMLInputElement>) => {
                 setIsFocused(false);
                 onBlur?.(e);
             },
@@ -31,12 +32,49 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
         );
 
         const onFocusInternal = useCallback(
-            (e: React.FocusEvent<HTMLInputElement, Element>) => {
+            (e: React.FocusEvent<HTMLInputElement>) => {
                 setIsFocused(true);
                 onFocus?.(e);
             },
             [onFocus]
         );
+
+        if (type === 'password') {
+            return (
+                <>
+                    <label
+                        htmlFor={id}
+                        className={classNames('inputLabel', {
+                            inputLabelUnfocused: !isFocused,
+                            inputLabelFocused: isFocused
+                        })}
+                    >
+                        {label}
+                    </label>
+                    <div className='emby-password-input-wrapper'>
+                        <input
+                            ref={ref}
+                            id={id}
+                            className={classNames('emby-input', className)}
+                            onBlur={onBlurInternal}
+                            onFocus={onFocusInternal}
+                            type={passwordVisible ? 'text' : 'password'}
+                            {...props}
+                        />
+                        <button
+                            type='button'
+                            className='emby-input-iconbutton paper-icon-button-light'
+                            onClick={() => setPasswordVisible(prev => !prev)}
+                            aria-label={passwordVisible ? 'Hide password' : 'Show password'}
+                        >
+                            <span className='material-icons' aria-hidden='true'>
+                                {passwordVisible ? 'visibility' : 'visibility_off'}
+                            </span>
+                        </button>
+                    </div>
+                </>
+            );
+        }
 
         return (
             <>
@@ -55,6 +93,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
                     className={classNames('emby-input', className)}
                     onBlur={onBlurInternal}
                     onFocus={onFocusInternal}
+                    type={type}
                     {...props}
                 />
             </>

--- a/src/elements/emby-input/emby-input.js
+++ b/src/elements/emby-input/emby-input.js
@@ -2,6 +2,7 @@ import browser from '../../scripts/browser';
 import dom from '../../utils/dom';
 import './emby-input.scss';
 import 'webcomponents.js/webcomponents-lite';
+import '../emby-button/paper-icon-button-light';
 
 const EmbyInputPrototype = Object.create(HTMLInputElement.prototype);
 
@@ -50,6 +51,42 @@ EmbyInputPrototype.createdCallback = function () {
     label.htmlFor = this.id;
     parentNode.insertBefore(label, this);
     this.labelElement = label;
+
+    if (this.type === 'password') {
+        const wrapper = document.createElement('div');
+        wrapper.classList.add('emby-password-input-wrapper');
+
+        const toggleBtn = document.createElement('button');
+        toggleBtn.setAttribute('type', 'button');
+        toggleBtn.setAttribute('is', 'paper-icon-button-light');
+        toggleBtn.classList.add('emby-input-iconbutton');
+        toggleBtn.setAttribute('aria-label', 'Show password');
+
+        parentNode.insertBefore(wrapper, this);
+        wrapper.appendChild(this);
+        wrapper.appendChild(toggleBtn);
+
+        const iconSpan = document.createElement('span');
+        iconSpan.classList.add('material-icons');
+        iconSpan.setAttribute('aria-hidden', 'true');
+        iconSpan.textContent = 'visibility_off';
+        toggleBtn.appendChild(iconSpan);
+
+        dom.addEventListener(toggleBtn, 'click', function () {
+            const input = wrapper.querySelector('input');
+            if (input.type === 'password') {
+                input.type = 'text';
+                iconSpan.textContent = 'visibility';
+                this.setAttribute('aria-label', 'Hide password');
+            } else {
+                input.type = 'password';
+                iconSpan.textContent = 'visibility_off';
+                this.setAttribute('aria-label', 'Show password');
+            }
+        }, {
+            passive: true
+        });
+    }
 
     dom.addEventListener(this, 'focus', function () {
         onChange.call(this);
@@ -115,4 +152,3 @@ document.registerElement('emby-input', {
     prototype: EmbyInputPrototype,
     extends: 'input'
 });
-

--- a/src/elements/emby-input/emby-input.scss
+++ b/src/elements/emby-input/emby-input.scss
@@ -70,3 +70,27 @@
 .emby-input-iconbutton {
     align-self: flex-end;
 }
+
+.emby-password-input-wrapper {
+    position: relative;
+    display: flex;
+    align-items: center;
+
+    input.emby-input {
+        width: 100%;
+        padding-right: 2.5em;
+    }
+
+    .emby-input-iconbutton {
+        position: absolute;
+        right: 0;
+        top: 50%;
+        transform: translateY(-50%);
+        margin: 0;
+    }
+}
+
+[dir="rtl"] .emby-password-input-wrapper .emby-input-iconbutton {
+    right: auto;
+    left: 0;
+}


### PR DESCRIPTION

### Changes
Add a standard password visibility toggle for password inputs. This covers the initial server login UI as well as the user administration UIs.

Note that the toggle is a button instead of a span, leaving it keyboard navigable/accessible.

<img width="1027" height="295" alt="image" src="https://github.com/user-attachments/assets/fc80567c-707b-4495-a54e-db5c38e0575a" />

<img width="1144" height="321" alt="image" src="https://github.com/user-attachments/assets/547d66ba-1e2d-41d1-9cbb-6aaf2ab892fb" />

### Issues
Resolves the request in https://features.jellyfin.org/posts/2924/add-a-show-password-button-on-login-screen

Replaces PRs #6325, #5928, and #7572 considering the feedback there.

I could not find any open github issues related to this.

### Code assistance
I asked an LLM to identify where the password input fields lived in the codebase.

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [*] I have verified that this is not duplicating changes in an existing PR.
* [*] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).

Note for the last two items, I have not provided a substantive review of another PR beyond reviewing the previous PR attempts at this feature. All but one of them are closed, and the remaining #6325 seems to be derelict.