### PR TITLE
Fix incorrect redirect after deleting an item from details page

### DIFF
--- a/src/apps/legacy/controllers/itemDetails/index.js
+++ b/src/apps/legacy/controllers/itemDetails/index.js
@@ -2043,7 +2043,9 @@ export default function (view, params) {
                             const parentId = selectedItem.SeasonId || selectedItem.SeriesId || selectedItem.ParentId;
 
                             if (parentId) {
-                                appRouter.showItem(parentId, item.ServerId);
+                                apiClient.getItem(apiClient.getCurrentUserId(), parentId).then(function(parentItem) {
+                                    appRouter.showItem(parentItem);
+                                });
                             } else {
                                 appRouter.goHome();
                             }


### PR DESCRIPTION


### Changes
When deleting an item from the details page, the app was redirecting 
to a legacy URL because showItem was called with just a parentId string. 
Fixed by fetching the full parent item first, so getRouteUrl receives 
the complete object with CollectionType and generates the correct modern URL.

### Issues
Fixes #8106

### Code assistance
Used Claude AI to navigate the codebase and identify the root cause. 
The fix and understanding of the routing logic are my own.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [ ] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
