### PR TITLE
Fix shuffle and repeat buttons in Remote Control

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -2176,6 +2176,8 @@ export class PlaybackManager {
                 state.PlayState.IsPaused = player.paused();
                 state.PlayState.RepeatMode = self.getRepeatMode(player);
                 state.PlayState.ShuffleMode = self.getQueueShuffleMode(player);
+                // Needed for remote control because ShuffleMode doesn't exist in PlayerStateInfo from the server
+                state.PlayState.PlaybackOrder = state.PlayState.ShuffleMode === 'Shuffle' ? 'Shuffle' : 'Default';
                 state.PlayState.MaxStreamingBitrate = self.getMaxStreamingBitrate(player);
 
                 state.PlayState.PositionTicks = getCurrentTicks(player);

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -2,6 +2,7 @@ import { BaseItemKind } from '@jellyfin/sdk/lib/generated-client/models/base-ite
 import { ItemFilter } from '@jellyfin/sdk/lib/generated-client/models/item-filter';
 import { ItemSortBy } from '@jellyfin/sdk/lib/generated-client/models/item-sort-by';
 import { MediaType } from '@jellyfin/sdk/lib/generated-client/models/media-type';
+import { PlaybackOrder } from '@jellyfin/sdk/lib/generated-client/models/playback-order';
 import { PlaybackErrorCode } from '@jellyfin/sdk/lib/generated-client/models/playback-error-code';
 import { getMediaInfoApi } from '@jellyfin/sdk/lib/utils/api/media-info-api';
 import merge from 'lodash-es/merge';
@@ -2177,7 +2178,7 @@ export class PlaybackManager {
                 state.PlayState.RepeatMode = self.getRepeatMode(player);
                 state.PlayState.ShuffleMode = self.getQueueShuffleMode(player);
                 // Needed for remote control because ShuffleMode doesn't exist in PlayerStateInfo from the server
-                state.PlayState.PlaybackOrder = state.PlayState.ShuffleMode === 'Shuffle' ? 'Shuffle' : 'Default';
+                state.PlayState.PlaybackOrder = state.PlayState.ShuffleMode === 'Shuffle' ? PlaybackOrder.Shuffle : PlaybackOrder.Default;
                 state.PlayState.MaxStreamingBitrate = self.getMaxStreamingBitrate(player);
 
                 state.PlayState.PositionTicks = getCurrentTicks(player);

--- a/src/plugins/sessionPlayer/plugin.js
+++ b/src/plugins/sessionPlayer/plugin.js
@@ -535,7 +535,9 @@ class SessionPlayer {
     }
 
     getRepeatMode() {
-        // not supported?
+        let state = this.lastPlayerData || {};
+        state = state.PlayState || {};
+        return state.RepeatMode || 'RepeatNone';
     }
 
     setQueueShuffleMode(mode) {
@@ -545,7 +547,9 @@ class SessionPlayer {
     }
 
     getQueueShuffleMode() {
-        // not supported?
+        let state = this.lastPlayerData || {};
+        state = state.PlayState || {};
+        return state.PlaybackOrder === 'Shuffle' ? 'Shuffle' : 'Sorted';
     }
 
     displayContent(options) {

--- a/src/plugins/sessionPlayer/plugin.js
+++ b/src/plugins/sessionPlayer/plugin.js
@@ -1,5 +1,7 @@
 import isEqual from 'lodash-es/isEqual';
 import { OutboundWebSocketMessageType, PeriodicListenerInterval } from '@jellyfin/sdk/lib/websocket';
+import { PlaybackOrder } from '@jellyfin/sdk/lib/generated-client/models/playback-order';
+import { RepeatMode } from '@jellyfin/sdk/lib/generated-client/models/repeat-mode';
 
 import { playbackManager } from 'components/playback/playbackmanager';
 import { PluginType } from 'constants/pluginType';
@@ -537,7 +539,7 @@ class SessionPlayer {
     getRepeatMode() {
         let state = this.lastPlayerData || {};
         state = state.PlayState || {};
-        return state.RepeatMode || 'RepeatNone';
+        return state.RepeatMode || RepeatMode.RepeatNone;
     }
 
     setQueueShuffleMode(mode) {
@@ -549,7 +551,7 @@ class SessionPlayer {
     getQueueShuffleMode() {
         let state = this.lastPlayerData || {};
         state = state.PlayState || {};
-        return state.PlaybackOrder === 'Shuffle' ? 'Shuffle' : 'Sorted';
+        return state.PlaybackOrder === PlaybackOrder.Shuffle ? 'Shuffle' : 'Sorted';
     }
 
     displayContent(options) {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

### Changes
<!--
Describe your changes here in 1-5 sentences.
Please include before/after screenshots of any UI changes.
-->

I implemented `getRepeatMode` and `getQueueShuffleMode` in `SessionPlayer`, and set `PlaybackOrder` in `PlaybackManager.getPlayerState`.

`RepeatMode` was already used in both the client and server, but `PlaybackOrder` only existed in `PlayerStateInfo` on the server. I used `PlaybackOrder` since `ShuffleMode` would be ignored when sent to the server.
This required a mildly hacky ternary expression in both places to translate between the two which I can extract to a helper function if preferred.

Before:
<img width="1235" height="919" alt="before" src="https://github.com/user-attachments/assets/6d3978f2-4359-45dc-a8a4-9cfbd4fd4a2d" />

After:
<img width="1235" height="919" alt="after" src="https://github.com/user-attachments/assets/b5719537-162d-4181-9831-77aa0fff7273" />

Please note that shuffling works but the queue currently does not refresh on the controlling client until other actions happen. I intend to raise a separate issue for this.

### Issues
<!--
Tag any issues that this PR solves here.
ex. Fixes #
-->

Fixes #8091 

### Code assistance
<!--
If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance.
-->

Claude Opus 4.8 was used to identify the source of the issue and draft the initial fix.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me). <sub><sup>I'll do that soon...</sup></sub>
