### PR TITLE
fix: add api check in useInstallPackage mutationFn

### DIFF
--- a/src/apps/dashboard/features/plugins/api/useInstallPackage.ts
+++ b/src/apps/dashboard/features/plugins/api/useInstallPackage.ts
@@ -10,10 +10,12 @@ import { QueryKey } from './queryKey';
 export const useInstallPackage = () => {
     const { api } = useApi();
     return useMutation({
-        mutationFn: (params: PackageApiInstallPackageRequest) => (
-            getPackageApi(api!)
-                .installPackage(params)
-        ),
+        mutationFn: (params: PackageApiInstallPackageRequest) => {
+            if (!api) {
+                throw new Error('API client not initialized');
+            }
+            return getPackageApi(api).installPackage(params);
+        },
         onSuccess: () => {
             void queryClient.invalidateQueries({
                 queryKey: [ QueryKey.ConfigurationPages ]


### PR DESCRIPTION
Added an explicit check for the API client in the useInstallPackage mutation function to prevent potential runtime errors when the API client is not initialized, improving robustness.