### PR TITLE
Fix New Collection button permissions

### DIFF
--- a/src/apps/experimental/features/libraries/components/LibraryToolbar.tsx
+++ b/src/apps/experimental/features/libraries/components/LibraryToolbar.tsx
@@ -17,6 +17,7 @@ import ShuffleButton from 'apps/experimental/components/library/ShuffleButton';
 import SortButton from 'apps/experimental/components/library/SortButton';
 import ViewSettingsButton from 'apps/experimental/components/library/ViewSettingsButton';
 import { playbackManager } from 'components/playback/playbackmanager';
+import { useApi } from 'hooks/useApi';
 import { useItem } from 'hooks/useItem';
 import { useUserSettings } from 'hooks/useUserSettings';
 import globalize from 'lib/globalize';
@@ -63,6 +64,8 @@ const LibraryToolbar: FC = () => {
     const hasFilters = Object.values(viewSettings?.Filters ?? {}).some(
         (filter) => !!filter
     );
+    const { user } = useApi();
+    const canCreateCollections = user?.Policy?.IsAdministrator || user?.Policy?.EnableCollectionManagement;
 
     // Pagination
     const startIndex = viewSettings?.StartIndex ?? 0;
@@ -145,7 +148,7 @@ const LibraryToolbar: FC = () => {
                             )}
                         </ButtonGroup>
 
-                        {isBtnNewCollectionEnabled && <NewCollectionButton isTextVisible={isSmallScreen} />}
+                        {isBtnNewCollectionEnabled && canCreateCollections && <NewCollectionButton isTextVisible={isSmallScreen} />}
                         {isBtnNewPlaylistEnabled && <NewPlaylistButton isTextVisible={isSmallScreen} />}
                     </>
                 )}


### PR DESCRIPTION
### Changes
Disable the New Collection button when a user doesn't have the appropriate privileges



### Issues
N/A

### Code assistance
N/A


---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
