### PR TITLE
Fix missing unaired filter submission

### DIFF
--- a/src/components/filterdialog/filterdialog.js
+++ b/src/components/filterdialog/filterdialog.js
@@ -102,8 +102,9 @@ function updateFilterControls(context, options) {
     context.querySelector('#chkThemeVideo').checked = query.HasThemeVideo === true;
     context.querySelector('#chkSpecialFeature').checked = query.HasSpecialFeature === true;
     context.querySelector('#chkSpecialEpisode').checked = query.ParentIndexNumber === 0;
-    context.querySelector('#chkMissingEpisode').checked = query.IsMissing === true;
-    context.querySelector('#chkFutureEpisode').checked = query.IsUnaired === true;
+    const isMissingChecked = query.IsMissing === true;
+    context.querySelector('#chkMissingEpisode').checked = isMissingChecked;
+    context.querySelector('#chkFutureEpisode').checked = query.IsUnaired === true || (isMissingChecked && query.IsUnaired === null);
     for (const elem of context.querySelectorAll('.chkStatus')) {
         const filters = `,${query.SeriesStatus || ''}`;
         const filterName = elem.getAttribute('data-filter');
@@ -125,6 +126,24 @@ function triggerChange(instance) {
     }
 
     Events.trigger(instance, 'filterchange');
+}
+
+function applyEpisodeStatusFilters(query, isMissingChecked, isUnairedChecked) {
+    query.StartIndex = 0;
+
+    if (isMissingChecked && isUnairedChecked) {
+        query.IsMissing = true;
+        query.IsUnaired = null;
+    } else if (isMissingChecked) {
+        query.IsMissing = true;
+        query.IsUnaired = false;
+    } else if (isUnairedChecked) {
+        query.IsMissing = null;
+        query.IsUnaired = true;
+    } else {
+        query.IsMissing = false;
+        query.IsUnaired = null;
+    }
 }
 
 function setVisibility(context, options) {
@@ -351,9 +370,9 @@ class FilterDialog {
             triggerChange(this);
         });
         const chkMissingEpisode = context.querySelector('#chkMissingEpisode');
+        const chkFutureEpisode = context.querySelector('#chkFutureEpisode');
         chkMissingEpisode.addEventListener('change', () => {
-            query.StartIndex = 0;
-            query.IsMissing = !!chkMissingEpisode.checked;
+            applyEpisodeStatusFilters(query, chkMissingEpisode.checked, chkFutureEpisode.checked);
             triggerChange(this);
         });
         const chkSpecialEpisode = context.querySelector('#chkSpecialEpisode');
@@ -362,16 +381,8 @@ class FilterDialog {
             query.ParentIndexNumber = chkSpecialEpisode.checked ? 0 : null;
             triggerChange(this);
         });
-        const chkFutureEpisode = context.querySelector('#chkFutureEpisode');
         chkFutureEpisode.addEventListener('change', () => {
-            query.StartIndex = 0;
-            if (chkFutureEpisode.checked) {
-                query.IsUnaired = true;
-                query.IsVirtualUnaired = null;
-            } else {
-                query.IsUnaired = null;
-                query.IsVirtualUnaired = false;
-            }
+            applyEpisodeStatusFilters(query, chkMissingEpisode.checked, chkFutureEpisode.checked);
             triggerChange(this);
         });
         const chkSubtitle = context.querySelector('#chkSubtitle');

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1188,6 +1188,7 @@
     "MessageNoItemsAvailable": "No Items are currently available.",
     "MessageNoFavoritesAvailable": "No favorites are currently available.",
     "MessageNoCollectionsAvailable": "Collections allow you to enjoy personalized groupings of Movies, Series, and Albums. Click the '+' button to start creating collections.",
+    "MessageNoEpisodesFound": "No episodes are currently available.",
     "MessageNoGenresAvailable": "Enable some metadata providers to pull genres from the internet.",
     "MessageNoMovieSuggestionsAvailable": "No movie suggestions are currently available. Start watching and rating your movies, and then come back to view your recommendations.",
     "MessageNoNextUpItems": "None found. Start watching your shows!",

--- a/src/utils/items.ts
+++ b/src/utils/items.ts
@@ -57,19 +57,32 @@ export const getEpisodeFilter = (
     viewType: LibraryTab,
     libraryViewSettings: LibraryViewSettings
 ) => {
+    const episodeFilters = libraryViewSettings.Filters?.EpisodeFilter;
+    const isMissingSelected = episodeFilters?.includes(EpisodeFilter.IsMissing);
+    const isUnairedSelected = episodeFilters?.includes(EpisodeFilter.IsUnaired);
+
+    let isMissing: boolean | undefined;
+    let isUnaired: boolean | undefined;
+
+    if (viewType === LibraryTab.Episodes) {
+        if (isMissingSelected) {
+            isMissing = true;
+            if (!isUnairedSelected) {
+                isUnaired = false;
+            }
+        } else if (isUnairedSelected) {
+            isUnaired = true;
+        } else {
+            isMissing = false;
+        }
+    }
+
     return {
-        parentIndexNumber: libraryViewSettings.Filters?.EpisodeFilter?.includes(
-            EpisodeFilter.ParentIndexNumber
-        ) ?
+        parentIndexNumber: episodeFilters?.includes(EpisodeFilter.ParentIndexNumber) ?
             0 :
             undefined,
-        isMissing:
-            viewType === LibraryTab.Episodes ?
-                !!libraryViewSettings.Filters?.EpisodeFilter?.includes(EpisodeFilter.IsMissing) :
-                undefined,
-        isUnaired: libraryViewSettings.Filters?.EpisodeFilter?.includes(EpisodeFilter.IsUnaired) ?
-            true :
-            undefined
+        isMissing,
+        isUnaired
     };
 };
 


### PR DESCRIPTION
This fixes missing and unaired filter on legacy and modern layout.

### Changes
Implement logic that sets the API filter values correctly based on what is user selected in the frontend.

### Issues


### Code assistance
None

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
