### PR TITLE
Avoid fetching Live TV route key as toolbar item

### DIFF
--- a/src/apps/modern/features/libraries/components/LibraryToolbar.tsx
+++ b/src/apps/modern/features/libraries/components/LibraryToolbar.tsx
@@ -27,6 +27,7 @@ import ViewSettingsButton from './ViewSettingsButton';
 
 import { useLibrary } from '../hooks/useLibrary';
 import { getDefaultLibraryViewSettings } from '../utils/settings';
+import { getToolbarParentItemId } from '../utils/toolbar';
 
 /** Views that only show the menu, not the toolbar buttons */
 const MENU_ONLY_VIEWS = [
@@ -57,7 +58,14 @@ const LibraryToolbar: FC = () => {
 
     const isSmallScreen = useMediaQuery(t => t.breakpoints.up('sm'));
 
-    const { data: item } = useItem(parentId || undefined);
+    const parentItemId = getToolbarParentItemId({
+        parentId,
+        collectionType,
+        isBtnPlayAllEnabled,
+        isBtnQueueEnabled,
+        isBtnShuffleEnabled
+    });
+    const { data: item } = useItem(parentItemId);
 
     const isPending = itemsResult?.isPending ?? true;
     const totalRecordCount = itemsResult?.data?.TotalRecordCount ?? 0;

--- a/src/apps/modern/features/libraries/utils/toolbar.test.ts
+++ b/src/apps/modern/features/libraries/utils/toolbar.test.ts
@@ -1,0 +1,37 @@
+import { CollectionType } from '@jellyfin/sdk/lib/generated-client/models/collection-type';
+import { describe, expect, it } from 'vitest';
+
+import { getToolbarParentItemId } from './toolbar';
+
+describe('getToolbarParentItemId', () => {
+    it('returns undefined when no item-backed toolbar buttons are enabled', () => {
+        expect(getToolbarParentItemId({
+            parentId: 'library-id',
+            collectionType: CollectionType.Movies
+        })).toBeUndefined();
+    });
+
+    it('returns the parent id when an item-backed toolbar button is enabled', () => {
+        expect(getToolbarParentItemId({
+            parentId: 'library-id',
+            collectionType: CollectionType.Movies,
+            isBtnPlayAllEnabled: true
+        })).toBe('library-id');
+    });
+
+    it('does not return the synthetic Live TV route key as an item id', () => {
+        expect(getToolbarParentItemId({
+            parentId: 'livetv',
+            collectionType: CollectionType.Livetv,
+            isBtnPlayAllEnabled: true
+        })).toBeUndefined();
+    });
+
+    it('returns undefined when there is no parent id', () => {
+        expect(getToolbarParentItemId({
+            parentId: null,
+            collectionType: CollectionType.Movies,
+            isBtnPlayAllEnabled: true
+        })).toBeUndefined();
+    });
+});

--- a/src/apps/modern/features/libraries/utils/toolbar.ts
+++ b/src/apps/modern/features/libraries/utils/toolbar.ts
@@ -1,0 +1,32 @@
+import { CollectionType } from '@jellyfin/sdk/lib/generated-client/models/collection-type';
+
+import type { ParentId } from 'types/library';
+
+interface GetToolbarParentItemIdOptions {
+    parentId: ParentId;
+    collectionType?: CollectionType;
+    isBtnPlayAllEnabled?: boolean;
+    isBtnQueueEnabled?: boolean;
+    isBtnShuffleEnabled?: boolean;
+}
+
+export function getToolbarParentItemId({
+    parentId,
+    collectionType,
+    isBtnPlayAllEnabled,
+    isBtnQueueEnabled,
+    isBtnShuffleEnabled
+}: GetToolbarParentItemIdOptions): string | undefined {
+    const needsParentItem = isBtnPlayAllEnabled || isBtnShuffleEnabled || isBtnQueueEnabled;
+
+    if (!needsParentItem || !parentId) {
+        return undefined;
+    }
+
+    // Live TV uses a synthetic route key as parentId, not a real library item id.
+    if (collectionType === CollectionType.Livetv) {
+        return undefined;
+    }
+
+    return parentId;
+}


### PR DESCRIPTION
### Changes

The modern library toolbar now only fetches the parent item when item-backed controls such as Play All, Shuffle, or Queue can use it.

Live TV uses a synthetic route key as its parent id, so the toolbar no longer treats it as an item id and no longer requests `/Items/livetv`.

Adds focused unit coverage for the toolbar parent-item selection logic.

### Issues

Fixes #8168

### Code assistance

Used Codex and Claude to review.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a substantive review of another web PR.
