### PR TITLE
Swap position of item count and play all controls in library toolbar

### DIFF
--- a/src/apps/modern/features/libraries/components/LibraryToolbar.tsx
+++ b/src/apps/modern/features/libraries/components/LibraryToolbar.tsx
@@ -104,61 +104,21 @@ const LibraryToolbar: FC = () => {
         >
             <LibraryViewMenu />
 
-            <Box
-                sx={{
-                    display: 'flex',
-                    flexGrow: {
-                        xs: 1,
-                        sm: 0
-                    },
-                    justifyContent: 'flex-end',
-                    marginLeft: 1
-                }}
-            >
-                <ButtonGroup
-                    variant='contained'
+            {!MENU_ONLY_VIEWS.includes(viewType) && (
+                <Box
+                    sx={{
+                        display: 'flex',
+                        flexGrow: {
+                            xs: 1,
+                            sm: 0
+                        },
+                        justifyContent: 'flex-end',
+                        marginLeft: 1
+                    }}
                 >
-                    {isBtnPlayAllEnabled && (
-                        <PlayAllButton
-                            item={item}
-                            items={items}
-                            viewType={viewType}
-                            collectionType={collectionType}
-                            hasFilters={hasFilters}
-                            isTextVisible={isSmallScreen}
-                            libraryViewSettings={libraryViewSettings}
-                        />
-                    )}
-
-                    {isBtnShuffleEnabled && (
-                        <ShuffleButton
-                            item={item}
-                            items={items}
-                            viewType={viewType}
-                            collectionType={collectionType}
-                            hasFilters={hasFilters}
-                            isTextVisible={isSmallScreen && !isBtnPlayAllEnabled}
-                            libraryViewSettings={libraryViewSettings}
-                        />
-                    )}
-
-                    {isBtnQueueEnabled && item && playbackManager.canQueue(item) && (
-                        <QueueButton
-                            item={item}
-                            items={items}
-                            hasFilters={hasFilters}
-                            isTextVisible={isSmallScreen && !isBtnPlayAllEnabled && !isBtnShuffleEnabled}
-                        />
-                    )}
-                </ButtonGroup>
-
-                {isBtnNewCollectionEnabled && canCreateCollections && (
-                    <NewCollectionButton isTextVisible={isSmallScreen} queryKey={allItemsQueryKey} />
-                )}
-                {isBtnNewPlaylistEnabled && (
-                    <NewPlaylistButton isTextVisible={isSmallScreen} queryKey={allItemsQueryKey} />
-                )}
-            </Box>
+                    <Chip label={itemCountDisplay} />
+                </Box>
+            )}
 
             {!MENU_ONLY_VIEWS.includes(viewType) && (
                 <Stack
@@ -174,7 +134,10 @@ const LibraryToolbar: FC = () => {
                             sm: 'auto'
                         },
                         flexGrow: 1,
-                        marginTop: 0.5,
+                        marginTop: {
+                            xs: 1,
+                            sm: 0.5
+                        },
                         marginBottom: 0.5
                     }}
                 >
@@ -188,7 +151,49 @@ const LibraryToolbar: FC = () => {
                             }
                         }}
                     >
-                        <Chip label={itemCountDisplay} />
+                        <ButtonGroup
+                            variant='contained'
+                        >
+                            {isBtnPlayAllEnabled && (
+                                <PlayAllButton
+                                    item={item}
+                                    items={items}
+                                    viewType={viewType}
+                                    collectionType={collectionType}
+                                    hasFilters={hasFilters}
+                                    isTextVisible={isSmallScreen}
+                                    libraryViewSettings={libraryViewSettings}
+                                />
+                            )}
+
+                            {isBtnShuffleEnabled && (
+                                <ShuffleButton
+                                    item={item}
+                                    items={items}
+                                    viewType={viewType}
+                                    collectionType={collectionType}
+                                    hasFilters={hasFilters}
+                                    isTextVisible={isSmallScreen && !isBtnPlayAllEnabled}
+                                    libraryViewSettings={libraryViewSettings}
+                                />
+                            )}
+
+                            {isBtnQueueEnabled && item && playbackManager.canQueue(item) && (
+                                <QueueButton
+                                    item={item}
+                                    items={items}
+                                    hasFilters={hasFilters}
+                                    isTextVisible={isSmallScreen && !isBtnPlayAllEnabled && !isBtnShuffleEnabled}
+                                />
+                            )}
+                        </ButtonGroup>
+
+                        {isBtnNewCollectionEnabled && canCreateCollections && (
+                            <NewCollectionButton isTextVisible={isSmallScreen} queryKey={allItemsQueryKey} />
+                        )}
+                        {isBtnNewPlaylistEnabled && (
+                            <NewPlaylistButton isTextVisible={isSmallScreen} queryKey={allItemsQueryKey} />
+                        )}
                     </Box>
 
                     <ButtonGroup


### PR DESCRIPTION
### Changes
Swaps the position of the item count and play all/shuffle controls on the library toolbar

### Issues
Should give item counts a bit more space (related to https://github.com/jellyfin/jellyfin-web/pull/7962#issuecomment-4596865381)

### Code assistance
Zed autocomplete

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
