### PR TITLE
Add audiobook chapter controls to playback UI

### DIFF
--- a/src/apps/legacy/controllers/playback/queue/index.html
+++ b/src/apps/legacy/controllers/playback/queue/index.html
@@ -12,7 +12,10 @@
                         <h2 class="nowPlayingPageTitle"></h2>
                         <div style="font-weight: bold;" class="nowPlayingSongName nowPlayingEpisode"></div>
                         <div class="nowPlayingAlbum nowPlayingSeason"></div>
-                        <div class="nowPlayingArtist nowPlayingSerie"></div>
+                        <div class="nowPlayingArtistChapterLine">
+                            <span class="nowPlayingArtist nowPlayingSerie"></span>
+                            <span class="nowPlayingChapterName hide"></span>
+                        </div>
                     </div>
                     <div class="nowPlayingPageUserDataButtonsTitle"></div>
 
@@ -21,6 +24,7 @@
                 <div class="sliderContainer flex" dir="ltr">
                     <div class="positionTime"></div>
                         <div class="nowPlayingPositionSliderContainer">
+                            <div class="sliderMarkerContainer"></div>
                             <input type="range" is="emby-slider" pin step="1" min="0" max="100" value="0" class="nowPlayingPositionSlider" data-slider-keep-progress="true" />
                         </div>
                     <div class="runtime"></div>
@@ -37,6 +41,10 @@
 
                         <button is="paper-icon-button-light" class="btnRewind btnNowPlayingRewind btnPlayStateCommand autoSize" title="${Rewind}">
                             <span class="material-icons replay_10" aria-hidden="true"></span>
+                        </button>
+
+                        <button is="paper-icon-button-light" class="btnPreviousChapter btnPlayStateCommand autoSize hide" title="${PreviousChapter}">
+                            <span class="material-icons undo" aria-hidden="true"></span>
                         </button>
 
                         <button is="paper-icon-button-light" class="btnPreviousTrack btnPlayStateCommand autoSize" title="${ButtonPreviousTrack}">
@@ -57,6 +65,10 @@
 
                         <button is="paper-icon-button-light" class="btnPlayStateCommand btnFastForward btnNowPlayingFastForward autoSize" title="${FastForward}">
                             <span class="material-icons forward_30" aria-hidden="true"></span>
+                        </button>
+
+                        <button is="paper-icon-button-light" class="btnNextChapter btnPlayStateCommand autoSize hide" title="${NextChapter}">
+                            <span class="material-icons redo" aria-hidden="true"></span>
                         </button>
 
                         <button is="paper-icon-button-light" class="btnShuffleQueue autoSize" title="${Shuffle}">
@@ -83,6 +95,10 @@
 
                         <button is="paper-icon-button-light" class="btnLyrics autoSize hide" title="${Lyrics}">
                             <span class="material-icons lyrics" style="top:0.05em" aria-hidden="true"></span>
+                        </button>
+
+                        <button is="paper-icon-button-light" class="btnChapters autoSize hide" title="${TableOfContents}">
+                            <span class="material-icons toc" aria-hidden="true"></span>
                         </button>
 
                         <button is="paper-icon-button-light" class="btnShuffleQueue autoSize" title="${Shuffle}">

--- a/src/components/nowPlayingBar/nowPlayingBar.js
+++ b/src/components/nowPlayingBar/nowPlayingBar.js
@@ -3,6 +3,7 @@ import { getItemTextLines } from 'apps/legacy/features/playback/utils/itemText';
 import { appRouter, isLyricsPage } from 'components/router/appRouter';
 import { AppFeature } from 'constants/appFeature';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
+import escapeHtml from 'escape-html';
 
 import datetime from '../../scripts/datetime';
 import Events from '../../utils/events.ts';
@@ -28,11 +29,14 @@ let currentTimeElement;
 let nowPlayingImageElement;
 let nowPlayingImageUrl;
 let nowPlayingTextElement;
