### PR TITLE
Fix sorting in the modern layout

### DIFF
--- a/src/apps/modern/features/libraries/components/ItemsView.tsx
+++ b/src/apps/modern/features/libraries/components/ItemsView.tsx
@@ -57,7 +57,7 @@ const ItemsView: FC = () => {
             listOptions.showArtist = true;
             listOptions.addToListButton = true;
         } else if (viewType === LibraryTab.Albums) {
-            listOptions.sortBy = libraryViewSettings.SortBy;
+            listOptions.sortBy = libraryViewSettings.SortBy[0];
             listOptions.addToListButton = true;
         } else if (viewType === LibraryTab.Episodes) {
             listOptions.showParentTitle = true;
@@ -171,7 +171,7 @@ const ItemsView: FC = () => {
         noItemsMessage
     ]);
 
-    const hasSortName = libraryViewSettings.SortBy !== ItemSortBy.Random;
+    const hasSortName = libraryViewSettings.SortBy[0] !== ItemSortBy.Random;
 
     const itemsContainerClass = classNames(
         'padded-left padded-right',

--- a/src/apps/modern/features/libraries/components/ItemsView.tsx
+++ b/src/apps/modern/features/libraries/components/ItemsView.tsx
@@ -171,7 +171,7 @@ const ItemsView: FC = () => {
         noItemsMessage
     ]);
 
