### PR TITLE
Show focus indicator for keyboard users on non-TV layouts

### DIFF
--- a/src/styles/site.scss
+++ b/src/styles/site.scss
@@ -101,6 +101,22 @@ div[data-role="page"] {
     outline: 0;
 }
 
+/*
+ * Restore a focus indicator for keyboard users on non-TV layouts.
+ * Many components set `outline: none !important` to suppress the ugly native
+ * outline on old TV browsers (see emby-button.scss), and the focus indicator
+ * for the TV layout is provided separately via the `.show-focus` scale. That
+ * left desktop/mobile keyboard users with no visible focus at all (#6600).
+ * `:focus-visible` only matches keyboard focus (not mouse clicks), and is
+ * ignored by the old TV browsers we still target, so the TV experience is
+ * unaffected; we additionally exclude `.layout-tv` so newer TV browsers that
+ * do support `:focus-visible` keep using the `.show-focus` indicator.
+ */
+:root:not(.layout-tv) :focus-visible {
+    outline: 0.14em solid var(--jf-palette-primary-main, currentcolor) !important;
+    outline-offset: 0.1em;
+}
+
 .pageTitle {
     margin-top: 0;
     font-family: inherit;


### PR DESCRIPTION
### Changes

Many components set `outline: none !important` to hide the native focus outline on old TV browsers (see `emby-button.scss`), and the TV layout shows focus separately via the `.show-focus` scale. As a result, keyboard users on the desktop and mobile layouts had no visible focus indicator at all when tabbing through the interface.

This adds a single global `:focus-visible` rule in `site.scss`, scoped to non-TV layouts (`:root:not(.layout-tv)`), that draws an outline using the theme accent color. `:focus-visible` matches only keyboard focus (not mouse clicks), and is ignored by the old TV browsers in our browserslist (it shipped in Chrome 86), so the TV experience is unchanged; newer TV browsers keep using the `.show-focus` indicator because of the `:not(.layout-tv)` scope.

Verified in a browser on the desktop layout: tabbing onto a button (which carries `outline: none !important`) now shows a focus ring, while focusing the same button with the mouse shows none. Before/after screenshots (keyboard focus shows a ring; mouse focus does not) can be added to this description.

### Issues

Fixes #6600

### Code assistance

Implemented with the help of an LLM (Claude Code): code-base investigation of how focus is currently shown (`.show-focus` is TV-only) and why `outline: none` exists (old TV browsers), drafting the fix, and browser-based verification of the keyboard-vs-mouse behavior.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
