### PR TITLE
Expose used SeriesName for Books in Metadata Editor

### DIFF
--- a/src/components/metadataEditor/metadataEditor.js
+++ b/src/components/metadataEditor/metadataEditor.js
@@ -142,6 +142,7 @@ function onSubmit(e) {
         Album: form.querySelector('#txtAlbum').value,
         AlbumArtists: getAlbumArtists(form),
         ArtistItems: getArtists(form),
+        SeriesName: form.querySelector('#txtseriesName').value,
         Overview: form.querySelector('#txtOverview').value,
         Status: form.querySelector('#selectStatus').value,
         AirDays: getSelectedAirDays(form),
@@ -580,6 +581,12 @@ function setFieldVisibilities(context, item) {
         hideElement('#fldCriticRating', context);
     }
 
+    if (item.Type === BaseItemKind.Book) {
+        showElement('#seriesName', context);
+    } else {
+        hideElement('#seriesName', context);
+    }
+
     if (item.Type === 'Series') {
         showElement('#fldStatus', context);
         showElement('#fldAirDays', context);
@@ -818,6 +825,10 @@ function fillItemInfo(context, item, parentalRatingOptions) {
     }).join(';');
 
     context.querySelector('#selectDisplayOrder').value = item.DisplayOrder || '';
+
+    if (item.Type == 'Book') {
+        context.querySelector('#txtseriesName').value = item.SeriesName || '';
+    }
 
     context.querySelector('#txtArtist').value = (item.ArtistItems || []).map(function (a) {
         return a.Name;

--- a/src/components/metadataEditor/metadataEditor.template.html
+++ b/src/components/metadataEditor/metadataEditor.template.html
@@ -61,7 +61,7 @@
                     <div class="fieldDescription">${LabelArtistsHelp}</div>
                 </div>
                 <div id="seriesName" class="hide inputContainer">
-                    <input is="emby-input" id="txtseriesName" type="text" label="${SeriesName}" />
+                    <input is="emby-input" id="txtseriesName" type="text" label="${SeriesName}" aria-label="${SeriesName}" />
                 </div>
                 <div id="fldAlbum" class="hide inputContainer">
                     <input is="emby-input" id="txtAlbum" type="text" label="${LabelAlbum}" />

--- a/src/components/metadataEditor/metadataEditor.template.html
+++ b/src/components/metadataEditor/metadataEditor.template.html
@@ -60,6 +60,9 @@
                     <input is="emby-input" id="txtAlbumArtist" type="text" label="${LabelAlbumArtists}" />
                     <div class="fieldDescription">${LabelArtistsHelp}</div>
                 </div>
+                <div id="seriesName" class="hide inputContainer">
+                    <input is="emby-input" id="txtseriesName" type="text" label="${SeriesName}" />
+                </div>
                 <div id="fldAlbum" class="hide inputContainer">
                     <input is="emby-input" id="txtAlbum" type="text" label="${LabelAlbum}" />
                 </div>

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1565,6 +1565,7 @@
     "Series": "Series",
     "SeriesCancelled": "Series cancelled.",
     "SeriesDisplayOrderHelp": "Order episodes by air date, DVD order, or absolute numbering.",
+    "SeriesName": "Series Name",
     "SeriesRecordingScheduled": "Series recording scheduled.",
     "SeriesSettings": "Series settings",
     "SeriesYearToPresent": "{0} - Present",


### PR DESCRIPTION
## Changes
SeriesName is already exposed on a book item card, however it is not editable. This allows users the ability to edit a Book's SeriesName metadata. Server PR allowing the change [here](https://github.com/jellyfin/jellyfin/pull/17250)

### Issues
None that I could find

### Code assistance
Just a code review to make sure I didn't miss anything

---

* [X] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [X] I have tested these changes.
* [X] I have verified that this is not duplicating changes in an existing PR.
* [X] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).

### Server Change
* https://github.com/jellyfin/jellyfin/pull/17250