### PR TITLE
Add type annotations to login/index.js

### DIFF
--- a/src/apps/dashboard/controllers/livetvguideprovider.js
+++ b/src/apps/dashboard/controllers/livetvguideprovider.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import loading from 'components/loading/loading';
 import globalize from 'lib/globalize';
 import Dashboard, { pageIdOn } from 'utils/dashboard';

--- a/src/apps/dashboard/controllers/livetvtuner.js
+++ b/src/apps/dashboard/controllers/livetvtuner.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import globalize from 'lib/globalize';
 import loading from 'components/loading/loading';
 import dom from 'utils/dom';

--- a/src/apps/legacy/controllers/edititemmetadata.js
+++ b/src/apps/legacy/controllers/edititemmetadata.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import loading from 'components/loading/loading';
 import { getCurrentItemId, setCurrentItemId } from 'scripts/editorsidebar';
 

--- a/src/apps/legacy/controllers/favorites.js
+++ b/src/apps/legacy/controllers/favorites.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { BaseItemKind } from '@jellyfin/sdk/lib/generated-client/models/base-item-kind';
 import { ImageType } from '@jellyfin/sdk/lib/generated-client/models/image-type';
 import { ItemFields } from '@jellyfin/sdk/lib/generated-client/models/item-fields';

--- a/src/apps/legacy/controllers/home.js
+++ b/src/apps/legacy/controllers/home.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import TabbedView from 'components/tabbedview/tabbedview';
 import globalize from 'lib/globalize';
 import 'elements/emby-tabs/emby-tabs';

--- a/src/apps/legacy/controllers/hometab.js
+++ b/src/apps/legacy/controllers/hometab.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as userSettings from 'scripts/settings/userSettings';
 import focusManager from 'components/focusManager';
 import homeSections from 'components/homesections/homesections';

--- a/src/apps/legacy/controllers/itemDetails/index.js
+++ b/src/apps/legacy/controllers/itemDetails/index.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { BaseItemKind } from '@jellyfin/sdk/lib/generated-client/models/base-item-kind';
 import { ItemFields } from '@jellyfin/sdk/lib/generated-client/models/item-fields';
 import { PersonKind } from '@jellyfin/sdk/lib/generated-client/models/person-kind';

--- a/src/apps/legacy/controllers/list.js
+++ b/src/apps/legacy/controllers/list.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import globalize from 'lib/globalize';
 import listView from 'components/listview/listview';
 import * as userSettings from 'scripts/settings/userSettings';

--- a/src/apps/legacy/controllers/livetv/livetvchannels.js
+++ b/src/apps/legacy/controllers/livetv/livetvchannels.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import cardBuilder from 'components/cardbuilder/cardBuilder';
 import imageLoader from 'components/images/imageLoader';
 import libraryBrowser from 'scripts/libraryBrowser';

