### PR TITLE
Prevent invalid paths from being added to the list of folder paths

### DIFF
--- a/src/components/mediaLibraryCreator/mediaLibraryCreator.js
+++ b/src/components/mediaLibraryCreator/mediaLibraryCreator.js
@@ -22,6 +22,7 @@ import './style.scss';
 import toast from '../toast/toast';
 import alert from '../alert';
 import template from './mediaLibraryCreator.template.html';
+import { ServerConnections } from 'lib/jellyfin-apiclient';
 
 function onAddLibrary(e) {
     e.preventDefault();
@@ -161,19 +162,19 @@ function renderPaths(page) {
     }
 }
 
-function addMediaLocation(page, path) {
+async function addMediaLocation(page, path) {
     // If the path already exists in the library, don't add it again.
     const isPathInLibrary = pathInfos.some(p => p.Path === path);
     if (isPathInLibrary) return;
 
-    ApiClient.getDirectoryContents(path)
-        .then(() => {
-            pathInfos.push({ Path: path });
-            renderPaths(page);
-        })
-        .catch(() => {
-            //  invalid paths handled by directorybrowser
-        });
+    try {
+        const apiClient = await ServerConnections.getCurrentApiClientAsync();
+        await apiClient.getDirectoryContents(path);
+        pathInfos.push({ Path: path });
+        renderPaths(page);
+    } catch {
+        // invalid paths handled by directorybrowser
+    }
 }
 
 function onRemoveClick(e) {

--- a/src/components/mediaLibraryCreator/mediaLibraryCreator.js
+++ b/src/components/mediaLibraryCreator/mediaLibraryCreator.js
@@ -166,8 +166,14 @@ function addMediaLocation(page, path) {
     const isPathInLibrary = pathInfos.some(p => p.Path === path);
     if (isPathInLibrary) return;
 
-    pathInfos.push({ Path: path });
-    renderPaths(page);
+    ApiClient.getDirectoryContents(path)
+        .then(() => {
+            pathInfos.push({ Path: path });
+            renderPaths(page);
+        })
+        .catch(() => {
+            //  invalid paths handled by directorybrowser
+        });
 }
 
 function onRemoveClick(e) {


### PR DESCRIPTION
When creating a library, entering an invalid path would show an error, but the path was still added to the folder list.

### Changes
Validate the path against the API before adding it to the list. 

### Issues
Prevents:

<img width="1127" height="692" alt="1" src="https://github.com/user-attachments/assets/e04ea2a0-79a7-4c1d-bf4f-1803b7ca9d3b" />

### Code assistance
N/A

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
