### PR TITLE
Fix startup crash when ApiClient has no serverId yet

### DIFF
--- a/src/lib/jellyfin-apiclient/connectionManager.js
+++ b/src/lib/jellyfin-apiclient/connectionManager.js
@@ -817,9 +817,16 @@ export default class ConnectionManager {
      * Returns or creates an Api instance for a given
      * server
      * @param {string} serverId The ID of the server
-     * @returns {import('@jellyfin/sdk').Api}
+     * @returns {import('@jellyfin/sdk').Api|undefined}
      */
     getApi(serverId) {
+        // serverId is not available until an ApiClient has connected/authenticated.
+        // Callers handle a missing Api, so return undefined rather than letting
+        // getApiClient() throw ('item or serverId cannot be null') and break startup.
+        if (!serverId) {
+            return undefined;
+        }
+
         const apiClient = this.getApiClient(serverId);
         apiClient._sdk ??= toApi(apiClient);
         return apiClient._sdk;


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

### Changes
PR #8011 added unconditional `this.getApi(apiClient.serverId())` calls to the `apiclientcreated` handler and to `setLocalApiClient()`. Both run during `initApiClient()`, before the client has connected/authenticated, so `serverId()` (which returns `serverInfo().Id`) is undefined. `getApi()` then calls `getApiClient(undefined)`, which throws "item or serverId cannot be null". The exception propagates out of the event trigger and aborts app startup, leaving the user stuck on the splash logo.

Validate the serverId in `getApi()` and return undefined when it is missing. All callers already handle an absent Api, so this fixes the crash centrally without touching each call site.

### Issues
Fixes #8090

### Code assistance
Claude Opus 4.8 for troubleshooting and generation of patch

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
