### PR TITLE
Update nix flake lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1739874174,
-        "narHash": "sha256-XGxSVtojlwjYRYGvGXex0Cw+/363EVJlbY9TPX9bARk=",
+        "lastModified": 1783687119,
+        "narHash": "sha256-UsCTZIw2zRrH5uY3aKc5e/ilTJxmOuJ6b4jJViQuijM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d2ab2691c798f6b633be91d74b1626980ddaff30",
+        "rev": "2e657a0bd8d4a2448dc0ee28155cd3bb5a3dd4b4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
### Changes

[When we updated to `nodejs_24`](https://github.com/jellyfin/jellyfin-web/pull/7282), the `flake.lock` was not updated. This meant we were still pointing at a version of `nixpkgs` that did not have `nodejs_24` which would cause an error when entering the `nix develop` shell:

```
       error: undefined variable 'nodejs_24'
       at /home/cwest/code/jellyfin/jellyfin-web/flake.nix:23:15:
           22|             buildInputs = [
           23|               nodejs_24
             |               ^
           24|             ];
```

- Ran `nix flake update`

### Code assistance
None

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
    - `nix develop` works again and puts node on your `PATH` as expected
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
    - I reviewed this similarly sized PR: https://github.com/jellyfin/jellyfin-web/pull/8188
