### PR TITLE
Fix Add to collection permissions

### DIFF
--- a/src/components/multiSelect/multiSelect.js
+++ b/src/components/multiSelect/multiSelect.js
@@ -191,12 +191,13 @@ function showMenuForSelectedItems(e) {
                 icon: 'select_all'
             });
 
-            menuItems.push({
-                name: globalize.translate('AddToCollection'),
-                id: 'addtocollection',
-                icon: 'add'
-            });
-
+            if (user.Policy.IsAdministrator || user.Policy.EnableCollectionManagement) {
+                menuItems.push({
+                    name: globalize.translate('AddToCollection'),
+                    id: 'addtocollection',
+                    icon: 'add'
+                });
+            }
             menuItems.push({
                 name: globalize.translate('AddToPlaylist'),
                 id: 'playlist',


### PR DESCRIPTION
### Changes
Disable "Add to collection" from the multi-select menu when a user doesn't have the appropriate privileges 
### Issues
Reported on Matrix
### Code assistance
N/A


---
* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
