### PR TITLE
Fix item details backdrop position on mobile

### DIFF
--- a/src/apps/modern/AppOverrides.scss
+++ b/src/apps/modern/AppOverrides.scss
@@ -26,7 +26,7 @@ $mui-bp-xl: 1536px;
 .layout-mobile {
     .itemBackdrop {
         // Fix backdrop position on mobile item details page
-        margin-top: 0 !important;
+        margin-top: -48px !important;
 
         // Add a subtle gradient over the backdrop to ensure the app bar buttons are visible
         &::before {


### PR DESCRIPTION
### Changes
Fixes the item details backdrop position on mobile in the modern app layout

### Issues
N/A

### Code assistance
None

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
