### PR TITLE
Fix errors on view change with pending requests

### DIFF
--- a/src/elements/emby-itemscontainer/emby-itemscontainer.js
+++ b/src/elements/emby-itemscontainer/emby-itemscontainer.js
@@ -421,6 +421,10 @@ function resetRefreshInterval(itemsContainer, intervalMs) {
 }
 
 function onDataFetched(result) {
+    // Skip updating if getItemsHtml is not defined.
+    // This happens when the view is unloaded while the request is still pending.
+    if (!this.getItemsHtml) return;
+
     const items = result.Items || result;
 
     const parentContainer = this.parentContainer;
@@ -476,4 +480,3 @@ document.registerElement('emby-itemscontainer', {
     prototype: ItemsContainerPrototype,
     extends: 'div'
 });
-


### PR DESCRIPTION
### Changes
Small fix to prevent errors when a view containing item containers is unloaded while api requests are pending

### Issues
None

### Code assistance
Zed autocomplete

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
