### PR TITLE
Use text numbers for audio rewind and fast forward instead of icon for all selectable values

### DIFF
--- a/src/apps/legacy/controllers/playback/queue/index.html
+++ b/src/apps/legacy/controllers/playback/queue/index.html
@@ -35,8 +35,9 @@
                             <span class="material-icons repeat" aria-hidden="true"></span>
                         </button>
 
-                        <button is="paper-icon-button-light" class="btnRewind btnNowPlayingRewind btnPlayStateCommand autoSize" title="${Rewind}">
-                            <span class="material-icons replay_10" aria-hidden="true"></span>
+                        <button is="paper-icon-button-light" class="btnPlayStateCommand btnRewind autoSize" title="${Rewind}">
+                            <span class="material-icons replay" aria-hidden="true"></span>
+                            <span class="skipButtonText" aria-hidden="true"></span>
                         </button>
 
                         <button is="paper-icon-button-light" class="btnPreviousTrack btnPlayStateCommand autoSize" title="${ButtonPreviousTrack}">
@@ -55,8 +56,9 @@
                             <span class="material-icons skip_next" aria-hidden="true"></span>
                         </button>
 
-                        <button is="paper-icon-button-light" class="btnPlayStateCommand btnFastForward btnNowPlayingFastForward autoSize" title="${FastForward}">
-                            <span class="material-icons forward_30" aria-hidden="true"></span>
+                        <button is="paper-icon-button-light" class="btnPlayStateCommand btnFastForward autoSize" title="${FastForward}">
+                            <span class="material-icons replay" aria-hidden="true"></span>
+                            <span class="skipButtonText" aria-hidden="true"></span>
                         </button>
 
                         <button is="paper-icon-button-light" class="btnShuffleQueue autoSize" title="${Shuffle}">

--- a/src/components/remotecontrol/remotecontrol.js
+++ b/src/components/remotecontrol/remotecontrol.js
@@ -31,6 +31,7 @@ import '../../elements/emby-slider/emby-slider';
 
 let showMuteButton = true;
 let showVolumeSlider = true;
+const msToSec = 1000;
 
 function showAudioMenu(context, player, button) {
     const currentIndex = playbackManager.getAudioStreamIndex(player);
@@ -221,6 +222,24 @@ function buttonVisible(btn, enabled) {
     }
 }
 
+function setSkipButtonSeconds(button, lengthMs) {
+    const textElement = button.querySelector('.skipButtonText');
+    if (textElement) {
+        textElement.textContent = Math.round(lengthMs / msToSec);
+    }
+}
+
+function updateSkipButtonIcons(context) {
+    const rewindButton = context.querySelector('.btnRewind');
+    if (rewindButton) {
+        setSkipButtonSeconds(rewindButton, userSettings.skipBackLength());
+    }
+    const fastForwardButton = context.querySelector('.btnFastForward');
+    if (fastForwardButton) {
+        setSkipButtonSeconds(fastForwardButton, userSettings.skipForwardLength());
+    }
+}
+
 function updateSupportedCommands(context, commands) {
     const all = context.querySelectorAll('.btnCommand');
 
@@ -298,6 +317,7 @@ export default function () {
             buttonVisible(context.querySelector('.btnRewind'), item != null);
             buttonVisible(context.querySelector('.btnFastForward'), item != null);
         }
+        updateSkipButtonIcons(context);
         const positionSlider = context.querySelector('.nowPlayingPositionSlider');
 
         if (positionSlider && item && item.RunTimeTicks) {
@@ -755,7 +775,7 @@ export default function () {
                     // to the previous track, unless we are at the first track so no previous track exists.
                     // currentTime is in msec.
 
-                    if (playbackManager.currentTime(currentPlayer) >= 5 * 1000 || playbackManager.getCurrentPlaylistIndex(currentPlayer) <= 0) {
+                    if (playbackManager.currentTime(currentPlayer) >= 5 * msToSec || playbackManager.getCurrentPlaylistIndex(currentPlayer) <= 0) {
                         playbackManager.seekPercent(0, currentPlayer);
                         // This is done automatically by playbackManager, however, setting this here gives instant visual feedback.
                         // TODO: Check why seekPercent doesn't reflect the changes inmmediately, so we can remove this workaround.

--- a/src/components/remotecontrol/remotecontrol.scss
+++ b/src/components/remotecontrol/remotecontrol.scss
@@ -475,3 +475,23 @@
         font-size: 4em;
     }
 }
+
+.btnRewind, .btnFastForward {
+    position: relative;
+}
+
+.btnFastForward .material-icons {
+    transform: scaleX(-1);
+}
+
+.skipButtonText {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-size: 0.4em;
+    font-weight: 600;
+    letter-spacing: -0.04em;
+    line-height: 1;
+    pointer-events: none;
+}

--- a/src/components/remotecontrol/remotecontrol.scss
+++ b/src/components/remotecontrol/remotecontrol.scss
@@ -486,7 +486,7 @@
 
 .skipButtonText {
     position: absolute;
-    top: 50%;
+    top: 52%;
     left: 50%;
     transform: translate(-50%, -50%);
     font-size: 0.4em;


### PR DESCRIPTION
### Changes
* The audio player has allows for users to specify rewind and fast forward times of 5, 10, 15, 20, 25 & 30 seconds. However the rewind icon is hard coded at 10 and the fast forward is hardcoded to 30. This change skips the built in icons and builds them on the fly.
* I also reordered the classes in the rewind button to match the order in the fast forward button as well removing the following unused classes (unused as far as I can see):
```
.btnNowPlayingRewind 
.btnNowPlayingFastForward 
```
* I added a const of `msPerSec` as there was already a 1000ms usage in that file

### Issues
I couldn't find any. Just me and my server users issue that's been flagged. Happy to create an issue if needed.

### Code assistance
None for this change, pretty straight forward change

---

* [X] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [X] I have tested these changes.
* [X] I have verified that this is not duplicating changes in an existing PR.
* [X] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
