### PR TITLE
Use loading indicator on button when scan is in progress

### DIFF
--- a/src/apps/dashboard/components/widgets/ServerInfoWidget.tsx
+++ b/src/apps/dashboard/components/widgets/ServerInfoWidget.tsx
@@ -76,7 +76,8 @@ const ServerInfoWidget = ({
                         sx={{
                             fontWeight: 'bold'
                         }}
-                        disabled={isScanning}
+                        loading={isScanning}
+                        loadingPosition='start'
                     >
                         {globalize.translate('ButtonScanAllLibraries')}
                     </Button>


### PR DESCRIPTION
### Changes
Use the loading indicator on the "Scan all libraries" dashboard button when a scan is in progress

### Issues
N/A

### Code assistance
Zed autocomplete

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
