### PR TITLE
Add selectable sub-menu to special features

### DIFF
--- a/src/controllers/itemDetails/index.html
+++ b/src/controllers/itemDetails/index.html
@@ -212,7 +212,12 @@
             </div>
 
             <div id="specialsCollapsible" class="verticalSection detailVerticalSection hide">
-                <h2 class="sectionTitle sectionTitle-cards padded-right">${SpecialFeatures}</h2>
+                <div class="sectionTitleContainer specialsSectionTitleContainer">
+                    <h2 class="sectionTitle sectionTitle-cards padded-right">${SpecialFeatures}</h2>
+                    <button id="specialsFeaturesMenuButton" type="button" is="paper-icon-button-light" class="sectionTitleIconButton specialsFeaturesMenuButton hide" title="${ButtonMore}">
+                        <span class="material-icons more_vert" aria-hidden="true"></span>
+                    </button>
+                </div>
                 <div is="emby-scroller" class="padded-top-focusscale padded-bottom-focusscale no-padding" data-centerfocus="true">
                     <div id="specialsContent" is="emby-itemscontainer" class="scrollSlider focuscontainer-x itemsContainer"></div>
                 </div>

--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -18,6 +18,7 @@ import imageLoader from 'components/images/imageLoader';
 import itemContextMenu from 'components/itemContextMenu';
 import itemHelper from 'components/itemHelper';
 import mediaInfo from 'components/mediainfo/mediainfo';
+import actionSheet from 'components/actionSheet/actionSheet';
 import layoutManager from 'components/layoutManager';
 import listView from 'components/listview/listview';
 import loading from 'components/loading/loading';
@@ -45,6 +46,7 @@ import { OutboundWebSocketMessageType } from '@jellyfin/sdk/lib/websocket';
 import 'elements/emby-itemscontainer/emby-itemscontainer';
 import 'elements/emby-checkbox/emby-checkbox';
 import 'elements/emby-button/emby-button';
+import 'elements/emby-button/paper-icon-button-light';
 import 'elements/emby-playstatebutton/emby-playstatebutton';
 import 'elements/emby-ratingbutton/emby-ratingbutton';
 import 'elements/emby-scroller/emby-scroller';
@@ -1767,8 +1769,58 @@ function getVideosHtml(items) {
 function renderSpecials(page, item, user) {
     ServerConnections.getApiClient(item.ServerId).getSpecialFeatures(user.Id, item.Id).then(function (specials) {
         const specialsContent = page.querySelector('#specialsContent');
-        specialsContent.innerHTML = getVideosHtml(specials);
-        imageLoader.lazyChildren(specialsContent);
+        const specialsMenuButton = page.querySelector('#specialsFeaturesMenuButton');
+
+        const allSpecials = specials;
+        const extraTypes = new Set();
+        allSpecials.forEach(special => {
+            if (special.ExtraType && special.ExtraType !== 'Unknown') {
+                extraTypes.add(special.ExtraType);
+            }
+        });
+
+        const menuTypes = ['All', ...extraTypes];
+        let selectedType = 'All';
+
+        function displayFilteredSpecials(filterValue) {
+            selectedType = filterValue;
+            const filtered = filterValue === 'All' ?
+                allSpecials :
+                allSpecials.filter(s => s.ExtraType === filterValue);
+
+            specialsContent.innerHTML = getVideosHtml(filtered);
+            imageLoader.lazyChildren(specialsContent);
+        }
+
+        function showFilterMenu() {
+            const menuItems = menuTypes.map(type => ({
+                id: type,
+                name: type === 'All' ? globalize.translate('All') : globalize.translate(type),
+                selected: type === selectedType
+            }));
+
+            actionSheet.show({
+                items: menuItems,
+                positionTo: specialsMenuButton,
+                resolveOnClick: true,
+                menuItemClass: 'actionSheetMenuItem',
+                offsetLeft: 0,
+                offsetTop: 0
+            }).then(function (type) {
+                displayFilteredSpecials(type);
+            }).catch(() => {
+                // Ignore when the user closes the menu without selecting
+            });
+        }
+
+        if (menuTypes.length > 1) {
+            specialsMenuButton.classList.remove('hide');
+            specialsMenuButton.addEventListener('click', showFilterMenu);
+        } else {
+            specialsMenuButton.classList.add('hide');
+        }
+
+        displayFilteredSpecials('All');
     });
 }
 

--- a/src/styles/librarybrowser.scss
+++ b/src/styles/librarybrowser.scss
@@ -1245,7 +1245,19 @@ div.itemDetailGalleryLink.defaultCardBackground {
     vertical-align: middle;
 }
 
-/* these next two rules are for the scroller element headers */
+.specialsSectionTitleContainer {
+    display: flex;
+    align-items: center;
+}
+
+.specialsFeaturesMenuButton {
+    margin-left: 0 !important;
+}
+
+#specialsFeaturesMenuButton .material-icons {
+  font-size: 2em !important;
+}
+
 .sectionTitleContainer-cards {
     margin: 0;
     padding-top: 1.25em;


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

### Changes
When browsing content with lots of extra features it is really difficult to find what you are looking for.  This change implements a menu button that presents a list of choices to filter the content on based on what that particular title has. It utilizes the existing elements in the API call so the content should be localized as a result. It also keeps the design consistent with other menu elements on the page. When you have 30 pieces of extra content this makes the scrolling functional.  This implements this feature request: https://features.jellyfin.org/posts/1940/selectable-sub-menu-for-special-features

This was tested in a live environment with titles that included 0, 1, and 3+ types of extra features.  This was also tested in various screen layouts to ensure this was responsive and screen friendly.
<img width="800" height="385" alt="FILAMENT-GoogleChrome2026-06-1522-28-26-ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/7b95f7a6-7334-4deb-9a21-18aaf8d52d04" />

### Issues
<!--
Tag any issues that this PR solves here.
ex. Fixes #
-->

### Code assistance
AI was used to locate the impacted section quickly since this is my first contribution to the code base.  The CSS and design was implemented by me.

---

* [X] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [X] I have tested these changes.
* [X] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
