### PR TITLE
Fix username validation on user create/edit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13208,6 +13208,21 @@
         }
       }
     },
+    "node_modules/html-encoding-sniffer/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -14739,6 +14754,21 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jsdom/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/jsdom/node_modules/entities": {
@@ -25006,6 +25036,21 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/whatwg-url/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/which": {

--- a/src/apps/dashboard/features/users/components/Profile.tsx
+++ b/src/apps/dashboard/features/users/components/Profile.tsx
@@ -251,30 +251,30 @@ const Profile = ({ userDto }: ProfileProps) => {
             user.Policy.EnableContentDeletionFromFolders = user.Policy.EnableContentDeletion ? [] : getCheckedElementDataIds(page.querySelectorAll('.chkFolder'));
             user.Policy.SyncPlayAccess = (page.querySelector('#selectSyncPlayAccess') as HTMLSelectElement).value as SyncPlayUserAccessType;
 
-            updateUser.mutate({ userId: user.Id, userDto: user }, {
-                onError: () => {
-                    loading.hide();
-                    setErrorMessage(globalize.translate('ErrorDefault'));
-                },
-                onSuccess: () => {
-                    if (user.Id) {
-                        updateUserPolicy.mutate({
-                            userId: user.Id,
-                            userPolicy: user.Policy || { PasswordResetProviderId: '', AuthenticationProviderId: '' }
-                        }, {
-                            onError: () => {
-                                loading.hide();
-                                setErrorMessage(globalize.translate('ErrorDefault'));
-                            },
-                            onSuccess: () => {
-                                loading.hide();
-                                navigate('/dashboard/users', {
-                                    state: { openSavedToast: true }
-                                });
-                            }
+            const onUpdateError = () => {
+                loading.hide();
+                setErrorMessage(globalize.translate('ErrorDefault'));
+            };
+
+            const onUpdateUserSuccess = () => {
+                if (!user.Id) return;
+                updateUserPolicy.mutate({
+                    userId: user.Id,
+                    userPolicy: user.Policy || { PasswordResetProviderId: '', AuthenticationProviderId: '' }
+                }, {
+                    onError: onUpdateError,
+                    onSuccess: () => {
+                        loading.hide();
+                        navigate('/dashboard/users', {
+                            state: { openSavedToast: true }
                         });
                     }
-                }
+                });
+            };
+
+            updateUser.mutate({ userId: user.Id, userDto: user }, {
+                onError: onUpdateError,
+                onSuccess: onUpdateUserSuccess
             });
         };
 

--- a/src/apps/dashboard/features/users/components/Profile.tsx
+++ b/src/apps/dashboard/features/users/components/Profile.tsx
@@ -17,6 +17,8 @@ import { useChannels } from 'apps/dashboard/features/users/api/useChannels';
 import { useUpdateUser } from 'apps/dashboard/features/users/api/useUpdateUser';
 import { useUpdateUserPolicy } from 'apps/dashboard/features/users/api/useUpdateUserPolicy';
 import { useNetworkConfig } from 'apps/dashboard/features/users/api/useNetworkConfig';
+import Toast from 'apps/dashboard/components/Toast';
+import { isValidUsername } from 'utils/string';
 
 interface ProfileProps {
     userDto: UserDto;
@@ -34,6 +36,7 @@ const getCheckedElementDataIds = (elements: NodeListOf<Element>) => (
 const Profile = ({ userDto }: ProfileProps) => {
     const navigate = useNavigate();
     const [ deleteFoldersAccess, setDeleteFoldersAccess ] = useState<ResetProvider[]>([]);
+    const [ errorMessage, setErrorMessage ] = useState('');
     const libraryMenu = useMemo(async () => ((await import('scripts/libraryMenu')).default), []);
 
     const [ authenticationProviderId, setAuthenticationProviderId ] = useState('');
@@ -214,7 +217,15 @@ const Profile = ({ userDto }: ProfileProps) => {
                 throw new Error('Unexpected null user id or policy');
             }
 
-            user.Name = (page.querySelector('#txtUserName') as HTMLInputElement).value.trim();
+            const nameValue = (page.querySelector('#txtUserName') as HTMLInputElement).value.trim();
+
+            if (!isValidUsername(nameValue)) {
+                loading.hide();
+                setErrorMessage(globalize.translate('MessageInvalidUsername'));
+                return;
+            }
+
+            user.Name = nameValue;
             user.Policy.IsAdministrator = (page.querySelector('.chkIsAdmin') as HTMLInputElement).checked;
             user.Policy.IsHidden = (page.querySelector('.chkIsHidden') as HTMLInputElement).checked;
             user.Policy.IsDisabled = (page.querySelector('.chkDisabled') as HTMLInputElement).checked;
@@ -241,12 +252,20 @@ const Profile = ({ userDto }: ProfileProps) => {
             user.Policy.SyncPlayAccess = (page.querySelector('#selectSyncPlayAccess') as HTMLSelectElement).value as SyncPlayUserAccessType;
 
             updateUser.mutate({ userId: user.Id, userDto: user }, {
+                onError: () => {
+                    loading.hide();
+                    setErrorMessage(globalize.translate('ErrorDefault'));
+                },
                 onSuccess: () => {
                     if (user.Id) {
                         updateUserPolicy.mutate({
                             userId: user.Id,
                             userPolicy: user.Policy || { PasswordResetProviderId: '', AuthenticationProviderId: '' }
                         }, {
+                            onError: () => {
+                                loading.hide();
+                                setErrorMessage(globalize.translate('ErrorDefault'));
+                            },
                             onSuccess: () => {
                                 loading.hide();
                                 navigate('/dashboard/users', {
@@ -306,6 +325,11 @@ const Profile = ({ userDto }: ProfileProps) => {
 
     return (
         <div ref={element}>
+            <Toast
+                open={!!errorMessage}
+                onClose={() => setErrorMessage('')}
+                message={errorMessage}
+            />
             <div
                 className='lnkEditUserPreferencesContainer'
                 style={{ paddingBottom: '1em' }}

--- a/src/apps/dashboard/routes/users/add.tsx
+++ b/src/apps/dashboard/routes/users/add.tsx
@@ -16,6 +16,7 @@ import { useChannels } from 'apps/dashboard/features/users/api/useChannels';
 import { useUpdateUserPolicy } from 'apps/dashboard/features/users/api/useUpdateUserPolicy';
 import { useCreateUser } from 'apps/dashboard/features/users/api/useCreateUser';
 import { useNavigate } from 'react-router-dom';
+import { isValidUsername } from 'utils/string';
 
 type ItemsArr = {
     Name?: string | null;
@@ -27,6 +28,7 @@ const UserNew = () => {
     const [ channelsItems, setChannelsItems ] = useState<ItemsArr[]>([]);
     const [ mediaFoldersItems, setMediaFoldersItems ] = useState<ItemsArr[]>([]);
     const [ isErrorToastOpen, setIsErrorToastOpen ] = useState(false);
+    const [ errorToastMessage, setErrorToastMessage ] = useState(globalize.translate('ErrorDefault'));
     const element = useRef<HTMLDivElement>(null);
 
     const handleToastClose = useCallback(() => {
@@ -121,11 +123,25 @@ const UserNew = () => {
         }
 
         const saveUser = () => {
+            const nameValue = (page.querySelector('#txtUsername') as HTMLInputElement).value;
+
+            if (!isValidUsername(nameValue)) {
+                loading.hide();
+                setErrorToastMessage(globalize.translate('MessageInvalidUsername'));
+                setIsErrorToastOpen(true);
+                return;
+            }
+
             const userInput: CreateUserByName = {
-                Name: (page.querySelector('#txtUsername') as HTMLInputElement).value,
+                Name: nameValue,
                 Password: (page.querySelector('#txtPassword') as HTMLInputElement).value
             };
             createUser.mutate({ createUserByName: userInput }, {
+                onError: () => {
+                    loading.hide();
+                    setErrorToastMessage(globalize.translate('ErrorDefault'));
+                    setIsErrorToastOpen(true);
+                },
                 onSuccess: (response) => {
                     const user = response.data;
 
@@ -214,7 +230,7 @@ const UserNew = () => {
             <Toast
                 open={isErrorToastOpen}
                 onClose={handleToastClose}
-                message={globalize.translate('ErrorDefault')}
+                message={errorToastMessage}
             />
             <div ref={element} className='content-primary'>
                 <div className='verticalSection'>

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1179,6 +1179,7 @@
     "MessageImageTypeNotSelected": "Please select an image type from the drop-down menu.",
     "MessageInvalidForgotPasswordPin": "An invalid or expired PIN code was entered. Please try again.",
     "MessageInvalidUser": "Invalid username or password. Please try again.",
+    "MessageInvalidUsername": "Username can only contain unicode characters, numbers (0-9), dashes (-), underscores (_), apostrophes ('), and periods (.)",
     "MessageItemsAdded": "Items added.",
     "MessageItemSaved": "Item saved.",
     "MessageLeaveEmptyToInherit": "Leave empty to inherit settings from a parent item or the global default value.",

--- a/src/utils/string.test.ts
+++ b/src/utils/string.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { isBlank, toBoolean, toFloat } from './string';
+import { isBlank, isValidUsername, toBoolean, toFloat } from './string';
 
 describe('isBlank', () => {
     it('Should return true if the string is blank', () => {
@@ -38,6 +38,39 @@ describe('toBoolean', () => {
 
         bool = toBoolean(null, true);
         expect(bool).toBe(true);
+    });
+});
+
+describe('isValidUsername()', () => {
+    it('should accept letters, numbers, dashes, underscores, apostrophes, and periods', () => {
+        expect(isValidUsername('john')).toBe(true);
+        expect(isValidUsername('john.doe')).toBe(true);
+        expect(isValidUsername('john-doe')).toBe(true);
+        expect(isValidUsername('john_doe')).toBe(true);
+        expect(isValidUsername("john'doe")).toBe(true);
+        expect(isValidUsername('user123')).toBe(true);
+    });
+
+    it('should accept unicode letters and symbols', () => {
+        expect(isValidUsername('ñoño')).toBe(true);
+        expect(isValidUsername('用户')).toBe(true);
+        expect(isValidUsername('Ångström')).toBe(true);
+    });
+
+    it('should reject spaces', () => {
+        expect(isValidUsername('test user')).toBe(false);
+        expect(isValidUsername('test / test')).toBe(false);
+    });
+
+    it('should reject special characters not in the allowed set', () => {
+        expect(isValidUsername('test/test')).toBe(false);
+        expect(isValidUsername('test+test')).toBe(false);
+        expect(isValidUsername('test&test')).toBe(false);
+        expect(isValidUsername('test@test')).toBe(false);
+    });
+
+    it('should reject empty strings', () => {
+        expect(isValidUsername('')).toBe(false);
     });
 });
 

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -30,6 +30,16 @@ export function toBoolean(value: string | undefined | null, defaultValue = false
 }
 
 /**
+ * Checks if a username contains only characters allowed by the server:
+ * unicode letters, numbers (0-9), dashes, underscores, apostrophes, and periods.
+ * Rejects spaces and special characters like / + & @ etc.
+ */
+export function isValidUsername(name: string): boolean {
+    if (!name.length) return false;
+    return !/[\s\/\+\&\@\#\$\%\^\*\(\)\[\]\{\}\<\>\=\!\?\:\;\,\~\`\|\\\"]/.test(name);
+}
+
+/**
  * Gets the value of a string as float number.
  * @param {string} value The value as a string.
  * @param {number} defaultValue The default value if the string is invalid.

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -36,7 +36,7 @@ export function toBoolean(value: string | undefined | null, defaultValue = false
  */
 export function isValidUsername(name: string): boolean {
     if (!name.length) return false;
-    return !/[\s\/\+\&\@\#\$\%\^\*\(\)\[\]\{\}\<\>\=\!\?\:\;\,\~\`\|\\\"]/.test(name);
+    return !/[\s/+&@#$%^*()[\]{}<>=!?:;,~`|\\"]/.test(name);
 }
 
 /**


### PR DESCRIPTION

The problem: 
We weren't validating usernames before sending them to the API.
If a user entered unsupported characters (/, +, &, spaces, etc.):

Create User -> generic error toast that doesn't tell you what's wrong.
Edit User -> spinner forever. No error. No way out besides leaving the page.


### Changes

**Fix**
- Added client-side username validation before the API call.
- Show a real error telling the user which characters are allowed.
- Stop the spinner immediately if validation fails.
- Added missing onError handlers to both mutations.
- Spinner now stops even if the API comes back with an unexpected error.


### Issues

Fixes #12480


### Code assistance

Both explanation of code base and debugging guidance were assisted with Claude code.
-->

---

* [ ] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [ ] I have tested these changes.
* [ ] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
