### PR TITLE
Fix backup list refreshing while backup jobs are active

### DIFF
--- a/src/apps/dashboard/features/backups/api/useBackups.ts
+++ b/src/apps/dashboard/features/backups/api/useBackups.ts
@@ -23,13 +23,13 @@ const fetchBackups = async (api: Api, options?: AxiosRequestConfig) => {
     return backups;
 };
 
-export const useBackups = () => {
+export const useBackups = (isEnabled = true) => {
     const { api } = useApi();
 
     return useQuery({
         queryKey: [ QUERY_KEY ],
         queryFn: ({ signal }) =>
             fetchBackups(api!, { signal }),
-        enabled: !!api
+        enabled: !!api && isEnabled
     });
 };

--- a/src/apps/dashboard/routes/backups/index.tsx
+++ b/src/apps/dashboard/routes/backups/index.tsx
@@ -28,10 +28,10 @@ import ConfirmDialog from 'components/ConfirmDialog';
 
 export const Component = () => {
     const { api } = useApi();
-    const { data: backups, isPending, isError } = useBackups();
     const [ isCreateFormOpen, setIsCreateFormOpen ] = useState(false);
     const [ backupInProgress, setBackupInProgress ] = useState(false);
     const [ restoreInProgress, setRestoreInProgress ] = useState(false);
+    const { data: backups, isPending, isError } = useBackups(!backupInProgress && !restoreInProgress);
     const [ isRestoreSuccess, setIsRestoreSuccess ] = useState(false);
     const [ isErrorOccurred, setIsErrorOccurred ] = useState(false);
     const [ isRestoreDialogOpen, setIsRestoreDialogOpen ] = useState(false);


### PR DESCRIPTION
We are currently querying for a backup list while backup jobs are running, leading to errors in the logs when the backup page is left open. 

This is a frontend fix, and a separate (independent) backend fix is in progress: https://github.com/jellyfin/jellyfin/pull/16223. 

### Changes
Don't query the backup manifest when a backup or restore is in progress. 

### Issues
Fixes: https://github.com/jellyfin/jellyfin/issues/15536

### Code assistance
N/A

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
