### PR TITLE
Allow selecting a video stream before playback

### DIFF
--- a/src/apps/legacy/controllers/itemDetails/index.js
+++ b/src/apps/legacy/controllers/itemDetails/index.js
@@ -259,7 +259,12 @@ function renderVideoSelections(page, mediaSources) {
 
         return '<option value="' + v.Index + '" ' + selected + '>' + (v.DisplayTitle || titleParts.join(' ')) + '</option>';
     }).join('');
-    select.setAttribute('disabled', 'disabled');
+
+    if (tracks.length > 1) {
+        select.removeAttribute('disabled');
+    } else {
+        select.setAttribute('disabled', 'disabled');
+    }
 
     if (tracks.length) {
         page.querySelector('.selectVideoContainer').classList.remove('hide');
@@ -1934,10 +1939,12 @@ export default function (view, params) {
     }
 
     function getPlayOptions(startPosition) {
+        const videoStreamIndex = view.querySelector('.selectVideo').value || null;
         const audioStreamIndex = view.querySelector('.selectAudio').value || null;
         return {
             startPositionTicks: startPosition,
             mediaSourceId: view.querySelector('.selectSource').value,
+            videoStreamIndex: videoStreamIndex,
             audioStreamIndex: audioStreamIndex,
             subtitleStreamIndex: view.querySelector('.selectSubtitles').value
         };

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -450,6 +450,9 @@ async function getPlaybackInfo(player, apiClient, item, deviceProfile, mediaSour
         query.AutoOpenLiveStream = false;
     }
 
+    if (options.videoStreamIndex != null) {
+        query.VideoStreamIndex = options.videoStreamIndex;
+    }
     if (options.audioStreamIndex != null) {
         query.AudioStreamIndex = options.audioStreamIndex;
     }
@@ -549,6 +552,9 @@ function getLiveStream(player, apiClient, item, playSessionId, deviceProfile, me
 
     if (options.maxBitrate) {
         query.MaxStreamingBitrate = options.maxBitrate;
+    }
+    if (options.videoStreamIndex != null) {
+        query.VideoStreamIndex = options.videoStreamIndex;
     }
     if (options.audioStreamIndex != null) {
         query.AudioStreamIndex = options.audioStreamIndex;
@@ -653,6 +659,7 @@ function truncatePlayOptions(playOptions) {
         aspectRatio: playOptions.aspectRatio,
         fullscreen: playOptions.fullscreen,
         mediaSourceId: playOptions.mediaSourceId,
+        videoStreamIndex: playOptions.videoStreamIndex,
         audioStreamIndex: playOptions.audioStreamIndex,
         subtitleStreamIndex: playOptions.subtitleStreamIndex,
         startPositionTicks: playOptions.startPositionTicks
@@ -2469,6 +2476,7 @@ export class PlaybackManager {
                     items,
                     startPositionTicks: options.startPosition || 0,
                     mediaSourceId,
+                    videoStreamIndex: options.videoStreamIndex,
                     audioStreamIndex: options.audioStreamIndex,
                     subtitleStreamIndex: options.subtitleStreamIndex,
                     startIndex: options.startIndex
@@ -2659,6 +2667,7 @@ export class PlaybackManager {
                 const user = responses[2];
                 const mediaStreams = responses[3];
 
+                const videoStreamIndex = playOptions.videoStreamIndex;
                 const audioStreamIndex = playOptions.audioStreamIndex;
                 const subtitleStreamIndex = playOptions.subtitleStreamIndex;
                 const options = {
@@ -2666,6 +2675,7 @@ export class PlaybackManager {
                     maxBitrate,
                     startPosition,
                     isPlayback: null,
+                    videoStreamIndex,
                     audioStreamIndex,
                     subtitleStreamIndex,
                     startIndex: playOptions.startIndex,


### PR DESCRIPTION
### Changes

Some MKVs carry more than one video track in a single file (say a 4K and a 1080p version). The detail page already had a video dropdown, but it was hardcoded to disabled, so you could see the tracks and never pick one. This turns it on when there's more than one video track and sends the picked index as `videoStreamIndex` when you hit play, the same way the audio and subtitle dropdowns already do.

Needs the server side too: https://github.com/jellyfin/jellyfin/pull/17123

Before it was greyed out, now you can open it and pick a track:
<img width="695" height="252" alt="Bildschirmfoto vom 2026-06-17 11-20-22" src="https://github.com/user-attachments/assets/d5f32ff0-e740-4bc6-97b7-2cad5be29858" />


### Issues

Related to #1421

### Follow-up / known gap

This only covers the web client. The native apps (Android TV, Swiftfin, Roku, ...) have their own UI and won't pick this up for free. I did look at the Android TV app, and the spot that makes sense is a video picker right next to the version button on the detail screen. But getting the selected index threaded through its playback launch path was more than I felt sure about doing right and testing properly, so I left it out instead of shipping something half-baked. Happy to do it as a follow-up.

### Code assistance

I used Claude on this one: finding my way around the codebase, writing the change, and setting up a local test server. I went over everything myself and tested it (build, the existing StreamBuilder tests, and by hand with multi-track files and a movie that has two versions).

---

* [X] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [X] I have tested these changes.
* [X] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of another web PR.
