### PR TITLE
Handle partial now playing items

### DIFF
--- a/src/components/remotecontrol/remotecontrol.js
+++ b/src/components/remotecontrol/remotecontrol.js
@@ -98,7 +98,10 @@ function updateNowPlayingInfo(context, state, serverId) {
         '';
     if (item) {
         const nowPlayingServerId = (item.ServerId || serverId);
-        if (item.Type == 'AudioBook' || item.Type == 'Audio' || item.MediaStreams[0].Type == 'Audio') {
+        const firstMediaStreamType = item.MediaStreams?.[0]?.Type;
+        const isAudioItem = item.Type === 'AudioBook' || item.Type === 'Audio' || firstMediaStreamType === 'Audio';
+
+        if (isAudioItem) {
             let artistsSeries = '';
             let albumName = '';
             if (item.Artists != null) {
@@ -164,17 +167,42 @@ function updateNowPlayingInfo(context, state, serverId) {
         if (autoFocusContextButton) {
             contextButton.focus();
         }
-        const options = {
-            play: false,
-            queue: false,
-            stopPlayback: true,
-            clearQueue: true,
-            openAlbum: false,
-            positionTo: contextButton
-        };
-        const apiClient = ServerConnections.getApiClient(item.ServerId);
+        contextButton.classList.add('hide');
+        context.querySelector('.nowPlayingPageUserDataButtonsTitle').innerHTML = '';
+        context.querySelector('.nowPlayingPageUserDataButtons').innerHTML = '';
+
+        setImageUrl(context, state, url);
+
+        if (item.ServerId) {
+            setBackdrops([item]);
+        } else {
+            clearBackdrop();
+        }
+
+        if (!item.Id || !nowPlayingServerId) {
+            return;
+        }
+
+        const apiClient = ServerConnections.getApiClient(nowPlayingServerId);
+        if (!apiClient) {
+            return;
+        }
+
         apiClient.getItem(apiClient.getCurrentUserId(), item.Id).then(function (fullItem) {
+            const options = {
+                play: false,
+                queue: false,
+                stopPlayback: true,
+                clearQueue: true,
+                openAlbum: false,
+                positionTo: contextButton
+            };
+            const userData = fullItem.UserData || {};
+            const likes = userData.Likes == null ? '' : userData.Likes;
+            context.querySelector('.nowPlayingPageUserDataButtonsTitle').innerHTML = '<button is="emby-ratingbutton" type="button" class="paper-icon-button-light" data-id="' + fullItem.Id + '" data-serverid="' + fullItem.ServerId + '" data-itemtype="' + fullItem.Type + '" data-likes="' + likes + '" data-isfavorite="' + userData.IsFavorite + '"><span class="material-icons favorite" aria-hidden="true"></span></button>';
+            context.querySelector('.nowPlayingPageUserDataButtons').innerHTML = '<button is="emby-ratingbutton" type="button" class="paper-icon-button-light" data-id="' + fullItem.Id + '" data-serverid="' + fullItem.ServerId + '" data-itemtype="' + fullItem.Type + '" data-likes="' + likes + '" data-isfavorite="' + userData.IsFavorite + '"><span class="material-icons favorite" aria-hidden="true"></span></button>';
             apiClient.getCurrentUser().then(function (user) {
+                contextButton.classList.remove('hide');
                 contextButton.addEventListener('click', function () {
                     itemContextMenu.show(Object.assign({
                         item: fullItem,
@@ -183,18 +211,12 @@ function updateNowPlayingInfo(context, state, serverId) {
                     }, options))
                         .catch(() => { /* no-op */ });
                 });
-            });
-        });
-        setImageUrl(context, state, url);
-        setBackdrops([item]);
-        apiClient.getItem(apiClient.getCurrentUserId(), item.Id).then(function (fullItem) {
-            const userData = fullItem.UserData || {};
-            const likes = userData.Likes == null ? '' : userData.Likes;
-            context.querySelector('.nowPlayingPageUserDataButtonsTitle').innerHTML = '<button is="emby-ratingbutton" type="button" class="paper-icon-button-light" data-id="' + fullItem.Id + '" data-serverid="' + fullItem.ServerId + '" data-itemtype="' + fullItem.Type + '" data-likes="' + likes + '" data-isfavorite="' + userData.IsFavorite + '"><span class="material-icons favorite" aria-hidden="true"></span></button>';
-            context.querySelector('.nowPlayingPageUserDataButtons').innerHTML = '<button is="emby-ratingbutton" type="button" class="paper-icon-button-light" data-id="' + fullItem.Id + '" data-serverid="' + fullItem.ServerId + '" data-itemtype="' + fullItem.Type + '" data-likes="' + likes + '" data-isfavorite="' + userData.IsFavorite + '"><span class="material-icons favorite" aria-hidden="true"></span></button>';
-        });
+            }).catch(() => { /* no-op */ });
+        }).catch(() => { /* no-op */ });
     } else {
         clearBackdrop();
+        context.querySelector('.btnToggleContextMenu').classList.add('hide');
+        context.querySelector('.nowPlayingPageUserDataButtonsTitle').innerHTML = '';
         context.querySelector('.nowPlayingPageUserDataButtons').innerHTML = '';
     }
 }


### PR DESCRIPTION
### Changes

Handle partial `NowPlayingItem` objects in the remote control page. External or virtual playback items, when played through casting, may not include a populated `MediaStreams` array or a resolvable library item id. The remote control page now renders available title and image metadata before optional library lookups, guards the media stream type check, and skips library-only controls when the item cannot be resolved.

No screenshots provided because this fixes missing metadata rendering without changing the intended UI layout.

### Issues

<!-- Fixes # -->

### Code assistance

Code assistance was used to inspect the remote control and Now Playing bar code paths, identify unsafe assumptions around partial `NowPlayingItem` objects, and draft the localized defensive checks. I tested the resulting change manually and ran `npm run lint -- src/components/remotecontrol/remotecontrol.js`.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pull/7425#issuecomment-4759766097).