### PR TITLE
Fix dark icons on card hover in light themes

### DIFF
--- a/src/components/cardbuilder/card.scss
+++ b/src/components/cardbuilder/card.scss
@@ -448,6 +448,11 @@ button::-moz-focus-inner {
     z-index: 1;
     padding: 0.75em;
     font-size: 88%;
+
+    /* The "modern" layout needs additional specificity to prevent MUI styles from overriding */
+    &.paper-icon-button-light {
+        color: rgba(255, 255, 255, 0.76);
+    }
 }
 
 .cardOverlayButton-br {


### PR DESCRIPTION
### Changes
Fixes the action buttons on cards having dark icons when using a light theme making them impossible to see

<img width="177" height="266" alt="Screenshot 2026-07-09 at 15-48-50 Display" src="https://github.com/user-attachments/assets/3e17371a-4912-45ef-8823-43ed24bdf270" />

### Issues
N/A

### Code assistance
Zed autocomplete

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
