### PR TITLE
Add LiveStreamKeepSeconds to encoding settings UI

### DIFF
--- a/src/apps/dashboard/routes/playback/transcoding.tsx
+++ b/src/apps/dashboard/routes/playback/transcoding.tsx
@@ -21,7 +21,10 @@ import Alert from '@mui/material/Alert';
 import Button from '@mui/material/Button';
 import { type ActionFunctionArgs, Form, useActionData, useNavigation, useSubmit } from 'react-router-dom';
 import { QUERY_KEY, useNamedConfiguration } from 'hooks/useNamedConfiguration';
-import type { EncodingOptions } from '@jellyfin/sdk/lib/generated-client/models/encoding-options';
+import type { EncodingOptions as SdkEncodingOptions } from '@jellyfin/sdk/lib/generated-client/models/encoding-options';
+
+// LiveStreamKeepSeconds is not yet in the published SDK — remove once the SDK is updated.
+type EncodingOptions = SdkEncodingOptions & { LiveStreamKeepSeconds?: number };
 import { HardwareAccelerationType } from '@jellyfin/sdk/lib/generated-client/models/hardware-acceleration-type';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
 import { getConfigurationApi } from '@jellyfin/sdk/lib/utils/api/configuration-api';
@@ -878,6 +881,22 @@ export const Component = () => {
                                 slotProps={{
                                     htmlInput: {
                                         min: 10,
+                                        max: 3600,
+                                        step: 1
+                                    }
+                                }}
+                            />
+
+                            <TextField
+                                name='LiveStreamKeepSeconds'
+                                value={config.LiveStreamKeepSeconds}
+                                onChange={onConfigChange}
+                                label={globalize.translate('LabelLiveStreamKeepSeconds')}
+                                helperText={globalize.translate('LabelLiveStreamKeepSecondsHelp')}
+                                type='number'
+                                slotProps={{
+                                    htmlInput: {
+                                        min: 0,
                                         max: 3600,
                                         step: 1
                                     }

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -41,6 +41,8 @@
     "LabelThrottleDelaySecondsHelp": "Time in seconds after which the transcoder will be throttled. Must be large enough for the client to maintain a healthy buffer. Only works if throttling is enabled.",
     "LabelSegmentKeepSeconds": "Time to keep segments",
     "LabelSegmentKeepSecondsHelp": "Time in seconds for which segments should be kept after they are downloaded by the client. Only works if segment deletion is enabled.",
+    "LabelLiveStreamKeepSeconds": "Live stream rewind buffer (seconds)",
+    "LabelLiveStreamKeepSecondsHelp": "Number of seconds of live TV capture to keep in a rolling chunk buffer for rewinding. Set to 0 to disable the buffer and use the legacy single-growing-file behaviour.",
     "AllowHWTranscodingHelp": "Allow the tuner to transcode streams on the fly. This may help reduce transcoding required by the server.",
     "AllowMediaConversion": "Allow media conversion",
     "AllowMediaConversionHelp": "Grant or deny access to the convert media feature.",


### PR DESCRIPTION
### Changes
Adds a number input for LiveStreamKeepSeconds to the admin encoding settings page, placed alongside SegmentKeepSeconds. The field accepts 0 or a positive integer (rolling chunk buffer duration in seconds) for the live TV rewind buffer.

This supports the equivalent backend fix in https://github.com/jellyfin/jellyfin/pull/17128

Includes a local type extension for EncodingOptions to cover the new property until the @jellyfin/sdk is updated with the server-side change https://github.com/jellyfin/jellyfin/pull/17128

### Code assistance
Claude Sonnet was used to implement the front end change to match changes made to the backend and test end to end. 

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
