### PR TITLE
Fix cast menu being empty when no targets available

### DIFF
--- a/src/apps/modern/components/AppToolbar/menus/RemotePlayMenu.tsx
+++ b/src/apps/modern/components/AppToolbar/menus/RemotePlayMenu.tsx
@@ -96,6 +96,14 @@ const RemotePlayMenu: FC<RemotePlayMenuProps> = ({
                     />
                 </MenuItem>
             ))}
+
+            {isChromecastPluginLoaded && playbackTargets.length === 0 && (
+                <MenuItem disabled>
+                    <ListItemText>
+                        {globalize.translate('NoCastTargets')}
+                    </ListItemText>
+                </MenuItem>
+            )}
         </Menu>
     );
 };

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1281,6 +1281,7 @@
     "NextTrack": "Skip to next",
     "NextUp": "Next Up",
     "No": "No",
+    "NoCastTargets": "No cast targets available",
     "NoCreatedLibraries": "Seems like you haven't created any libraries yet. {0}Would you like to create one now?{1}",
     "NoLyricsSearchResultsFound": "No lyrics found.",
     "None": "None",


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

### Changes
Renders a placeholder label when there are no playbackTargets

Before:
<img width="262" height="174" alt="image" src="https://github.com/user-attachments/assets/09bf7777-7832-432c-9676-d077f3e9bba5" />

After:
<img width="1029" height="565" alt="image" src="https://github.com/user-attachments/assets/ee9a5e1d-124d-4162-82a2-97ad4182fcc0" />

### Issues
Fixes #8108

### Code assistance
nO

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