-    const hasSortName = libraryViewSettings.SortBy[0] !== ItemSortBy.Random;
+    const hasSortName = !libraryViewSettings.SortBy.includes(ItemSortBy.Random);
 
     const itemsContainerClass = classNames(
         'padded-left padded-right',

--- a/src/apps/modern/features/libraries/components/PlayAllButton.tsx
+++ b/src/apps/modern/features/libraries/components/PlayAllButton.tsx
@@ -43,7 +43,7 @@ const PlayAllButton: FC<PlayAllButtonProps> = ({
                 items: [item],
                 autoplay: true,
                 queryOptions: {
-                    SortBy: [libraryViewSettings.SortBy],
+                    SortBy: libraryViewSettings.SortBy,
                     SortOrder: [libraryViewSettings.SortOrder]
                 }
             }).catch(err => {
@@ -56,7 +56,7 @@ const PlayAllButton: FC<PlayAllButtonProps> = ({
                 queryOptions: {
                     ParentId: item?.Id ?? undefined,
                     ...getFiltersQuery(viewType, libraryViewSettings),
-                    SortBy: [libraryViewSettings.SortBy],
+                    SortBy: libraryViewSettings.SortBy,
                     SortOrder: [libraryViewSettings.SortOrder]
                 }
             }).catch(err => {

--- a/src/apps/modern/features/libraries/components/SortButton.tsx
+++ b/src/apps/modern/features/libraries/components/SortButton.tsx
@@ -17,49 +17,49 @@ import { LibraryTab } from 'types/libraryTab';
 
 type SortOption = {
     label: string;
-    value: ItemSortBy;
+    value: ItemSortBy[];
 };
 
 type SortOptionsMapping = Record<string, SortOption[]>;
 
 const collectionMovieOptions: SortOption[] = [
-    { label: 'Name', value: ItemSortBy.SortName },
-    { label: 'OptionRandom', value: ItemSortBy.Random },
-    { label: 'OptionCommunityRating', value: ItemSortBy.CommunityRating },
-    { label: 'OptionDateAdded', value: ItemSortBy.DateCreated },
-    { label: 'OptionParentalRating', value: ItemSortBy.OfficialRating },
-    { label: 'OptionReleaseDate', value: ItemSortBy.PremiereDate }
+    { label: 'Name', value: [ItemSortBy.SortName] },
+    { label: 'OptionRandom', value: [ItemSortBy.Random] },
+    { label: 'OptionCommunityRating', value: [ItemSortBy.CommunityRating, ItemSortBy.SortName] },
+    { label: 'OptionDateAdded', value: [ItemSortBy.DateCreated, ItemSortBy.SortName] },
+    { label: 'OptionParentalRating', value: [ItemSortBy.OfficialRating, ItemSortBy.SortName] },
+    { label: 'OptionReleaseDate', value: [ItemSortBy.ProductionYear, ItemSortBy.PremiereDate, ItemSortBy.SortName] }
 ];
 
 const movieOrFavoriteOptions = [
-    { label: 'Name', value: ItemSortBy.SortName },
-    { label: 'OptionRandom', value: ItemSortBy.Random },
-    { label: 'OptionCommunityRating', value: ItemSortBy.CommunityRating },
-    { label: 'OptionCriticRating', value: ItemSortBy.CriticRating },
-    { label: 'OptionDateAdded', value: ItemSortBy.DateCreated },
-    { label: 'OptionDatePlayed', value: ItemSortBy.DatePlayed },
-    { label: 'OptionParentalRating', value: ItemSortBy.OfficialRating },
-    { label: 'OptionPlayCount', value: ItemSortBy.PlayCount },
-    { label: 'OptionReleaseDate', value: ItemSortBy.PremiereDate },
-    { label: 'Runtime', value: ItemSortBy.Runtime }
+    { label: 'Name', value: [ItemSortBy.SortName] },
+    { label: 'OptionRandom', value: [ItemSortBy.Random] },
+    { label: 'OptionCommunityRating', value: [ItemSortBy.CommunityRating, ItemSortBy.SortName] },
+    { label: 'OptionCriticRating', value: [ItemSortBy.CriticRating, ItemSortBy.SortName] },
+    { label: 'OptionDateAdded', value: [ItemSortBy.DateCreated, ItemSortBy.SortName] },
+    { label: 'OptionDatePlayed', value: [ItemSortBy.DatePlayed, ItemSortBy.SortName] },
+    { label: 'OptionParentalRating', value: [ItemSortBy.OfficialRating, ItemSortBy.SortName] },
+    { label: 'OptionPlayCount', value: [ItemSortBy.PlayCount, ItemSortBy.SortName] },
+    { label: 'OptionReleaseDate', value: [ItemSortBy.ProductionYear, ItemSortBy.PremiereDate, ItemSortBy.SortName] },
+    { label: 'Runtime', value: [ItemSortBy.Runtime, ItemSortBy.SortName] }
 ];
 
 const photosOrPhotoAlbumsOptions = [
-    { label: 'Name', value: ItemSortBy.SortName },
-    { label: 'OptionRandom', value: ItemSortBy.Random },
-    { label: 'OptionDateAdded', value: ItemSortBy.DateCreated }
+    { label: 'Name', value: [ItemSortBy.SortName] },
+    { label: 'OptionRandom', value: [ItemSortBy.Random] },
+    { label: 'OptionDateAdded', value: [ItemSortBy.DateCreated, ItemSortBy.SortName] }
 ];
 
 const videoOrMusicVideoOptions = [
-    { label: 'Name', value: ItemSortBy.SortName },
-    { label: 'OptionRandom', value: ItemSortBy.Random },
-    { label: 'OptionCommunityRating', value: ItemSortBy.CommunityRating },
-    { label: 'OptionDateAdded', value: ItemSortBy.DateCreated },
-    { label: 'OptionDatePlayed', value: ItemSortBy.DatePlayed },
-    { label: 'OptionParentalRating', value: ItemSortBy.OfficialRating },
-    { label: 'OptionPlayCount', value: ItemSortBy.PlayCount },
-    { label: 'OptionReleaseDate', value: ItemSortBy.PremiereDate },
-    { label: 'Runtime', value: ItemSortBy.Runtime }
+    { label: 'Name', value: [ItemSortBy.SortName] },
+    { label: 'OptionRandom', value: [ItemSortBy.Random] },
+    { label: 'OptionCommunityRating', value: [ItemSortBy.CommunityRating, ItemSortBy.SortName] },
+    { label: 'OptionDateAdded', value: [ItemSortBy.DateCreated, ItemSortBy.SortName] },
+    { label: 'OptionDatePlayed', value: [ItemSortBy.DatePlayed, ItemSortBy.SortName] },
+    { label: 'OptionParentalRating', value: [ItemSortBy.OfficialRating, ItemSortBy.SortName] },
+    { label: 'OptionPlayCount', value: [ItemSortBy.PlayCount, ItemSortBy.SortName] },
+    { label: 'OptionReleaseDate', value: [ItemSortBy.ProductionYear, ItemSortBy.PremiereDate, ItemSortBy.SortName] },
+    { label: 'Runtime', value: [ItemSortBy.Runtime, ItemSortBy.SortName] }
 ];
 
 const sortOptionsMapping: SortOptionsMapping = {
@@ -67,91 +67,91 @@ const sortOptionsMapping: SortOptionsMapping = {
     [LibraryTab.Collections]: collectionMovieOptions,
     [LibraryTab.Favorites]: movieOrFavoriteOptions,
     [LibraryTab.Series]: [
-        { label: 'Name', value: ItemSortBy.SortName },
-        { label: 'OptionRandom', value: ItemSortBy.Random },
-        { label: 'OptionCommunityRating', value: ItemSortBy.CommunityRating },
-        { label: 'OptionDateShowAdded', value: ItemSortBy.DateCreated },
-        { label: 'OptionDateEpisodeAdded', value: ItemSortBy.DateLastContentAdded },
-        { label: 'OptionDatePlayed', value: ItemSortBy.SeriesDatePlayed },
-        { label: 'OptionParentalRating', value: ItemSortBy.OfficialRating },
-        { label: 'OptionReleaseDate', value: ItemSortBy.PremiereDate }
+        { label: 'Name', value: [ItemSortBy.SortName] },
+        { label: 'OptionRandom', value: [ItemSortBy.Random] },
+        { label: 'OptionCommunityRating', value: [ItemSortBy.CommunityRating, ItemSortBy.SortName] },
+        { label: 'OptionDateShowAdded', value: [ItemSortBy.DateCreated, ItemSortBy.SortName] },
+        { label: 'OptionDateEpisodeAdded', value: [ItemSortBy.DateLastContentAdded, ItemSortBy.SortName] },
+        { label: 'OptionDatePlayed', value: [ItemSortBy.SeriesDatePlayed, ItemSortBy.SortName] },
+        { label: 'OptionParentalRating', value: [ItemSortBy.OfficialRating, ItemSortBy.SortName] },
+        { label: 'OptionReleaseDate', value: [ItemSortBy.ProductionYear, ItemSortBy.PremiereDate, ItemSortBy.SortName] }
     ],
     [LibraryTab.Episodes]: [
-        { label: 'Name', value: ItemSortBy.SeriesSortName },
-        { label: 'OptionRandom', value: ItemSortBy.Random },
-        { label: 'OptionCommunityRating', value: ItemSortBy.CommunityRating },
-        { label: 'OptionDateAdded', value: ItemSortBy.DateCreated },
-        { label: 'OptionReleaseDate', value: ItemSortBy.PremiereDate },
-        { label: 'OptionDatePlayed', value: ItemSortBy.DatePlayed },
-        { label: 'OptionParentalRating', value: ItemSortBy.OfficialRating },
-        { label: 'OptionPlayCount', value: ItemSortBy.PlayCount },
-        { label: 'Runtime', value: ItemSortBy.Runtime }
+        { label: 'Name', value: [ItemSortBy.SeriesSortName] },
+        { label: 'OptionRandom', value: [ItemSortBy.Random] },
+        { label: 'OptionCommunityRating', value: [ItemSortBy.CommunityRating, ItemSortBy.SortName] },
+        { label: 'OptionDateAdded', value: [ItemSortBy.DateCreated, ItemSortBy.SortName] },
+        { label: 'OptionReleaseDate', value: [ItemSortBy.ProductionYear, ItemSortBy.PremiereDate, ItemSortBy.SortName] },
+        { label: 'OptionDatePlayed', value: [ItemSortBy.DatePlayed, ItemSortBy.SortName] },
+        { label: 'OptionParentalRating', value: [ItemSortBy.OfficialRating, ItemSortBy.SortName] },
+        { label: 'OptionPlayCount', value: [ItemSortBy.PlayCount, ItemSortBy.SortName] },
+        { label: 'Runtime', value: [ItemSortBy.Runtime, ItemSortBy.SortName] }
     ],
     [LibraryTab.Albums]: [
-        { label: 'Name', value: ItemSortBy.SortName },
-        { label: 'OptionRandom', value: ItemSortBy.Random },
-        { label: 'AlbumArtist', value: ItemSortBy.AlbumArtist },
-        { label: 'OptionCommunityRating', value: ItemSortBy.CommunityRating },
-        { label: 'OptionCriticRating', value: ItemSortBy.CriticRating },
-        { label: 'OptionReleaseDate', value: ItemSortBy.ProductionYear },
-        { label: 'OptionDateAdded', value: ItemSortBy.DateCreated }
+        { label: 'Name', value: [ItemSortBy.SortName] },
+        { label: 'OptionRandom', value: [ItemSortBy.Random] },
+        { label: 'AlbumArtist', value: [ItemSortBy.AlbumArtist, ItemSortBy.SortName] },
+        { label: 'OptionCommunityRating', value: [ItemSortBy.CommunityRating, ItemSortBy.SortName] },
+        { label: 'OptionCriticRating', value: [ItemSortBy.CriticRating, ItemSortBy.SortName] },
+        { label: 'OptionReleaseDate', value: [ItemSortBy.ProductionYear, ItemSortBy.PremiereDate, ItemSortBy.SortName] },
+        { label: 'OptionDateAdded', value: [ItemSortBy.DateCreated, ItemSortBy.SortName] }
     ],
     [LibraryTab.Books]: [
-        { label: 'Name', value: ItemSortBy.SortName },
-        { label: 'OptionRandom', value: ItemSortBy.Random },
-        { label: 'OptionReleaseDate', value: ItemSortBy.ProductionYear },
-        { label: 'OptionDateAdded', value: ItemSortBy.DateCreated },
-        { label: 'OptionDatePlayed', value: ItemSortBy.DatePlayed },
-        { label: 'IndexNumber', value: ItemSortBy.IndexNumber }
+        { label: 'Name', value: [ItemSortBy.SortName] },
+        { label: 'OptionRandom', value: [ItemSortBy.Random] },
+        { label: 'OptionReleaseDate', value: [ItemSortBy.ProductionYear, ItemSortBy.PremiereDate, ItemSortBy.SortName] },
+        { label: 'OptionDateAdded', value: [ItemSortBy.DateCreated, ItemSortBy.SortName] },
+        { label: 'OptionDatePlayed', value: [ItemSortBy.DatePlayed, ItemSortBy.SortName] },
+        { label: 'IndexNumber', value: [ItemSortBy.IndexNumber, ItemSortBy.SortName] }
     ],
     [LibraryTab.Songs]: [
-        { label: 'Name', value: ItemSortBy.SortName },
-        { label: 'OptionRandom', value: ItemSortBy.Random },
-        { label: 'Album', value: ItemSortBy.Album },
-        { label: 'AlbumArtist', value: ItemSortBy.AlbumArtist },
-        { label: 'Artist', value: ItemSortBy.Artist },
-        { label: 'OptionDateAdded', value: ItemSortBy.DateCreated },
-        { label: 'OptionDatePlayed', value: ItemSortBy.DatePlayed },
-        { label: 'OptionPlayCount', value: ItemSortBy.PlayCount },
-        { label: 'OptionReleaseDate', value: ItemSortBy.PremiereDate },
-        { label: 'Runtime', value: ItemSortBy.Runtime }
+        { label: 'Name', value: [ItemSortBy.SortName] },
+        { label: 'OptionRandom', value: [ItemSortBy.Random] },
+        { label: 'Album', value: [ItemSortBy.Album, ItemSortBy.SortName] },
+        { label: 'AlbumArtist', value: [ItemSortBy.AlbumArtist, ItemSortBy.SortName] },
+        { label: 'Artist', value: [ItemSortBy.Artist, ItemSortBy.SortName] },
+        { label: 'OptionDateAdded', value: [ItemSortBy.DateCreated, ItemSortBy.SortName] },
+        { label: 'OptionDatePlayed', value: [ItemSortBy.DatePlayed, ItemSortBy.SortName] },
+        { label: 'OptionPlayCount', value: [ItemSortBy.PlayCount, ItemSortBy.SortName] },
+        { label: 'OptionReleaseDate', value: [ItemSortBy.ProductionYear, ItemSortBy.PremiereDate, ItemSortBy.SortName] },
+        { label: 'Runtime', value: [ItemSortBy.Runtime, ItemSortBy.SortName] }
     ],
     [LibraryTab.Playlists]: [
-        { label: 'Name', value: ItemSortBy.SortName },
-        { label: 'OptionRandom', value: ItemSortBy.Random },
-        { label: 'OptionDateAdded', value: ItemSortBy.DateCreated },
-        { label: 'OptionDatePlaylistUpdated', value: ItemSortBy.DateLastContentAdded },
-        { label: 'OptionReleaseDate', value: ItemSortBy.PremiereDate },
-        { label: 'Runtime', value: ItemSortBy.Runtime }
+        { label: 'Name', value: [ItemSortBy.SortName] },
+        { label: 'OptionRandom', value: [ItemSortBy.Random] },
+        { label: 'OptionDateAdded', value: [ItemSortBy.DateCreated, ItemSortBy.SortName] },
+        { label: 'OptionDatePlaylistUpdated', value: [ItemSortBy.DateLastContentAdded, ItemSortBy.SortName] },
+        { label: 'OptionReleaseDate', value: [ItemSortBy.ProductionYear, ItemSortBy.PremiereDate, ItemSortBy.SortName] },
+        { label: 'Runtime', value: [ItemSortBy.Runtime, ItemSortBy.SortName] }
     ],
     [LibraryTab.PhotoAlbums]: photosOrPhotoAlbumsOptions,
     [LibraryTab.Photos]: photosOrPhotoAlbumsOptions,
     [LibraryTab.Videos]:videoOrMusicVideoOptions,
     [LibraryTab.MusicVideos]:videoOrMusicVideoOptions,
     [LibraryTab.Folders]: [
-        { label: 'Name', value: ItemSortBy.SortName },
-        { label: 'OptionRandom', value: ItemSortBy.Random },
-        { label: 'OptionCommunityRating', value: ItemSortBy.CommunityRating },
-        { label: 'OptionDateAdded', value: ItemSortBy.DateCreated },
-        { label: 'OptionDatePlayed', value: ItemSortBy.DatePlayed },
-        { label: 'Folders', value: ItemSortBy.IsFolder },
-        { label: 'OptionParentalRating', value: ItemSortBy.OfficialRating },
-        { label: 'OptionPlayCount', value: ItemSortBy.PlayCount },
-        { label: 'OptionReleaseDate', value: ItemSortBy.PremiereDate },
-        { label: 'Runtime', value: ItemSortBy.Runtime }
+        { label: 'Name', value: [ItemSortBy.SortName] },
+        { label: 'OptionRandom', value: [ItemSortBy.Random] },
+        { label: 'OptionCommunityRating', value: [ItemSortBy.CommunityRating, ItemSortBy.SortName] },
+        { label: 'OptionDateAdded', value: [ItemSortBy.DateCreated, ItemSortBy.SortName] },
+        { label: 'OptionDatePlayed', value: [ItemSortBy.DatePlayed, ItemSortBy.SortName] },
+        { label: 'Folders', value: [ItemSortBy.IsFolder, ItemSortBy.SortName] },
+        { label: 'OptionParentalRating', value: [ItemSortBy.OfficialRating, ItemSortBy.SortName] },
+        { label: 'OptionPlayCount', value: [ItemSortBy.PlayCount, ItemSortBy.SortName] },
+        { label: 'OptionReleaseDate', value: [ItemSortBy.ProductionYear, ItemSortBy.PremiereDate, ItemSortBy.SortName] },
+        { label: 'Runtime', value: [ItemSortBy.Runtime, ItemSortBy.SortName] }
     ],
     [LibraryTab.Mixed]: [
-        { label: 'Name', value: ItemSortBy.SortName },
-        { label: 'OptionRandom', value: ItemSortBy.Random },
-        { label: 'OptionCommunityRating', value: ItemSortBy.CommunityRating },
-        { label: 'OptionCriticRating', value: ItemSortBy.CriticRating },
-        { label: 'OptionDateAdded', value: ItemSortBy.DateCreated },
-        { label: 'OptionDateEpisodeAdded', value: ItemSortBy.DateLastContentAdded },
-        { label: 'OptionDatePlayed', value: ItemSortBy.DatePlayed },
-        { label: 'OptionParentalRating', value: ItemSortBy.OfficialRating },
-        { label: 'OptionPlayCount', value: ItemSortBy.PlayCount },
-        { label: 'OptionReleaseDate', value: ItemSortBy.PremiereDate },
-        { label: 'Runtime', value: ItemSortBy.Runtime }
+        { label: 'Name', value: [ItemSortBy.SortName] },
+        { label: 'OptionRandom', value: [ItemSortBy.Random] },
+        { label: 'OptionCommunityRating', value: [ItemSortBy.CommunityRating, ItemSortBy.SortName] },
+        { label: 'OptionCriticRating', value: [ItemSortBy.CriticRating, ItemSortBy.SortName] },
+        { label: 'OptionDateAdded', value: [ItemSortBy.DateCreated, ItemSortBy.SortName] },
+        { label: 'OptionDateEpisodeAdded', value: [ItemSortBy.DateLastContentAdded, ItemSortBy.SortName] },
+        { label: 'OptionDatePlayed', value: [ItemSortBy.DatePlayed, ItemSortBy.SortName] },
+        { label: 'OptionParentalRating', value: [ItemSortBy.OfficialRating, ItemSortBy.SortName] },
+        { label: 'OptionPlayCount', value: [ItemSortBy.PlayCount, ItemSortBy.SortName] },
+        { label: 'OptionReleaseDate', value: [ItemSortBy.ProductionYear, ItemSortBy.PremiereDate, ItemSortBy.SortName] },
+        { label: 'Runtime', value: [ItemSortBy.Runtime, ItemSortBy.SortName] }
     ]
 };
 
@@ -186,11 +186,11 @@ const SortButton: FC<SortButtonProps> = ({
     }, []);
 
     const onMenuItemClick = useCallback(
-        (sortBy: ItemSortBy) => {
+        (sortBy: ItemSortBy[]) => {
             setLibraryViewSettings((prevState) => {
                 let sortOrder: SortOrder = SortOrder.Ascending;
                 // If the user clicks the currently selected sort option, toggle the sort order
-                if (prevState.SortBy === sortBy) {
+                if (prevState.SortBy[0] === sortBy[0]) {
                     sortOrder = prevState.SortOrder === SortOrder.Ascending ? SortOrder.Descending : SortOrder.Ascending;
                 }
 
@@ -235,7 +235,7 @@ const SortButton: FC<SortButtonProps> = ({
                     {sortMenuOptions
                         .map((option) => (
                             <MenuItem
-                                key={option.value}
+                                key={option.value.join(',')}
                                 // eslint-disable-next-line react/jsx-no-bind
                                 onClick={() => onMenuItemClick(option.value)}
                             >
@@ -243,7 +243,7 @@ const SortButton: FC<SortButtonProps> = ({
                                     {globalize.translate(option.label)}
                                 </ListItemText>
                                 <ListItemIcon sx={{ justifyContent: 'flex-end' }}>
-                                    {libraryViewSettings.SortBy === option.value && (
+                                    {libraryViewSettings.SortBy[0] === option.value[0] && (
                                         libraryViewSettings.SortOrder === SortOrder.Ascending ? (
                                             <ArrowUpward fontSize='small' />
                                         ) : (

--- a/src/apps/modern/features/libraries/components/SortButton.tsx
+++ b/src/apps/modern/features/libraries/components/SortButton.tsx
@@ -14,6 +14,7 @@ import Popover from '@mui/material/Popover';
 import globalize from 'lib/globalize';
 import { LibraryViewSettings } from 'types/library';
 import { LibraryTab } from 'types/libraryTab';
+import isEqual from 'lodash-es/isEqual';
 
 type SortOption = {
     label: string;
@@ -190,7 +191,7 @@ const SortButton: FC<SortButtonProps> = ({
             setLibraryViewSettings((prevState) => {
                 let sortOrder: SortOrder = SortOrder.Ascending;
                 // If the user clicks the currently selected sort option, toggle the sort order
-                if (prevState.SortBy[0] === sortBy[0]) {
+                if (isEqual(prevState.SortBy, sortBy)) {
                     sortOrder = prevState.SortOrder === SortOrder.Ascending ? SortOrder.Descending : SortOrder.Ascending;
                 }
 
@@ -243,7 +244,7 @@ const SortButton: FC<SortButtonProps> = ({
                                     {globalize.translate(option.label)}
                                 </ListItemText>
                                 <ListItemIcon sx={{ justifyContent: 'flex-end' }}>
-                                    {libraryViewSettings.SortBy[0] === option.value[0] && (
+                                    {isEqual(libraryViewSettings.SortBy, option.value) && (
                                         libraryViewSettings.SortOrder === SortOrder.Ascending ? (
                                             <ArrowUpward fontSize='small' />
                                         ) : (

--- a/src/apps/modern/features/libraries/components/SortButton.tsx
+++ b/src/apps/modern/features/libraries/components/SortButton.tsx
@@ -106,16 +106,16 @@ const sortOptionsMapping: SortOptionsMapping = {
         { label: 'IndexNumber', value: [ItemSortBy.IndexNumber, ItemSortBy.SortName] }
     ],
     [LibraryTab.Songs]: [
-        { label: 'Name', value: [ItemSortBy.SortName] },
+        { label: 'OptionTrackName', value: [ItemSortBy.Name] },
         { label: 'OptionRandom', value: [ItemSortBy.Random] },
-        { label: 'Album', value: [ItemSortBy.Album, ItemSortBy.SortName] },
-        { label: 'AlbumArtist', value: [ItemSortBy.AlbumArtist, ItemSortBy.SortName] },
-        { label: 'Artist', value: [ItemSortBy.Artist, ItemSortBy.SortName] },
+        { label: 'Album', value: [ItemSortBy.Album, ItemSortBy.AlbumArtist, ItemSortBy.SortName] },
+        { label: 'AlbumArtist', value: [ItemSortBy.AlbumArtist, ItemSortBy.Album, ItemSortBy.SortName] },
+        { label: 'Artist', value: [ItemSortBy.Artist, ItemSortBy.Album, ItemSortBy.SortName] },
         { label: 'OptionDateAdded', value: [ItemSortBy.DateCreated, ItemSortBy.SortName] },
         { label: 'OptionDatePlayed', value: [ItemSortBy.DatePlayed, ItemSortBy.SortName] },
         { label: 'OptionPlayCount', value: [ItemSortBy.PlayCount, ItemSortBy.SortName] },
-        { label: 'OptionReleaseDate', value: [ItemSortBy.ProductionYear, ItemSortBy.PremiereDate, ItemSortBy.SortName] },
-        { label: 'Runtime', value: [ItemSortBy.Runtime, ItemSortBy.SortName] }
+        { label: 'OptionReleaseDate', value: [ItemSortBy.ProductionYear, ItemSortBy.PremiereDate, ItemSortBy.AlbumArtist, ItemSortBy.Album, ItemSortBy.SortName] },
+        { label: 'Runtime', value: [ItemSortBy.Runtime, ItemSortBy.AlbumArtist, ItemSortBy.Album, ItemSortBy.SortName] }
     ],
     [LibraryTab.Playlists]: [
         { label: 'Name', value: [ItemSortBy.SortName] },

--- a/src/apps/modern/features/libraries/utils/settings.ts
+++ b/src/apps/modern/features/libraries/utils/settings.ts
@@ -6,12 +6,12 @@ import { SortOrder } from '@jellyfin/sdk/lib/generated-client/models/sort-order'
 import { type ParentId, ViewMode, type LibraryViewSettings } from 'types/library';
 import { LibraryTab } from 'types/libraryTab';
 
-export const getDefaultSortBy = (viewType: LibraryTab) => {
+export const getDefaultSortBy = (viewType: LibraryTab): ItemSortBy[] => {
     if (viewType === LibraryTab.Episodes) {
-        return ItemSortBy.SeriesSortName;
+        return [ItemSortBy.SeriesSortName];
     }
 
-    return ItemSortBy.SortName;
+    return [ItemSortBy.SortName];
 };
 
 export const getDefaultLibraryViewSettings = (viewType: LibraryTab): LibraryViewSettings => {

--- a/src/hooks/useFetchItems.ts
+++ b/src/hooks/useFetchItems.ts
@@ -245,7 +245,7 @@ const fetchGetItemsViewByType = async (
                         ...getFiltersQuery(viewType, libraryViewSettings),
                         ...getLimitQuery(),
                         ...getAlphaPickerQuery(libraryViewSettings),
-                        sortBy: [libraryViewSettings.SortBy],
+                        sortBy: libraryViewSettings.SortBy,
                         sortOrder: [libraryViewSettings.SortOrder],
                         includeItemTypes: itemType,
                         startIndex: libraryViewSettings.StartIndex
@@ -266,7 +266,7 @@ const fetchGetItemsViewByType = async (
                         ...getFiltersQuery(viewType, libraryViewSettings),
                         ...getLimitQuery(),
                         ...getAlphaPickerQuery(libraryViewSettings),
-                        sortBy: [libraryViewSettings.SortBy],
+                        sortBy: libraryViewSettings.SortBy,
                         sortOrder: [libraryViewSettings.SortOrder],
                         includeItemTypes: itemType,
                         startIndex: libraryViewSettings.StartIndex
@@ -341,9 +341,7 @@ const fetchGetItemsViewByType = async (
                         ...getFiltersQuery(viewType, libraryViewSettings),
                         ...getLimitQuery(),
                         ...getAlphaPickerQuery(libraryViewSettings),
-                        sortBy: libraryViewSettings.SortBy === ItemSortBy.IsFolder ?
-                            [ItemSortBy.IsFolder, ItemSortBy.SortName] :
-                            [libraryViewSettings.SortBy],
+                        sortBy: libraryViewSettings.SortBy,
                         sortOrder: [libraryViewSettings.SortOrder],
                         includeItemTypes: itemType,
                         startIndex: libraryViewSettings.StartIndex
@@ -378,7 +376,7 @@ const fetchGetItemsViewByType = async (
                         ...getLimitQuery(),
                         ...getAlphaPickerQuery(libraryViewSettings),
                         isFavorite: viewType === LibraryTab.Favorites ? true : undefined,
-                        sortBy: [libraryViewSettings.SortBy],
+                        sortBy: libraryViewSettings.SortBy,
                         sortOrder: [libraryViewSettings.SortOrder],
                         includeItemTypes: itemType,
                         startIndex: libraryViewSettings.StartIndex

--- a/src/types/library.ts
+++ b/src/types/library.ts
@@ -53,7 +53,7 @@ export enum ViewMode {
 }
 
 export interface LibraryViewSettings {
-    SortBy: ItemSortBy;
+    SortBy: ItemSortBy[];
     SortOrder: SortOrder;
     StartIndex: number;
     CardLayout: boolean;


### PR DESCRIPTION
### Changes
- Make `SortBy` an array 
- Set `OptionReleaseDate` consistently to `[ProductionYear, PremiereDate, SortName]` across all tabs
- Add `SortName` as a tiebreaker to all sort options except `Random`
- Update the songs tab sorting based on the [legacy view](https://github.com/jellyfin/jellyfin-web/blob/09d565e76ea4ca11eb36433135b527aeb67596ab/src/apps/legacy/controllers/music/songs.js#L168)

### Issues
Fixes: #8105

### Code assistance
N/A

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
