### PR TITLE
Use plugin provided icon if available

### DIFF
--- a/src/apps/dashboard/components/drawer/sections/PluginDrawerSection.tsx
+++ b/src/apps/dashboard/components/drawer/sections/PluginDrawerSection.tsx
@@ -1,5 +1,5 @@
 import Extension from '@mui/icons-material/Extension';
-import Folder from '@mui/icons-material/Folder';
+import Icon from '@mui/material/Icon';
 import List from '@mui/material/List';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
@@ -50,8 +50,7 @@ const PluginDrawerSection = () => {
                     to={`/${Dashboard.getPluginUrl(pageInfo.Name)}`}
                 >
                     <ListItemIcon>
-                        {/* TODO: Support different icons? */}
-                        <Folder />
+                        <Icon>{pageInfo.MenuIcon ?? 'folder'}</Icon>
                     </ListItemIcon>
                     <ListItemText primary={pageInfo.DisplayName} />
                 </ListItemLink>


### PR DESCRIPTION
Plugins can define their own menu item but we don't respect it and instead always use `folder`

### Changes
* Only use folder icon as fallback

### Code assistance
None

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
