### PR TITLE
Fix position of subtitle sync

### DIFF
--- a/src/components/subtitlesync/subtitlesync.scss
+++ b/src/components/subtitlesync/subtitlesync.scss
@@ -1,5 +1,6 @@
 .subtitleSync {
     position: absolute;
+    top: 10%;
     width: 100%;
 }
 


### PR DESCRIPTION
The container of SubtitleSync is positioned relative to the `reactRoot`. At some point, the latter was changed to occupy the entire screen, and SubtitleSync was pushed out of view.

Probably, it started on Experimental (Modern) layout, then spread to other layouts.

Regression:
    3709b99d334619fcba4f715cb7ddfa3fd2848a2b
    f6265c1b7bc70cf3d99eeb652de17380da21ce78

### Changes
_(Quick and dirty  fix)_ Set absolute position of SubtitleSync.

### Issues
N/A

### Code assistance
None

### Screens
Before regression (some old version):
<img width="3840" height="2160" alt="subtitlesync-1" src="https://github.com/user-attachments/assets/d0b35fce-3130-41a5-ad04-2980f75a252b" />
After fix:
<img width="3840" height="2160" alt="subtitlesync-2" src="https://github.com/user-attachments/assets/eef8967d-1545-4ce2-a5c6-81cfe6cb343e" />

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
