### PR TITLE
Fix subtitles not showing in iOS native player

### DIFF
--- a/src/apps/legacy/features/playback/utils/subtitleStyles.test.ts
+++ b/src/apps/legacy/features/playback/utils/subtitleStyles.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { SubtitleStylingOption } from 'apps/legacy/features/playback/constants/subtitleStylingOption';
+import browser from 'scripts/browser';
+import type { UserSettings } from 'scripts/settings/userSettings';
+
+import { useCustomSubtitles } from './subtitleStyles';
+
+const browserMock = vi.hoisted(() => ({ default: {} as typeof browser }));
+vi.mock('scripts/browser', () => browserMock);
+
+function userSettingsWith(subtitleStyling: string): UserSettings {
+    return {
+        getSubtitleAppearanceSettings: () => ({ subtitleStyling })
+    } as unknown as UserSettings;
+}
+
+function setBrowser(flags: Partial<typeof browser>): void {
+    for (const key of Object.keys(browser)) {
+        delete (browser as Record<string, unknown>)[key];
+    }
+    Object.assign(browser, flags);
+}
+
+function setElementFullscreenSupport(supported: boolean): void {
+    const element = document.documentElement as unknown as Record<string, unknown>;
+    if (supported) {
+        element.requestFullscreen = () => Promise.resolve();
+    } else {
+        delete element.requestFullscreen;
+    }
+}
+
+describe('useCustomSubtitles', () => {
+    afterEach(() => {
+        setElementFullscreenSupport(false);
+    });
+
+    describe('explicit subtitle styling option', () => {
+        it('returns false when styling is Native, regardless of browser', () => {
+            setBrowser({ safari: true });
+            expect(useCustomSubtitles(userSettingsWith(SubtitleStylingOption.Native))).toBe(false);
+        });
+
+        it('returns true when styling is Custom, regardless of browser', () => {
+            setBrowser({});
+            expect(useCustomSubtitles(userSettingsWith(SubtitleStylingOption.Custom))).toBe(true);
+        });
+    });
+
+    describe('Auto styling: browser-based fallback', () => {
+        it('returns false when no custom-subtitle browser quirk applies', () => {
+            setBrowser({});
+            expect(useCustomSubtitles(userSettingsWith(SubtitleStylingOption.Auto))).toBe(false);
+        });
+
+        it('returns true on PS4', () => {
+            setBrowser({ ps4: true });
+            expect(useCustomSubtitles(userSettingsWith(SubtitleStylingOption.Auto))).toBe(true);
+        });
+
+        it('returns true on Tizen 5 and above', () => {
+            setBrowser({ tizenVersion: 5 });
+            expect(useCustomSubtitles(userSettingsWith(SubtitleStylingOption.Auto))).toBe(true);
+        });
+
+        it('returns false on Tizen versions below 5', () => {
+            setBrowser({ tizenVersion: 4 });
+            expect(useCustomSubtitles(userSettingsWith(SubtitleStylingOption.Auto))).toBe(false);
+        });
+
+        it('returns true on webOS', () => {
+            setBrowser({ web0s: true });
+            expect(useCustomSubtitles(userSettingsWith(SubtitleStylingOption.Auto))).toBe(true);
+        });
+
+        it('returns true on Edge', () => {
+            setBrowser({ edge: true });
+            expect(useCustomSubtitles(userSettingsWith(SubtitleStylingOption.Auto))).toBe(true);
+        });
+
+        it('returns true on Firefox', () => {
+            setBrowser({ firefox: true });
+            expect(useCustomSubtitles(userSettingsWith(SubtitleStylingOption.Auto))).toBe(true);
+        });
+
+        it('returns true on Safari when an element can go fullscreen', () => {
+            setBrowser({ safari: true, osx: true });
+            setElementFullscreenSupport(true);
+            expect(useCustomSubtitles(userSettingsWith(SubtitleStylingOption.Auto))).toBe(true);
+        });
+
+        it('returns false on Safari when only the video can go fullscreen', () => {
+            setBrowser({ safari: true, iOS: true });
+            setElementFullscreenSupport(false);
+            expect(useCustomSubtitles(userSettingsWith(SubtitleStylingOption.Auto))).toBe(false);
+        });
+    });
+});

--- a/src/apps/legacy/features/playback/utils/subtitleStyles.ts
+++ b/src/apps/legacy/features/playback/utils/subtitleStyles.ts
@@ -7,6 +7,20 @@ interface SubtitleAppearanceSettings {
     subtitleStyling: SubtitleStylingOption
 }
 
+interface PrefixedFullscreenElement {
+    webkitRequestFullscreen?: unknown
+    mozRequestFullScreen?: unknown
+    msRequestFullscreen?: unknown
+}
+
+function supportsElementFullscreen() {
+    const element = document.documentElement as HTMLElement & PrefixedFullscreenElement;
+    return !!(element.requestFullscreen
+        || element.webkitRequestFullscreen
+        || element.mozRequestFullScreen
+        || element.msRequestFullscreen);
+}
+
 export function useCustomSubtitles(userSettings: UserSettings) {
     const subtitleAppearance = userSettings.getSubtitleAppearanceSettings() as SubtitleAppearanceSettings;
     switch (subtitleAppearance.subtitleStyling) {
@@ -36,7 +50,7 @@ export function useCustomSubtitles(userSettings: UserSettings) {
             }
 
             // iOS/macOS global caption settings are causing huge font-size and margins
-            if (browser.safari) return true;
+            if (browser.safari && supportsElementFullscreen()) return true;
 
             return false;
     }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

### Changes

Since 10.11 (#7141), useCustomSubtitles returned true for all of Safari, forcing the custom subtitle overlay element. On iPhone, the `<video>` goes fullscreen via the native player (webkitEnterFullscreen) rather than the element-level Fullscreen API, and that native player can only render native `<track>` cues, not a DOM overlay. So text subtitles silently disappeared in the iOS native player.

Gate the Safari branch on supportsElementFullscreen() (the element-level Fullscreen API, excluding the video-only webkitEnterFullscreen). Browsers that can take an element fullscreen (macOS Safari, iPad) keep the custom overlay that fixes the oversized native caption styling; iPhone falls back to native cues so subtitles show in the native player. This is a capability check, so it self-corrects if iPhone ever ships the Fullscreen API.

### Issues
Fixes #8065

### Code assistance
<!--
If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance.
-->

Claude Code for testing in the iOS Simulator and generate website to play around with subtitles setting without full jellyfin stack involved, commit message

<img width="585" height="1266" alt="662077BB-4292-439A-ACBB-5DE2D2B943B5" src="https://github.com/user-attachments/assets/827c5cb9-e26f-4849-b444-3b71d0d93fd3" />

<img width="585" height="1266" alt="D68B6A25-6BCC-4F07-A774-5BF2C38E5AD8" src="https://github.com/user-attachments/assets/147cf120-4fd7-4163-a035-c5e322434624" />

<img width="585" height="1266" alt="B1F7814C-1719-4AA0-92F8-F8E05E511642" src="https://github.com/user-attachments/assets/0c26756e-ae5b-4702-b320-a0abb75ed3de" />

<img width="1266" height="585" alt="C286FEFF-992E-4DCB-A5E4-68638E1A8827" src="https://github.com/user-attachments/assets/24d618b4-52a5-47dd-b75c-aeb7ae32dbe0" />

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
