### PR TITLE
Cleanup Api instance retrieval

### DIFF
--- a/src/apps/dashboard/features/sessions/utils/getNowPlayingImageUrl.ts
+++ b/src/apps/dashboard/features/sessions/utils/getNowPlayingImageUrl.ts
@@ -7,6 +7,10 @@ const getNowPlayingImageUrl = (item: BaseItemDto) => {
     if (!item.ServerId) return null;
 
     const apiClient = ServerConnections.getApiClient(item.ServerId);
+    if (!apiClient) {
+        console.error('[getNowPlayingImageUrl] No ApiClient instance available for serverId', item.ServerId);
+        return null;
+    }
 
     /* Screen width is multiplied by 0.2, as the there is currently no way to get the width of
                 elements that aren't created yet. */

--- a/src/apps/dashboard/features/sessions/utils/getNowPlayingName.ts
+++ b/src/apps/dashboard/features/sessions/utils/getNowPlayingName.ts
@@ -35,25 +35,28 @@ const getNowPlayingName = (session: SessionInfo): NowPlayingInfo => {
         bottomText = nowPlayingItem.ProductionYear.toString();
     }
 
-    if (nowPlayingItem.ImageTags?.Logo) {
-        imgUrl = ServerConnections.getApiClient(session.ServerId!).getScaledImageUrl(nowPlayingItem.Id!, {
-            tag: nowPlayingItem.ImageTags.Logo,
-            maxHeight: 24,
-            maxWidth: 130,
-            type: 'Logo'
-        });
-    } else if (nowPlayingItem.ParentLogoImageTag) {
-        imgUrl = ServerConnections.getApiClient(session.ServerId!).getScaledImageUrl(nowPlayingItem.ParentLogoItemId!, {
-            tag: nowPlayingItem.ParentLogoImageTag,
-            maxHeight: 24,
-            maxWidth: 130,
-            type: 'Logo'
-        });
+    const apiClient = ServerConnections.getApiClient(session.ServerId);
+    if (apiClient) {
+        if (nowPlayingItem.ImageTags?.Logo) {
+            imgUrl = apiClient.getScaledImageUrl(nowPlayingItem.Id!, {
+                tag: nowPlayingItem.ImageTags.Logo,
+                maxHeight: 24,
+                maxWidth: 130,
+                type: 'Logo'
+            });
+        } else if (nowPlayingItem.ParentLogoImageTag) {
+            imgUrl = apiClient.getScaledImageUrl(nowPlayingItem.ParentLogoItemId!, {
+                tag: nowPlayingItem.ParentLogoImageTag,
+                maxHeight: 24,
+                maxWidth: 130,
+                type: 'Logo'
+            });
+        }
     }
 
     return {
-        topText: topText,
-        bottomText: bottomText,
+        topText,
+        bottomText,
         image: imgUrl
     };
 };

--- a/src/apps/dashboard/routes/branding/index.tsx
+++ b/src/apps/dashboard/routes/branding/index.tsx
@@ -33,7 +33,7 @@ const BrandingOption = {
 };
 
 export const action = async ({ request }: ActionFunctionArgs) => {
-    const api = ServerConnections.getCurrentApi();
+    const api = ServerConnections.getApi();
     if (!api) throw new Error('No Api instance available');
 
     const formData = await request.formData();
@@ -61,7 +61,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 };
 
 export const loader = async () => {
-    const api = ServerConnections.getCurrentApi();
+    const api = ServerConnections.getApi();
     if (!api) return {};
 
     return queryClient.ensureQueryData(

--- a/src/apps/dashboard/routes/libraries/display.tsx
+++ b/src/apps/dashboard/routes/libraries/display.tsx
@@ -25,7 +25,7 @@ import type { MetadataConfiguration } from '@jellyfin/sdk/lib/generated-client/m
 const CONFIG_KEY = 'metadata';
 
 export const action = async ({ request }: ActionFunctionArgs) => {
-    const api = ServerConnections.getCurrentApi();
+    const api = ServerConnections.getApi();
     if (!api) throw new Error('No Api instance available');
 
     const formData = await request.formData();

--- a/src/apps/dashboard/routes/libraries/metadata.tsx
+++ b/src/apps/dashboard/routes/libraries/metadata.tsx
@@ -21,7 +21,7 @@ import { ActionData } from 'types/actionData';
 import { queryClient } from 'utils/query/queryClient';
 
 export const action = async ({ request }: ActionFunctionArgs) => {
-    const api = ServerConnections.getCurrentApi();
+    const api = ServerConnections.getApi();
     if (!api) throw new Error('No Api instance available');
 
     const formData = await request.formData();

--- a/src/apps/dashboard/routes/libraries/nfo.tsx
+++ b/src/apps/dashboard/routes/libraries/nfo.tsx
@@ -26,7 +26,7 @@ import type { XbmcMetadataOptions } from '@jellyfin/sdk/lib/generated-client/mod
 const CONFIG_KEY = 'xbmcmetadata';
 
 export const action = async ({ request }: ActionFunctionArgs) => {
-    const api = ServerConnections.getCurrentApi();
+    const api = ServerConnections.getApi();
     if (!api) throw new Error('No Api instance available');
 
     const formData = await request.formData();

--- a/src/apps/dashboard/routes/livetv/recordings.tsx
+++ b/src/apps/dashboard/routes/livetv/recordings.tsx
@@ -28,7 +28,7 @@ import { ActionData } from 'types/actionData';
 const CONFIG_KEY = 'livetv';
 
 export const action = async ({ request }: ActionFunctionArgs) => {
-    const api = ServerConnections.getCurrentApi();
+    const api = ServerConnections.getApi();
     if (!api) throw new Error('No Api instance available');
 
     const data = await request.json() as LiveTvOptions;

--- a/src/apps/dashboard/routes/logs/index.tsx
+++ b/src/apps/dashboard/routes/logs/index.tsx
@@ -20,7 +20,7 @@ import { ActionData } from 'types/actionData';
 import LogItemList from 'apps/dashboard/features/logs/components/LogItemList';
 
 export const action = async ({ request }: ActionFunctionArgs) => {
-    const api = ServerConnections.getCurrentApi();
+    const api = ServerConnections.getApi();
     if (!api) throw new Error('No Api instance available');
 
     const formData = await request.formData();

--- a/src/apps/dashboard/routes/networking/index.tsx
+++ b/src/apps/dashboard/routes/networking/index.tsx
@@ -31,7 +31,7 @@ import Switch from '@mui/material/Switch';
 const CONFIG_KEY = 'network';
 
 export const action = async ({ request }: ActionFunctionArgs) => {
-    const api = ServerConnections.getCurrentApi();
+    const api = ServerConnections.getApi();
     if (!api) throw new Error('No Api instance available');
 
     const formData = await request.formData();

--- a/src/apps/dashboard/routes/playback/resume.tsx
+++ b/src/apps/dashboard/routes/playback/resume.tsx
@@ -16,7 +16,7 @@ import { getConfigurationApi } from '@jellyfin/sdk/lib/utils/api/configuration-a
 import { queryClient } from 'utils/query/queryClient';
 
 export const action = async ({ request }: ActionFunctionArgs) => {
-    const api = ServerConnections.getCurrentApi();
+    const api = ServerConnections.getApi();
     if (!api) throw new Error('No Api instance available');
 
     const { data: config } = await getConfigurationApi(api).getConfiguration();

--- a/src/apps/dashboard/routes/playback/streaming.tsx
+++ b/src/apps/dashboard/routes/playback/streaming.tsx
@@ -16,7 +16,7 @@ import { ActionData } from 'types/actionData';
 import { queryClient } from 'utils/query/queryClient';
 
 export const action = async ({ request }: ActionFunctionArgs) => {
-    const api = ServerConnections.getCurrentApi();
+    const api = ServerConnections.getApi();
     if (!api) throw new Error('No Api instance available');
 
     const { data: config } = await getConfigurationApi(api).getConfiguration();

--- a/src/apps/dashboard/routes/playback/transcoding.tsx
+++ b/src/apps/dashboard/routes/playback/transcoding.tsx
@@ -33,7 +33,7 @@ import SimpleAlert from 'components/SimpleAlert';
 const CONFIG_KEY = 'encoding';
 
 export const action = async ({ request }: ActionFunctionArgs) => {
-    const api = ServerConnections.getCurrentApi();
+    const api = ServerConnections.getApi();
     if (!api) throw new Error('No Api instance available');
 
     const data = await request.json() as EncodingOptions;

--- a/src/apps/dashboard/routes/playback/trickplay.tsx
+++ b/src/apps/dashboard/routes/playback/trickplay.tsx
@@ -24,7 +24,7 @@ import { ActionData } from 'types/actionData';
 import { queryClient } from 'utils/query/queryClient';
 
 export const action = async ({ request }: ActionFunctionArgs) => {
-    const api = ServerConnections.getCurrentApi();
+    const api = ServerConnections.getApi();
     if (!api) throw new Error('No Api instance available');
 
     const formData = await request.formData();

--- a/src/apps/dashboard/routes/settings/index.tsx
+++ b/src/apps/dashboard/routes/settings/index.tsx
@@ -27,7 +27,7 @@ import { queryClient } from 'utils/query/queryClient';
 import { ActionData } from 'types/actionData';
 
 export const action = async ({ request }: ActionFunctionArgs) => {
-    const api = ServerConnections.getCurrentApi();
+    const api = ServerConnections.getApi();
     if (!api) throw new Error('No Api instance available');
 
     const { data: config } = await getConfigurationApi(api).getConfiguration();

--- a/src/apps/stable/features/playback/utils/image.ts
+++ b/src/apps/stable/features/playback/utils/image.ts
@@ -14,23 +14,29 @@ interface ImageOptions {
 function getSeriesImageUrl(item: ItemDto, options: ImageOptions = {}) {
     if (!item.ServerId) return null;
 
+    const apiClient = ServerConnections.getApiClient(item.ServerId);
+    if (!apiClient) {
+        console.error('[getSeriesImageUrl] No ApiClient instance available for serverId', item.ServerId);
+        return null;
+    }
+
     if (item.SeriesId && options.type === ImageType.Primary && item.SeriesPrimaryImageTag) {
         options.tag = item.SeriesPrimaryImageTag;
 
-        return ServerConnections.getApiClient(item.ServerId).getScaledImageUrl(item.SeriesId, options);
+        return apiClient.getScaledImageUrl(item.SeriesId, options);
     }
 
     if (options.type === ImageType.Thumb) {
         if (item.SeriesId && item.SeriesThumbImageTag) {
             options.tag = item.SeriesThumbImageTag;
 
-            return ServerConnections.getApiClient(item.ServerId).getScaledImageUrl(item.SeriesId, options);
+            return apiClient.getScaledImageUrl(item.SeriesId, options);
         }
 
         if (item.ParentThumbItemId && item.ParentThumbImageTag) {
             options.tag = item.ParentThumbImageTag;
 
-            return ServerConnections.getApiClient(item.ServerId).getScaledImageUrl(item.ParentThumbItemId, options);
+            return apiClient.getScaledImageUrl(item.ParentThumbItemId, options);
         }
     }
 
@@ -40,6 +46,12 @@ function getSeriesImageUrl(item: ItemDto, options: ImageOptions = {}) {
 export function getImageUrl(item: ItemDto, options: ImageOptions = {}) {
     if (!item.ServerId) return null;
 
+    const apiClient = ServerConnections.getApiClient(item.ServerId);
+    if (!apiClient) {
+        console.error('[getImageUrl] No ApiClient instance available for serverId', item.ServerId);
+        return null;
+    }
+
     options.type = options.type || ImageType.Primary;
 
     if (item.Type === BaseItemKind.Episode) return getSeriesImageUrl(item, options);
@@ -48,12 +60,12 @@ export function getImageUrl(item: ItemDto, options: ImageOptions = {}) {
 
     if (itemId && item.ImageTags?.[options.type]) {
         options.tag = item.ImageTags[options.type] ?? undefined;
-        return ServerConnections.getApiClient(item.ServerId).getScaledImageUrl(itemId, options);
+        return apiClient.getScaledImageUrl(itemId, options);
     }
 
     if (item.AlbumId && item.AlbumPrimaryImageTag) {
         options.tag = item.AlbumPrimaryImageTag;
-        return ServerConnections.getApiClient(item.ServerId).getScaledImageUrl(item.AlbumId, options);
+        return apiClient.getScaledImageUrl(item.AlbumId, options);
     }
 
     return null;

--- a/src/apps/stable/features/playback/utils/mediaSegmentManager.ts
+++ b/src/apps/stable/features/playback/utils/mediaSegmentManager.ts
@@ -9,7 +9,6 @@ import { ServerConnections } from 'lib/jellyfin-apiclient';
 import { currentSettings as userSettings } from 'scripts/settings/userSettings';
 import type { PlayerState } from 'types/playbackStopInfo';
 import type { Event } from 'utils/events';
-import { toApi } from 'utils/jellyfin-apiclient/compat';
 
 import { getMediaSegmentAction } from './mediaSegmentSettings';
 import { findCurrentSegment } from './mediaSegments';
@@ -109,7 +108,12 @@ class MediaSegmentManager extends PlaybackSubscriber {
             return;
         }
 
-        const api = toApi(ServerConnections.getApiClient(serverId));
+        const api = ServerConnections.getApi(serverId);
+        if (!api) {
+            console.error('[MediaSegmentManager] no api instance available for server', serverId);
+            return;
+        }
+
         void this.fetchMediaSegments(
             api,
             itemId,

--- a/src/apps/stable/routes/session/forgotPassword/index.tsx
+++ b/src/apps/stable/routes/session/forgotPassword/index.tsx
@@ -17,7 +17,7 @@ export const ForgotPasswordPage = () => {
 
     const forgotPasswordMutation = useMutation({
         mutationFn: async (enteredUsername: string) => {
-            const currentApi = ServerConnections.getCurrentApi();
+            const currentApi = ServerConnections.getApi();
             if (!currentApi) {
                 throw new Error('API not available');
             }

--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -15,7 +15,6 @@ import dom from 'utils/dom';
 import globalize from 'lib/globalize';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
 import { getItemTypeIcon, getLibraryIcon } from 'utils/image';
-import { toApi } from 'utils/jellyfin-apiclient/compat';
 
 import focusManager from '../focusManager';
 import imageLoader from '../images/imageLoader';
@@ -746,7 +745,7 @@ function buildCard(index, item, apiClient, options) {
 
     // TODO move card creation code to Card component
 
-    const imgInfo = getCardImageUrl({ api: toApi(apiClient), item, options, shape });
+    const imgInfo = getCardImageUrl({ api: ServerConnections.getApi(apiClient.serverId()), item, options, shape });
     const imgUrl = imgInfo.imgUrl;
     const blurhash = imgInfo.blurhash;
     const forceName = imgInfo.forceName;

--- a/src/components/cardbuilder/cardImage.ts
+++ b/src/components/cardbuilder/cardImage.ts
@@ -2,8 +2,8 @@ import type { BaseItemDto } from '@jellyfin/sdk/lib/generated-client/models/base
 import { BaseItemKind } from '@jellyfin/sdk/lib/generated-client/models/base-item-kind';
 import type { ApiClient } from 'jellyfin-apiclient';
 
+import ServerConnections from 'lib/jellyfin-apiclient/ServerConnections';
 import type { CardOptions } from 'types/cardOptions';
-import { toApi } from 'utils/jellyfin-apiclient/compat';
 
 import { getDefaultText } from './cardBuilder';
 import { CardShape } from './utils/shape';
@@ -31,7 +31,7 @@ export function buildCardImage(
     }
 
     const image = getCardImageUrl({
-        api: toApi(apiClient),
+        api: ServerConnections.getApi(apiClient.serverId()),
         item,
         options,
         shape

--- a/src/components/displaySettings/displaySettings.js
+++ b/src/components/displaySettings/displaySettings.js
@@ -4,7 +4,6 @@ import { AppFeature } from 'constants/appFeature';
 import { PluginType } from 'constants/pluginType';
 import { getUserQuery } from 'hooks/api/useUser';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
-import { toApi } from 'utils/jellyfin-apiclient/compat';
 import { queryClient } from 'utils/query/queryClient';
 
 import browser from '../../scripts/browser';
@@ -246,10 +245,11 @@ class DisplaySettings {
         loading.show();
 
         const userId = self.options.userId;
+        const api = ServerConnections.getApi(self.options.serverId);
         const apiClient = ServerConnections.getApiClient(self.options.serverId);
         const userSettings = self.options.userSettings;
 
-        const user = await queryClient.fetchQuery(getUserQuery(toApi(apiClient), { userId }));
+        const user = await queryClient.fetchQuery(getUserQuery(api, { userId }));
         await userSettings.setUserInfo(userId, apiClient);
 
         self.dataLoaded = true;

--- a/src/components/homeScreenSettings/homeScreenSettings.js
+++ b/src/components/homeScreenSettings/homeScreenSettings.js
@@ -3,7 +3,6 @@ import escapeHtml from 'escape-html';
 
 import { getUserViewsQuery } from 'hooks/api/useUserViews';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
-import { toApi } from 'utils/jellyfin-apiclient/compat';
 import { queryClient } from 'utils/query/queryClient';
 
 import layoutManager from '../layoutManager';
@@ -389,7 +388,7 @@ function loadForm(context, user, userSettings, apiClient) {
 
     const promise1 = queryClient
         .fetchQuery(getUserViewsQuery(
-            toApi(apiClient),
+            ServerConnections.getApi(apiClient.serverId()),
             {
                 userId: user.Id,
                 includeHidden: true

--- a/src/components/homesections/homesections.js
+++ b/src/components/homesections/homesections.js
@@ -2,8 +2,8 @@ import layoutManager from 'components/layoutManager';
 import { DEFAULT_SECTIONS, HomeSectionType } from 'constants/homeSectionType';
 import { getUserViewsQuery } from 'hooks/api/useUserViews';
 import globalize from 'lib/globalize';
+import ServerConnections from 'lib/jellyfin-apiclient/ServerConnections';
 import Dashboard from 'utils/dashboard';
-import { toApi } from 'utils/jellyfin-apiclient/compat';
 import { queryClient } from 'utils/query/queryClient';
 
 import { loadRecordings } from './sections/activeRecordings';
@@ -56,9 +56,10 @@ function getAllSectionsToShow(userSettings) {
 }
 
 export function loadSections(elem, apiClient, user, userSettings) {
+    const api = ServerConnections.getApi(apiClient.serverId());
     const userId = user.Id || apiClient.getCurrentUserId();
     return queryClient
-        .fetchQuery(getUserViewsQuery(toApi(apiClient), { userId }))
+        .fetchQuery(getUserViewsQuery(api, { userId }))
         .then(result => result.Items || [])
         .then(function (userViews) {
             let html = '';
@@ -186,4 +187,3 @@ export default {
     pause,
     resume
 };
-

--- a/src/components/homesections/sections/activeRecordings.ts
+++ b/src/components/homesections/sections/activeRecordings.ts
@@ -6,7 +6,6 @@ import { getRecordingsQuery } from 'apps/stable/features/liveTv/api/useRecording
 import cardBuilder from 'components/cardbuilder/cardBuilder';
 import globalize from 'lib/globalize';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
-import { toApi } from 'utils/jellyfin-apiclient/compat';
 import { queryClient } from 'utils/query/queryClient';
 
 import type { SectionContainerElement, SectionOptions } from './section';
@@ -17,9 +16,10 @@ function getLatestRecordingsFetchFn(
     { enableOverflow }: SectionOptions
 ) {
     return function () {
+        const api = ServerConnections.getApi(serverId);
         const apiClient = ServerConnections.getApiClient(serverId);
-        return queryClient.fetchQuery(getRecordingsQuery(toApi(apiClient), {
-            userId: apiClient.getCurrentUserId(),
+        return queryClient.fetchQuery(getRecordingsQuery(api, {
+            userId: apiClient?.getCurrentUserId(),
             limit: enableOverflow ? 12 : 5,
             fields: [ ItemFields.PrimaryImageAspectRatio ],
             enableTotalRecordCount: false,

--- a/src/components/homesections/sections/liveTv.ts
+++ b/src/components/homesections/sections/liveTv.ts
@@ -4,23 +4,24 @@ import { ItemFields } from '@jellyfin/sdk/lib/generated-client/models/item-field
 import type { UserDto } from '@jellyfin/sdk/lib/generated-client/models/user-dto';
 import type { ApiClient } from 'jellyfin-apiclient';
 
+import { getRecommendedProgramsQuery } from 'apps/stable/features/liveTv/api/useRecommendedPrograms';
 import { appRouter } from 'components/router/appRouter';
 import cardBuilder from 'components/cardbuilder/cardBuilder';
 import { getBackdropShape } from 'components/cardbuilder/utils/shape';
 import layoutManager from 'components/layoutManager';
 import globalize from 'lib/globalize';
+import ServerConnections from 'lib/jellyfin-apiclient/ServerConnections';
+import { queryClient } from 'utils/query/queryClient';
 
 import type { SectionContainerElement, SectionOptions } from './section';
-import { queryClient } from 'utils/query/queryClient';
-import { getRecommendedProgramsQuery } from 'apps/stable/features/liveTv/api/useRecommendedPrograms';
-import { toApi } from 'utils/jellyfin-apiclient/compat';
 
 function getOnNowFetchFn(
     apiClient: ApiClient
 ) {
     return function () {
+        const api = ServerConnections.getApi(apiClient.serverId());
         return queryClient
-            .fetchQuery(getRecommendedProgramsQuery(toApi(apiClient), {
+            .fetchQuery(getRecommendedProgramsQuery(api, {
                 userId: apiClient.getCurrentUserId(),
                 isAiring: true,
                 limit: 24,
@@ -177,8 +178,9 @@ export function loadLiveTV(
         return Promise.resolve();
     }
 
+    const api = ServerConnections.getApi(apiClient.serverId());
     return queryClient
-        .fetchQuery(getRecommendedProgramsQuery(toApi(apiClient), {
+        .fetchQuery(getRecommendedProgramsQuery(api, {
             userId: apiClient.getCurrentUserId(),
             isAiring: true,
             limit: 1,

--- a/src/components/homesections/sections/nextUp.ts
+++ b/src/components/homesections/sections/nextUp.ts
@@ -9,9 +9,9 @@ import { getBackdropShape } from 'components/cardbuilder/utils/shape';
 import layoutManager from 'components/layoutManager';
 import { appRouter } from 'components/router/appRouter';
 import globalize from 'lib/globalize';
+import ServerConnections from 'lib/jellyfin-apiclient/ServerConnections';
 import type { UserSettings } from 'scripts/settings/userSettings';
 import { toIsoDateOnlyString } from 'utils/date';
-import { toApi } from 'utils/jellyfin-apiclient/compat';
 import { queryClient } from 'utils/query/queryClient';
 
 import type { SectionContainerElement, SectionOptions } from './section';
@@ -22,10 +22,11 @@ function getNextUpFetchFn(
     { enableOverflow }: SectionOptions
 ) {
     return function () {
+        const api = ServerConnections.getApi(apiClient.serverId());
         const oldestDateForNextUp = new Date();
         oldestDateForNextUp.setDate(oldestDateForNextUp.getDate() - userSettings.maxDaysForNextUp());
         return queryClient
-            .fetchQuery(getNextUpQuery(toApi(apiClient), {
+            .fetchQuery(getNextUpQuery(api, {
                 userId: apiClient.getCurrentUserId(),
                 limit: enableOverflow ? 24 : 15,
                 fields: [

--- a/src/components/homesections/sections/recentlyAdded.ts
+++ b/src/components/homesections/sections/recentlyAdded.ts
@@ -13,7 +13,7 @@ import { getBackdropShape, getPortraitShape, getSquareShape } from 'components/c
 import layoutManager from 'components/layoutManager';
 import { appRouter } from 'components/router/appRouter';
 import globalize from 'lib/globalize';
-import { toApi } from 'utils/jellyfin-apiclient/compat';
+import ServerConnections from 'lib/jellyfin-apiclient/ServerConnections';
 import { queryClient } from 'utils/query/queryClient';
 
 import type { SectionContainerElement, SectionOptions } from './section';
@@ -26,6 +26,8 @@ function getFetchLatestItemsFn(
     { enableOverflow }: SectionOptions
 ) {
     return function () {
+        const api = ServerConnections.getApi(apiClient.serverId());
+
         let limit = 16;
 
         if (enableOverflow) {
@@ -57,7 +59,7 @@ function getFetchLatestItemsFn(
         };
 
         return queryClient
-            .fetchQuery(getLatestMediaQuery(toApi(apiClient), options));
+            .fetchQuery(getLatestMediaQuery(api, options));
     };
 }
 

--- a/src/components/homesections/sections/resume.ts
+++ b/src/components/homesections/sections/resume.ts
@@ -8,9 +8,9 @@ import { getResumeItemsQuery } from 'apps/stable/features/libraries/api/useResum
 import cardBuilder from 'components/cardbuilder/cardBuilder';
 import { getBackdropShape, getPortraitShape } from 'components/cardbuilder/utils/shape';
 import globalize from 'lib/globalize';
+import ServerConnections from 'lib/jellyfin-apiclient/ServerConnections';
 import { queryClient } from 'utils/query/queryClient';
 import type { UserSettings } from 'scripts/settings/userSettings';
-import { toApi } from 'utils/jellyfin-apiclient/compat';
 
 import type { SectionContainerElement, SectionOptions } from './section';
 
@@ -25,6 +25,7 @@ function getItemsToResumeFn(
     { enableOverflow }: SectionOptions
 ) {
     return function () {
+        const api = ServerConnections.getApi(apiClient.serverId());
         const limit = enableOverflow ? 12 : 5;
 
         const options = {
@@ -42,7 +43,7 @@ function getItemsToResumeFn(
         };
 
         return queryClient
-            .fetchQuery(getResumeItemsQuery(toApi(apiClient), options));
+            .fetchQuery(getResumeItemsQuery(api, options));
     };
 }
 

--- a/src/components/itemContextMenu.js
+++ b/src/components/itemContextMenu.js
@@ -2,13 +2,12 @@ import { BaseItemKind } from '@jellyfin/sdk/lib/generated-client/models/base-ite
 import { getLibraryApi } from '@jellyfin/sdk/lib/utils/api/library-api';
 
 import { AppFeature } from 'constants/appFeature';
-import { toApi } from 'utils/jellyfin-apiclient/compat';
+import { ServerConnections } from 'lib/jellyfin-apiclient';
 
 import browser from '../scripts/browser';
 import { copy } from '../scripts/clipboard';
 import dom from '../utils/dom';
 import globalize from '../lib/globalize';
-import { ServerConnections } from 'lib/jellyfin-apiclient';
 import actionsheet from './actionSheet/actionSheet';
 import { appHost } from './apphost';
 import { appRouter } from './router/appRouter';
@@ -390,7 +389,7 @@ function executeCommand(item, id, options) {
     const itemId = item.Id;
     const serverId = item.ServerId;
     const apiClient = ServerConnections.getApiClient(serverId);
-    const api = toApi(apiClient);
+    const api = ServerConnections.getApi(serverId);
 
     return new Promise(function (resolve, reject) {
         // eslint-disable-next-line sonarjs/max-switch-cases

--- a/src/components/itemHelper.js
+++ b/src/components/itemHelper.js
@@ -9,7 +9,6 @@ import { appHost } from './apphost';
 import { AppFeature } from 'constants/appFeature';
 import globalize from 'lib/globalize';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
-import { toApi } from 'utils/jellyfin-apiclient/compat';
 
 export function getDisplayName(item, options = {}) {
     if (!item) {
@@ -165,8 +164,7 @@ export function canEditImages (user, item) {
 }
 
 export async function canEditPlaylist(user, item) {
-    const apiClient = ServerConnections.getApiClient(item.ServerId);
-    const api = toApi(apiClient);
+    const api = ServerConnections.getApi(item.ServerId);
 
     try {
         const { data: permissions } = await getPlaylistsApi(api)

--- a/src/components/lyricseditor/lyricseditor.js
+++ b/src/components/lyricseditor/lyricseditor.js
@@ -1,7 +1,6 @@
 import escapeHtml from 'escape-html';
 
 import { getLyricsApi } from '@jellyfin/sdk/lib/utils/api/lyrics-api';
-import { toApi } from 'utils/jellyfin-apiclient/compat';
 import dialogHelper from '../dialogHelper/dialogHelper';
 import layoutManager from '../layoutManager';
 import globalize from 'lib/globalize';
@@ -26,9 +25,8 @@ let currentItem;
 let hasChanges;
 
 function downloadRemoteLyrics(context, id) {
-    const api = toApi(ServerConnections.getApiClient(currentItem.ServerId));
-    const lyricsApi = getLyricsApi(api);
-    lyricsApi.downloadRemoteLyrics({
+    const api = ServerConnections.getApi(currentItem.ServerId);
+    getLyricsApi(api).downloadRemoteLyrics({
         itemId: currentItem.Id,
         lyricId: id
     }).then(function () {
@@ -128,9 +126,8 @@ function renderSearchResults(context, results) {
 function searchForLyrics(context) {
     loading.show();
 
-    const api = toApi(ServerConnections.getApiClient(currentItem.ServerId));
-    const lyricsApi = getLyricsApi(api);
-    lyricsApi.searchRemoteLyrics({
+    const api = ServerConnections.getApi(currentItem.ServerId);
+    getLyricsApi(api).searchRemoteLyrics({
         itemId: currentItem.Id
     }).then(function (results) {
         renderSearchResults(context, results.data);
@@ -296,9 +293,8 @@ function onDeleteLyrics(e) {
 }
 
 function fillCurrentLyrics(context, apiClient, item) {
-    const api = toApi(apiClient);
-    const lyricsApi = getLyricsApi(api);
-    lyricsApi.getLyrics({
+    const api = ServerConnections.getApi(apiClient.serverId());
+    getLyricsApi(api).getLyrics({
         itemId: item.Id
     }).then((response) => {
         if (!response.data.Lyrics) {

--- a/src/components/lyricsuploader/lyricsuploader.js
+++ b/src/components/lyricsuploader/lyricsuploader.js
@@ -1,7 +1,6 @@
 import escapeHtml from 'escape-html';
-
 import { getLyricsApi } from '@jellyfin/sdk/lib/utils/api/lyrics-api';
-import { toApi } from 'utils/jellyfin-apiclient/compat';
+
 import dialogHelper from '../../components/dialogHelper/dialogHelper';
 import dom from '../../utils/dom';
 import loading from '../../components/loading/loading';
@@ -90,12 +89,13 @@ async function onSubmit(e) {
     loading.show();
     const dlg = dom.parentWithClass(this, 'dialog');
 
-    const api = toApi(ServerConnections.getApiClient(currentServerId));
-    const lyricsApi = getLyricsApi(api);
+    const api = ServerConnections.getApi(currentServerId);
     const data = await readFileAsText(file);
 
-    lyricsApi.uploadLyrics({
-        itemId: currentItemId, fileName: file.name, body: data
+    getLyricsApi(api).uploadLyrics({
+        itemId: currentItemId,
+        fileName: file.name,
+        body: data
     }).then(function () {
         dlg.querySelector('#uploadLyrics').value = '';
         loading.hide();

--- a/src/components/playback/displayMirrorManager.ts
+++ b/src/components/playback/displayMirrorManager.ts
@@ -1,6 +1,5 @@
 import { getItemQuery } from 'hooks/useItem';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
-import { toApi } from 'utils/jellyfin-apiclient/compat';
 import { queryClient } from 'utils/query/queryClient';
 
 import { playbackManager } from './playbackmanager';
@@ -10,9 +9,9 @@ async function mirrorIfEnabled(serverId: string, itemId: string) {
         const playerInfo = playbackManager.getPlayerInfo();
 
         if (playerInfo && !playerInfo.isLocalPlayer && playerInfo.supportedCommands.indexOf('DisplayContent') !== -1) {
+            const api = ServerConnections.getApi(serverId);
             const apiClient = ServerConnections.getApiClient(serverId);
-            const api = toApi(apiClient);
-            const userId = apiClient.getCurrentUserId();
+            const userId = apiClient?.getCurrentUserId();
 
             try {
                 const item = await queryClient.fetchQuery(getItemQuery(

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -3740,7 +3740,7 @@ export class PlaybackManager {
                 let _unsubscribeRemoteControl;
                 Events.on(ServerConnections, 'localusersignedin', () => {
                     _unsubscribeRemoteControl?.();
-                    const api = ServerConnections.getCurrentApi();
+                    const api = ServerConnections.getApi();
                     _unsubscribeRemoteControl = api?.subscribe(
                         [OutboundWebSocketMessageType.ServerShuttingDown, OutboundWebSocketMessageType.ServerRestarting],
                         self.setDefaultPlayerActive.bind(self)

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -32,7 +32,6 @@ import { ServerConnections } from 'lib/jellyfin-apiclient';
 import { OutboundWebSocketMessageType } from '@jellyfin/sdk/lib/websocket';
 import { MediaError } from 'types/mediaError';
 import { getMediaError } from 'utils/mediaError';
-import { toApi } from 'utils/jellyfin-apiclient/compat';
 import { bindSkipSegment } from './skipsegment.ts';
 import * as bitrateTest from 'utils/bitrateTest';
 
@@ -441,8 +440,7 @@ async function getPlaybackInfo(player, apiClient, item, deviceProfile, mediaSour
         StartTimeTicks: options.startPosition || 0
     };
 
-    const api = toApi(apiClient);
-    const mediaInfoApi = getMediaInfoApi(api);
+    const api = ServerConnections.getApi(apiClient.serverId());
 
     if (options.isPlayback) {
         query.IsPlayback = true;
@@ -501,7 +499,7 @@ async function getPlaybackInfo(player, apiClient, item, deviceProfile, mediaSour
 
     query.DeviceProfile = deviceProfile;
 
-    const res = await mediaInfoApi.getPostedPlaybackInfo({ itemId: itemId, playbackInfoDto: query });
+    const res = await getMediaInfoApi(api).getPostedPlaybackInfo({ itemId: itemId, playbackInfoDto: query });
     return res.data;
 }
 
@@ -1400,6 +1398,7 @@ export class PlaybackManager {
                 return player.setMaxStreamingBitrate(options);
             }
 
+            const api = ServerConnections.getApi(self.currentItem(player).ServerId);
             const apiClient = ServerConnections.getApiClient(self.currentItem(player).ServerId);
 
             apiClient.getEndpointInfo().then(function (endpointInfo) {
@@ -1409,7 +1408,7 @@ export class PlaybackManager {
                 let promise;
                 if (options.enableAutomaticBitrateDetection) {
                     appSettings.enableAutomaticBitrateDetection(endpointInfo.IsInNetwork, mediaType, true);
-                    promise = bitrateTest.detectBitrate(toApi(apiClient), true);
+                    promise = bitrateTest.detectBitrate(api, true);
                 } else {
                     appSettings.enableAutomaticBitrateDetection(endpointInfo.IsInNetwork, mediaType, false);
                     promise = Promise.resolve(options.maxBitrate);
@@ -2366,8 +2365,6 @@ export class PlaybackManager {
 
             playOptions.isFirstItem = playOptions.isFirstItem || !prevSource;
 
-            const apiClient = ServerConnections.getApiClient(item.ServerId);
-
             // TODO: This should be the media type requested, not the original media type
             const mediaType = item.MediaType;
 
@@ -2378,7 +2375,7 @@ export class PlaybackManager {
                         loading.show();
                     }
                 })
-                .then(() => detectBitrate(apiClient, item, mediaType))
+                .then(() => detectBitrate(item, mediaType))
                 .then((bitrate) => {
                     return playAfterBitrateDetect(bitrate, item, playOptions, onPlaybackStartedFn, prevSource)
                         .catch(onPlaybackRejection);
@@ -2579,7 +2576,10 @@ export class PlaybackManager {
             }
         }
 
-        function detectBitrate(apiClient, item, mediaType) {
+        function detectBitrate(item, mediaType) {
+            const api = ServerConnections.getApi(item.ServerId);
+            const apiClient = ServerConnections.getApiClient(item.ServerId);
+
             // FIXME: This is gnarly, but don't want to change too much here in a bugfix
             return Promise.resolve()
                 .then(() => {
@@ -2590,7 +2590,7 @@ export class PlaybackManager {
                     return apiClient.getEndpointInfo()
                         .then((endpointInfo) => {
                             if ((mediaType === 'Video' || mediaType === 'Audio') && appSettings.enableAutomaticBitrateDetection(endpointInfo.IsInNetwork, mediaType)) {
-                                return bitrateTest.detectBitrate(toApi(apiClient))
+                                return bitrateTest.detectBitrate(api)
                                     .then((bitrate) => {
                                         appSettings.maxStreamingBitrate(endpointInfo.IsInNetwork, mediaType, bitrate);
                                         return bitrate;

--- a/src/components/playlisteditor/playlisteditor.ts
+++ b/src/components/playlisteditor/playlisteditor.ts
@@ -13,7 +13,6 @@ import { ServerConnections } from 'lib/jellyfin-apiclient';
 import { currentSettings as userSettings } from 'scripts/settings/userSettings';
 import dom from 'utils/dom';
 import Events from 'utils/events';
-import { toApi } from 'utils/jellyfin-apiclient/compat';
 import { queryClient } from 'utils/query/queryClient';
 import { isBlank } from 'utils/string';
 
@@ -90,10 +89,11 @@ function createPlaylist(dlg: DialogElement) {
     const name = dlg.querySelector<HTMLInputElement>('#txtNewPlaylistName')?.value;
     if (isBlank(name)) return Promise.reject(new Error('Playlist name should not be blank'));
 
+    const api = ServerConnections.getApi(currentServerId);
     const apiClient = ServerConnections.getApiClient(currentServerId);
-    const api = toApi(apiClient);
-
     const itemIds = dlg.querySelector<HTMLInputElement>('.fldSelectedItemIds')?.value || undefined;
+
+    if (!api) return Promise.reject(new Error('No Api instance available'));
 
     return getPlaylistsApi(api)
         .createPlaylist({
@@ -101,7 +101,7 @@ function createPlaylist(dlg: DialogElement) {
                 Name: name ?? '',
                 IsPublic: dlg.querySelector<HTMLInputElement>('#chkPlaylistPublic')?.checked,
                 Ids: itemIds?.split(','),
-                UserId: apiClient.getCurrentUserId()
+                UserId: apiClient?.getCurrentUserId()
             }
         })
         .then(result => {
@@ -111,7 +111,7 @@ function createPlaylist(dlg: DialogElement) {
             // The playlist user view is only available after a playlist is created.
             // Ideally we would only invalidate if there are no other playlists.
             void queryClient.invalidateQueries({
-                queryKey: ['User', apiClient.getCurrentUserId(), 'Views']
+                queryKey: ['User', apiClient?.getCurrentUserId(), 'Views']
             });
             // If a new playlist is created, then trigger a refresh of the library views
             Events.trigger(document, EventType.REFRESH_NEEDED);
@@ -130,8 +130,8 @@ function updatePlaylist(dlg: DialogElement) {
     const name = dlg.querySelector<HTMLInputElement>('#txtNewPlaylistName')?.value;
     if (isBlank(name)) return Promise.reject(new Error('Playlist name should not be blank'));
 
-    const apiClient = ServerConnections.getApiClient(currentServerId);
-    const api = toApi(apiClient);
+    const api = ServerConnections.getApi(currentServerId);
+    if (!api) return Promise.reject(new Error('No Api instance available'));
 
     return getPlaylistsApi(api)
         .updatePlaylist({
@@ -148,8 +148,8 @@ function updatePlaylist(dlg: DialogElement) {
 }
 
 function addToPlaylist(dlg: DialogElement, id: string) {
+    const api = ServerConnections.getApi(currentServerId);
     const apiClient = ServerConnections.getApiClient(currentServerId);
-    const api = toApi(apiClient);
     const itemIds = dlg.querySelector<HTMLInputElement>('.fldSelectedItemIds')?.value || '';
 
     if (id === 'queue') {
@@ -164,11 +164,13 @@ function addToPlaylist(dlg: DialogElement, id: string) {
         return Promise.resolve();
     }
 
+    if (!api) return Promise.reject(new Error('No Api instance available'));
+
     return getPlaylistsApi(api)
         .addItemToPlaylist({
             playlistId: id,
             ids: itemIds.split(','),
-            userId: apiClient.getCurrentUserId()
+            userId: apiClient?.getCurrentUserId()
         })
         .then(() => {
             dlg.submitted = true;
@@ -191,13 +193,15 @@ function populatePlaylists(editorOptions: PlaylistEditorOptions, panel: DialogEl
 
     panel.querySelector('.newPlaylistInfo')?.classList.add('hide');
 
+    const api = ServerConnections.getApi(currentServerId);
     const apiClient = ServerConnections.getApiClient(currentServerId);
-    const api = toApi(apiClient);
     const SyncPlay = pluginManager.firstOfType(PluginType.SyncPlay)?.instance;
+
+    if (!api) return Promise.reject(new Error('No Api instance available'));
 
     return getItemsApi(api)
         .getItems({
-            userId: apiClient.getCurrentUserId(),
+            userId: apiClient?.getCurrentUserId(),
             includeItemTypes: [ BaseItemKind.Playlist ],
             sortBy: [ ItemSortBy.SortName ],
             recursive: true,
@@ -209,13 +213,14 @@ function populatePlaylists(editorOptions: PlaylistEditorOptions, panel: DialogEl
                     item,
                     permissions: undefined
                 };
+                const userId = apiClient?.getCurrentUserId();
 
-                if (!item.Id) return playlist;
+                if (!item.Id || !userId) return playlist;
 
                 return getPlaylistsApi(api)
                     .getPlaylistUser({
                         playlistId: item.Id,
-                        userId: apiClient.getCurrentUserId()
+                        userId
                     })
                     .then(({ data: permissions }) => ({
                         ...playlist,
@@ -340,8 +345,12 @@ function initEditor(content: DialogElement, options: PlaylistEditorOptions, item
             return;
         }
 
-        const apiClient = ServerConnections.getApiClient(currentServerId);
-        const api = toApi(apiClient);
+        const api = ServerConnections.getApi(currentServerId);
+        if (!api) {
+            console.error('[PlaylistEditor] no Api instance available');
+            return;
+        }
+
         Promise.all([
             getUserLibraryApi(api)
                 .getItem({ itemId: options.id }),

--- a/src/components/router/appRouter.js
+++ b/src/components/router/appRouter.js
@@ -10,7 +10,6 @@ import layoutManager from 'components/layoutManager';
 import { LayoutMode } from 'constants/layoutMode';
 import { getItemQuery } from 'hooks/useItem';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
-import { toApi } from 'utils/jellyfin-apiclient/compat';
 import { queryClient } from 'utils/query/queryClient';
 import { history } from 'RootAppRouter';
 
@@ -137,8 +136,8 @@ class AppRouter {
     showItem(item, serverId, options) {
         // TODO: Refactor this so it only gets items, not strings.
         if (typeof item === 'string') {
+            const api = ServerConnections.getApi(serverId);
             const apiClient = serverId ? ServerConnections.getApiClient(serverId) : ServerConnections.currentApiClient();
-            const api = toApi(apiClient);
             const userId = apiClient.getCurrentUserId();
 
             queryClient

--- a/src/components/shortcuts.js
+++ b/src/components/shortcuts.js
@@ -7,7 +7,6 @@ import { EventType } from 'constants/eventType';
 import { ItemAction } from 'constants/itemAction';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
 import Events from 'utils/events';
-import { toApi } from 'utils/jellyfin-apiclient/compat';
 
 import { playbackManager } from './playback/playbackmanager';
 import inputManager from '../scripts/inputManager';
@@ -132,20 +131,20 @@ function showContextMenu(card, options = {}) {
             }
         }
 
+        const api = ServerConnections.getApi(item.ServerId);
         const apiClient = ServerConnections.getApiClient(item.ServerId);
-        const api = toApi(apiClient);
 
         Promise.all([
             // Import the item menu component
             import('./itemContextMenu'),
             // Fetch the current user
-            apiClient.getCurrentUser(),
+            apiClient?.getCurrentUser(),
             // Fetch playlist perms if item is a child of a playlist
-            playlistId ?
+            api && playlistId ?
                 getPlaylistsApi(api)
                     .getPlaylistUser({
                         playlistId,
-                        userId: apiClient.getCurrentUserId()
+                        userId: apiClient?.getCurrentUserId()
                     })
                     .then(({ data }) => data)
                     .catch(err => {

--- a/src/components/slideshow/slideshow.js
+++ b/src/components/slideshow/slideshow.js
@@ -7,7 +7,6 @@ import screenfull from 'screenfull';
 
 import { AppFeature } from 'constants/appFeature';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
-import { toApi } from 'utils/jellyfin-apiclient/compat';
 import { randomInt } from 'utils/number';
 
 import dialogHelper from '../dialogHelper/dialogHelper';
@@ -92,14 +91,14 @@ function getBackdropImageUrl(item, options, apiClient) {
  * @returns {string} URL of the item's image.
  */
 function getImgUrl(item, user) {
+    const api = ServerConnections.getApi(item.ServerId);
     const apiClient = ServerConnections.getApiClient(item);
-    const api = toApi(apiClient);
     const imageOptions = {};
 
     if (item.BackdropImageTags?.length) {
         return getBackdropImageUrl(item, imageOptions, apiClient);
     } else {
-        if (item.MediaType === 'Photo' && user?.Policy.EnableContentDownloading) {
+        if (api && item.MediaType === 'Photo' && user?.Policy.EnableContentDownloading) {
             return getLibraryApi(api).getDownloadUrl({ itemId: item.Id });
         }
         imageOptions.type = 'Primary';

--- a/src/components/subtitleuploader/subtitleuploader.js
+++ b/src/components/subtitleuploader/subtitleuploader.js
@@ -1,7 +1,6 @@
 import escapeHtml from 'escape-html';
-
 import { getSubtitleApi } from '@jellyfin/sdk/lib/utils/api/subtitle-api';
-import { toApi } from 'utils/jellyfin-apiclient/compat';
+
 import dialogHelper from '../../components/dialogHelper/dialogHelper';
 import dom from '../../utils/dom';
 import loading from '../../components/loading/loading';
@@ -96,12 +95,16 @@ async function onSubmit(e) {
     const isForced = dlg.querySelector('#chkIsForced').checked;
     const isHearingImpaired = dlg.querySelector('#chkIsHearingImpaired').checked;
 
-    const subtitleApi = getSubtitleApi(toApi(ServerConnections.getApiClient(currentServerId)));
+    const api = ServerConnections.getApi(currentServerId);
+    if (!api) {
+        console.error('[SubtitleUploader] No Api instance available for server', currentServerId);
+        return;
+    }
 
     const data = await readFileAsBase64(file);
     const format = file.name.substring(file.name.lastIndexOf('.') + 1).toLowerCase();
 
-    subtitleApi.uploadSubtitle({
+    getSubtitleApi(api).uploadSubtitle({
         itemId: currentItemId,
         uploadSubtitleDto: { Data: data, Language: language, IsForced: isForced, Format: format, IsHearingImpaired: isHearingImpaired }
     }).then(function () {

--- a/src/components/themeMediaPlayer.js
+++ b/src/components/themeMediaPlayer.js
@@ -7,7 +7,6 @@ import { ServerConnections } from 'lib/jellyfin-apiclient';
 import { currentSettings as userSettings } from 'scripts/settings/userSettings';
 import { ItemKind } from 'types/base/models/item-kind';
 import Events from 'utils/events.ts';
-import { toApi } from 'utils/jellyfin-apiclient/compat';
 import { queryClient } from 'utils/query/queryClient';
 
 import { playbackManager } from './playback/playbackmanager';
@@ -78,9 +77,9 @@ const excludeTypes = [
 ];
 
 async function loadThemeMedia(serverId, itemId) {
+    const api = ServerConnections.getApi(serverId);
     const apiClient = ServerConnections.getApiClient(serverId);
-    const api = toApi(apiClient);
-    const userId = apiClient.getCurrentUserId();
+    const userId = apiClient?.getCurrentUserId();
 
     try {
         const item = await queryClient.fetchQuery(getItemQuery(

--- a/src/controllers/favorites.js
+++ b/src/controllers/favorites.js
@@ -10,7 +10,6 @@ import focusManager from 'components/focusManager';
 import layoutManager from 'components/layoutManager';
 import { appRouter } from 'components/router/appRouter';
 import dom from 'utils/dom';
-import { toApi } from 'utils/jellyfin-apiclient/compat';
 import globalize from 'lib/globalize';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
 
@@ -203,7 +202,13 @@ function getFetchDataFn(section) {
         const userId = apiClient.getCurrentUserId();
 
         if (section.types === BaseItemKind.Studio) {
-            return getStudiosApi(toApi(apiClient))
+            const api = ServerConnections.getApi(apiClient.serverId());
+            if (!api) {
+                console.error('[Favorites] no Api instance available for server', apiClient.serverId());
+                return Promise.resolve(undefined);
+            }
+
+            return getStudiosApi(api)
                 .getStudios({
                     userId,
                     isFavorite: true,
@@ -376,4 +381,3 @@ class FavoritesTab {
 }
 
 export default FavoritesTab;
-

--- a/src/controllers/itemDetails/index.js
+++ b/src/controllers/itemDetails/index.js
@@ -40,7 +40,6 @@ import * as userSettings from 'scripts/settings/userSettings';
 import Dashboard from 'utils/dashboard';
 import Events from 'utils/events';
 import { getItemBackdropImageUrl } from 'utils/jellyfin-apiclient/backdropImage';
-import { toApi } from 'utils/jellyfin-apiclient/compat';
 import { OutboundWebSocketMessageType } from '@jellyfin/sdk/lib/websocket';
 
 import 'elements/emby-itemscontainer/emby-itemscontainer';
@@ -1847,7 +1846,7 @@ window.ItemDetailPage = new ItemDetailPage();
 
 export default function (view, params) {
     function getApiClient() {
-        return params.serverId ? ServerConnections.getApiClient(params.serverId) : ApiClient;
+        return params.serverId ? ServerConnections.getApiClient(params.serverId) : ServerConnections.currentApiClient();
     }
 
     function reload(instance, page, pageParams) {
@@ -1958,7 +1957,12 @@ export default function (view, params) {
     }
 
     function onDownloadClick() {
-        const api = toApi(getApiClient());
+        const api = ServerConnections.getApi(currentItem.ServerId);
+        if (!api) {
+            console.error('[ItemDetails] no Api instance available for server', currentItem.ServerId);
+            return;
+        }
+
         const url = getLibraryApi(api).getDownloadUrl({ itemId: currentItem.Id });
         download([{
             url,
@@ -2107,9 +2111,14 @@ export default function (view, params) {
         }
 
         const apiClient = ServerConnections.getApiClient(currentItem.ServerId);
-        const api = toApi(apiClient);
+        const api = ServerConnections.getApi(currentItem.ServerId);
+        if (!api) {
+            console.error('[ItemDetails] no Api instance available for server', currentItem.ServerId);
+            return;
+        }
+
         getUserLibraryApi(api).getItem({
-            userId: apiClient.getCurrentUserId(),
+            userId: apiClient?.getCurrentUserId(),
             itemId: selectedId
         }).then(function ({ data: altItem }) {
             if (view.querySelector('.selectSource').value !== selectedId) {

--- a/src/controllers/lyrics.js
+++ b/src/controllers/lyrics.js
@@ -13,7 +13,6 @@ import { ServerConnections } from 'lib/jellyfin-apiclient';
 import keyboardNavigation from 'scripts/keyboardNavigation';
 import LibraryMenu from 'scripts/libraryMenu';
 import Events from 'utils/events';
-import { toApi } from 'utils/jellyfin-apiclient/compat';
 
 import '../styles/lyrics.scss';
 
@@ -132,10 +131,13 @@ export default function (view) {
     }
 
     function getLyrics(serverId, itemId) {
-        const apiClient = ServerConnections.getApiClient(serverId);
-        const lyricsApi = getLyricsApi(toApi(apiClient));
+        const api = ServerConnections.getApi(serverId);
+        if (!api) {
+            console.error('[Lyrics] no Api instance available for server', serverId);
+            return;
+        }
 
-        return lyricsApi.getLyrics({ itemId })
+        return getLyricsApi(api).getLyrics({ itemId })
             .then(({ data }) => {
                 if (!data.Lyrics?.length) {
                     throw new Error('No lyrics returned');

--- a/src/lib/jellyfin-apiclient/ServerConnections.js
+++ b/src/lib/jellyfin-apiclient/ServerConnections.js
@@ -36,7 +36,6 @@ class ServerConnections extends ConnectionManager {
     constructor() {
         super(...arguments);
         this.localApiClient = null;
-        this.api = null;
         this.firstConnection = null;
 
         Events.on(this, 'localusersignedout', (_e, logoutInfo) => {
@@ -53,12 +52,8 @@ class ServerConnections extends ConnectionManager {
             apiClient.getMaxBandwidth = getMaxBandwidth;
             apiClient.normalizeImageOptions = normalizeImageOptions;
 
-            const api = this.getApi(apiClient.serverId());
-
-            if ((!this.api && api) || this.localApiClient === apiClient) {
-                this.api = api;
-            }
-
+            // Calling getApi will ensure apiClient._sdk is initialized.
+            this.getApi(apiClient.serverId());
             apiClient.subscribe = apiClient._sdk.subscribe.bind(apiClient._sdk);
         });
     }
@@ -98,11 +93,8 @@ class ServerConnections extends ConnectionManager {
         if (apiClient) {
             this.localApiClient = apiClient;
             window.ApiClient = apiClient;
-
-            const api = this.getApi(apiClient.serverId());
-            if (api) {
-                this.api = api;
-            }
+            // Calling getApi will ensure apiClient._sdk is initialized.
+            this.getApi(apiClient.serverId());
         }
     }
 
@@ -129,24 +121,6 @@ class ServerConnections extends ConnectionManager {
     }
 
     /**
-     * Gets the Api that is currently connected.
-     * @returns {import('@jellyfin/sdk').Api|undefined} The current Api instance.
-     */
-    getCurrentApi() {
-        let api = this.api;
-
-        if (!api) {
-            const server = this.getLastUsedServer();
-
-            if (server) {
-                api = this.getApi(server.Id);
-            }
-        }
-
-        return api;
-    }
-
-    /**
      * Gets the ApiClient that is currently connected or throws if not defined.
      * @async
      * @returns {Promise<ApiClient>} The current ApiClient instance.
@@ -161,7 +135,7 @@ class ServerConnections extends ConnectionManager {
     onLocalUserSignedIn(user) {
         const apiClient = this.getApiClient(user.ServerId);
         this.setLocalApiClient(apiClient);
-        setTimeout(() => detectBitrate(this.getCurrentApi(), true), 6000);
+        setTimeout(() => detectBitrate(this.getApi(user.ServerId), true), 6000);
         return setUserInfo(user.Id, apiClient).then(() => {
             if (window.NativeShell && typeof window.NativeShell.onLocalUserSignedIn === 'function') {
                 return window.NativeShell.onLocalUserSignedIn(user, apiClient.accessToken());

--- a/src/lib/jellyfin-apiclient/connectionManager.js
+++ b/src/lib/jellyfin-apiclient/connectionManager.js
@@ -814,15 +814,19 @@ export default class ConnectionManager {
     }
 
     /**
-     * Returns or creates an Api instance for a given
-     * server
-     * @param {string} serverId The ID of the server
+     * Returns or creates an Api instance for a given server. If no serverId is provided,
+     * the last used server will be used instead.
+     * @param {string} [serverId] The ID of the server
      * @returns {import('@jellyfin/sdk').Api|undefined}
      */
     getApi(serverId) {
-        // serverId is not available until an ApiClient has connected/authenticated.
-        // Callers handle a missing Api, so return undefined rather than letting
-        // getApiClient() throw ('item or serverId cannot be null') and break startup.
+        // If no serverId is provided, try to use the last used server
+        if (!serverId) {
+            const server = this.getLastUsedServer();
+            serverId = server?.Id;
+        }
+
+        // If no serverId is available still, return undefined
         if (!serverId) {
             return undefined;
         }

--- a/src/lib/jellyfin-apiclient/connectionManager.js
+++ b/src/lib/jellyfin-apiclient/connectionManager.js
@@ -792,8 +792,8 @@ export default class ConnectionManager {
 
     /**
      * Gets the ApiClient for a given BaseItem or ServerId.
-     * @param {import('@jellyfin/sdk/lib/generated-client').BaseItemDto | string | undefined} item
-     * @returns {import('jellyfin-apiclient').ApiClient}
+     * @param {import('@jellyfin/sdk/lib/generated-client').BaseItemDto | string | null | undefined} item
+     * @returns {import('jellyfin-apiclient').ApiClient | undefined}
      */
     getApiClient(item) {
         if (!item) {

--- a/src/plugins/bookPlayer/plugin.js
+++ b/src/plugins/bookPlayer/plugin.js
@@ -5,7 +5,6 @@ import { PluginType } from 'constants/pluginType';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
 import browser from 'scripts/browser';
 import TouchHelper from 'scripts/touchHelper';
-import { toApi } from 'utils/jellyfin-apiclient/compat';
 
 import loading from '../../components/loading/loading';
 import keyboardnavigation from '../../scripts/keyboardNavigation';
@@ -327,7 +326,11 @@ export class BookPlayer {
 
         return new Promise((resolve, reject) => {
             import('epubjs').then(({ default: epubjs }) => {
-                const api = toApi(ServerConnections.getApiClient(item));
+                const api = ServerConnections.getApi(item.ServerId);
+                if (!api) {
+                    console.error('[BookPlayer] no Api instance available for server', item.ServerId);
+                    return;
+                }
                 const downloadHref = getLibraryApi(api).getDownloadUrl({ itemId: item.Id });
                 const book = epubjs(downloadHref, { openAs: 'epub' });
 

--- a/src/plugins/comicsPlayer/plugin.js
+++ b/src/plugins/comicsPlayer/plugin.js
@@ -3,7 +3,6 @@ import { Archive } from 'libarchive.js';
 
 import { PluginType } from 'constants/pluginType';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
-import { toApi } from 'utils/jellyfin-apiclient/compat';
 
 import loading from '../../components/loading/loading';
 import dialogHelper from '../../components/dialogHelper/dialogHelper';
@@ -295,7 +294,12 @@ export class ComicsPlayer {
             workerUrl: appRouter.baseUrl() + '/libraries/worker-bundle.js'
         });
 
-        const api = toApi(ServerConnections.getApiClient(item));
+        const api = ServerConnections.getApi(item.ServerId);
+        if (!api) {
+            console.error('[ComicsPlayer] no Api instance available for server', item.ServerId);
+            return;
+        }
+
         const downloadUrl = getLibraryApi(api).getDownloadUrl({ itemId: item.Id });
         this.archiveSource = new ArchiveSource(downloadUrl);
 

--- a/src/plugins/pdfPlayer/plugin.js
+++ b/src/plugins/pdfPlayer/plugin.js
@@ -1,7 +1,6 @@
 import { getLibraryApi } from '@jellyfin/sdk/lib/utils/api/library-api';
 
 import { PluginType } from 'constants/pluginType';
-import { toApi } from 'utils/jellyfin-apiclient/compat';
 
 import loading from '../../components/loading/loading';
 import keyboardnavigation from '../../scripts/keyboardNavigation';
@@ -210,7 +209,12 @@ export class PdfPlayer {
         };
 
         return import('pdfjs-dist').then(({ GlobalWorkerOptions, getDocument }) => {
-            const api = toApi(ServerConnections.getApiClient(item));
+            const api = ServerConnections.getApi(item.ServerId);
+            if (!api) {
+                console.error('[PdfPlayer] no Api instance available for server', item.ServerId);
+                return;
+            }
+
             const downloadHref = getLibraryApi(api).getDownloadUrl({ itemId: item.Id });
 
             this.bindEvents();

--- a/src/scripts/autoBackdrops.js
+++ b/src/scripts/autoBackdrops.js
@@ -64,7 +64,7 @@ function showBackdrop(type, parentId) {
 }
 
 async function showSplashScreen() {
-    const api = ServerConnections.getCurrentApi();
+    const api = ServerConnections.getApi();
     const brandingOptions = await queryClient.fetchQuery(getBrandingOptionsQuery(api));
     if (brandingOptions.SplashscreenEnabled) {
         setBackdropImages([
@@ -95,4 +95,3 @@ pageClassOn('pageshow', 'page', function () {
         }
     }
 });
-

--- a/src/scripts/libraryMenu.js
+++ b/src/scripts/libraryMenu.js
@@ -7,7 +7,6 @@ import { getUserViewsQuery } from 'hooks/api/useUserViews';
 import globalize from 'lib/globalize';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
 import { EventType } from 'constants/eventType';
-import { toApi } from 'utils/jellyfin-apiclient/compat';
 import { queryClient } from 'utils/query/queryClient';
 
 import dom from '../utils/dom';
@@ -391,8 +390,10 @@ function onSidebarLinkClick() {
 }
 
 function getUserViews(apiClient, userId) {
+    const api = ServerConnections.getApi(apiClient.serverId());
+
     return queryClient
-        .fetchQuery(getUserViewsQuery(toApi(apiClient), { userId }))
+        .fetchQuery(getUserViewsQuery(api, { userId }))
         .then(function (result) {
             const items = result.Items;
             const list = [];

--- a/src/scripts/playlistViewer.js
+++ b/src/scripts/playlistViewer.js
@@ -2,7 +2,6 @@ import { getPlaylistsApi } from '@jellyfin/sdk/lib/utils/api/playlists-api';
 
 import listView from 'components/listview/listview';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
-import { toApi } from 'utils/jellyfin-apiclient/compat';
 
 function getFetchPlaylistItemsFn(apiClient, itemId) {
     return function () {
@@ -31,8 +30,13 @@ function getItemsHtmlFn(playlistId, isEditable = false) {
 }
 
 async function init(page, item) {
+    const api = ServerConnections.getApi(item.ServerId);
     const apiClient = ServerConnections.getApiClient(item.ServerId);
-    const api = toApi(apiClient);
+
+    if (!api || !apiClient) {
+        console.error('[PlaylistViewer] No Api or ApiClient instance is available', { api, apiClient });
+        return;
+    }
 
     let isEditable = false;
     const { data } = await getPlaylistsApi(api)

--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -1,9 +1,9 @@
 import { getDisplayPreferencesQuery } from 'hooks/api/useDisplayPreferences';
 import { getUserQuery } from 'hooks/api/useUser';
 import { QUERY_KEY } from 'hooks/useUsers';
+import { ServerConnections } from 'lib/jellyfin-apiclient';
 import { StillWatchingOptions } from 'plugins/stillWatching/constants';
 import Events from 'utils/events';
-import { toApi } from 'utils/jellyfin-apiclient/compat';
 import { queryClient } from 'utils/query/queryClient';
 import { toBoolean } from 'utils/string';
 
@@ -78,9 +78,10 @@ export class UserSettings {
 
         const self = this;
 
+        const api = ServerConnections.getApi(apiClient.serverId());
         return queryClient
             .fetchQuery(getDisplayPreferencesQuery(
-                toApi(apiClient),
+                api,
                 {
                     displayPreferencesId: DISPLAY_PREFERENCES_ID,
                     client: CLIENT_ID,
@@ -149,8 +150,9 @@ export class UserSettings {
                 });
         }
 
+        const api = ServerConnections.getApi(apiClient.serverId());
         return queryClient
-            .fetchQuery(getUserQuery(toApi(apiClient), { userId: this.currentUserId }))
+            .fetchQuery(getUserQuery(api, { userId: this.currentUserId }))
             .then(user => user.Configuration);
     }
 


### PR DESCRIPTION
### Changes
- Reduce some complexity in `ServerConnections` by removing the `getCurrentApi` method and integrating that functionality directly into the `getApi` method.
- Replaces usages of `toApi` with `getApi`
- Fix typing of `getApiClient` to include the possibility of returning `undefined`

### Issues
N/A

### Code assistance
Zed autocomplete

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
