### PR TITLE
Fix folder view card titles opening the typed library view

### DIFF
--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -415,7 +415,7 @@ function getCardFooterText(item, apiClient, options, footerClass, progressHtml, 
             Type: item.Type,
             CollectionType: item.CollectionType,
             IsFolder: item.IsFolder
-        }));
+        }, null, null, options.context));
     }
 
     if (showOtherText) {
@@ -609,9 +609,10 @@ function getCardFooterText(item, apiClient, options, footerClass, progressHtml, 
  * @param {Object} item - Item used to generate the action button.
  * @param {string} text - Text of the action button.
  * @param {string} serverId - ID of the server.
+ * @param {string} [context] - Router context (e.g. `folders`) used to resolve the link URL, so the title links to the same view as the card image.
  * @returns {string} HTML markup of the action button.
  */
-function getTextActionButton(item, text, serverId) {
+function getTextActionButton(item, text, serverId, context) {
     if (!text) {
         text = itemHelper.getDisplayName(item);
     }
@@ -622,7 +623,7 @@ function getTextActionButton(item, text, serverId) {
         return text;
     }
 
-    const url = appRouter.getRouteUrl(item);
+    const url = appRouter.getRouteUrl(item, { context });
     let html = '<a href="' + url + '" ' + itemShortcuts.getShortcutAttributesHtml(item, serverId) + ' class="itemAction textActionButton" title="' + text + `" data-action="${ItemAction.Link}">`;
     html += text;
     html += '</a>';


### PR DESCRIPTION
### Changes

In the Folders view, clicking a library card's title opened the typed library view (e.g. `#/movies`) while clicking the card image opened the generic folder view (`#/list`). The image link is dispatched through `shortcuts.js`, which forwards the card's router `context` (`data-context`) to `appRouter.showItem`, but the title link built by `getTextActionButton` called `appRouter.getRouteUrl` without any context. `getRouteUrl` only skips typed-view routing when `context === 'folders'`, so the title resolved to a different page than the image.

This threads the card's `options.context` through `getTextActionButton` into `getRouteUrl`, so a card's title links to the same view as its image. When no context is set (all other views) the resolved URL is unchanged.

### Issues

Fixes #5956

### Code assistance

Developed with the assistance of an LLM (Claude). It was used to locate the root cause across `cardBuilder.js` / `shortcuts.js` / `appRouter.js`, implement the one-file change, and run ESLint and the cardbuilder Vitest suite (113 passed). The change and its (nil) impact outside the folder view are reviewed and understood.

---

* [x] I have read and followed the contributing guidelines.
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of another web PR.
