### PR TITLE
Add TV Shows creators to item details

### DIFF
--- a/src/components/itemDetails/ItemDetailsMetadataList.tsx
+++ b/src/components/itemDetails/ItemDetailsMetadataList.tsx
@@ -49,6 +49,8 @@ function getLabel(type: BaseItemKind | PersonKind, itemCount: number): string | 
     switch (type) {
         case PersonKind.Author:
             return globalize.translate(itemCount > 1 ? 'Authors' : 'Author');
+        case PersonKind.Creator:
+            return globalize.translate(itemCount > 1 ? 'Creators' : 'Creator');
         case PersonKind.Director:
             return globalize.translate(itemCount > 1 ? 'Directors' : 'Director');
         case PersonKind.Writer:
@@ -76,6 +78,7 @@ function getLink(type: BaseItemKind | PersonKind, item: BaseItemDto, context: st
 function getRouteType(type: BaseItemKind | PersonKind, context: string): string | null {
     switch (type) {
         case PersonKind.Author:
+        case PersonKind.Creator:
         case PersonKind.Director:
         case PersonKind.Writer:
             return 'Person';
@@ -91,6 +94,7 @@ function getRouteType(type: BaseItemKind | PersonKind, context: string): string 
 function getMetadataItems(type: BaseItemKind | PersonKind, item: BaseItemDto): NameGuidPair[] | null {
     switch (type) {
         case PersonKind.Author:
+        case PersonKind.Creator:
         case PersonKind.Director:
         case PersonKind.Writer:
             return item.People?.filter(person => person.Type === type).map(person => ({ Id: person.Id, Name: person.Name })) ?? null;

--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -989,6 +989,7 @@ function renderDetails(page, instance, item, apiClient, context) {
 
         const metadataTypes = [
             PersonKind.Author,
+            PersonKind.Creator,
             PersonKind.Director,
             PersonKind.Writer,
             BaseItemKind.Studio,

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -208,6 +208,7 @@
     "CoverArtist": "Cover artist",
     "Create": "Create",
     "Creator": "Creator",
+    "Creators": "Creators",
     "CriticRating": "Critics rating",
     "Cursive": "Cursive",
     "Custom": "Custom",


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

### Changes
Companion to https://github.com/jellyfin/jellyfin/pull/17107 (MERGED)

Adds TV Show Creators to the main summary, which is arguably the most important field for Tv shows, on par with Director for movies.

### Issues
Fixes https://github.com/jellyfin/jellyfin/issues/16543

### Code assistance
Used Claude to help find all the places I needed to add Creators

result:

<img width="1762" height="540" alt="Screenshot from 2026-06-15 11-15-12" src="https://github.com/user-attachments/assets/3a05fd93-6044-4674-ae47-68ce81b5fa64" />

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
