### PR TITLE
Add Screensaver Time to Experimental layout

### DIFF
--- a/src/apps/experimental/features/preferences/components/DisplayPreferences.tsx
+++ b/src/apps/experimental/features/preferences/components/DisplayPreferences.tsx
@@ -145,10 +145,10 @@ export function DisplayPreferences({ onChange, values }: Readonly<DisplayPrefere
 
                     <FormControl fullWidth>
                         <TextField
-                            aria-describedby='display-settings-screensaver-interval-description'
-                            value={values.screensaverInterval}
-                            label={globalize.translate('LabelBackdropScreensaverInterval')}
-                            name='screensaverInterval'
+                            aria-describedby='display-settings-screensaver-time-description'
+                            value={values.screensaverTime}
+                            label={globalize.translate('LabelScreensaverTime')}
+                            name='screensaverTime'
                             onChange={onChange}
                             slotProps={{
                                 htmlInput: {
@@ -162,7 +162,31 @@ export function DisplayPreferences({ onChange, values }: Readonly<DisplayPrefere
                                 }
                             }}
                         />
-                        <FormHelperText id='display-settings-screensaver-interval-description'>
+                        <FormHelperText id='display-settings-screensaver-time-description'>
+                            {globalize.translate('LabelScreensaverTimeHelp')}
+                        </FormHelperText>
+                    </FormControl>
+
+                    <FormControl fullWidth>
+                        <TextField
+                            aria-describedby='display-settings-backdrop-screensaver-interval-description'
+                            value={values.backdropScreensaverInterval}
+                            label={globalize.translate('LabelBackdropScreensaverInterval')}
+                            name='backdropScreensaverInterval'
+                            onChange={onChange}
+                            slotProps={{
+                                htmlInput: {
+                                    inputMode: 'numeric',
+                                    max: '3600',
+                                    min: '1',
+                                    pattern: '[0-9]',
+                                    required: true,
+                                    step: '1',
+                                    type: 'number'
+                                }
+                            }}
+                        />
+                        <FormHelperText id='display-settings-backdrop-screensaver-interval-description'>
                             {globalize.translate('LabelBackdropScreensaverIntervalHelp')}
                         </FormHelperText>
                     </FormControl>

--- a/src/apps/experimental/features/preferences/hooks/useDisplaySettings.ts
+++ b/src/apps/experimental/features/preferences/hooks/useDisplaySettings.ts
@@ -102,7 +102,8 @@ async function loadDisplaySettings({
         libraryPageSize: settings.libraryPageSize(),
         maxDaysForNextUp: settings.maxDaysForNextUp(),
         screensaver: settings.screensaver() || 'none',
-        screensaverInterval: settings.backdropScreensaverInterval(),
+        screensaverTime: settings.screensaverTime(),
+        backdropScreensaverInterval: settings.backdropScreensaverInterval(),
         slideshowInterval: settings.slideshowInterval(),
         theme: settings.theme() || defaultTheme?.id || FALLBACK_THEME_ID
     };
@@ -146,7 +147,8 @@ async function saveDisplaySettings({
     userSettings.libraryPageSize(newDisplaySettings.libraryPageSize);
     userSettings.maxDaysForNextUp(newDisplaySettings.maxDaysForNextUp);
     userSettings.screensaver(normalizeValue(newDisplaySettings.screensaver));
-    userSettings.backdropScreensaverInterval(newDisplaySettings.screensaverInterval);
+    userSettings.screensaverTime(newDisplaySettings.screensaverTime);
+    userSettings.backdropScreensaverInterval(newDisplaySettings.backdropScreensaverInterval);
     userSettings.slideshowInterval(newDisplaySettings.slideshowInterval);
     userSettings.theme(newDisplaySettings.theme);
 

--- a/src/apps/experimental/features/preferences/types/displaySettingsValues.ts
+++ b/src/apps/experimental/features/preferences/types/displaySettingsValues.ts
@@ -17,7 +17,8 @@ export interface DisplaySettingsValues {
     libraryPageSize: number;
     maxDaysForNextUp: number;
     screensaver: string;
-    screensaverInterval: number;
+    screensaverTime: number;
+    backdropScreensaverInterval: number;
     slideshowInterval: number;
     theme: string;
 }


### PR DESCRIPTION
### Changes
Add missing Screensaver Time to Experimental layout.

### Issues
N/A

### Code assistance
None

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).

### Screenshots
<img width="1350" height="855" alt="screensaver-time" src="https://github.com/user-attachments/assets/aa155363-4b61-417a-8241-631a14d21629" />
