### PR TITLE
Fix scroll icon color for light themes

### DIFF
--- a/src/themes/_base/_theme.scss
+++ b/src/themes/_base/_theme.scss
@@ -133,6 +133,10 @@ html {
     color: var(--jf-palette-primary-main, $primary-main);
 }
 
+.emby-scrollbuttons {
+    color: var(--jf-palette-text-secondary, $text-secondary);
+}
+
 a[data-role="button"],
 .fab,
 .raised {


### PR DESCRIPTION
### Changes
Fixes the scroll button using white icons in light themes making them difficult to see.

### Issues
N/A

### Code assistance
Zed autocomplete

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
