### PR TITLE
Add audiobooks to the authors tab

### DIFF
--- a/src/apps/experimental/features/libraries/constants/views/books.ts
+++ b/src/apps/experimental/features/libraries/constants/views/books.ts
@@ -31,6 +31,7 @@ const suggestionsTabContent: LibraryTabContent = {
 const authorsTabContent: LibraryTabContent = {
     viewType: LibraryTab.Authors,
     collectionType: CollectionType.Books,
+    itemType: [BaseItemKind.AudioBook, BaseItemKind.Book],
     isBtnSortEnabled: false
 };
 

--- a/src/apps/experimental/features/libraries/constants/views/books.ts
+++ b/src/apps/experimental/features/libraries/constants/views/books.ts
@@ -31,7 +31,6 @@ const suggestionsTabContent: LibraryTabContent = {
 const authorsTabContent: LibraryTabContent = {
     viewType: LibraryTab.Authors,
     collectionType: CollectionType.Books,
-    itemType: [BaseItemKind.AudioBook, BaseItemKind.Book],
     isBtnSortEnabled: false
 };
 

--- a/src/scripts/itemsByName.js
+++ b/src/scripts/itemsByName.js
@@ -68,6 +68,11 @@ function renderItems(page, item) {
         });
     }
 
+    sections.push({
+        name: globalize.translate('HeaderAudioBooks'),
+        type: 'Audiobook'
+    });
+
     // TODO add a check when the API reports BookCount or PersonRoles
     sections.push({
         name: globalize.translate('Books'),
@@ -214,6 +219,22 @@ function renderSection(item, element, type) {
                 coverImage: true,
                 centerText: true,
                 overlayPlayButton: true
+            });
+            break;
+
+        case 'Audiobook':
+            loadItems(element, item, type, {
+                IncludeItemTypes: 'Audiobook',
+                SortBy: 'ProductionYear,SortName',
+                SortOrder: 'Descending,Ascending',
+                Limit: 10
+            }, {
+                shape: 'overflowPortrait',
+                showTitle: true,
+                centerText: true,
+                overlayMoreButton: true,
+                overlayText: false,
+                showYear: true
             });
             break;
 

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -402,7 +402,7 @@
     "HeaderApiKeysHelp": "External applications are required to have an API key in order to communicate with the server. Keys are issued by logging in with a normal user account or manually granting the application a key.",
     "HeaderApp": "App",
     "HeaderAppearsOn": "Appears On",
-    "HeaderAudioBooks": "Audio Books",
+    "HeaderAudioBooks": "Audiobooks",
     "HeaderAudioAdvanced": "Audio Advanced",
     "HeaderAudioSettings": "Audio Settings",
     "HeaderAutoDiscovery": "Network Discovery",


### PR DESCRIPTION
In the book library, which can contain books and audiobooks, only books are currently enabled in the author's tab.

### Changes
Add audiobooks to the author's tab and add a case for audiobooks

### Issues
Question: The English translation for audiobooks has it as two separate words: "HeaderAudioBooks": "Audio Books".
Please let me know if that should be updated to "Audiobooks". 


### Code assistance
N/A

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
