### PR TITLE
Fix forgot password routing in modern layout

### DIFF
--- a/src/apps/modern/routes/asyncRoutes/index.ts
+++ b/src/apps/modern/routes/asyncRoutes/index.ts
@@ -1,1 +1,2 @@
+export * from './public';
 export * from './user';

--- a/src/apps/modern/routes/asyncRoutes/public.ts
+++ b/src/apps/modern/routes/asyncRoutes/public.ts
@@ -1,0 +1,5 @@
+import { AsyncRoute } from '../../../../components/router/AsyncRoute';
+
+export const ASYNC_PUBLIC_ROUTES: AsyncRoute[] = [
+    { path: 'forgotpassword', page: 'session/forgotPassword' }
+];

--- a/src/apps/modern/routes/legacyRoutes/public.ts
+++ b/src/apps/modern/routes/legacyRoutes/public.ts
@@ -23,13 +23,6 @@ export const LEGACY_PUBLIC_ROUTES: LegacyRoute[] = [
         }
     },
     {
-        path: 'forgotpassword',
-        pageProps: {
-            controller: 'session/forgotPassword/index',
-            view: 'session/forgotPassword/index.html'
-        }
-    },
-    {
         path: 'forgotpasswordpin',
         pageProps: {
             controller: 'session/resetPassword/index',

--- a/src/apps/modern/routes/routes.tsx
+++ b/src/apps/modern/routes/routes.tsx
@@ -7,7 +7,7 @@ import { toViewManagerPageRoute } from 'components/router/LegacyRoute';
 import ErrorBoundary from 'components/router/ErrorBoundary';
 import FallbackRoute from 'components/router/FallbackRoute';
 
-import { ASYNC_USER_ROUTES } from './asyncRoutes';
+import { ASYNC_PUBLIC_ROUTES, ASYNC_USER_ROUTES } from './asyncRoutes';
 import { LEGACY_PUBLIC_ROUTES, LEGACY_USER_ROUTES } from './legacyRoutes';
 import VideoPage from './video';
 
@@ -38,6 +38,7 @@ export const APP_ROUTES: RouteObject[] = [
                 /* Public routes */
                 element: <ConnectionRequired level='public' />,
                 children: [
+                    ...ASYNC_PUBLIC_ROUTES.map(toAsyncPageRoute),
                     ...LEGACY_PUBLIC_ROUTES.map(toViewManagerPageRoute),
 
                     /* Fallback route for invalid paths */


### PR DESCRIPTION
### Changes

Use the existing async React route for the Forgot Password page in the modern layout.

This also removes the old controller and view mapping that was causing Webpack to fail with:

`Cannot find module './session/forgotPassword/index'`

There are no changes to the page itself, the API behaviour, or the visual design.

### Issues

Fixes #8176

### Code assistance

N/A

### Testing

- `npm run build:check`
- Ran ESLint against the changed files
- `npm test` — 169 tests passed
- `npm run build:development`
- Manually tested in Chromium with the web client:
  - Opened the login page
  - Clicked **Forgot Password**
  - Confirmed the recovery form loaded at `#/forgotpassword`
  - Confirmed there was no Webpack overlay, page error, or related console error
  - Checked both desktop and mobile layouts

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).