### PR TITLE
Create dedicated Favorites page using modern library UI

### DIFF
--- a/src/apps/legacy/controllers/itemDetails/index.js
+++ b/src/apps/legacy/controllers/itemDetails/index.js
@@ -2043,7 +2043,9 @@ export default function (view, params) {
                             const parentId = selectedItem.SeasonId || selectedItem.SeriesId || selectedItem.ParentId;
 
                             if (parentId) {
-                                appRouter.showItem(parentId, item.ServerId);
+                                apiClient.getItem(apiClient.getCurrentUserId(), parentId).then(function(parentItem) {
+                                    appRouter.showItem(parentItem);
+                                });
                             } else {
                                 appRouter.goHome();
                             }

--- a/src/apps/modern/features/libraries/constants/libraryRoutes.ts
+++ b/src/apps/modern/features/libraries/constants/libraryRoutes.ts
@@ -345,4 +345,14 @@ export const LibraryRoutes: LibraryRoute[] = [
             }
         ]
     }
+    ,
+    {
+        path: '/favorites',
+        views: [
+            { index: 0, label: 'Movies', view: LibraryTab.Movies, isDefault: true },
+            { index: 1, label: 'Shows', view: LibraryTab.Series },
+            { index: 2, label: 'Episodes', view: LibraryTab.Episodes }
+        ]
+    }
 ];
+

--- a/src/apps/modern/features/libraries/constants/views/favorites.ts
+++ b/src/apps/modern/features/libraries/constants/views/favorites.ts
@@ -1,0 +1,33 @@
+import { BaseItemKind } from '@jellyfin/sdk/lib/generated-client/models/base-item-kind';
+import { LibraryTab } from 'types/libraryTab';
+import type { LibraryTabContent } from 'types/libraryTabContent';
+
+const moviesTabContent: LibraryTabContent = {
+    viewType: LibraryTab.Favorites,
+    itemType: [BaseItemKind.Movie],
+    isBtnPlayAllEnabled: true,
+    isBtnShuffleEnabled: true
+};
+
+const showsTabContent: LibraryTabContent = {
+    viewType: LibraryTab.Favorites,
+    itemType: [BaseItemKind.Series],
+    isBtnPlayAllEnabled: true,
+    isBtnShuffleEnabled: true
+};
+
+const episodesTabContent: LibraryTabContent = {
+    viewType: LibraryTab.Favorites,
+    itemType: [BaseItemKind.Episode],
+    isAlphabetPickerEnabled: false,
+    isBtnPlayAllEnabled: true,
+    isBtnShuffleEnabled: true
+};
+
+const favoritesViews: Record<number, LibraryTabContent> = {
+    0: moviesTabContent,
+    1: showsTabContent,
+    2: episodesTabContent
+};
+
+export default favoritesViews;

--- a/src/apps/modern/features/libraries/hooks/useLibrary.tsx
+++ b/src/apps/modern/features/libraries/hooks/useLibrary.tsx
@@ -1,3 +1,4 @@
+import defaultViewContent from '../constants/views/defaults';
 import { CollectionType } from '@jellyfin/sdk/lib/generated-client/models/collection-type';
 import { UseQueryResult } from '@tanstack/react-query';
 import React, { type FC, type PropsWithChildren, createContext, useContext, useMemo } from 'react';
@@ -42,7 +43,10 @@ export const LibraryProvider: FC<PropsWithChildren<unknown>> = ({ children }) =>
     const isLibPath = isLibraryPath(pathname);
     const id = libraryId ?? undefined;
 
-    const content = useMemo(() => collectionType && getViewContent(collectionType, activeTab), [collectionType, activeTab]);
+    const content = useMemo(() => {
+        if (collectionType) return getViewContent(collectionType, activeTab);
+        return route?.views[activeTab] ? { ...defaultViewContent, viewType: route.views[activeTab].view } as LibraryTabContent : undefined;
+    }, [collectionType, activeTab, route]);
     const viewType = content?.viewType;
 
     // Local storage requires the view type to be known upfront so default to movies if unknown

--- a/src/apps/modern/features/libraries/types/LibraryRoute.ts
+++ b/src/apps/modern/features/libraries/types/LibraryRoute.ts
@@ -10,6 +10,6 @@ interface LibraryViewDefinition {
 
 export interface LibraryRoute {
     path: string,
-    type: CollectionType,
+    type?: CollectionType,
     views: LibraryViewDefinition[]
 }

--- a/src/apps/modern/features/libraries/utils/viewContent.ts
+++ b/src/apps/modern/features/libraries/utils/viewContent.ts
@@ -1,14 +1,15 @@
 import { CollectionType } from '@jellyfin/sdk/lib/generated-client/models/collection-type';
-
 import { LibraryTabContent } from 'types/libraryTabContent';
-
 import defaultViewContent from '../constants/views/defaults';
 import viewsByKind from '../constants/views';
 
 export function getViewContent(
-    collectionType: CollectionType,
+    collectionType: CollectionType | undefined,
     viewIndex: number
 ): LibraryTabContent {
+    if (!collectionType) {
+        return { ...defaultViewContent } as LibraryTabContent;
+    }
     const viewContent = viewsByKind[collectionType][viewIndex];
     return {
         ...defaultViewContent,

--- a/src/apps/modern/routes/asyncRoutes/user.ts
+++ b/src/apps/modern/routes/asyncRoutes/user.ts
@@ -17,5 +17,6 @@ export const ASYNC_USER_ROUTES: AsyncRoute[] = [
     { path: 'quickconnect', page: 'quickConnect' },
     { path: 'search' },
     { path: 'tv', page: 'shows', type: AppType.Modern },
+    { path: 'favorites', type: AppType.Modern },
     { path: 'userprofile', page: 'user/userprofile' }
 ];

--- a/src/apps/modern/routes/favorites/index.tsx
+++ b/src/apps/modern/routes/favorites/index.tsx
@@ -1,0 +1,25 @@
+import React, { type FC } from 'react';
+import Page from 'components/Page';
+import useCurrentTab from 'hooks/useCurrentTab';
+import PageTabContent from 'apps/modern/features/libraries/components/PageTabContent';
+import favoritesViews from 'apps/modern/features/libraries/constants/views/favorites';
+
+const Favorites: FC = () => {
+    const { libraryId, activeTab } = useCurrentTab();
+    const currentTab = favoritesViews[activeTab] ?? favoritesViews[0];
+
+    return (
+        <Page
+            id='favoritesPage'
+            className='mainAnimatedPage libraryPage pageWithAbsoluteTabs withTabs'
+        >
+            <PageTabContent
+                key={`${currentTab.viewType}-${libraryId}`}
+                currentTab={currentTab}
+                parentId={libraryId}
+            />
+        </Page>
+    );
+};
+
+export default Favorites;


### PR DESCRIPTION


### Changes
Created a new /favorites route using modern MUI components instead of 
the legacy UI. Added favoritesViews configuration for Movies, Shows 
and Episodes tabs. Extended LibraryRoute type to support routes without 
CollectionType, and updated LibraryProvider to handle this case.

**Before:**

<img width="1568" height="102" alt="preview" src="https://github.com/user-attachments/assets/687cea91-c116-4e45-93a9-5bc89d668f33" />

**After:**

<img width="1218" height="152" alt="Screenshot 2026-07-02 at 13 19 17" src="https://github.com/user-attachments/assets/cd65ed3c-376d-4d11-b874-63f23dd2ad8c" />


### Issues
Fixes #8101

### Code assistance
Used Claude AI to navigate the codebase and understand the library 
architecture. The implementation and understanding of the changes are my own.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
