### PR TITLE
Add audiobook playback rate control via context menu

### DIFF
--- a/src/components/itemContextMenu.js
+++ b/src/components/itemContextMenu.js
@@ -83,6 +83,14 @@ export async function getCommands(options) {
                 icon: 'clear_all'
             });
         }
+        if (item.Type === 'AudioBook') {
+            const currentRate = Number.parseFloat(userSettings.get('audioBookPlaybackRate')) || 1;
+            commands.push({
+                name: globalize.translate('PlaybackRate') + ' (' + Number(currentRate).toFixed(2) + 'x)',
+                id: 'audiobookPlaybackRate',
+                icon: 'speed'
+            });
+        }
     }
 
     if (playbackManager.canQueue(item)) {
@@ -375,6 +383,30 @@ export async function getCommands(options) {
     return commands;
 }
 
+function showAudioBookRateMenu() {
+    const player = playbackManager.getCurrentPlayer();
+    const currentRate = Number.parseFloat(userSettings.get('audioBookPlaybackRate')) || 1;
+
+    const rates = [0.8, 1, 1.1, 1.25, 1.5, 1.75, 2, 2.25, 2.5];
+    const menuItems = rates.map(r => ({
+        name: r + 'x',
+        id: String(r),
+        selected: Math.abs(r - currentRate) < 0.01
+    }));
+
+    return actionsheet.show({
+        items: menuItems
+    }).then(function (id) {
+        if (id) {
+            const rate = Number.parseFloat(id);
+            // Capture the position before changing the rate, since restartStream re-reads it.
+            const resumePositionTicks = playbackManager.getCurrentTicks(player);
+            userSettings.set('audioBookPlaybackRate', String(rate));
+            playbackManager.restartStream(player, resumePositionTicks);
+        }
+    });
+}
+
 function getResolveFunction(resolve, commandId, changed, deleted, itemId) {
     return function () {
         resolve({
@@ -655,6 +687,10 @@ function executeCommand(item, id, options) {
                 break;
             case 'cancelseriestimer':
                 deleteSeriesTimer(apiClient, item, resolve, id);
+                break;
+            case 'audiobookPlaybackRate':
+                showAudioBookRateMenu();
+                getResolveFunction(resolve, id)();
                 break;
             default:
                 reject();

--- a/src/components/nowPlayingBar/nowPlayingBar.js
+++ b/src/components/nowPlayingBar/nowPlayingBar.js
@@ -9,7 +9,7 @@ import Events from '../../utils/events.ts';
 import browser from '../../scripts/browser';
 import imageLoader from '../images/imageLoader';
 import layoutManager from '../layoutManager';
-import { playbackManager } from '../playback/playbackmanager';
+import { playbackManager, getAudiobookPlaybackRate } from '../playback/playbackmanager';
 import { appHost } from '../apphost';
 import dom from '../../utils/dom';
 import globalize from 'lib/globalize';
@@ -369,7 +369,7 @@ function updatePlayerStateInternal(event, state, player) {
     }
 
     const nowPlayingItem = state.NowPlayingItem || {};
-    updateTimeDisplay(playState.PositionTicks, nowPlayingItem.RunTimeTicks, playbackManager.getBufferedRanges(player));
+    updateTimeDisplay(playState.PositionTicks, nowPlayingItem.RunTimeTicks, playbackManager.getBufferedRanges(player), nowPlayingItem);
 
     updateNowPlayingInfo(state);
     updateLyricButton(nowPlayingItem);
@@ -396,7 +396,19 @@ function updateRepeatModeDisplay(repeatMode) {
     }
 }
 
-function updateTimeDisplay(positionTicks, runtimeTicks, bufferedRanges) {
+function getAudiobookRemainingTimeText(runtimeTicks, positionTicks, nowPlayingItem) {
+    if (nowPlayingItem?.Type !== 'AudioBook' || positionTicks == null) {
+        return null;
+    }
+    const rate = getAudiobookPlaybackRate();
+    if (!rate) {
+        return null;
+    }
+    const remainingTicks = Math.max(0, runtimeTicks - positionTicks);
+    return datetime.getDisplayRunningTime(remainingTicks / rate);
+}
+
+function updateTimeDisplay(positionTicks, runtimeTicks, bufferedRanges, nowPlayingItem) {
     // See bindEvents for why this is necessary
     if (positionSlider && !positionSlider.dragging) {
         if (runtimeTicks) {
@@ -416,7 +428,9 @@ function updateTimeDisplay(positionTicks, runtimeTicks, bufferedRanges) {
     if (currentTimeElement) {
         let timeText = positionTicks == null ? '--:--' : datetime.getDisplayRunningTime(positionTicks);
         if (runtimeTicks) {
-            timeText += ' / ' + datetime.getDisplayRunningTime(runtimeTicks);
+            const runtimeText = getAudiobookRemainingTimeText(runtimeTicks, positionTicks, nowPlayingItem)
+                ?? datetime.getDisplayRunningTime(runtimeTicks);
+            timeText += ' / ' + runtimeText;
         }
 
         currentTimeElement.innerHTML = timeText;
@@ -677,7 +691,7 @@ function onTimeUpdate() {
 
     const player = this;
     currentRuntimeTicks = playbackManager.duration(player);
-    updateTimeDisplay(playbackManager.currentTime(player) * 10000, currentRuntimeTicks, playbackManager.getBufferedRanges(player));
+    updateTimeDisplay(playbackManager.currentTime(player) * 10000, currentRuntimeTicks, playbackManager.getBufferedRanges(player), playbackManager.currentItem(player));
 }
 
 function releaseCurrentPlayer() {

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -1727,15 +1727,8 @@ export class PlaybackManager {
                 if (currentItem?.Type === 'AudioBook') {
                     const rate = getAudiobookPlaybackRate();
                     if (rate) {
-                        const streamInfo = getPlayerData(player).streamInfo;
-                        const startTicks = streamInfo?.playerStartPositionTicks || 0;
-                        // Atempo streams have no content before their start, so rebuild to seek earlier.
-                        if (ticks < startTicks) {
-                            self.restartStream(player, ticks);
-                            return;
-                        }
-                        // element = (ticks - start) / rate
-                        player.currentTime(Number.parseInt(((ticks - startTicks) / rate) / 10000, 10));
+                        // Inverse of getCurrentTicks: element output time = content / rate.
+                        player.currentTime(Number.parseInt((ticks / rate) / 10000, 10));
                         return;
                     }
                 }
@@ -2294,13 +2287,12 @@ export class PlaybackManager {
 
             const streamInfo = getPlayerData(player).streamInfo;
 
-            // Atempo streams are 0-based at wall-clock speed: content = start + element * rate.
+            // The atempo HLS playlist is full and 0-based in output time, so content = currentTime * rate.
             const currentItem = self.currentItem(player);
             if (currentItem?.Type === 'AudioBook' && streamInfo) {
                 const rate = getAudiobookPlaybackRate();
                 if (rate) {
-                    const startTicks = streamInfo.playerStartPositionTicks || 0;
-                    return startTicks + Math.floor(playerTime * rate);
+                    return Math.floor(playerTime * rate);
                 }
             }
 

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -305,11 +305,18 @@ function getAudioMaxValues(deviceProfile) {
 }
 
 let startingPlaySession = new Date().getTime();
+
+export function getAudiobookPlaybackRate() {
+    const rate = Number.parseFloat(userSettings.get('audioBookPlaybackRate'));
+    return (rate && Math.abs(rate - 1) > 0.001) ? rate : null;
+}
+
 function getAudioStreamUrl(item, transcodingProfile, directPlayContainers, apiClient, startPosition, maxValues) {
     const url = 'Audio/' + item.Id + '/universal';
 
     startingPlaySession++;
-    return apiClient.getUrl(url, {
+
+    const params = {
         UserId: apiClient.getCurrentUserId(),
         DeviceId: apiClient.deviceId(),
         MaxStreamingBitrate: maxValues.maxAudioBitrate || maxValues.maxBitrate,
@@ -325,7 +332,16 @@ function getAudioStreamUrl(item, transcodingProfile, directPlayContainers, apiCl
         EnableRedirection: true,
         EnableRemoteMedia: appHost.supports(AppFeature.RemoteAudio),
         EnableAudioVbrEncoding: transcodingProfile.EnableAudioVbrEncoding
-    });
+    };
+
+    if (item.Type === 'AudioBook') {
+        const rate = getAudiobookPlaybackRate();
+        if (rate) {
+            params.AudioPlaybackRate = rate;
+        }
+    }
+
+    return apiClient.getUrl(url, params);
 }
 
 function getAudioStreamUrlFromDeviceProfile(item, deviceProfile, maxBitrate, apiClient, startPosition) {
@@ -1348,6 +1364,16 @@ export class PlaybackManager {
             }
         };
 
+        self.restartStream = function (player, positionTicks) {
+            player = player || self._currentPlayer;
+            if (player && enableLocalPlaylistManagement(player)) {
+                loading.show();
+                // Optional explicit position; falls back to the current position.
+                const ticks = positionTicks == null ? getCurrentTicks(player) : positionTicks;
+                changeStream(player, ticks, {});
+            }
+        };
+
         function getSavedMaxStreamingBitrate(apiClient, mediaType) {
             if (!apiClient) {
                 // This should hopefully never happen
@@ -1697,6 +1723,22 @@ export class PlaybackManager {
 
         function changeStream(player, ticks, params) {
             if (canPlayerSeek(player) && params == null) {
+                const currentItem = self.currentItem(player);
+                if (currentItem?.Type === 'AudioBook') {
+                    const rate = getAudiobookPlaybackRate();
+                    if (rate) {
+                        const streamInfo = getPlayerData(player).streamInfo;
+                        const startTicks = streamInfo?.playerStartPositionTicks || 0;
+                        // Atempo streams have no content before their start, so rebuild to seek earlier.
+                        if (ticks < startTicks) {
+                            self.restartStream(player, ticks);
+                            return;
+                        }
+                        // element = (ticks - start) / rate
+                        player.currentTime(Number.parseInt(((ticks - startTicks) / rate) / 10000, 10));
+                        return;
+                    }
+                }
                 player.currentTime(parseInt(ticks / 10000, 10));
                 return;
             }
@@ -1790,12 +1832,14 @@ export class PlaybackManager {
             playerData.streamInfo = streamInfo;
 
             return player.play(streamInfo).then(function () {
+                loading.hide();
                 playerData.isChangingStream = false;
                 streamInfo.started = true;
                 streamInfo.ended = false;
 
                 sendProgressUpdate(player, 'timeupdate');
             }, function (e) {
+                loading.hide();
                 playerData.isChangingStream = false;
 
                 onPlaybackError.call(player, e, {
@@ -2249,8 +2293,19 @@ export class PlaybackManager {
             let playerTime = Math.floor(10000 * (player).currentTime());
 
             const streamInfo = getPlayerData(player).streamInfo;
+
+            // Atempo streams are 0-based at wall-clock speed: content = start + element * rate.
+            const currentItem = self.currentItem(player);
+            if (currentItem?.Type === 'AudioBook' && streamInfo) {
+                const rate = getAudiobookPlaybackRate();
+                if (rate) {
+                    const startTicks = streamInfo.playerStartPositionTicks || 0;
+                    return startTicks + Math.floor(playerTime * rate);
+                }
+            }
+
             if (streamInfo) {
-                playerTime += getPlayerData(player).streamInfo.transcodingOffsetTicks || 0;
+                playerTime += streamInfo.transcodingOffsetTicks || 0;
             }
 
             return playerTime;

--- a/src/components/remotecontrol/remotecontrol.js
+++ b/src/components/remotecontrol/remotecontrol.js
@@ -9,7 +9,7 @@ import datetime from '../../scripts/datetime';
 import { clearBackdrop, setBackdrops } from '../backdrop/backdrop';
 import listView from '../listview/listview';
 import imageLoader from '../images/imageLoader';
-import { playbackManager } from '../playback/playbackmanager';
+import { playbackManager, getAudiobookPlaybackRate } from '../playback/playbackmanager';
 import Events from '../../utils/events.ts';
 import { appHost } from '../apphost';
 import globalize from '../../lib/globalize';
@@ -312,7 +312,7 @@ export default function () {
         }
 
         updatePlayPauseState(playState.IsPaused, item != null);
-        updateTimeDisplay(playState.PositionTicks, item ? item.RunTimeTicks : null);
+        updateTimeDisplay(playState.PositionTicks, item ? item.RunTimeTicks : null, item);
         updatePlayerVolumeState(context, playState.IsMuted, playState.VolumeLevel);
 
         if (item && item.MediaType == 'Video') {
@@ -425,7 +425,7 @@ export default function () {
         buttonVisible(btnPlayPause, isActive);
     }
 
-    function updateTimeDisplay(positionTicks, runtimeTicks) {
+    function updateTimeDisplay(positionTicks, runtimeTicks, item) {
         const context = dlg;
         const positionSlider = context.querySelector('.nowPlayingPositionSlider');
 
@@ -440,7 +440,21 @@ export default function () {
         }
 
         context.querySelector('.positionTime').innerHTML = Number.isFinite(positionTicks) ? datetime.getDisplayRunningTime(positionTicks) : '--:--';
-        context.querySelector('.runtime').innerHTML = Number.isFinite(runtimeTicks) ? datetime.getDisplayRunningTime(runtimeTicks) : '--:--';
+
+        let runtimeDisplay;
+        if (Number.isFinite(runtimeTicks)) {
+            if (item?.Type === 'AudioBook' && Number.isFinite(positionTicks)) {
+                const rate = getAudiobookPlaybackRate();
+                if (rate) {
+                    const remainingTicks = Math.max(0, runtimeTicks - positionTicks);
+                    runtimeDisplay = datetime.getDisplayRunningTime(remainingTicks / rate);
+                }
+            }
+            runtimeDisplay = runtimeDisplay ?? datetime.getDisplayRunningTime(runtimeTicks);
+        } else {
+            runtimeDisplay = '--:--';
+        }
+        context.querySelector('.runtime').innerHTML = runtimeDisplay;
     }
 
     function getPlaylistItems(player) {
@@ -585,7 +599,7 @@ export default function () {
             lastUpdateTime = now;
             const player = this;
             currentRuntimeTicks = playbackManager.duration(player);
-            updateTimeDisplay(playbackManager.currentTime(player) * 10000, currentRuntimeTicks);
+            updateTimeDisplay(playbackManager.currentTime(player) * 10000, currentRuntimeTicks, playbackManager.currentItem(player));
         }
     }
 

--- a/src/plugins/htmlAudioPlayer/plugin.js
+++ b/src/plugins/htmlAudioPlayer/plugin.js
@@ -149,10 +149,9 @@ class HtmlAudioPlayer {
                 console.error('Failed to add/change gainNode', err);
             });
 
-            // Convert to seconds
-            // Atempo streams start at the resume position server-side, so begin the element at 0.
-            const isAtempoStream = val.includes('AudioPlaybackRate=');
-            const seconds = isAtempoStream ? 0 : (options.playerStartPositionTicks || 0) / 10000000;
+            // Convert to seconds. Atempo uses a 0-based output timeline, so the resume position in element time is contentSeconds / rate.
+            const atempoRate = parseFloat((val.match(/AudioPlaybackRate=([\d.]+)/) || [])[1]) || 1;
+            const seconds = (options.playerStartPositionTicks || 0) / 10000000 / atempoRate;
             if (seconds) {
                 val += '#t=' + seconds;
             }
@@ -339,9 +338,10 @@ class HtmlAudioPlayer {
                 self._started = true;
                 this.removeAttribute('controls');
 
-                // Atempo streams start at the resume position server-side, so skip the element seek.
-                const isAtempoStream = (self._currentPlayOptions.url || '').includes('AudioPlaybackRate=');
-                htmlMediaHelper.seekOnPlaybackStart(self, e.target, isAtempoStream ? 0 : self._currentPlayOptions.playerStartPositionTicks);
+                // Atempo uses a 0-based output timeline, so the resume position in element time is contentTicks / rate.
+                const atempoRate = parseFloat(((self._currentPlayOptions.url || '').match(/AudioPlaybackRate=([\d.]+)/) || [])[1]) || 1;
+                const startTicks = self._currentPlayOptions.playerStartPositionTicks;
+                htmlMediaHelper.seekOnPlaybackStart(self, e.target, startTicks ? startTicks / atempoRate : startTicks);
             }
             Events.trigger(self, 'playing');
         }

--- a/src/plugins/htmlAudioPlayer/plugin.js
+++ b/src/plugins/htmlAudioPlayer/plugin.js
@@ -150,7 +150,9 @@ class HtmlAudioPlayer {
             });
 
             // Convert to seconds
-            const seconds = (options.playerStartPositionTicks || 0) / 10000000;
+            // Atempo streams start at the resume position server-side, so begin the element at 0.
+            const isAtempoStream = val.includes('AudioPlaybackRate=');
+            const seconds = isAtempoStream ? 0 : (options.playerStartPositionTicks || 0) / 10000000;
             if (seconds) {
                 val += '#t=' + seconds;
             }
@@ -337,7 +339,9 @@ class HtmlAudioPlayer {
                 self._started = true;
                 this.removeAttribute('controls');
 
-                htmlMediaHelper.seekOnPlaybackStart(self, e.target, self._currentPlayOptions.playerStartPositionTicks);
+                // Atempo streams start at the resume position server-side, so skip the element seek.
+                const isAtempoStream = (self._currentPlayOptions.url || '').includes('AudioPlaybackRate=');
+                htmlMediaHelper.seekOnPlaybackStart(self, e.target, isAtempoStream ? 0 : self._currentPlayOptions.playerStartPositionTicks);
             }
             Events.trigger(self, 'playing');
         }

--- a/src/plugins/htmlAudioPlayer/plugin.js
+++ b/src/plugins/htmlAudioPlayer/plugin.js
@@ -150,7 +150,7 @@ class HtmlAudioPlayer {
             });
 
             // Convert to seconds. Atempo uses a 0-based output timeline, so the resume position in element time is contentSeconds / rate.
-            const atempoRate = parseFloat((val.match(/AudioPlaybackRate=([\d.]+)/) || [])[1]) || 1;
+            const atempoRate = Number.parseFloat((val.match(/AudioPlaybackRate=([\d.]+)/) || [])[1]) || 1;
             const seconds = (options.playerStartPositionTicks || 0) / 10000000 / atempoRate;
             if (seconds) {
                 val += '#t=' + seconds;
@@ -339,7 +339,7 @@ class HtmlAudioPlayer {
                 this.removeAttribute('controls');
 
                 // Atempo uses a 0-based output timeline, so the resume position in element time is contentTicks / rate.
-                const atempoRate = parseFloat(((self._currentPlayOptions.url || '').match(/AudioPlaybackRate=([\d.]+)/) || [])[1]) || 1;
+                const atempoRate = Number.parseFloat(((self._currentPlayOptions.url || '').match(/AudioPlaybackRate=([\d.]+)/) || [])[1]) || 1;
                 const startTicks = self._currentPlayOptions.playerStartPositionTicks;
                 htmlMediaHelper.seekOnPlaybackStart(self, e.target, startTicks ? startTicks / atempoRate : startTicks);
             }


### PR DESCRIPTION
### Changes
- When [server-side atempo](https://github.com/jellyfin/jellyfin/pull/17063) is active (not 1.0x) the stream transcodes and is compressed by the playback rate
- Make sure currentTime uses the stream position rather than original-file position.
- Scale the stream-relative time by the playback rate in getCurrentTicks before adding transcodingOffsetTicks, so that progress reported to the server is correct (a 1 hour audio file playing at 2x for 15 minutes should resume on another device at minute 30 not minute 15).
- Finally make sure the loader spins while fetching the new steam (transcoded or not)
- Also extracts the repeated audioBookPlaybackRate read-and-threshold check into a getAudiobookPlaybackRate() helper.

### Issues
- https://features.jellyfin.org/posts/590/adjust-audiobook-playback-speed
- https://features.jellyfin.org/posts/1242/android-app-playback-speed-for-audio

### Code assistance
- Opus used to identify the locations I would need to target to match with the [server change](https://github.com/jellyfin/jellyfin/pull/17063) I currently have open
- Opus used to review the code changes

---

* [X] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [X] I have tested these changes. Yes on Android, iOS, and Web
* [X] I have verified that this is not duplicating changes in an existing PR.
* [X] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
I reviewed: https://github.com/jellyfin/jellyfin-web/pull/7300 & https://github.com/jellyfin/jellyfin-web/pull/7781

### Notes
- Originally I wrote this without a server fix and just utilizing the browser playback rate. However, while working for Web and Android, this broke on iOS. Hence the change on the server attached above. This should allow for across the board support as the compression happens on the server and the client treats the playback as a true 1.0x. 
- This was tested on Web, iOS, and Android phone (technically Android Auto as well). It was not tested on WebOS or any other client that uses a web wrapper
- To test this, you will need the [server change](https://github.com/jellyfin/jellyfin/pull/17063) as well
- This cannot be deployed before the [Server change](https://github.com/jellyfin/jellyfin/pull/17063) is deployed