### PR TITLE
Allow folders to be marked as played

### DIFF
--- a/src/components/itemHelper.js
+++ b/src/components/itemHelper.js
@@ -264,6 +264,7 @@ export function canMarkPlayed (item) {
     return item.Type === 'Series'
         || item.Type === 'Season'
         || item.Type === 'BoxSet'
+        || item.Type === 'Folder'
         || item.MediaType === 'Book';
 }
 


### PR DESCRIPTION
Books, Mixed Media, Home Videos, and Music Videos can be viewed by folder, but folders cannot be marked as watched. Users must instead mark each item within the folder individually.

### Changes
Add Folder type to the `canMarkPlayed` function

### Issues
Fixes https://github.com/jellyfin/jellyfin/issues/8010

### Code assistance
N/A

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
