### PR TITLE
Adjust the section header link limit

### DIFF
--- a/src/components/common/SectionContainer.tsx
+++ b/src/components/common/SectionContainer.tsx
@@ -35,7 +35,7 @@ const SectionHeader: FC<SectionHeaderProps> = ({
 
     return (
         <Box className={sectionHeaderClass}>
-            {url && itemsLength > 5 ? (
+            {url && itemsLength > 1 ? (
                 <Link
                     className='clearLink button-flat sectionTitleTextButton'
                     underline='none'


### PR DESCRIPTION
In the legacy view, users can click into a list view where they can play all or shuffle music for a specific genre, regardless of the number of items in the category. This is not currently possible in the modern layout unless there are at least 6 albums in that genre category.

### Changes
Changes the threshold for showing the URL link in the section header from >5 to  >1

### Issues
N/A

### Code assistance
N/A

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
