### PR TITLE
Always round up for card image sizes

### DIFF
--- a/src/components/cardbuilder/utils/url.ts
+++ b/src/components/cardbuilder/utils/url.ts
@@ -154,8 +154,8 @@ export function getCardImageUrl({
             imgType,
             {
                 // Dimensions must be rounded or the API will reject the request
-                fillHeight: height ? Math.round(height * dpr) : undefined,
-                fillWidth: width ? Math.round(width * dpr) : undefined,
+                fillHeight: height ? Math.ceil(height * dpr) : undefined,
+                fillWidth: width ? Math.ceil(width * dpr) : undefined,
                 quality: 96,
                 tag: imgTag
             }


### PR DESCRIPTION
### Changes
Ensure image is large enough.
No reason to do a `.5` split. It uses container size measured in current container.

### Issues
-

### Code assistance
no

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
