### PR TITLE
Remove pagination controls if user disabled

### DIFF
--- a/src/apps/experimental/features/libraries/components/LibraryToolbar.tsx
+++ b/src/apps/experimental/features/libraries/components/LibraryToolbar.tsx
@@ -78,8 +78,9 @@ const LibraryToolbar: FC = () => {
     const paginationEnd = paginationLimit ?
         Math.min(startIndex + paginationLimit, totalRecordCount) :
         totalRecordCount;
+    const isUserPaginationEnabled = paginationLimit > 0;
     /** True if the data is larger than the page limit */
-    const isPaginationRequired = paginationLimit > 0 && paginationLimit < totalRecordCount;
+    const isPaginationRequired = isUserPaginationEnabled && paginationLimit < totalRecordCount;
 
     const itemCountDisplay = useMemo(() => {
         if (isPending) return '\u2219'; // Bullet "operator" character as a loading indicator
@@ -225,7 +226,7 @@ const LibraryToolbar: FC = () => {
                         )}
                     </ButtonGroup>
 
-                    {isPaginationEnabled && (
+                    {isPaginationEnabled && isUserPaginationEnabled && (
                         <Pagination
                             setLibraryViewSettings={setLibraryViewSettings}
                             index={startIndex}


### PR DESCRIPTION
### Changes
Remove the pagination controls if the user manually disabled pagination by setting the item limit to 0

### Issues
N/A

### Code assistance
Zed autocomplete

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
