### PR TITLE
Fix mobile detail layout in landscape

### DIFF
--- a/src/apps/experimental/AppOverrides.scss
+++ b/src/apps/experimental/AppOverrides.scss
@@ -23,10 +23,21 @@ $mui-bp-xl: 1536px;
     padding-top: 0 !important;
 }
 
-.layout-mobile {
+.layout-mobile .itemDetailPage {
+    box-sizing: border-box;
+    padding-top: 3.9em !important;
+    padding-top: calc(3.9em + env(safe-area-inset-top)) !important;
+    position: relative;
+
     .itemBackdrop {
-        // Fix backdrop position on mobile item details page
+        display: block !important;
+        position: absolute !important;
+        top: 0;
+        left: 0;
+        right: 0;
+        z-index: 0;
         margin-top: 0 !important;
+        pointer-events: none;
 
         // Add a subtle gradient over the backdrop to ensure the app bar buttons are visible
         &::before {
@@ -35,6 +46,48 @@ $mui-bp-xl: 1536px;
             height: 100%;
             width: 100%;
             background: linear-gradient(180deg, rgba(32, 32, 32, 0.6) 0%, rgba(32, 32, 32, 0.2) 4rem, rgba(0, 0, 0, 0) 50%);
+        }
+    }
+
+    @media all and (orientation: landscape) {
+        .itemBackdrop {
+            height: 32vh !important;
+            min-height: 10rem !important;
+            max-height: 20rem !important;
+        }
+
+        .detailPagePrimaryContainer {
+            min-height: 18rem;
+        }
+
+        .detailImageContainer .card {
+            top: 0.5rem !important;
+            bottom: auto !important;
+            width: 10rem !important;
+            max-width: 20vw !important;
+            max-height: none !important;
+        }
+
+        [dir="ltr"] & .detailPagePrimaryContent {
+            padding-left: calc(5% + 11rem) !important;
+        }
+
+        [dir="rtl"] & .detailPagePrimaryContent {
+            padding-right: calc(5% + 11rem) !important;
+        }
+    }
+
+    .detailPageWrapperContainer {
+        position: relative;
+        z-index: 1;
+    }
+
+    .detailImageContainer {
+        .cardImage,
+        .cardImageContainer.coveredImage {
+            background-color: #000;
+            background-repeat: no-repeat !important;
+            background-size: contain !important;
         }
     }
 }

--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -2043,7 +2043,7 @@ export default function (view, params) {
         view.addEventListener('viewshow', function (e) {
             const page = this;
 
-            libraryMenu.setTransparentMenu(!layoutManager.mobile);
+            libraryMenu.setTransparentMenu(true);
 
             if (e.detail.isRestored) {
                 if (currentItem) {

--- a/src/styles/librarybrowser.scss
+++ b/src/styles/librarybrowser.scss
@@ -580,7 +580,7 @@
     .layout-mobile & {
         background-attachment: initial;
         background-position: top center;
-        margin-top: 3rem;
+        margin-top: 0;
 
         @media all and (orientation: portrait) and (max-width: 40em) {
             height: 30vh;
@@ -589,6 +589,61 @@
 
     .layout-tv & {
         display: none;
+    }
+}
+
+html.layout-mobile .mainAnimatedPages .itemDetailPage {
+    // Keep mobile details content below the fixed header even when the backdrop is hidden.
+    box-sizing: border-box;
+    padding-top: 3.9em !important;
+    padding-top: calc(3.9em + env(safe-area-inset-top)) !important;
+    position: relative;
+}
+
+html.layout-mobile .mainAnimatedPages .itemDetailPage #itemBackdrop.itemBackdrop {
+    display: block !important;
+    position: absolute !important;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 0;
+    margin-top: 0 !important;
+    pointer-events: none;
+}
+
+html.layout-mobile .mainAnimatedPages .itemDetailPage .detailImageContainer .cardImage,
+html.layout-mobile .mainAnimatedPages .itemDetailPage .detailImageContainer .cardImageContainer.coveredImage {
+    background-color: #000;
+    background-repeat: no-repeat !important;
+    background-size: contain !important;
+}
+
+@media all and (orientation: landscape) {
+    html.layout-mobile .mainAnimatedPages .itemDetailPage #itemBackdrop.itemBackdrop {
+        // Mobile layout can be forced on wide landscape WebViews, such as VR headset apps.
+        height: 32vh !important;
+        min-height: 10rem !important;
+        max-height: 20rem !important;
+    }
+
+    html.layout-mobile .mainAnimatedPages .itemDetailPage .detailPagePrimaryContainer {
+        min-height: 18rem;
+    }
+
+    html.layout-mobile .mainAnimatedPages .itemDetailPage .detailImageContainer .card {
+        top: 0.5rem !important;
+        bottom: auto !important;
+        width: 10rem !important;
+        max-width: 20vw !important;
+        max-height: none !important;
+    }
+
+    html.layout-mobile[dir="ltr"] .mainAnimatedPages .itemDetailPage .detailPagePrimaryContent {
+        padding-left: calc(5% + 11rem) !important;
+    }
+
+    html.layout-mobile[dir="rtl"] .mainAnimatedPages .itemDetailPage .detailPagePrimaryContent {
+        padding-right: calc(5% + 11rem) !important;
     }
 }
 
@@ -1138,6 +1193,11 @@ div.itemDetailGalleryLink.defaultCardBackground {
         flex-direction: column;
         min-height: 60vh;
     }
+}
+
+html.layout-mobile .mainAnimatedPages .itemDetailPage .detailPageWrapperContainer {
+    position: relative;
+    z-index: 1;
 }
 
 .mediaInfoContent .btnCopy .material-icons {


### PR DESCRIPTION
﻿## Changes

- Keep mobile item detail content below the fixed app header, including safe-area inset spacing.
- Render the mobile detail backdrop as a real top-layer background instead of offsetting it below the header.
- Reuse the existing semi-transparent app header on item detail pages so the mobile header backdrop can be visible.
- Adjust forced-mobile landscape layouts so poster art stays visible and detail content is offset beside it instead of overlapping or cropping it.
- Mirror the same detail-page override behavior in the experimental app overrides.

## Why

When a client forces the mobile layout on a wide landscape viewport, such as headset WebViews, the fixed header can cover the top of legacy item detail pages. The mobile detail backdrop is also offset below the header while the detail poster remains absolutely positioned from the bottom of the header area, which can crop or hide content on landscape mobile screens.

## Impact

This keeps mobile detail pages readable on wide landscape mobile/WebView clients without changing desktop or TV detail layouts.

## Testing

- `npx.cmd stylelint src/styles/librarybrowser.scss src/apps/experimental/AppOverrides.scss`
- `npx.cmd eslint src/controllers/itemDetails/index.js` (existing warnings only)
- `npm.cmd run build:check`
- `npm.cmd run build:production` (existing asset size warnings only)
- Manually checked the affected mobile detail layout at a 1280x800 landscape viewport during local Jellyfin verification.
