### PR TITLE
Fix Safari audio crackling by not over-reporting surround channels

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -463,6 +463,13 @@ function getPhysicalAudioChannels(options, videoTestElement) {
 
     // AC3/EAC3 hinted that device is able to play dolby surround sound.
     if (isAc3Eac3Supported && isSurroundSoundSupportedBrowser) {
+        // Desktop Safari (Apple Silicon) crackles when it downmixes multichannel audio
+        // to a stereo output device. When the real output is known to be stereo, trust it
+        // so the server downmixes cleanly instead of Safari. jellyfin/jellyfin#15999
+        if (browser.safari && !browser.iOS && speakerCount > 0 && speakerCount <= 2) {
+            return speakerCount;
+        }
+
         return speakerCount > 6 ? speakerCount : 6;
     }
 


### PR DESCRIPTION
### Changes

`getPhysicalAudioChannels()` infers that a device has surround speakers whenever the browser can decode AC3/EAC3, returning at least 6 channels. On desktop Safari with a stereo output device (`AudioContext.destination.maxChannelCount === 2`), this makes the server deliver a 5.1 stream that Safari then downmixes to stereo itself, producing intermittent crackling/popping throughout playback.

This is not specific to Jellyfin. The same artifact reproduces in Safari on Apple Silicon with independent multichannel AAC content (e.g. Fraunhofer's browser AAC multichannel test), does not occur in Chrome on the same machine, and does not occur when the audio is downmixed to stereo before Safari receives it. It appears to be an upstream Safari issue with multichannel audio; this change works around it by not advertising more channels than the output actually has.

For desktop Safari, when the real output is known to be stereo (`maxChannelCount <= 2`), trust it so the server performs the downmix cleanly instead of Safari. Macs connected to a surround device still report 6/8 channels and keep full surround. iOS was tested and is not affected, so the change is scoped to desktop Safari.

This replaces the earlier approach in this PR (removing AC3/EAC3 from `hlsInFmp4VideoAudioCodecs`); no codec support is removed.

### Testing

Same source (HEVC video + 5.1 AAC), Safari on an Apple Silicon Mac, unless noted. Only the audio channel count changes the outcome:

| Audio | Delivery | Result |
| --- | --- | --- |
| 5.1 (copy) | fMP4 HLS (`+frag_discont`) | crackle |
| 5.1 (copy) | fMP4 HLS (no `+frag_discont`) | crackle |
| 5.1 (copy) | MPEG-TS → hls.js/MSE | crackle |
| 5.1 (copy) | progressive MP4, direct play | crackle |
| 5.1 (re-encoded) | fMP4 HLS | crackle |
| 2.0 (downmixed) | fMP4 HLS | clean |
| 5.1 | in Chrome, same Mac | clean |
| 7.1 (Fraunhofer, non-Jellyfin) | native | crackle on AirPods Max |

Container, HLS fragmentation, the `+frag_discont` flag, and copy-vs-re-encode were all ruled out — the only variable that changes the result is channel count (with the output device / Spatial Audio state).

### Issues

Fixes jellyfin/jellyfin-web#8097

### Code assistance

Used AI tooling to generate the A/B test variants (remuxed HLS with different channel counts, containers, and codecs) and to help analyze the code path. I listened to each variant myself to identify which reproduced the crackling — that manual comparison is what isolated channel count as the trigger. The change itself is a small guard in the channel-count heuristic.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
