### PR TITLE
Base desktop browser HDR support on display capability

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -253,14 +253,25 @@ function supportsHdr10(options) {
             || browser.safari && ((browser.iOS && browser.iOSVersion >= 11) || browser.osx)
             // Chrome mobile and Firefox have no client side tone-mapping
             // Edge Chromium 121+ fixed the tone-mapping color issue on Nvidia
-            || browser.edgeChromium && (browser.versionMajor >= 121)
-            || browser.chrome && !browser.mobile
+            // Desktop Chromium tone-mapping to SDR is unreliable (dark picture) with
+            // hardware decoding, so only report HDR support when the display is in
+            // HDR mode and no tone-mapping is needed. The video-dynamic-range query
+            // is still flagged as experimental in Chromium, so use dynamic-range.
+            || browser.edgeChromium && (browser.versionMajor >= 121) && window.matchMedia('(dynamic-range: high)').matches
+            || browser.chrome && !browser.mobile && window.matchMedia('(dynamic-range: high)').matches
             // Firefox 100+ has support for HDR on macOS/OS X. It requires OS support, which was
             // added in macOS 10.15 Catalina. If enabling HDR on other platforms, be careful about
             // allowing HDR VP9 in mp4 containers.
             //  * https://www.mozilla.org/en-US/firefox/100.0/releasenotes/
             //  * https://bugzilla.mozilla.org/show_bug.cgi?id=1915265
             || browser.firefox && browser.osx && (!browser.iphone && !browser.ipod && !browser.ipad) && (browser.versionMajor >= 100)
+            // Firefox reports HDR video support on other platforms through the
+            // video-dynamic-range media query (Windows support is experimental in
+            // Firefox 148). It evaluates to standard until HDR playback is available,
+            // so this cannot match versions before 148. The HDR VP9 color issue in
+            // mp4 containers noted above was fixed in Firefox 131.
+            //  * https://mozillagfx.wordpress.com/2026/01/16/experimental-high-dynamic-range-video-playback-on-windows-in-firefox-nightly-148/
+            || browser.firefox && !browser.mobile && !browser.osx && window.matchMedia('(video-dynamic-range: high)').matches
     );
 }
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

### Changes
<!--
Describe your changes here in 1-5 sentences.
Please include before/after screenshots of any UI changes.
-->
I made this change as playback of (HEVC) HDR files through a chromium browser on a SDR display, would fail to transcode and tone map the file, as it would be perceived as an HDR capable display, despite HDR non being enabled in windows. This adds a media query backup to check the browser's self reported dynamic range, and won't report as HDR if the media query returns standard.

I also added the equivalent check for Firefox with their upcoming HDR in windows support (see comment)
### Issues
<!--
Tag any issues that this PR solves here.
ex. Fixes #
-->

### Code assistance

I used GH Copilot as semantic search for getting familiar with the codebase as well as researching how to determine HDR capabilities in browser API's. I also have LLM tab completion, which I cannot recall was used or not.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
