### PR TITLE
Clear the Alphabet filter when resetting filters

### DIFF
--- a/src/components/filterdialog/filterdialog.js
+++ b/src/components/filterdialog/filterdialog.js
@@ -469,6 +469,7 @@ class FilterDialog {
         query.HasTrailer = null;
         query.Tags = null;
         query.Years = '';
+        query.NameStartsWith = null;
     }
 
     show() {


### PR DESCRIPTION
### Changes

`Reset filters` did not clear the **Alphabet** (A–Z) filter. `FilterDialog.resetQuery()` resets every other filter but never touched `query.NameStartsWith` (set by the alpha picker), which is persisted, so an A–Z selection survived a reset. `resetQuery()` now clears it too; on reload the controllers' `alphaPicker.updateControls(query)` clears the picker highlight.

### Issues

Fixes #8050

### Code assistance

Prepared with an AI coding agent (Claude): used to locate `resetQuery`, confirm `NameStartsWith` is the only unreset filter, and trace the `alphaPicker.updateControls` sync. Reviewed + verified before submitting.

---

* [x] I have read and followed the contributing guidelines.
* [x] I have tested these changes. <!-- eslint clean + traced the reset→reload→updateControls path; FilterDialog imports an .html template so it is not vitest-importable (suite covers src/utils/*). -->
* [x] I have verified this is not duplicating an existing PR.
* [ ] I have provided a substantive review of another web PR.