### PR TITLE
Prevent screensaver while viewing photos or reading books

### DIFF
--- a/src/components/slideshow/slideshow.js
+++ b/src/components/slideshow/slideshow.js
@@ -576,6 +576,8 @@ export default function (options) {
         inputManager.off(window, onInputCommand);
         /* eslint-disable-next-line compat/compat */
         document.removeEventListener((window.PointerEvent ? 'pointermove' : 'mousemove'), onPointerMove);
+
+        currentOptions.onClose?.();
     }
 
     /**

--- a/src/plugins/bookPlayer/plugin.js
+++ b/src/plugins/bookPlayer/plugin.js
@@ -4,6 +4,7 @@ import Screenfull from 'screenfull';
 import { PluginType } from 'constants/pluginType';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
 import browser from 'scripts/browser';
+import screenSaverManager from 'scripts/screensavermanager';
 import TouchHelper from 'scripts/touchHelper';
 
 import loading from '../../components/loading/loading';
@@ -61,6 +62,7 @@ export class BookPlayer {
         this.cancellationToken = false;
         this.loaded = false;
 
+        screenSaverManager.block();
         loading.show();
         const elem = this.createMediaElement(options);
         return this.setCurrentSrc(elem, options);
@@ -69,6 +71,7 @@ export class BookPlayer {
     stop() {
         this.unbindEvents();
         this.unmountBookOsd();
+        screenSaverManager.unblock();
 
         const stopInfo = {
             src: this.item

--- a/src/plugins/comicsPlayer/plugin.js
+++ b/src/plugins/comicsPlayer/plugin.js
@@ -3,6 +3,7 @@ import { Archive } from 'libarchive.js';
 
 import { PluginType } from 'constants/pluginType';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
+import screenSaverManager from 'scripts/screensavermanager';
 
 import loading from '../../components/loading/loading';
 import dialogHelper from '../../components/dialogHelper/dialogHelper';
@@ -45,6 +46,7 @@ export class ComicsPlayer {
         const mediaSourceId = options.items[0].Id;
         this.comicsPlayerSettings = userSettings.getComicsPlayerSettings(mediaSourceId);
 
+        screenSaverManager.block();
         const elem = this.createMediaElement(options);
         return this.setCurrentSrc(elem, options);
     }
@@ -52,6 +54,7 @@ export class ComicsPlayer {
     stop() {
         this.unbindEvents();
         this.unmountBookOsd?.();
+        screenSaverManager.unblock();
 
         const stopInfo = {
             src: this.item

--- a/src/plugins/pdfPlayer/plugin.js
+++ b/src/plugins/pdfPlayer/plugin.js
@@ -8,6 +8,7 @@ import dialogHelper from '../../components/dialogHelper/dialogHelper';
 import dom from '../../utils/dom';
 import { appRouter } from '../../components/router/appRouter';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
+import screenSaverManager from 'scripts/screensavermanager';
 import Events from '../../utils/events.ts';
 import BookOsd from '../bookPlayer/BookOsd/BookOsd';
 import { renderComponent } from '../../utils/reactUtils';
@@ -36,6 +37,7 @@ export class PdfPlayer {
         this.cancellationToken = false;
         this.pages = {};
 
+        screenSaverManager.block();
         loading.show();
 
         const elem = this.createMediaElement(options);
@@ -45,6 +47,7 @@ export class PdfPlayer {
     stop() {
         this.unbindEvents();
         this.unmountBookOsd?.();
+        screenSaverManager.unblock();
 
         const stopInfo = {
             src: this.item

--- a/src/plugins/photoPlayer/plugin.js
+++ b/src/plugins/photoPlayer/plugin.js
@@ -1,5 +1,6 @@
 import { PluginType } from 'constants/pluginType';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
+import screenSaverManager from 'scripts/screensavermanager';
 import * as userSettings from 'scripts/settings/userSettings';
 
 export default class PhotoPlayer {
@@ -28,9 +29,11 @@ export default class PhotoPlayer {
                         autoplay: {
                             delay: userSettings.slideshowInterval() * 1000
                         },
-                        user: result
+                        user: result,
+                        onClose: () => screenSaverManager.unblock()
                     });
 
+                    screenSaverManager.block();
                     newSlideShow.show();
                     resolve();
                 });

--- a/src/scripts/screensavermanager.js
+++ b/src/scripts/screensavermanager.js
@@ -49,6 +49,7 @@ function getScreensaverPlugin(isLoggedIn) {
 
 function ScreenSaverManager() {
     let activeScreenSaver;
+    let blockCount = 0;
 
     function showScreenSaver(screensaver) {
         if (activeScreenSaver) {
@@ -91,6 +92,22 @@ function ScreenSaverManager() {
         return activeScreenSaver != null;
     };
 
+    /**
+     * Prevents the screensaver from activating until a matching unblock() call.
+     */
+    this.block = () => {
+        blockCount++;
+    };
+
+    /**
+     * Releases a previous block(); the screensaver can activate once all blocks are cleared.
+     */
+    this.unblock = () => {
+        if (blockCount > 0) {
+            blockCount--;
+        }
+    };
+
     this.show = function () {
         let isLoggedIn;
         const apiClient = ServerConnections.currentApiClient();
@@ -112,6 +129,10 @@ function ScreenSaverManager() {
 
     const onInterval = () => {
         if (this.isShowing()) {
+            return;
+        }
+
+        if (blockCount > 0) {
             return;
         }
 


### PR DESCRIPTION
### Changes
The screensaver could activate while viewing a photo slideshow or reading a book, PDF, or comic. These players don't set themselves as the current player in the `PlaybackManager` and don't emit playback events, so the screensaver's idle check had no way to know they were active.

Adds a block/unblock counter to the `ScreenSaverManager`. The photo, book, PDF, and comic players block the screensaver when they open and unblock it when they close, so it stays inhibited for as long as the viewer is open regardless of idle time.

### Issues
Fixes #7873

### Code assistance
None

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
