### PR TITLE
Improve styling of person cards in purple haze theme

### DIFF
--- a/src/themes/purplehaze/theme.scss
+++ b/src/themes/purplehaze/theme.scss
@@ -103,14 +103,14 @@ progress::-webkit-progress-value {
     background: #ff77f1;
 }
 
-div[data-role=controlgroup] .controlGroupButton.ui-btn-active,
-div[data-role=controlgroup] a.ui-btn-active {
+div[data-role="controlgroup"] .controlGroupButton.ui-btn-active,
+div[data-role="controlgroup"] a.ui-btn-active {
     background: #55828b !important;
     color: #e1e5f2 !important;
 }
 
 .controlGroupButton,
-a[data-role=button] {
+a[data-role="button"] {
     background: rgba(2, 43, 58, 0.521) !important;
 }
 
@@ -288,7 +288,7 @@ a[data-role=button] {
     color: rgba(255, 255, 255, 0.78);
 }
 
-@supports (backdrop-filter:blur(10px)) or (-webkit-backdrop-filter:blur(10px)) {
+@supports (backdrop-filter: blur(10px)) or (-webkit-backdrop-filter: blur(10px)) {
     .appfooter {
         background: rgba(6, 37, 111, 0.7);
         backdrop-filter: blur(20px);
@@ -570,7 +570,7 @@ a[data-role=button] {
 
 .personCard .cardScalable {
     border-radius: 50% !important;
-    border: 1px solid rgb(255, 255, 255);
+    border: 1px solid transparent;
 }
 
 .cardBox:not(.visualCardBox) .cardPadder {
@@ -637,7 +637,8 @@ a[data-role=button] {
 }
 
 .personCard .coveredImage {
-    clip-path: circle(50% at 50% 50%);
+    background-position-y: 20%;
+    border-radius: 50%;
 }
 
 .personCard .cardOverlayContainer {


### PR DESCRIPTION
### Changes
Improves the styling of person cards in the purple haze theme
- Removes the white border
- Adjusts the background position to better frame faces (images are in portrait but normally the face is in the top not centered)
- Uses border radius instead of clipping to prevent cutoff circle when placeholder is used

**Before**
<img width="1102" height="304" alt="Screenshot 2026-07-01 at 11-45-07 Jellyfin Edge" src="https://github.com/user-attachments/assets/9ec5ad50-9a40-4582-8f31-e327079a78a4" />

**After**
<img width="1175" height="297" alt="Screenshot 2026-07-01 at 11-45-33 Jellyfin Edge" src="https://github.com/user-attachments/assets/9c72b2b1-272f-41d0-be4b-6fec0e248f58" />

### Issues
None

### Code assistance
Zed autocomplete

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