+let nowPlayingChapterElement;
 let nowPlayingUserData;
 let muteButton;
 let volumeSlider;
 let volumeSliderContainer;
 let playPauseButtons;
+let previousChapterButton;
+let nextChapterButton;
 let positionSlider;
 let toggleAirPlayButton;
 let toggleRepeatButton;
@@ -55,6 +59,7 @@ function getNowPlayingBarHtml() {
 
     html += '<div class="nowPlayingBarTop">';
     html += '<div class="nowPlayingBarPositionContainer sliderContainer" dir="ltr">';
+    html += '<div class="sliderMarkerContainer"></div>';
     html += '<input type="range" is="emby-slider" pin step=".01" min="0" max="100" value="0" class="slider-medium-thumb nowPlayingBarPositionSlider" data-slider-keep-progress="true"/>';
     html += '</div>';
 
@@ -67,10 +72,12 @@ function getNowPlayingBarHtml() {
     html += '<div class="nowPlayingBarCenter" dir="ltr">';
 
     html += `<button is="paper-icon-button-light" class="previousTrackButton mediaButton" title="${globalize.translate('ButtonPreviousTrack')}"><span class="material-icons skip_previous" aria-hidden="true"></span></button>`;
+    html += `<button is="paper-icon-button-light" class="previousChapterButton mediaButton hide" title="${globalize.translate('PreviousChapter')}"><span class="material-icons undo" aria-hidden="true"></span></button>`;
 
     html += `<button is="paper-icon-button-light" class="playPauseButton mediaButton" title="${globalize.translate('ButtonPause')}"><span class="material-icons pause" aria-hidden="true"></span></button>`;
 
     html += `<button is="paper-icon-button-light" class="stopButton mediaButton" title="${globalize.translate('ButtonStop')}"><span class="material-icons stop" aria-hidden="true"></span></button>`;
+    html += `<button is="paper-icon-button-light" class="nextChapterButton mediaButton hide" title="${globalize.translate('NextChapter')}"><span class="material-icons redo" aria-hidden="true"></span></button>`;
     if (!layoutManager.mobile) {
         html += `<button is="paper-icon-button-light" class="nextTrackButton mediaButton" title="${globalize.translate('ButtonNextTrack')}"><span class="material-icons skip_next" aria-hidden="true"></span></button>`;
     }
@@ -143,12 +150,83 @@ function onPlayPauseClick() {
     playbackManager.playPause(currentPlayer);
 }
 
+function getChapterDisplayName(chapter, index) {
+    return chapter.Name || datetime.getDisplayRunningTime(chapter.StartPositionTicks) || `${index + 1}`;
+}
+
+function getChapterAtPosition(item, positionTicks) {
+    let chapter;
+    let index = -1;
+
+    for (let i = 0, length = (item.Chapters || []).length; i < length; i++) {
+        const currentChapter = item.Chapters[i];
+
+        if (positionTicks < currentChapter.StartPositionTicks) {
+            break;
+        }
+
+        chapter = currentChapter;
+        index = i;
+    }
+
+    return {
+        chapter,
+        index
+    };
+}
+
+function hasChapterInfo(item) {
+    return (item?.Chapters || []).length > 1;
+}
+
+function getChapterMarkerInfo(item) {
+    if (!item?.RunTimeTicks) {
+        return [];
+    }
+
+    return (item.Chapters || []).map(chapter => ({
+        name: chapter.Name,
+        progress: chapter.StartPositionTicks / item.RunTimeTicks
+    }));
+}
+
+function updateChapterButtons(item, canSeek) {
+    const showChapterButtons = hasChapterInfo(item) && canSeek;
+
+    previousChapterButton?.classList.toggle('hide', !showChapterButtons);
+    nextChapterButton?.classList.toggle('hide', !showChapterButtons);
+}
+
+function updateChapterDisplay(item, positionTicks) {
+    if (!nowPlayingChapterElement) {
+        return;
+    }
+
+    if (!hasChapterInfo(item) || !Number.isFinite(positionTicks)) {
+        nowPlayingChapterElement.textContent = '';
+        nowPlayingChapterElement.classList.add('hide');
+        return;
+    }
+
+    const { chapter, index } = getChapterAtPosition(item, positionTicks);
+
+    if (chapter) {
+        nowPlayingChapterElement.textContent = getChapterDisplayName(chapter, index);
+        nowPlayingChapterElement.classList.remove('hide');
+    } else {
+        nowPlayingChapterElement.textContent = '';
+        nowPlayingChapterElement.classList.add('hide');
+    }
+}
+
 function bindEvents(elem) {
     currentTimeElement = elem.querySelector('.nowPlayingBarCurrentTime');
     nowPlayingImageElement = elem.querySelector('.nowPlayingImage');
     nowPlayingTextElement = elem.querySelector('.nowPlayingBarText');
     nowPlayingUserData = elem.querySelector('.nowPlayingBarUserDataButtons');
     positionSlider = elem.querySelector('.nowPlayingBarPositionSlider');
+    previousChapterButton = elem.querySelector('.previousChapterButton');
+    nextChapterButton = elem.querySelector('.nextChapterButton');
     muteButton = elem.querySelector('.muteButton');
     playPauseButtons = elem.querySelectorAll('.playPauseButton');
     toggleRepeatButton = elem.querySelector('.toggleRepeatButton');
@@ -170,6 +248,18 @@ function bindEvents(elem) {
 
     playPauseButtons.forEach((button) => {
         button.addEventListener('click', onPlayPauseClick);
+    });
+
+    previousChapterButton.addEventListener('click', function () {
+        if (currentPlayer) {
+            playbackManager.previousChapter(currentPlayer);
+        }
+    });
+
+    nextChapterButton.addEventListener('click', function () {
+        if (currentPlayer) {
+            playbackManager.nextChapter(currentPlayer);
+        }
     });
 
     elem.querySelector('.nextTrackButton').addEventListener('click', function () {
@@ -261,7 +351,7 @@ function bindEvents(elem) {
         }
     });
 
-    positionSlider.getBubbleText = function (value) {
+    positionSlider.getBubbleHtml = function (value) {
         const state = lastPlayerState;
 
         if (!state?.NowPlayingItem || !currentRuntimeTicks) {
@@ -272,7 +362,27 @@ function bindEvents(elem) {
         ticks /= 100;
         ticks *= value;
 
-        return datetime.getDisplayRunningTime(ticks);
+        const runtimeText = datetime.getDisplayRunningTime(ticks);
+        const { chapter, index } = getChapterAtPosition(state.NowPlayingItem, ticks);
+
+        if (hasChapterInfo(state.NowPlayingItem) && chapter) {
+            return '<div class="nowPlayingBarChapterBubble">'
+                + `<div class="sliderBubbleText">${runtimeText}</div>`
+                + `<div class="nowPlayingBarChapterBubbleName">${escapeHtml(getChapterDisplayName(chapter, index))}</div>`
+                + '</div>';
+        }
+
+        return runtimeText;
+    };
+
+    positionSlider.getMarkerInfo = function () {
+        const item = lastPlayerState?.NowPlayingItem;
+
+        if (!hasChapterInfo(item)) {
+            return [];
+        }
+
+        return getChapterMarkerInfo(item);
     };
 
     elem.addEventListener('click', function (e) {
@@ -372,6 +482,8 @@ function updatePlayerStateInternal(event, state, player) {
     updateTimeDisplay(playState.PositionTicks, nowPlayingItem.RunTimeTicks, playbackManager.getBufferedRanges(player));
 
     updateNowPlayingInfo(state);
+    updateChapterButtons(nowPlayingItem, playState.CanSeek);
+    updateChapterDisplay(nowPlayingItem, playState.PositionTicks);
     updateLyricButton(nowPlayingItem);
 }
 
@@ -487,6 +599,9 @@ function updateNowPlayingInfo(state) {
             text.innerText = textLines[1];
             secondaryText.appendChild(text);
         }
+        nowPlayingChapterElement = document.createElement('span');
+        nowPlayingChapterElement.classList.add('nowPlayingBarChapterText', 'hide');
+        secondaryText.appendChild(nowPlayingChapterElement);
 
         if (textLines[0]) {
             const text = document.createElement('a');
@@ -677,7 +792,9 @@ function onTimeUpdate() {
 
     const player = this;
     currentRuntimeTicks = playbackManager.duration(player);
-    updateTimeDisplay(playbackManager.currentTime(player) * 10000, currentRuntimeTicks, playbackManager.getBufferedRanges(player));
+    const positionTicks = playbackManager.currentTime(player) * 10000;
+    updateTimeDisplay(positionTicks, currentRuntimeTicks, playbackManager.getBufferedRanges(player));
+    updateChapterDisplay(playbackManager.currentItem(player), positionTicks);
 }
 
 function releaseCurrentPlayer() {

--- a/src/components/nowPlayingBar/nowPlayingBar.scss
+++ b/src/components/nowPlayingBar/nowPlayingBar.scss
@@ -70,6 +70,62 @@
     }
 }
 
+.nowPlayingBarSecondaryText {
+    display: flex;
+    min-width: 0;
+}
+
+.nowPlayingBarSecondaryText a,
+.nowPlayingBarChapterText {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.nowPlayingBarSecondaryText a {
+    flex-shrink: 0;
+    max-width: 50%;
+}
+
+.nowPlayingBarChapterText {
+    min-width: 0;
+    color: rgba(255, 255, 255, 0.7);
+
+    [dir="ltr"] & {
+        margin-left: 0.5em;
+    }
+
+    [dir="rtl"] & {
+        margin-right: 0.5em;
+    }
+}
+
+.nowPlayingBarChapterText::before {
+    content: "\2022";
+
+    [dir="ltr"] & {
+        margin-right: 0.5em;
+    }
+
+    [dir="rtl"] & {
+        margin-left: 0.5em;
+    }
+}
+
+.nowPlayingBarChapterBubble {
+    max-width: 18em;
+}
+
+.nowPlayingBarChapterBubble .sliderBubbleText {
+    opacity: 0.75;
+}
+
+.nowPlayingBarChapterBubbleName {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 .nowPlayingBarCenter {
     vertical-align: middle;
     text-align: center;

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -132,13 +132,17 @@ function normalizeName(t) {
 function getItemsForPlayback(serverId, query) {
     const apiClient = ServerConnections.getApiClient(serverId);
 
-    if (query.Ids && query.Ids.split(',').length === 1) {
-        const itemId = query.Ids.split(',');
+    query.Fields = ['Chapters', 'Trickplay'];
+    query.ExcludeLocationTypes = 'Virtual';
+    query.EnableTotalRecordCount = false;
+    query.CollapseBoxSetItems = false;
 
-        return apiClient.getItem(apiClient.getCurrentUserId(), itemId).then(function (item) {
+    if (query.Ids && query.Ids.split(',').length === 1) {
+        return getItems(apiClient, apiClient.getCurrentUserId(), query).then(function (result) {
+            const item = result.Items[0];
             return {
-                Items: [item],
-                TotalRecordCount: 1
+                Items: item ? [item] : [],
+                TotalRecordCount: result.TotalRecordCount || (item ? 1 : 0)
             };
         });
     } else {
@@ -147,13 +151,31 @@ function getItemsForPlayback(serverId, query) {
         } else {
             query.Limit = query.Limit || 300;
         }
-        query.Fields = ['Chapters', 'Trickplay'];
-        query.ExcludeLocationTypes = 'Virtual';
-        query.EnableTotalRecordCount = false;
-        query.CollapseBoxSetItems = false;
 
         return getItems(apiClient, apiClient.getCurrentUserId(), query);
     }
+}
+
+async function ensurePlaybackFields(items) {
+    if (!items.length) {
+        return items;
+    }
+
+    const serverId = items[0].ServerId;
+    const shouldRefetch = serverId
+        && items.every(item => item.ServerId === serverId)
+        && items.some(item => (item.MediaType === MediaType.Audio || item.MediaType === MediaType.Video) && item.Chapters == null);
+
+    if (!shouldRefetch) {
+        return items;
+    }
+
+    const result = await getItemsForPlayback(serverId, {
+        Ids: items.map(item => item.Id).join(',')
+    });
+
+    const itemsById = new Map(result.Items.map(item => [item.Id, item]));
+    return items.map(item => itemsById.get(item.Id) || item);
 }
 
 function createStreamInfoFromUrlItem(item) {
@@ -1819,7 +1841,7 @@ export class PlaybackManager {
                 const result = await promise;
                 return result ? result.Items : items;
             } else {
-                return items;
+                return ensurePlaybackFields(items);
             }
         }
 

--- a/src/components/remotecontrol/remotecontrol.js
+++ b/src/components/remotecontrol/remotecontrol.js
@@ -91,6 +91,102 @@ function showSubtitleMenu(context, player, button) {
     });
 }
 
+function getChapterDisplayName(chapter, index) {
+    return chapter.Name || datetime.getDisplayRunningTime(chapter.StartPositionTicks) || `${index + 1}`;
+}
+
+function getChapterAtPosition(item, positionTicks) {
+    let chapter;
+    let index = -1;
+
+    for (let i = 0, length = (item.Chapters || []).length; i < length; i++) {
+        const currentChapter = item.Chapters[i];
+
+        if (positionTicks < currentChapter.StartPositionTicks) {
+            break;
+        }
+
+        chapter = currentChapter;
+        index = i;
+    }
+
+    return {
+        chapter,
+        index
+    };
+}
+
+function hasChapterInfo(item) {
+    return (item?.Chapters || []).length > 1;
+}
+
+function showChapterMenu(player, button) {
+    const item = playbackManager.currentItem(player);
+    const chapters = item?.Chapters || [];
+
+    if (!chapters.length) {
+        return;
+    }
+
+    const currentChapterIndex = getChapterAtPosition(item, playbackManager.getCurrentTicks(player)).index;
+    const menuItems = chapters.map((chapter, index) => ({
+        name: getChapterDisplayName(chapter, index),
+        id: index.toString(),
+        asideText: datetime.getDisplayRunningTime(chapter.StartPositionTicks),
+        selected: index === currentChapterIndex
+    }));
+
+    import('../actionSheet/actionSheet').then((actionsheet) => {
+        actionsheet.show({
+            title: globalize.translate('TableOfContents'),
+            items: menuItems,
+            positionTo: button,
+            callback: function (id) {
+                const chapter = chapters[parseInt(id, 10)];
+
+                if (chapter) {
+                    playbackManager.seek(chapter.StartPositionTicks, player);
+                }
+            }
+        }).catch(() => { /* Dialog closed */ });
+    });
+}
+
+function getChapterMarkerInfo(item) {
+    if (!item?.RunTimeTicks) {
+        return [];
+    }
+
+    return (item.Chapters || [])
+        .map(chapter => ({
+            name: chapter.Name,
+            progress: chapter.StartPositionTicks / item.RunTimeTicks
+        }));
+}
+
+function updateChapterDisplay(context, item, positionTicks) {
+    const chapterElement = context.querySelector('.nowPlayingChapterName');
+    if (!chapterElement) {
+        return;
+    }
+
+    if (!hasChapterInfo(item) || !Number.isFinite(positionTicks)) {
+        chapterElement.textContent = '';
+        chapterElement.classList.add('hide');
+        return;
+    }
+
+    const { chapter, index } = getChapterAtPosition(item, positionTicks);
+
+    if (chapter) {
+        chapterElement.textContent = getChapterDisplayName(chapter, index);
+        chapterElement.classList.remove('hide');
+    } else {
+        chapterElement.textContent = '';
+        chapterElement.classList.add('hide');
+    }
+}
+
 function updateNowPlayingInfo(context, state, serverId) {
     const item = state.NowPlayingItem;
     const displayName = item ?
@@ -281,6 +377,9 @@ export default function () {
         }
 
         buttonVisible(context.querySelector('.btnLyrics'), item?.Type === 'Audio' && !layoutManager.mobile);
+        buttonVisible(context.querySelector('.btnChapters'), hasChapterInfo(item));
+        buttonVisible(context.querySelector('.btnPreviousChapter'), hasChapterInfo(item) && playState.CanSeek);
+        buttonVisible(context.querySelector('.btnNextChapter'), hasChapterInfo(item) && playState.CanSeek);
         buttonVisible(context.querySelector('.btnStop'), item != null);
         buttonVisible(context.querySelector('.btnNextTrack'), item != null);
         buttonVisible(context.querySelector('.btnPreviousTrack'), item != null);
@@ -299,6 +398,7 @@ export default function () {
             buttonVisible(context.querySelector('.btnFastForward'), item != null);
         }
         const positionSlider = context.querySelector('.nowPlayingPositionSlider');
+        currentRuntimeTicks = item?.RunTimeTicks || 0;
 
         if (positionSlider && item && item.RunTimeTicks) {
             positionSlider.setKeyboardSteps(userSettings.skipBackLength() * 1000000 / item.RunTimeTicks,
@@ -313,6 +413,7 @@ export default function () {
 
         updatePlayPauseState(playState.IsPaused, item != null);
         updateTimeDisplay(playState.PositionTicks, item ? item.RunTimeTicks : null);
+        updateChapterDisplay(context, item, playState.PositionTicks);
         updatePlayerVolumeState(context, playState.IsMuted, playState.VolumeLevel);
 
         if (item && item.MediaType == 'Video') {
@@ -585,7 +686,9 @@ export default function () {
             lastUpdateTime = now;
             const player = this;
             currentRuntimeTicks = playbackManager.duration(player);
-            updateTimeDisplay(playbackManager.currentTime(player) * 10000, currentRuntimeTicks);
+            const positionTicks = playbackManager.currentTime(player) * 10000;
+            updateTimeDisplay(positionTicks, currentRuntimeTicks);
+            updateChapterDisplay(dlg, playbackManager.currentItem(player), positionTicks);
         }
     }
 
@@ -731,8 +834,23 @@ export default function () {
                 playbackManager.fastForward(currentPlayer);
             }
         });
+        context.querySelector('.btnPreviousChapter').addEventListener('click', function () {
+            if (currentPlayer) {
+                playbackManager.previousChapter(currentPlayer);
+            }
+        });
+        context.querySelector('.btnNextChapter').addEventListener('click', function () {
+            if (currentPlayer) {
+                playbackManager.nextChapter(currentPlayer);
+            }
+        });
         context.querySelector('.btnLyrics').addEventListener('click', function () {
             appRouter.show('lyrics');
+        });
+        context.querySelector('.btnChapters').addEventListener('click', function (e) {
+            if (currentPlayer && lastPlayerState?.NowPlayingItem) {
+                showChapterMenu(currentPlayer, e.target);
+            }
         });
 
         for (const shuffleButton of context.querySelectorAll('.btnShuffleQueue')) {
@@ -781,17 +899,36 @@ export default function () {
             }
         });
 
-        positionSlider.getBubbleText = function (value) {
+        positionSlider.getBubbleHtml = function (value) {
             const state = lastPlayerState;
 
             if (!state?.NowPlayingItem || !currentRuntimeTicks) {
-                return '--:--';
+                return '<h1 class="sliderBubbleText">--:--</h1>';
             }
 
             let ticks = currentRuntimeTicks;
             ticks /= 100;
             ticks *= value;
-            return datetime.getDisplayRunningTime(ticks);
+
+            const { chapter, index } = getChapterAtPosition(state.NowPlayingItem, ticks);
+            if (hasChapterInfo(state.NowPlayingItem) && chapter) {
+                return '<div class="nowPlayingChapterBubble">'
+                    + `<h1 class="sliderBubbleText">${datetime.getDisplayRunningTime(ticks)}</h1>`
+                    + `<div class="nowPlayingChapterBubbleName">${escapeHtml(getChapterDisplayName(chapter, index))}</div>`
+                    + '</div>';
+            }
+
+            return `<h1 class="sliderBubbleText">${datetime.getDisplayRunningTime(ticks)}</h1>`;
+        };
+
+        positionSlider.getMarkerInfo = function () {
+            const item = lastPlayerState?.NowPlayingItem;
+
+            if (!hasChapterInfo(item)) {
+                return [];
+            }
+
+            return getChapterMarkerInfo(item);
         };
 
         context.querySelector('.nowPlayingVolumeSlider').addEventListener('input', (e) => {

--- a/src/components/remotecontrol/remotecontrol.scss
+++ b/src/components/remotecontrol/remotecontrol.scss
@@ -51,6 +51,30 @@
     color: inherit !important;
 }
 
+.nowPlayingArtistChapterLine {
+    display: flex;
+    gap: 0.5em;
+    align-items: baseline;
+    min-width: 0;
+}
+
+.nowPlayingArtist,
+.nowPlayingChapterName {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.nowPlayingChapterName {
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.nowPlayingChapterName::before {
+    content: "\2022";
+    margin-right: 0.5em;
+}
+
 .nowPlayingButtonsContainer {
     display: flex;
 
@@ -77,6 +101,22 @@
     margin: 0.2em 1em 0.2em 1em;
     width: 100%;
     z-index: 0;
+}
+
+.nowPlayingChapterBubble {
+    max-width: min(24em, 70vw);
+    padding: 0.5em 0.75em;
+    text-align: center;
+}
+
+.nowPlayingChapterBubble .sliderBubbleText {
+    padding: 0;
+}
+
+.nowPlayingChapterBubbleName {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .nowPlayingInfoButtons {


### PR DESCRIPTION
### Changes

Adds chapter-aware controls for audio playback when item chapters are provided by the server. This shows the current chapter beside the title and author text, adds chapter markers to the progress bar, adds chapters controls, and adds a chapter table-of-contents menu in the full Now Playing view. Playback item loading now requests Chapters so single-item and already-loaded audio playback paths can populate the controls. This relies on the server commit f5f75ed2e1b10dc1f4e55d5cdd9dd7fd69ea8f2b
feat/audiobook_chapters (#16518) which added the needed server side routes.

Before: 
<img width="2878" height="974" alt="image" src="https://github.com/user-attachments/assets/cf60d3d0-aac7-4c85-aafc-6b95d5477084" />
<img width="2878" height="126" alt="image" src="https://github.com/user-attachments/assets/35e9d313-7516-4718-b47c-071160596c04" />

Afterr:
<img width="2878" height="136" alt="image" src="https://github.com/user-attachments/assets/168ac174-5689-4c24-bac9-81bcddf7ca13" />
<img width="2878" height="1555" alt="image" src="https://github.com/user-attachments/assets/a0a2d46a-ce51-453a-9243-a18a4ad8e19f" />
<img width="2873" height="1641" alt="image" src="https://github.com/user-attachments/assets/87094348-2b5f-4b57-89ad-0dd9ea38bdfe" />

### Issues

None.

### Code assistance

Code assistance was used for adding comments to the code, and adding buttons/editing CSS where needed.
---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.