### PR TITLE
Fetch and play previous episode

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -3146,7 +3146,7 @@ export class PlaybackManager {
             }
         };
 
-        self.previousTrack = function (player) {
+        self.previousTrack = async function (player) {
             player = player || self._currentPlayer;
             if (player && !enableLocalPlaylistManagement(player)) {
                 return player.previousTrack();
@@ -3164,6 +3164,30 @@ export class PlaybackManager {
                     playInternal(newItem, newItemPlayOptions, function () {
                         setPlaylistState(newItem.PlaylistItemId, newIndex);
                     }, getPreviousSource(player));
+                }
+            } else {
+                const state = self.getPlayerState(player);
+                const item = state.NowPlayingItem;
+                if (item?.Type === 'Episode') {
+                    const apiClient = ServerConnections.getApiClient(item.ServerId);
+                    const episodes = await apiClient.getEpisodes(item.SeriesId, {
+                        adjacentTo: item.Id
+                    });
+                    const newEpisodeIndex = episodes.Items.findIndex(i => i.Id == item.Id) - 1;
+
+                    const newItem = episodes.Items[newEpisodeIndex];
+
+                    if (newItem) {
+                        const newItemPlayOptions = newItem.playOptions || getDefaultPlayOptions();
+                        newItemPlayOptions.startPositionTicks = 0;
+
+                        playInternal(newItem, newItemPlayOptions, function () {
+                            self._playQueueManager.queueNext([newItem]);
+                            Events.trigger(player, 'playlistitemadd');
+                            self.movePlaylistItem(newItem.PlaylistItemId, 0, player);
+                            setPlaylistState(newItem.PlaylistItemId, 0);
+                        }, getPreviousSource(player));
+                    }
                 }
             }
         };


### PR DESCRIPTION
Enable previous track button for episode based media. The player will look for the latest episode available before the current playing one.

### Changes
- Code starts if playlist doesn't have a previous track
- For episode based media, fetch list of episodes available for the series
- Look for the index of current episode
- Add index before to the end of the playlist
- Move new item to the beginning of the playlist
- Start playing the added item

### Issues
Fix #8089 

### Code assistance
None

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
