### PR TITLE
Hide studios filter when empty

### DIFF
--- a/src/apps/experimental/components/library/filter/FilterButton.tsx
+++ b/src/apps/experimental/components/library/filter/FilterButton.tsx
@@ -440,7 +440,7 @@ const FilterButton: FC<FilterButtonProps> = ({
                         )}
                     </>
                 )}
-                {isFiltersStudiosEnabled() && studios && (
+                {isFiltersStudiosEnabled() && studios && studios.length > 0 && (
                     <Accordion
                         expanded={expanded === 'filtersStudios'}
                         onChange={handleChange('filtersStudios')}


### PR DESCRIPTION
### Changes
Add a length check to prevent the studio filter from showing if empty.

### Issues
N/A

### Code assistance
N/A


---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