--- a/src/apps/legacy/controllers/livetv/livetvguide.js
+++ b/src/apps/legacy/controllers/livetv/livetvguide.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import Guide from 'components/guide/guide';
 
 export default function (view, params, tabContent) {

--- a/src/apps/legacy/controllers/livetv/livetvrecordings.js
+++ b/src/apps/legacy/controllers/livetv/livetvrecordings.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import cardBuilder from 'components/cardbuilder/cardBuilder';
 import { getBackdropShape } from 'components/cardbuilder/utils/shape';
 import imageLoader from 'components/images/imageLoader';

--- a/src/apps/legacy/controllers/livetv/livetvschedule.js
+++ b/src/apps/legacy/controllers/livetv/livetvschedule.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import cardBuilder from 'components/cardbuilder/cardBuilder';
 import { getBackdropShape } from 'components/cardbuilder/utils/shape';
 import imageLoader from 'components/images/imageLoader';

--- a/src/apps/legacy/controllers/livetv/livetvseriestimers.js
+++ b/src/apps/legacy/controllers/livetv/livetvseriestimers.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import cardBuilder from 'components/cardbuilder/cardBuilder';
 import imageLoader from 'components/images/imageLoader';
 import loading from 'components/loading/loading';

--- a/src/apps/legacy/controllers/livetv/livetvsuggested.js
+++ b/src/apps/legacy/controllers/livetv/livetvsuggested.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import cardBuilder from 'components/cardbuilder/cardBuilder';
 import { getBackdropShape, getPortraitShape } from 'components/cardbuilder/utils/shape';
 import imageLoader from 'components/images/imageLoader';

--- a/src/apps/legacy/controllers/lyrics.js
+++ b/src/apps/legacy/controllers/lyrics.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { getLyricApi } from '@jellyfin/sdk/lib/utils/api/lyric-api';
 import escapeHtml from 'escape-html';
 

--- a/src/apps/legacy/controllers/movies/moviecollections.js
+++ b/src/apps/legacy/controllers/movies/moviecollections.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import loading from 'components/loading/loading';
 import libraryBrowser from 'scripts/libraryBrowser';
 import { AlphaPicker } from 'components/alphaPicker/alphaPicker';

--- a/src/apps/legacy/controllers/movies/moviegenres.js
+++ b/src/apps/legacy/controllers/movies/moviegenres.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import escapeHtml from 'escape-html';
 
 import cardBuilder from 'components/cardbuilder/cardBuilder';

--- a/src/apps/legacy/controllers/movies/movies.js
+++ b/src/apps/legacy/controllers/movies/movies.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import loading from 'components/loading/loading';
 import * as userSettings from 'scripts/settings/userSettings';
 import libraryBrowser from 'scripts/libraryBrowser';

--- a/src/apps/legacy/controllers/movies/moviesrecommended.js
+++ b/src/apps/legacy/controllers/movies/moviesrecommended.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import escapeHtml from 'escape-html';
 
 import cardBuilder from 'components/cardbuilder/cardBuilder';

--- a/src/apps/legacy/controllers/music/musicalbums.js
+++ b/src/apps/legacy/controllers/music/musicalbums.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { playbackManager } from 'components/playback/playbackmanager';
 import loading from 'components/loading/loading';
 import libraryBrowser from 'scripts/libraryBrowser';

--- a/src/apps/legacy/controllers/music/musicartists.js
+++ b/src/apps/legacy/controllers/music/musicartists.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import loading from 'components/loading/loading';
 import libraryBrowser from 'scripts/libraryBrowser';
 import imageLoader from 'components/images/imageLoader';

--- a/src/apps/legacy/controllers/music/musicgenres.js
+++ b/src/apps/legacy/controllers/music/musicgenres.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as userSettings from 'scripts/settings/userSettings';
 import cardBuilder from 'components/cardbuilder/cardBuilder';
 import imageLoader from 'components/images/imageLoader';

--- a/src/apps/legacy/controllers/music/musicplaylists.js
+++ b/src/apps/legacy/controllers/music/musicplaylists.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as userSettings from 'scripts/settings/userSettings';
 import cardBuilder from 'components/cardbuilder/cardBuilder';
 import imageLoader from 'components/images/imageLoader';

--- a/src/apps/legacy/controllers/music/musicrecommended.js
+++ b/src/apps/legacy/controllers/music/musicrecommended.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import cardBuilder from 'components/cardbuilder/cardBuilder';
 import { getSquareShape } from 'components/cardbuilder/utils/shape';
 import imageLoader from 'components/images/imageLoader';

--- a/src/apps/legacy/controllers/music/songs.js
+++ b/src/apps/legacy/controllers/music/songs.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 
 import libraryBrowser from 'scripts/libraryBrowser';
 import imageLoader from 'components/images/imageLoader';

--- a/src/apps/legacy/controllers/playback/queue/index.js
+++ b/src/apps/legacy/controllers/playback/queue/index.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import RemoteControl from 'components/remotecontrol/remotecontrol';
 import { playbackManager } from 'components/playback/playbackmanager';
 import { clearBackdrop } from 'components/backdrop/backdrop';

--- a/src/apps/legacy/controllers/playback/video/index.js
+++ b/src/apps/legacy/controllers/playback/video/index.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import escapeHtml from 'escape-html';
 
 import { PlayerEvent } from 'apps/legacy/features/playback/constants/playerEvent';

--- a/src/apps/legacy/controllers/session/addServer/index.js
+++ b/src/apps/legacy/controllers/session/addServer/index.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import loading from 'components/loading/loading';
 import globalize from 'lib/globalize';
 import { ConnectionState, ServerConnections } from 'lib/jellyfin-apiclient';

--- a/src/apps/legacy/controllers/session/login/index.js
+++ b/src/apps/legacy/controllers/session/login/index.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import DOMPurify from 'dompurify';
 import markdownIt from 'markdown-it';
 

--- a/src/apps/legacy/controllers/session/login/index.js
+++ b/src/apps/legacy/controllers/session/login/index.js
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import DOMPurify from 'dompurify';
 import markdownIt from 'markdown-it';
 
@@ -23,17 +22,31 @@ import { getDefaultBackgroundClass } from 'components/cardbuilder/utils/builder'
 
 import './login.scss';
 
+/**
+ * @typedef {import('jellyfin-apiclient').ApiClient} ApiClient
+ * @typedef {import('@jellyfin/sdk/lib/generated-client').AuthenticationResult} AuthenticationResult
+ * @typedef {import('@jellyfin/sdk/lib/generated-client').UserDto} UserDto
+ * @typedef {import('@jellyfin/sdk/lib/generated-client').BrandingOptionsDto} BrandingOptionsDto
+ */
+
 const enableFocusTransform = !browser.slow && !browser.edge;
 
+/**
+* @param {HTMLElement} page
+* @param {ApiClient} apiClient
+* @param {string} url
+* @param {string} username
+* @param {string} password
+*/
 function authenticateUserByName(page, apiClient, url, username, password) {
     loading.show();
     apiClient.authenticateUserByName(username, password).then(function (result) {
-        const user = result.User;
+        const user = /** @type {UserDto} */ (result.User);
         loading.hide();
 
         onLoginSuccessful(user.Id, result.AccessToken, apiClient, url);
     }, function (response) {
-        page.querySelector('#txtManualPassword').value = '';
+        /** @type {HTMLInputElement} */ (page.querySelector('#txtManualPassword')).value = '';
         loading.hide();
 
         const UnauthorizedOrForbidden = [401, 403];
@@ -49,8 +62,13 @@ function authenticateUserByName(page, apiClient, url, username, password) {
     });
 }
 
+/**
+ * @param {ApiClient} apiClient
+ * @param {string} targetUrl
+ */
 function authenticateQuickConnect(apiClient, targetUrl) {
     const url = apiClient.getUrl('/QuickConnect/Initiate');
+    // @ts-expect-error: The signature of ajax has just one argument. TODO: This should be investigated
     apiClient.ajax({ type: 'POST', url }, true).then(res => res.json()).then(function (json) {
         if (!json.Secret || !json.Code) {
             console.error('Malformed quick connect response', json);
@@ -82,7 +100,8 @@ function authenticateQuickConnect(apiClient, targetUrl) {
                 }
 
                 const result = await apiClient.quickConnect(data.Secret);
-                onLoginSuccessful(result.User.Id, result.AccessToken, apiClient, targetUrl);
+                const user = /** @type {UserDto} */ (result.User);
+                onLoginSuccessful(user.Id, result.AccessToken, apiClient, targetUrl);
             }, function (e) {
                 clearInterval(interval);
 
@@ -113,30 +132,50 @@ function authenticateQuickConnect(apiClient, targetUrl) {
     });
 }
 
+/**
+ * @param {string | null | undefined} id
+ * @param {string | null | undefined} accessToken
+ * @param {ApiClient} apiClient
+ * @param {string} url
+ */
 function onLoginSuccessful(id, accessToken, apiClient, url) {
     Dashboard.onServerChanged(id, accessToken, apiClient);
     Dashboard.navigate(url || 'home');
 }
 
+/**
+ * Hide the user cards (i.e., the '.visualLoginForm') and show the manual form
+ * @param {HTMLElement} context
+ * @param {boolean} showCancel
+ * @param {boolean?} [focusPassword]
+ */
 function showManualForm(context, showCancel, focusPassword) {
-    context.querySelector('.chkRememberLogin').checked = appSettings.enableAutoLogin();
-    context.querySelector('.manualLoginForm').classList.remove('hide');
-    context.querySelector('.visualLoginForm').classList.add('hide');
-    context.querySelector('.btnManual').classList.add('hide');
+    /** @type {HTMLInputElement}*/ (context.querySelector('.chkRememberLogin')).checked = appSettings.enableAutoLogin();
+    /** @type {Element} */ (context.querySelector('.manualLoginForm')).classList.remove('hide');
+    /** @type {Element} */ (context.querySelector('.visualLoginForm')).classList.add('hide');
+    /** @type {Element} */ (context.querySelector('.btnManual')).classList.add('hide');
 
     if (focusPassword) {
-        context.querySelector('#txtManualPassword').focus();
+        /** @type {HTMLInputElement}*/ (context.querySelector('#txtManualPassword')).focus();
     } else {
-        context.querySelector('#txtManualName').focus();
+        /** @type {HTMLInputElement}*/ (context.querySelector('#txtManualName')).focus();
     }
 
     if (showCancel) {
-        context.querySelector('.btnCancel').classList.remove('hide');
+        /** @type {Element} */ (context.querySelector('.btnCancel')).classList.remove('hide');
     } else {
-        context.querySelector('.btnCancel').classList.add('hide');
+        /** @type {Element} */ (context.querySelector('.btnCancel')).classList.add('hide');
     }
 }
 
+/**
+ * Transform UserDto objects into html and inject them into the user div (#divUsers).
+ * This creates the user icons for users that are not hidden on the login screen.
+ *
+ * @param {HTMLElement} context
+ * @param {ApiClient} apiClient
+ * @param {UserDto[]} users
+ */
 function loadUserList(context, apiClient, users) {
     let html = '';
 
@@ -161,7 +200,7 @@ function loadUserList(context, apiClient, users) {
         let imgUrl;
 
         if (user.PrimaryImageTag) {
-            imgUrl = apiClient.getUserImageUrl(user.Id, {
+            imgUrl = apiClient.getUserImageUrl(/** @type {string} */ (user.Id), {
                 width: 300,
                 tag: user.PrimaryImageTag,
                 type: 'Primary'
@@ -183,10 +222,15 @@ function loadUserList(context, apiClient, users) {
         html += '</button>';
     }
 
-    context.querySelector('#divUsers').innerHTML = html;
+    /** @type {Element} */ (context.querySelector('#divUsers')).innerHTML = html;
 }
 
+/**
+ * @param {HTMLElement} view
+ * @param {Object.<string, string>} params
+ */
 export default function (view, params) {
+    /** @returns {ApiClient} */
     function getApiClient() {
         const serverId = params.serverid;
 
@@ -194,9 +238,12 @@ export default function (view, params) {
             return ServerConnections.getOrCreateApiClient(serverId);
         }
 
+        // TODO: This should be investigated
+        // @ts-expect-error: It appears we're returning a type definition here instead of an instance of the object, but this code works, so it's not as it seems
         return ApiClient;
     }
 
+    /** @returns {string} */
     function getTargetUrl() {
         if (params.url) {
             try {
@@ -210,56 +257,63 @@ export default function (view, params) {
     }
 
     function showVisualForm() {
-        view.querySelector('.visualLoginForm').classList.remove('hide');
-        view.querySelector('.manualLoginForm').classList.add('hide');
-        view.querySelector('.btnManual').classList.remove('hide');
+        /** @type {Element} */ (view.querySelector('.visualLoginForm')).classList.remove('hide');
+        /** @type {Element} */ (view.querySelector('.manualLoginForm')).classList.add('hide');
+        /** @type {Element} */ (view.querySelector('.btnManual')).classList.remove('hide');
 
         import('components/autoFocuser').then(({ default: autoFocuser }) => {
             autoFocuser.autoFocus(view);
         });
     }
 
-    view.querySelector('#divUsers').addEventListener('click', function (e) {
-        const card = dom.parentWithClass(e.target, 'card');
+    // On user selected one of the user cards
+    /** @type {Element} */ (view.querySelector('#divUsers')).addEventListener('click', function (e) {
+        const card = dom.parentWithClass(/** @type {HTMLElement} */ (e.target), 'card');
         const cardContent = card ? card.querySelector('.cardContent') : null;
 
         if (cardContent) {
             const context = view;
             const id = cardContent.getAttribute('data-userid');
-            const name = cardContent.getAttribute('data-username');
+            const name = /** @type {string} */ (cardContent.getAttribute('data-username'));
             const haspw = cardContent.getAttribute('data-haspw');
 
             if (id === 'manual') {
-                context.querySelector('#txtManualName').value = '';
+                /** @type {HTMLInputElement} */ (context.querySelector('#txtManualName')).value = '';
                 showManualForm(context, true);
             } else if (haspw == 'false') {
                 authenticateUserByName(context, getApiClient(), getTargetUrl(), name, '');
             } else {
-                context.querySelector('#txtManualName').value = name;
-                context.querySelector('#txtManualPassword').value = '';
+                /** @type {HTMLInputElement} */ (context.querySelector('#txtManualName')).value = name;
+                /** @type {HTMLInputElement} */ (context.querySelector('#txtManualPassword')).value = '';
                 showManualForm(context, true, true);
             }
         }
     });
-    view.querySelector('.manualLoginForm').addEventListener('submit', function (e) {
-        appSettings.enableAutoLogin(view.querySelector('.chkRememberLogin').checked);
-        authenticateUserByName(view, getApiClient(), getTargetUrl(), view.querySelector('#txtManualName').value, view.querySelector('#txtManualPassword').value);
+    /** @type {Element} */ (view.querySelector('.manualLoginForm')).addEventListener('submit', function (e) {
+        appSettings.enableAutoLogin(/** @type {HTMLInputElement} */ (view.querySelector('.chkRememberLogin')).checked);
+        authenticateUserByName(
+            view,
+            getApiClient(),
+            getTargetUrl(),
+            /** @type {HTMLInputElement} */ (view.querySelector('#txtManualName')).value,
+            /** @type {HTMLInputElement} */ (view.querySelector('#txtManualPassword')).value
+        );
         e.preventDefault();
         return false;
     });
-    view.querySelector('.btnForgotPassword').addEventListener('click', function () {
+    /** @type {Element} */ (view.querySelector('.btnForgotPassword')).addEventListener('click', function () {
         Dashboard.navigate('forgotpassword');
     });
-    view.querySelector('.btnCancel').addEventListener('click', showVisualForm);
-    view.querySelector('.btnQuick').addEventListener('click', function () {
+    /** @type {Element} */ (view.querySelector('.btnCancel')).addEventListener('click', showVisualForm);
+    /** @type {Element} */ (view.querySelector('.btnQuick')).addEventListener('click', function () {
         authenticateQuickConnect(getApiClient(), getTargetUrl());
         return false;
     });
-    view.querySelector('.btnManual').addEventListener('click', function () {
-        view.querySelector('#txtManualName').value = '';
+    /** @type {Element} */ (view.querySelector('.btnManual')).addEventListener('click', function () {
+        /** @type {HTMLInputElement} */ (view.querySelector('#txtManualName')).value = '';
         showManualForm(view, true);
     });
-    view.querySelector('.btnSelectServer').addEventListener('click', function () {
+    /** @type {Element} */ (view.querySelector('.btnSelectServer')).addEventListener('click', function () {
         Dashboard.selectServer();
     });
 
@@ -268,7 +322,7 @@ export default function (view, params) {
         libraryMenu.setTransparentMenu(true);
 
         if (!appHost.supports(AppFeature.MultiServer)) {
-            view.querySelector('.btnSelectServer').classList.add('hide');
+            /** @type {Element} */ (view.querySelector('.btnSelectServer')).classList.add('hide');
         }
 
         const apiClient = getApiClient();
@@ -276,7 +330,7 @@ export default function (view, params) {
         apiClient.getQuickConnect('Enabled')
             .then(enabled => {
                 if (enabled === true) {
-                    view.querySelector('.btnQuick').classList.remove('hide');
+                    /** @type {Element} */ (view.querySelector('.btnQuick')).classList.remove('hide');
                 }
             })
             .catch(() => {
@@ -288,14 +342,14 @@ export default function (view, params) {
                 showVisualForm();
                 loadUserList(view, apiClient, users);
             } else {
-                view.querySelector('#txtManualName').value = '';
+                /** @type {HTMLInputElement} */ (view.querySelector('#txtManualName')).value = '';
                 showManualForm(view, false, false);
             }
         }).catch().then(function () {
             loading.hide();
         });
-        apiClient.getJSON(apiClient.getUrl('Branding/Configuration')).then(function (options) {
-            const loginDisclaimer = view.querySelector('.loginDisclaimer');
+        apiClient.getJSON(apiClient.getUrl('Branding/Configuration')).then(/** @param {BrandingOptionsDto} options */ function (options) {
+            const loginDisclaimer = /** @type {Element} */ (view.querySelector('.loginDisclaimer'));
 
             // eslint-disable-next-line sonarjs/disabled-auto-escaping
             loginDisclaimer.innerHTML = DOMPurify.sanitize(markdownIt({ html: true }).render(options.LoginDisclaimer || ''));

--- a/src/apps/legacy/controllers/session/resetPassword/index.js
+++ b/src/apps/legacy/controllers/session/resetPassword/index.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import globalize from 'lib/globalize';
 import Dashboard from 'utils/dashboard';
 

--- a/src/apps/legacy/controllers/session/selectServer/index.js
+++ b/src/apps/legacy/controllers/session/selectServer/index.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import escapeHtml from 'escape-html';
 import loading from 'components/loading/loading';
 import { appRouter } from 'components/router/appRouter';

--- a/src/apps/legacy/controllers/shows/episodes.js
+++ b/src/apps/legacy/controllers/shows/episodes.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import loading from 'components/loading/loading';
 import libraryBrowser from 'scripts/libraryBrowser';
 import imageLoader from 'components/images/imageLoader';

--- a/src/apps/legacy/controllers/shows/tvgenres.js
+++ b/src/apps/legacy/controllers/shows/tvgenres.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import escapeHtml from 'escape-html';
 
 import cardBuilder from 'components/cardbuilder/cardBuilder';

--- a/src/apps/legacy/controllers/shows/tvrecommended.js
+++ b/src/apps/legacy/controllers/shows/tvrecommended.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import autoFocuser from 'components/autoFocuser';
 import cardBuilder from 'components/cardbuilder/cardBuilder';
 import { getBackdropShape } from 'components/cardbuilder/utils/shape';

--- a/src/apps/legacy/controllers/shows/tvshows.js
+++ b/src/apps/legacy/controllers/shows/tvshows.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import loading from 'components/loading/loading';
 import libraryBrowser from 'scripts/libraryBrowser';
 import imageLoader from 'components/images/imageLoader';

--- a/src/apps/legacy/controllers/shows/tvstudios.js
+++ b/src/apps/legacy/controllers/shows/tvstudios.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import loading from 'components/loading/loading';
 import cardBuilder from 'components/cardbuilder/cardBuilder';
 

--- a/src/apps/legacy/controllers/shows/tvupcoming.js
+++ b/src/apps/legacy/controllers/shows/tvupcoming.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import cardBuilder from 'components/cardbuilder/cardBuilder';
 import { getBackdropShape } from 'components/cardbuilder/utils/shape';
 import imageLoader from 'components/images/imageLoader';

--- a/src/apps/legacy/controllers/user/controls/index.js
+++ b/src/apps/legacy/controllers/user/controls/index.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import layoutManager from 'components/layoutManager';
 import toast from 'components/toast/toast';
 import globalize from 'lib/globalize';

--- a/src/apps/legacy/controllers/user/display/index.js
+++ b/src/apps/legacy/controllers/user/display/index.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import DisplaySettings from 'components/displaySettings/displaySettings';
 import * as userSettings from 'scripts/settings/userSettings';
 import autoFocuser from 'components/autoFocuser';

--- a/src/apps/legacy/controllers/user/home/index.js
+++ b/src/apps/legacy/controllers/user/home/index.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import HomescreenSettings from 'components/homeScreenSettings/homeScreenSettings';
 import * as userSettings from 'scripts/settings/userSettings';
 import autoFocuser from 'components/autoFocuser';

--- a/src/apps/legacy/controllers/user/playback/index.js
+++ b/src/apps/legacy/controllers/user/playback/index.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 
 import PlaybackSettings from 'components/playbackSettings/playbackSettings';
 import * as userSettings from 'scripts/settings/userSettings';

--- a/src/apps/legacy/controllers/user/subtitles/index.js
+++ b/src/apps/legacy/controllers/user/subtitles/index.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import SubtitleSettings from 'components/subtitlesettings/subtitlesettings';
 import * as userSettings from 'scripts/settings/userSettings';
 import autoFocuser from 'components/autoFocuser';

--- a/src/apps/wizard/controllers/finish/index.js
+++ b/src/apps/wizard/controllers/finish/index.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import loading from 'components/loading/loading';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
 

--- a/src/apps/wizard/controllers/library.js
+++ b/src/apps/wizard/controllers/library.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import escapeHtml from 'escape-html';
 
 import { getDefaultBackgroundClass } from 'components/cardbuilder/utils/builder';

--- a/src/apps/wizard/controllers/remote/index.js
+++ b/src/apps/wizard/controllers/remote/index.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import loading from 'components/loading/loading';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
 import Dashboard from 'utils/dashboard';

--- a/src/apps/wizard/controllers/settings/index.js
+++ b/src/apps/wizard/controllers/settings/index.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import loading from 'components/loading/loading';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
 import Dashboard from 'utils/dashboard';

--- a/src/apps/wizard/controllers/start/index.js
+++ b/src/apps/wizard/controllers/start/index.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import loading from 'components/loading/loading';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
 import Dashboard from 'utils/dashboard';

--- a/src/apps/wizard/controllers/user/index.js
+++ b/src/apps/wizard/controllers/user/index.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import loading from 'components/loading/loading';
 import toast from 'components/toast/toast';
 import globalize from 'lib/globalize';

--- a/src/components/accessSchedule/accessSchedule.js
+++ b/src/components/accessSchedule/accessSchedule.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Module for controlling user parental control from.
  * @module components/accessSchedule/accessSchedule

--- a/src/components/alert.js
+++ b/src/components/alert.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { appRouter } from './router/appRouter';
 import dialog from './dialog/dialog';
 import globalize from '../lib/globalize';

--- a/src/components/alphaPicker/alphaPicker.js
+++ b/src/components/alphaPicker/alphaPicker.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Module alphaPicker.
  * @module components/alphaPicker/alphaPicker

--- a/src/components/appFooter/appFooter.js
+++ b/src/components/appFooter/appFooter.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import './appFooter.scss';
 
 function render() {

--- a/src/components/apphost.js
+++ b/src/components/apphost.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import appSettings from '../scripts/settings/appSettings';
 import browser from '../scripts/browser';
 import Events from '../utils/events.ts';

--- a/src/components/autoFocuser.js
+++ b/src/components/autoFocuser.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Module for performing auto-focus.
  * @module components/autoFocuser

--- a/src/components/backdrop/backdrop.js
+++ b/src/components/backdrop/backdrop.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import isEqual from 'lodash-es/isEqual';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
 import browser from '../../scripts/browser';

--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 
 /**
  * Module for building cards from item data.

--- a/src/components/cardbuilder/chaptercardbuilder.js
+++ b/src/components/cardbuilder/chaptercardbuilder.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 
 /**
  * Module for building cards from item data.

--- a/src/components/cardbuilder/peoplecardbuilder.js
+++ b/src/components/cardbuilder/peoplecardbuilder.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 
 /**
  * Module for building cards from item data.

--- a/src/components/channelMapper/channelMapper.js
+++ b/src/components/channelMapper/channelMapper.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import escapeHtml from 'escape-html';
 import dom from '../../utils/dom';
 import dialogHelper from '../dialogHelper/dialogHelper';

--- a/src/components/collectionEditor/collectionEditor.js
+++ b/src/components/collectionEditor/collectionEditor.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import escapeHtml from 'escape-html';
 import dom from '../../utils/dom';
 import dialogHelper from '../dialogHelper/dialogHelper';

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import DOMPurify from 'dompurify';
 import escapeHtml from 'escape-html';
 import dialogHelper from '../dialogHelper/dialogHelper';

--- a/src/components/dialogHelper/dialogHelper.js
+++ b/src/components/dialogHelper/dialogHelper.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import focusManager from '../focusManager';
 import browser from '../../scripts/browser';
 import layoutManager from '../layoutManager';

--- a/src/components/directorybrowser/directorybrowser.js
+++ b/src/components/directorybrowser/directorybrowser.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import escapeHtml from 'escape-html';
 import loading from '../loading/loading';
 import dialogHelper from '../dialogHelper/dialogHelper';

--- a/src/components/displaySettings/displaySettings.js
+++ b/src/components/displaySettings/displaySettings.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import escapeHtml from 'escape-html';
 
 import { AppFeature } from 'constants/appFeature';

--- a/src/components/favoriteitems.js
+++ b/src/components/favoriteitems.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { getBackdropShape, getPortraitShape, getSquareShape } from 'components/cardbuilder/utils/shape';
 import dom from 'utils/dom';
 import globalize from 'lib/globalize';

--- a/src/components/filterdialog/filterIndicator.js
+++ b/src/components/filterdialog/filterIndicator.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import './filterIndicator.scss';
 
 export function getFilterStatus(query) {

--- a/src/components/filterdialog/filterdialog.js
+++ b/src/components/filterdialog/filterdialog.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import dom from '../../utils/dom';
 import dialogHelper from '../dialogHelper/dialogHelper';
 import globalize from '../../lib/globalize';

--- a/src/components/filtermenu/filtermenu.js
+++ b/src/components/filtermenu/filtermenu.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import escapeHtml from 'escape-html';
 import dom from '../../utils/dom';
 import focusManager from '../focusManager';

--- a/src/components/focusManager.js
+++ b/src/components/focusManager.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import dom from '../utils/dom';
 import scrollManager from './scrollManager';
 

--- a/src/components/groupedcards.js
+++ b/src/components/groupedcards.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { ServerConnections } from 'lib/jellyfin-apiclient';
 import dom from '../utils/dom';
 import { appRouter } from './router/appRouter';

--- a/src/components/guide/guide-settings.js
+++ b/src/components/guide/guide-settings.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import dialogHelper from '../dialogHelper/dialogHelper';
 import globalize from '../../lib/globalize';
 import * as userSettings from '../../scripts/settings/userSettings';

--- a/src/components/guide/guide.js
+++ b/src/components/guide/guide.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import escapeHtml from 'escape-html';
 
 import { ItemAction } from 'constants/itemAction';

--- a/src/components/homeScreenSettings/homeScreenSettings.js
+++ b/src/components/homeScreenSettings/homeScreenSettings.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 
 import escapeHtml from 'escape-html';
 

--- a/src/components/homesections/homesections.js
+++ b/src/components/homesections/homesections.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import layoutManager from 'components/layoutManager';
 import { DEFAULT_SECTIONS, HomeSectionType } from 'constants/homeSectionType';
 import { getUserViewsQuery } from 'hooks/api/useUserViews';

--- a/src/components/htmlMediaHelper.js
+++ b/src/components/htmlMediaHelper.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import appSettings from '../scripts/settings/appSettings' ;
 import browser from '../scripts/browser';
 import Events from '../utils/events.ts';

--- a/src/components/imageDownloader/imageDownloader.js
+++ b/src/components/imageDownloader/imageDownloader.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { AppFeature } from 'constants/appFeature';
 import dom from '../../utils/dom';
 import loading from '../loading/loading';

--- a/src/components/imageOptionsEditor/imageOptionsEditor.js
+++ b/src/components/imageOptionsEditor/imageOptionsEditor.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 
 /**
  * Module for image Options Editor.

--- a/src/components/imageUploader/imageUploader.js
+++ b/src/components/imageUploader/imageUploader.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 
 /**
  * Module for imageUploader.

--- a/src/components/imageeditor/imageeditor.js
+++ b/src/components/imageeditor/imageeditor.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { AppFeature } from 'constants/appFeature';
 import { queryClient } from 'utils/query/queryClient';
 

--- a/src/components/images/imageLoader.js
+++ b/src/components/images/imageLoader.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import Worker from './blurhash.worker.ts'; // eslint-disable-line import/default
 import * as lazyLoader from '../lazyLoader/lazyLoaderIntersectionObserver';
 import * as userSettings from '../../scripts/settings/userSettings';

--- a/src/components/indicators/indicators.js
+++ b/src/components/indicators/indicators.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import datetime from '../../scripts/datetime';
 import itemHelper from '../itemHelper';
 import '../../elements/emby-progressbar/emby-progressbar';

--- a/src/components/itemContextMenu.js
+++ b/src/components/itemContextMenu.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { BaseItemKind } from '@jellyfin/sdk/lib/generated-client/models/base-item-kind';
 import { getLibraryApi } from '@jellyfin/sdk/lib/utils/api/library-api';
 

--- a/src/components/itemHelper.js
+++ b/src/components/itemHelper.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { CollectionType } from '@jellyfin/sdk/lib/generated-client/models/collection-type';
 import { BaseItemKind } from '@jellyfin/sdk/lib/generated-client/models/base-item-kind';
 import { LocationType } from '@jellyfin/sdk/lib/generated-client/models/location-type';

--- a/src/components/itemMediaInfo/itemMediaInfo.js
+++ b/src/components/itemMediaInfo/itemMediaInfo.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 
 /**
  * Module for display media info.

--- a/src/components/itemidentifier/itemidentifier.js
+++ b/src/components/itemidentifier/itemidentifier.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 
 /**
  * Module for itemidentifier media item.

--- a/src/components/layoutManager.js
+++ b/src/components/layoutManager.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { LayoutMode, LegacyLayoutModes } from 'constants/layoutMode';
 
 import { appHost } from './apphost';

--- a/src/components/lazyLoader/lazyLoaderIntersectionObserver.js
+++ b/src/components/lazyLoader/lazyLoaderIntersectionObserver.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 
 export class LazyLoader {
     constructor(options) {

--- a/src/components/libraryoptionseditor/libraryoptionseditor.js
+++ b/src/components/libraryoptionseditor/libraryoptionseditor.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 
 /**
  * Module for library options editor.

--- a/src/components/listview/listview.js
+++ b/src/components/listview/listview.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 
 /**
  * Module for display list view.

--- a/src/components/lyricseditor/lyricseditor.js
+++ b/src/components/lyricseditor/lyricseditor.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import escapeHtml from 'escape-html';
 
 import { getLyricApi } from '@jellyfin/sdk/lib/utils/api/lyric-api';

--- a/src/components/lyricsuploader/lyricsuploader.js
+++ b/src/components/lyricsuploader/lyricsuploader.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import escapeHtml from 'escape-html';
 import { getLyricApi } from '@jellyfin/sdk/lib/utils/api/lyric-api';
 

--- a/src/components/maintabsmanager.js
+++ b/src/components/maintabsmanager.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import dom from '../utils/dom';
 import browser from '../scripts/browser';
 import layoutManager from './layoutManager';

--- a/src/components/mediaLibraryCreator/mediaLibraryCreator.js
+++ b/src/components/mediaLibraryCreator/mediaLibraryCreator.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 
 /**
  * Module for media library creator.

--- a/src/components/mediaLibraryEditor/mediaLibraryEditor.js
+++ b/src/components/mediaLibraryEditor/mediaLibraryEditor.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Module for media library editor.
  * @module components/mediaLibraryEditor/mediaLibraryEditor

--- a/src/components/mediainfo/mediainfo.js
+++ b/src/components/mediainfo/mediainfo.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import escapeHtml from 'escape-html';
 import datetime from '../../scripts/datetime';
 import globalize from '../../lib/globalize';

--- a/src/components/metadataEditor/metadataEditor.js
+++ b/src/components/metadataEditor/metadataEditor.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import escapeHtml from 'escape-html';
 import dom from '../../utils/dom';
 import layoutManager from '../layoutManager';

--- a/src/components/metadataEditor/personEditor.js
+++ b/src/components/metadataEditor/personEditor.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { PersonKind } from '@jellyfin/sdk/lib/generated-client/models/person-kind';
 
 import dialogHelper from '../dialogHelper/dialogHelper';

--- a/src/components/multiSelect/multiSelect.js
+++ b/src/components/multiSelect/multiSelect.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { BaseItemKind } from '@jellyfin/sdk/lib/generated-client/models/base-item-kind';
 
 import { AppFeature } from 'constants/appFeature';

--- a/src/components/notifications/notifications.js
+++ b/src/components/notifications/notifications.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { playbackManager } from '../playback/playbackmanager';
 import Events from '../../utils/events.ts';
 import globalize from '../../lib/globalize';

--- a/src/components/nowPlayingBar/nowPlayingBar.js
+++ b/src/components/nowPlayingBar/nowPlayingBar.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { getImageUrl } from 'apps/legacy/features/playback/utils/image';
 import { getItemTextLines } from 'apps/legacy/features/playback/utils/itemText';
 import { appRouter, isLyricsPage } from 'components/router/appRouter';

--- a/src/components/playback/brightnessosd.js
+++ b/src/components/playback/brightnessosd.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { playbackManager } from './playbackmanager';
 import dom from '../../utils/dom';
 import browser from '../../scripts/browser';

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { BaseItemKind } from '@jellyfin/sdk/lib/generated-client/models/base-item-kind';
 import { ItemFilter } from '@jellyfin/sdk/lib/generated-client/models/item-filter';
 import { ItemSortBy } from '@jellyfin/sdk/lib/generated-client/models/item-sort-by';

--- a/src/components/playback/playbackorientation.js
+++ b/src/components/playback/playbackorientation.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { playbackManager } from './playbackmanager';
 import layoutManager from '../layoutManager';
 import Events from '../../utils/events.ts';

--- a/src/components/playback/playerSelectionMenu.js
+++ b/src/components/playback/playerSelectionMenu.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { AppFeature } from 'constants/appFeature';
 import Events from '../../utils/events.ts';
 import browser from '../../scripts/browser';

--- a/src/components/playback/playersettingsmenu.js
+++ b/src/components/playback/playersettingsmenu.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import actionsheet from '../actionSheet/actionSheet';
 import { playbackManager } from '../playback/playbackmanager';
 import globalize from 'lib/globalize';

--- a/src/components/playback/playmethodhelper.js
+++ b/src/components/playback/playmethodhelper.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 export function getDisplayPlayMethod(session) {
     if (!session.NowPlayingItem) {
         return null;

--- a/src/components/playback/playqueuemanager.js
+++ b/src/components/playback/playqueuemanager.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { randomInt } from '../../utils/number.ts';
 
 let currentId = 0;

--- a/src/components/playback/remotecontrolautoplay.js
+++ b/src/components/playback/remotecontrolautoplay.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { playbackManager } from '../playback/playbackmanager';
 import Events from '../../utils/events.ts';
 

--- a/src/components/playback/volumeosd.js
+++ b/src/components/playback/volumeosd.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 
 import { playbackManager } from './playbackmanager';
 import dom from '../../utils/dom';

--- a/src/components/playbackSettings/playbackSettings.js
+++ b/src/components/playbackSettings/playbackSettings.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { MediaSegmentType } from '@jellyfin/sdk/lib/generated-client/models/media-segment-type';
 import escapeHTML from 'escape-html';
 

--- a/src/components/playerstats/playerstats.js
+++ b/src/components/playerstats/playerstats.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { PluginType } from 'constants/pluginType';
 import globalize from 'lib/globalize';
 import { ServerConnections } from 'lib/jellyfin-apiclient';

--- a/src/components/playmenu.js
+++ b/src/components/playmenu.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import actionsheet from './actionSheet/actionSheet';
 import datetime from '../scripts/datetime';
 import { playbackManager } from './playback/playbackmanager';

--- a/src/components/pluginManager.js
+++ b/src/components/pluginManager.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import Events from '../utils/events.ts';
 import globalize from '../lib/globalize';
 import loading from './loading/loading';

--- a/src/components/prompt/prompt.js
+++ b/src/components/prompt/prompt.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import dialogHelper from '../dialogHelper/dialogHelper';
 import layoutManager from '../layoutManager';
 import scrollHelper from '../../scripts/scrollHelper';

--- a/src/components/qualityOptions.js
+++ b/src/components/qualityOptions.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import globalize from '../lib/globalize';
 
 export function getVideoQualityOptions(options) {

--- a/src/components/recordingcreator/recordingbutton.js
+++ b/src/components/recordingcreator/recordingbutton.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { ServerConnections } from 'lib/jellyfin-apiclient';
 import dom from '../../utils/dom';
 import recordingHelper from './recordinghelper';

--- a/src/components/recordingcreator/recordingcreator.js
+++ b/src/components/recordingcreator/recordingcreator.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import dialogHelper from '../dialogHelper/dialogHelper';
 import globalize from '../../lib/globalize';
 import { ServerConnections } from 'lib/jellyfin-apiclient';

--- a/src/components/recordingcreator/recordingeditor.js
+++ b/src/components/recordingcreator/recordingeditor.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 
 import dialogHelper from '../dialogHelper/dialogHelper';
 import globalize from '../../lib/globalize';

--- a/src/components/recordingcreator/recordingfields.js
+++ b/src/components/recordingcreator/recordingfields.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import globalize from '../../lib/globalize';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
 import { OutboundWebSocketMessageType } from '@jellyfin/sdk/lib/websocket';

--- a/src/components/recordingcreator/recordinghelper.js
+++ b/src/components/recordingcreator/recordinghelper.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import globalize from 'lib/globalize';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
 import loading from '../loading/loading';

--- a/src/components/recordingcreator/seriesrecordingeditor.js
+++ b/src/components/recordingcreator/seriesrecordingeditor.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import dialogHelper from '../dialogHelper/dialogHelper';
 import globalize from '../../lib/globalize';
 import { ServerConnections } from 'lib/jellyfin-apiclient';

--- a/src/components/refreshdialog/refreshdialog.js
+++ b/src/components/refreshdialog/refreshdialog.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import dom from '../../utils/dom';
 import dialogHelper from '../dialogHelper/dialogHelper';
 import loading from '../loading/loading';

--- a/src/components/remotecontrol/remotecontrol.js
+++ b/src/components/remotecontrol/remotecontrol.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import escapeHtml from 'escape-html';
 
 import { getImageUrl } from 'apps/legacy/features/playback/utils/image';

--- a/src/components/router/appRouter.js
+++ b/src/components/router/appRouter.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { CollectionType } from '@jellyfin/sdk/lib/generated-client/models/collection-type';
 
 import { setBackdropTransparency } from '../backdrop/backdrop';

--- a/src/components/sanitizeFilename.js
+++ b/src/components/sanitizeFilename.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 // TODO: Check if needed and move to external dependency
 // From https://github.com/parshap/node-sanitize-filename
 

--- a/src/components/scrollManager.js
+++ b/src/components/scrollManager.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Module for controlling scroll behavior.
  * @module components/scrollManager

--- a/src/components/settingshelper.js
+++ b/src/components/settingshelper.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import globalize from 'lib/globalize';
 
 /**

--- a/src/components/shortcuts.js
+++ b/src/components/shortcuts.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * "Shortcut" action handlers for BaseItems.
  */

--- a/src/components/slideshow/slideshow.js
+++ b/src/components/slideshow/slideshow.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Image viewer component
  * @module components/slideshow/slideshow

--- a/src/components/sortmenu/sortmenu.js
+++ b/src/components/sortmenu/sortmenu.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import dialogHelper from '../dialogHelper/dialogHelper';
 import layoutManager from '../layoutManager';
 import globalize from '../../lib/globalize';

--- a/src/components/subtitleeditor/subtitleeditor.js
+++ b/src/components/subtitleeditor/subtitleeditor.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import escapeHtml from 'escape-html';
 
 import { AppFeature } from 'constants/appFeature';

--- a/src/components/subtitlesettings/subtitleappearancehelper.js
+++ b/src/components/subtitlesettings/subtitleappearancehelper.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Subtitle settings visual helper.
  * @module components/subtitleSettings/subtitleAppearanceHelper

--- a/src/components/subtitlesettings/subtitlesettings.js
+++ b/src/components/subtitlesettings/subtitlesettings.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { AppFeature } from 'constants/appFeature';
 import globalize from '../../lib/globalize';
 import { ServerConnections } from 'lib/jellyfin-apiclient';

--- a/src/components/subtitlesync/subtitlesync.js
+++ b/src/components/subtitlesync/subtitlesync.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 
 import { playbackManager } from '../playback/playbackmanager';
 import layoutManager from '../layoutManager';

--- a/src/components/subtitleuploader/subtitleuploader.js
+++ b/src/components/subtitleuploader/subtitleuploader.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import escapeHtml from 'escape-html';
 import { getSubtitleApi } from '@jellyfin/sdk/lib/utils/api/subtitle-api';
 

--- a/src/components/tabbedview/tabbedview.js
+++ b/src/components/tabbedview/tabbedview.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { clearBackdrop } from '../backdrop/backdrop';
 import * as mainTabsManager from '../maintabsmanager';
 import layoutManager from '../layoutManager';

--- a/src/components/themeMediaPlayer.js
+++ b/src/components/themeMediaPlayer.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { ItemSortBy } from '@jellyfin/sdk/lib/generated-client/models/item-sort-by';
 import { MediaType } from '@jellyfin/sdk/lib/generated-client/models/media-type';
 import { getLibraryApi } from '@jellyfin/sdk/lib/utils/api/library-api';

--- a/src/components/tunerPicker.js
+++ b/src/components/tunerPicker.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import dialogHelper from './dialogHelper/dialogHelper';
 import dom from '../utils/dom';
 import layoutManager from './layoutManager';

--- a/src/components/tvproviders/schedulesdirect.js
+++ b/src/components/tvproviders/schedulesdirect.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import 'jquery';
 import loading from '../loading/loading';
 import globalize from '../../lib/globalize';

--- a/src/components/tvproviders/xmltv.js
+++ b/src/components/tvproviders/xmltv.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import 'jquery';
 import loading from '../loading/loading';
 import globalize from '../../lib/globalize';

--- a/src/components/upnextdialog/upnextdialog.js
+++ b/src/components/upnextdialog/upnextdialog.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import dom from '../../utils/dom';
 import { playbackManager } from '../playback/playbackmanager';
 import Events from '../../utils/events.ts';

--- a/src/components/userdatabuttons/userdatabuttons.js
+++ b/src/components/userdatabuttons/userdatabuttons.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import globalize from '../../lib/globalize';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
 import dom from '../../utils/dom';

--- a/src/components/viewContainer.js
+++ b/src/components/viewContainer.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { importModule } from '@uupaa/dynamic-import-polyfill';
 import './viewManager/viewContainer.scss';
 import Dashboard from '../utils/dashboard';

--- a/src/components/viewManager/viewManager.js
+++ b/src/components/viewManager/viewManager.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import viewContainer from '../viewContainer';
 import focusManager from '../focusManager';
 import layoutManager from '../layoutManager';

--- a/src/components/viewSettings/viewSettings.js
+++ b/src/components/viewSettings/viewSettings.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import dialogHelper from '../dialogHelper/dialogHelper';
 import layoutManager from '../layoutManager';
 import globalize from '../../lib/globalize';

--- a/src/elements/emby-button/emby-button.js
+++ b/src/elements/emby-button/emby-button.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import 'webcomponents.js/webcomponents-lite';
 
 import { appHost } from 'components/apphost';

--- a/src/elements/emby-button/paper-icon-button-light.js
+++ b/src/elements/emby-button/paper-icon-button-light.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import layoutManager from '../../components/layoutManager';
 import './emby-button.scss';
 import 'webcomponents.js/webcomponents-lite';

--- a/src/elements/emby-checkbox/emby-checkbox.js
+++ b/src/elements/emby-checkbox/emby-checkbox.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import browser from '../../scripts/browser';
 import dom from '../../utils/dom';
 import './emby-checkbox.scss';

--- a/src/elements/emby-collapse/emby-collapse.js
+++ b/src/elements/emby-collapse/emby-collapse.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import './emby-collapse.scss';
 import 'webcomponents.js/webcomponents-lite';
 import '../emby-button/emby-button';

--- a/src/elements/emby-input/emby-input.js
+++ b/src/elements/emby-input/emby-input.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import browser from '../../scripts/browser';
 import dom from '../../utils/dom';
 import './emby-input.scss';

--- a/src/elements/emby-itemrefreshindicator/emby-itemrefreshindicator.js
+++ b/src/elements/emby-itemrefreshindicator/emby-itemrefreshindicator.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import EmbyProgressRing from '../emby-progressring/emby-progressring';
 import dom from '../../utils/dom';
 import { ServerConnections } from 'lib/jellyfin-apiclient';

--- a/src/elements/emby-itemscontainer/emby-itemscontainer.js
+++ b/src/elements/emby-itemscontainer/emby-itemscontainer.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import 'webcomponents.js/webcomponents-lite';
 import Sortable from 'sortablejs';
 

--- a/src/elements/emby-playstatebutton/emby-playstatebutton.js
+++ b/src/elements/emby-playstatebutton/emby-playstatebutton.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import globalize from '../../lib/globalize';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
 import { OutboundWebSocketMessageType } from '@jellyfin/sdk/lib/websocket';

--- a/src/elements/emby-programcell/emby-programcell.js
+++ b/src/elements/emby-programcell/emby-programcell.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 const ProgramCellPrototype = Object.create(HTMLButtonElement.prototype);
 
 ProgramCellPrototype.detachedCallback = function () {

--- a/src/elements/emby-progressbar/emby-progressbar.js
+++ b/src/elements/emby-progressbar/emby-progressbar.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 
 const ProgressBarPrototype = Object.create(HTMLDivElement.prototype);
 

--- a/src/elements/emby-progressring/emby-progressring.js
+++ b/src/elements/emby-progressring/emby-progressring.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import './emby-progressring.scss';
 import 'webcomponents.js/webcomponents-lite';
 import template from './emby-progressring.template.html';

--- a/src/elements/emby-radio/emby-radio.js
+++ b/src/elements/emby-radio/emby-radio.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import layoutManager from '../../components/layoutManager';
 import browser from '../../scripts/browser';
 import 'webcomponents.js/webcomponents-lite';

--- a/src/elements/emby-ratingbutton/emby-ratingbutton.js
+++ b/src/elements/emby-ratingbutton/emby-ratingbutton.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import globalize from '../../lib/globalize';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
 import { OutboundWebSocketMessageType } from '@jellyfin/sdk/lib/websocket';

--- a/src/elements/emby-scrollbuttons/emby-scrollbuttons.js
+++ b/src/elements/emby-scrollbuttons/emby-scrollbuttons.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import './emby-scrollbuttons.scss';
 import 'webcomponents.js/webcomponents-lite';
 import '../emby-button/paper-icon-button-light';

--- a/src/elements/emby-scroller/emby-scroller.js
+++ b/src/elements/emby-scroller/emby-scroller.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import ScrollerFactory from 'lib/scroller';
 import dom from '../../utils/dom';
 import layoutManager from '../../components/layoutManager';

--- a/src/elements/emby-select/emby-select.js
+++ b/src/elements/emby-select/emby-select.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import layoutManager from '../../components/layoutManager';
 import browser from '../../scripts/browser';
 import actionsheet from '../../components/actionSheet/actionSheet';

--- a/src/elements/emby-slider/emby-slider.js
+++ b/src/elements/emby-slider/emby-slider.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import isEqual from 'lodash-es/isEqual';
 
 import browser from '../../scripts/browser';

--- a/src/elements/emby-tabs/emby-tabs.js
+++ b/src/elements/emby-tabs/emby-tabs.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import 'webcomponents.js/webcomponents-lite';
 import dom from '../../utils/dom';
 import ScrollerFactory from 'lib/scroller';

--- a/src/elements/emby-textarea/emby-textarea.js
+++ b/src/elements/emby-textarea/emby-textarea.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import './emby-textarea.scss';
 import 'webcomponents.js/webcomponents-lite';
 import '../emby-input/emby-input';

--- a/src/elements/emby-toggle/emby-toggle.js
+++ b/src/elements/emby-toggle/emby-toggle.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import './emby-toggle.scss';
 import 'webcomponents.js/webcomponents-lite';
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 // Import legacy browser polyfills
 import 'lib/legacy';
 

--- a/src/lib/globalize/index.js
+++ b/src/lib/globalize/index.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import isEmpty from 'lodash-es/isEmpty';
 
 import { currentSettings as userSettings } from 'scripts/settings/userSettings';

--- a/src/lib/jellyfin-apiclient/ServerConnections.js
+++ b/src/lib/jellyfin-apiclient/ServerConnections.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { Credentials } from 'jellyfin-apiclient';
 
 import { appHost } from 'components/apphost';

--- a/src/lib/jellyfin-apiclient/connectionManager.js
+++ b/src/lib/jellyfin-apiclient/connectionManager.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { AUTHORIZATION_HEADER } from '@jellyfin/sdk/lib/constants';
 import { getAuthorizationHeader } from '@jellyfin/sdk/lib/utils';
 import { MINIMUM_VERSION } from '@jellyfin/sdk/lib/versions';

--- a/src/lib/legacy/domParserTextHtml.js
+++ b/src/lib/legacy/domParserTextHtml.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /*
  * DOMParser HTML extension
  * 2019-11-13

--- a/src/lib/legacy/elementAppendPrepend.js
+++ b/src/lib/legacy/elementAppendPrepend.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * MIT License
  *

--- a/src/lib/legacy/focusPreventScroll.js
+++ b/src/lib/legacy/focusPreventScroll.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 // Polyfill to add support for preventScroll by focus function
 
 if (HTMLElement.prototype.nativeFocus === undefined) {

--- a/src/lib/legacy/htmlMediaElement.js
+++ b/src/lib/legacy/htmlMediaElement.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Polyfill for HTMLMediaElement
  * - HTMLMediaElement.play

--- a/src/lib/legacy/keyboardEvent.js
+++ b/src/lib/legacy/keyboardEvent.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Polyfill for KeyboardEvent
  * - Constructor.

--- a/src/lib/legacy/patchHeaders.js
+++ b/src/lib/legacy/patchHeaders.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Patch 'Headers' to accept 'undefined'.
  * Fixes `TypeError: Failed to construct 'Headers': No matching constructor signature.`

--- a/src/lib/legacy/vendorStyles.js
+++ b/src/lib/legacy/vendorStyles.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 // Polyfill for vendor prefixed style properties
 
 (function () {

--- a/src/lib/navdrawer/navdrawer.js
+++ b/src/lib/navdrawer/navdrawer.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * NOTE: This file should not be modified.
  * It is a legacy library that should be replaced at some point.

--- a/src/lib/scroller/index.js
+++ b/src/lib/scroller/index.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * NOTE: This file should not be modified.
  * It is a legacy library that should be replaced at some point.

--- a/src/plugins/backdropScreensaver/plugin.js
+++ b/src/plugins/backdropScreensaver/plugin.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { PluginType } from 'constants/pluginType';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
 import * as userSettings from 'scripts/settings/userSettings';

--- a/src/plugins/bookPlayer/plugin.js
+++ b/src/plugins/bookPlayer/plugin.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { getLibraryApi } from '@jellyfin/sdk/lib/utils/api/library-api';
 import Screenfull from 'screenfull';
 

--- a/src/plugins/bookPlayer/tableOfContents.js
+++ b/src/plugins/bookPlayer/tableOfContents.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import escapeHTML from 'escape-html';
 import dialogHelper from '../../components/dialogHelper/dialogHelper';
 import layoutManager from 'components/layoutManager';

--- a/src/plugins/chromecastPlayer/castSenderApi.js
+++ b/src/plugins/chromecastPlayer/castSenderApi.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 class CastSenderApi {
     load() {
         if (window.appMode === 'cordova' || window.appMode === 'android') {

--- a/src/plugins/chromecastPlayer/plugin.js
+++ b/src/plugins/chromecastPlayer/plugin.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { PluginType } from 'constants/pluginType';
 
 import appSettings from '../../scripts/settings/appSettings';

--- a/src/plugins/comicsPlayer/plugin.js
+++ b/src/plugins/comicsPlayer/plugin.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { getLibraryApi } from '@jellyfin/sdk/lib/utils/api/library-api';
 import { Archive } from 'libarchive.js';
 

--- a/src/plugins/experimentalWarnings/plugin.js
+++ b/src/plugins/experimentalWarnings/plugin.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { PluginType } from 'constants/pluginType';
 
 import globalize from '../../lib/globalize';

--- a/src/plugins/htmlAudioPlayer/plugin.js
+++ b/src/plugins/htmlAudioPlayer/plugin.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { AppFeature } from 'constants/appFeature';
 import { PluginType } from 'constants/pluginType';
 import { MediaError } from 'types/mediaError';

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import DOMPurify from 'dompurify';
 import debounce from 'lodash-es/debounce';
 import Screenfull from 'screenfull';

--- a/src/plugins/logoScreensaver/plugin.js
+++ b/src/plugins/logoScreensaver/plugin.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import icon from '@jellyfin/ux-web/icon-transparent.png';
 
 import { PluginType } from 'constants/pluginType';

--- a/src/plugins/pdfPlayer/plugin.js
+++ b/src/plugins/pdfPlayer/plugin.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { getLibraryApi } from '@jellyfin/sdk/lib/utils/api/library-api';
 
 import { PluginType } from 'constants/pluginType';

--- a/src/plugins/photoPlayer/plugin.js
+++ b/src/plugins/photoPlayer/plugin.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { PluginType } from 'constants/pluginType';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
 import * as userSettings from 'scripts/settings/userSettings';

--- a/src/plugins/playAccessValidation/plugin.js
+++ b/src/plugins/playAccessValidation/plugin.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import alert from 'components/alert';
 import { PluginType } from 'constants/pluginType';
 import globalize from 'lib/globalize';

--- a/src/plugins/sessionPlayer/plugin.js
+++ b/src/plugins/sessionPlayer/plugin.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import isEqual from 'lodash-es/isEqual';
 import { OutboundWebSocketMessageType, PeriodicListenerInterval } from '@jellyfin/sdk/lib/websocket';
 

--- a/src/plugins/syncPlay/core/Controller.js
+++ b/src/plugins/syncPlay/core/Controller.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Module that exposes SyncPlay calls to external modules.
  * @module components/syncPlay/core/Controller

--- a/src/plugins/syncPlay/core/Helper.js
+++ b/src/plugins/syncPlay/core/Helper.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Module that offers some utility functions.
  * @module components/syncPlay/core/Helper

--- a/src/plugins/syncPlay/core/Manager.js
+++ b/src/plugins/syncPlay/core/Manager.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Module that manages the SyncPlay feature.
  * @module components/syncPlay/core/Manager

--- a/src/plugins/syncPlay/core/PlaybackCore.js
+++ b/src/plugins/syncPlay/core/PlaybackCore.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Module that manages the playback of SyncPlay.
  * @module components/syncPlay/core/PlaybackCore

--- a/src/plugins/syncPlay/core/QueueCore.js
+++ b/src/plugins/syncPlay/core/QueueCore.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Module that manages the queue of SyncPlay.
  * @module components/syncPlay/core/QueueCore

--- a/src/plugins/syncPlay/core/Settings.js
+++ b/src/plugins/syncPlay/core/Settings.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Module that manages SyncPlay settings.
  * @module components/syncPlay/core/Settings

--- a/src/plugins/syncPlay/core/index.js
+++ b/src/plugins/syncPlay/core/index.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as Helper from './Helper';
 import ManagerClass from './Manager';
 import PlayerFactoryClass from './players/PlayerFactory';

--- a/src/plugins/syncPlay/core/players/GenericPlayer.js
+++ b/src/plugins/syncPlay/core/players/GenericPlayer.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Module that translates events from a player to SyncPlay events.
  * @module components/syncPlay/core/players/GenericPlayer

--- a/src/plugins/syncPlay/core/players/PlayerFactory.js
+++ b/src/plugins/syncPlay/core/players/PlayerFactory.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Module that creates wrappers for known players.
  * @module components/syncPlay/core/players/PlayerFactory

--- a/src/plugins/syncPlay/core/timeSync/TimeSync.js
+++ b/src/plugins/syncPlay/core/timeSync/TimeSync.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Module that manages time syncing with another device.
  * @module components/syncPlay/core/timeSync/TimeSync

--- a/src/plugins/syncPlay/core/timeSync/TimeSyncCore.js
+++ b/src/plugins/syncPlay/core/timeSync/TimeSyncCore.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Module that manages time syncing with several devices.
  * @module components/syncPlay/core/timeSync/TimeSyncCore

--- a/src/plugins/syncPlay/core/timeSync/TimeSyncServer.js
+++ b/src/plugins/syncPlay/core/timeSync/TimeSyncServer.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Module that manages time syncing with server.
  * @module components/syncPlay/core/timeSync/TimeSyncServer

--- a/src/plugins/syncPlay/ui/groupSelectionMenu.js
+++ b/src/plugins/syncPlay/ui/groupSelectionMenu.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { PluginType } from 'constants/pluginType';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
 

--- a/src/plugins/syncPlay/ui/playbackPermissionManager.js
+++ b/src/plugins/syncPlay/ui/playbackPermissionManager.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { appHost } from 'components/apphost';
 import { AppFeature } from 'constants/appFeature';
 

--- a/src/plugins/syncPlay/ui/players/HtmlAudioPlayer.js
+++ b/src/plugins/syncPlay/ui/players/HtmlAudioPlayer.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Module that manages the HtmlAudioPlayer for SyncPlay.
  * @module components/syncPlay/ui/players/HtmlAudioPlayer

--- a/src/plugins/syncPlay/ui/players/HtmlVideoPlayer.js
+++ b/src/plugins/syncPlay/ui/players/HtmlVideoPlayer.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Module that manages the HtmlVideoPlayer for SyncPlay.
  * @module components/syncPlay/ui/players/HtmlVideoPlayer

--- a/src/plugins/syncPlay/ui/players/NoActivePlayer.js
+++ b/src/plugins/syncPlay/ui/players/NoActivePlayer.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Module that manages the PlaybackManager when there's no active player.
  * @module components/syncPlay/ui/players/NoActivePlayer

--- a/src/plugins/syncPlay/ui/players/QueueManager.js
+++ b/src/plugins/syncPlay/ui/players/QueueManager.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Module that replaces the PlaybackManager's queue.
  * @module components/syncPlay/ui/players/QueueManager

--- a/src/plugins/syncPlay/ui/settings/SettingsEditor.js
+++ b/src/plugins/syncPlay/ui/settings/SettingsEditor.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Module that displays an editor for changing SyncPlay settings.
  * @module components/syncPlay/settings/SettingsEditor

--- a/src/plugins/youtubePlayer/plugin.js
+++ b/src/plugins/youtubePlayer/plugin.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { PluginType } from 'constants/pluginType';
 
 import browser from '../../scripts/browser';

--- a/src/scripts/alphanumericshortcuts.js
+++ b/src/scripts/alphanumericshortcuts.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import dom from '../utils/dom';
 import focusManager from '../components/focusManager';
 

--- a/src/scripts/autoBackdrops.js
+++ b/src/scripts/autoBackdrops.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { clearBackdrop, setBackdropImages, setBackdrops } from '../components/backdrop/backdrop';
 import * as userSettings from './settings/userSettings';
 import libraryMenu from './libraryMenu';

--- a/src/scripts/autoThemes.js
+++ b/src/scripts/autoThemes.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as userSettings from './settings/userSettings';
 import skinManager from './themeManager';
 import { ServerConnections } from 'lib/jellyfin-apiclient';

--- a/src/scripts/autocast.js
+++ b/src/scripts/autocast.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { playbackManager } from 'components/playback/playbackmanager';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
 import Events from 'utils/events.ts';

--- a/src/scripts/browser.js
+++ b/src/scripts/browser.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 function isTv(userAgent) {
     // This is going to be really difficult to get right
 

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import browser from './browser';
 import appSettings from './settings/appSettings';
 import * as userSettings from './settings/userSettings';

--- a/src/scripts/clipboard.js
+++ b/src/scripts/clipboard.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import browser from './browser';
 
 /**

--- a/src/scripts/datetime.js
+++ b/src/scripts/datetime.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import globalize from 'lib/globalize';
 
 export function parseISO8601Date(s, toLocal) {

--- a/src/scripts/deleteHelper.js
+++ b/src/scripts/deleteHelper.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 
 import { BaseItemKind } from '@jellyfin/sdk/lib/generated-client/models/base-item-kind';
 

--- a/src/scripts/editorsidebar.js
+++ b/src/scripts/editorsidebar.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import escapeHtml from 'escape-html';
 import 'jquery';
 import 'material-design-icons-iconfont';

--- a/src/scripts/fileDownloader.js
+++ b/src/scripts/fileDownloader.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import multiDownload from './multiDownload';
 import shell from './shell';
 

--- a/src/scripts/gamepadtokey.js
+++ b/src/scripts/gamepadtokey.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 // #      The MIT License (MIT)
 // #
 // #      Copyright (c) 2016 Microsoft. All rights reserved.

--- a/src/scripts/inputManager.js
+++ b/src/scripts/inputManager.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { appHost } from 'components/apphost';
 import focusManager from 'components/focusManager';
 import { playbackManager } from 'components/playback/playbackmanager';

--- a/src/scripts/itemsByName.js
+++ b/src/scripts/itemsByName.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { BaseItemKind } from '@jellyfin/sdk/lib/generated-client/models/base-item-kind';
 
 import listView from 'components/listview/listview';

--- a/src/scripts/keyboardNavigation.js
+++ b/src/scripts/keyboardNavigation.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Module for performing keyboard navigation.
  * @module components/input/keyboardnavigation

--- a/src/scripts/libraryBrowser.js
+++ b/src/scripts/libraryBrowser.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import globalize from 'lib/globalize';
 
 export function showLayoutMenu (button, currentLayout, views) {

--- a/src/scripts/libraryMenu.js
+++ b/src/scripts/libraryMenu.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import escapeHtml from 'escape-html';
 import Headroom from 'headroom.js';
 

--- a/src/scripts/livetvcomponents.js
+++ b/src/scripts/livetvcomponents.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import cardBuilder from 'components/cardbuilder/cardBuilder';
 import { getBackdropShape } from 'components/cardbuilder/utils/shape';
 import layoutManager from 'components/layoutManager';

--- a/src/scripts/mouseManager.js
+++ b/src/scripts/mouseManager.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import inputManager from './inputManager';
 import focusManager from '../components/focusManager';
 import browser from './browser';

--- a/src/scripts/multiDownload.js
+++ b/src/scripts/multiDownload.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import browser from '../scripts/browser';
 
 function fallback(urls) {

--- a/src/scripts/playlistViewer.js
+++ b/src/scripts/playlistViewer.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { getPlaylistApi } from '@jellyfin/sdk/lib/utils/api/playlist-api';
 
 import listView from 'components/listview/listview';

--- a/src/scripts/screensavermanager.js
+++ b/src/scripts/screensavermanager.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { playbackManager } from 'components/playback/playbackmanager';
 import { pluginManager } from 'components/pluginManager';
 import { PluginType } from 'constants/pluginType';

--- a/src/scripts/serverNotifications.js
+++ b/src/scripts/serverNotifications.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { OutboundWebSocketMessageType } from '@jellyfin/sdk/lib/websocket';
 
 import alert from 'components/alert';

--- a/src/scripts/settings/appSettings.js
+++ b/src/scripts/settings/appSettings.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import browser from 'scripts/browser';
 import Events from '../../utils/events.ts';
 import { toBoolean } from '../../utils/string.ts';

--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { getDisplayPreferencesQuery } from 'hooks/api/useDisplayPreferences';
 import { getUserQuery } from 'hooks/api/useUser';
 import { QUERY_KEY } from 'hooks/useUsers';

--- a/src/scripts/settings/webSettings.js
+++ b/src/scripts/settings/webSettings.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import DefaultConfig from '../../config.json';
 import fetchLocal from '../../utils/fetchLocal.ts';
 

--- a/src/scripts/shell.js
+++ b/src/scripts/shell.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 // TODO: This seems like a good candidate for deprecation
 export default {
     enableFullscreen: function() {

--- a/src/scripts/taskbutton.js
+++ b/src/scripts/taskbutton.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 
 import globalize from 'lib/globalize';
 import { ServerConnections } from 'lib/jellyfin-apiclient';

--- a/src/scripts/themeManager.js
+++ b/src/scripts/themeManager.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import Events from 'utils/events';
 import { EventType } from 'constants/eventType';
 

--- a/src/scripts/touchHelper.js
+++ b/src/scripts/touchHelper.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import dom from '../utils/dom';
 import Events from '../utils/events.ts';
 

--- a/src/serviceworker.js
+++ b/src/serviceworker.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 function getApiClient(serverId) {
     return Promise.resolve(window.connectionManager.getApiClient(serverId));
 }

--- a/src/utils/dashboard.js
+++ b/src/utils/dashboard.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { appHost } from 'components/apphost';
 import viewContainer from 'components/viewContainer';
 import { AppFeature } from 'constants/appFeature';

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 
 /**
  * Useful DOM utilities.

--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 export function getFetchPromise(request) {
     const headers = request.headers || {};
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "outDir": "./dist/",
-    "checkJs": false,
+    "checkJs": true,
     "strictNullChecks": true,
     "jsx": "react-jsx",
     "downlevelIteration": true


### PR DESCRIPTION
This PR should be reviewed after reviewing [the js type checking PR](https://github.com/jellyfin/jellyfin-web/pull/8191) that this branch is based on.

### Changes

- Add type annotations to `src/apps/legacy/controllers/session/login/index.js`

_Currently, this PR is based on another branch with a bunch of 1 line changes to every `.js` file. The only file that matters for this PR is [`src/apps/legacy/controllers/session/login/index.js`](https://github.com/jellyfin/jellyfin-web/pull/8189/changes#diff-8719cd6f7b6dc9ca52ca3c0138d8aecb35a6a385ff943966b3b66bab2a833208). If the js type checking PR is merged, the diff will be greatly simplified._

I left two `TODO`s in the code. I don't intend for this PR to make any functional changes and fixing those two todos would require making a functional change. These issues already existed, they just weren't noticeable until adding type checking to the file.

### Code assistance
None, just me and a language server.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
    * in progress
