### PR TITLE
Fix playback retry position

### DIFF
--- a/src/components/htmlMediaHelper.js
+++ b/src/components/htmlMediaHelper.js
@@ -260,11 +260,16 @@ export function destroyFlvPlayer(instance) {
 }
 
 export function bindEventsToHlsPlayer(instance, hls, elem, onErrorFn, resolve, reject) {
+    let rejectStartup = reject;
+
     hls.on(Hls.Events.MANIFEST_PARSED, function () {
-        playWithPromise(elem, onErrorFn).then(resolve, function () {
-            if (reject) {
-                reject();
-                reject = null;
+        playWithPromise(elem, onErrorFn).then(function () {
+            rejectStartup = null;
+            resolve();
+        }, function () {
+            if (rejectStartup) {
+                rejectStartup();
+                rejectStartup = null;
             }
         });
     });
@@ -281,9 +286,9 @@ export function bindEventsToHlsPlayer(instance, hls, elem, onErrorFn, resolve, r
             // Trigger failure differently depending on whether this is prior to start of playback, or after
             hls.destroy();
 
-            if (reject) {
-                reject(MediaError.SERVER_ERROR);
-                reject = null;
+            if (rejectStartup) {
+                rejectStartup(MediaError.SERVER_ERROR);
+                rejectStartup = null;
             } else {
                 onErrorInternal(instance, MediaError.SERVER_ERROR);
             }
@@ -303,9 +308,9 @@ export function bindEventsToHlsPlayer(instance, hls, elem, onErrorFn, resolve, r
                         // Trigger failure differently depending on whether this is prior to start of playback, or after
                         hls.destroy();
 
-                        if (reject) {
-                            reject(MediaError.NETWORK_ERROR);
-                            reject = null;
+                        if (rejectStartup) {
+                            rejectStartup(MediaError.NETWORK_ERROR);
+                            rejectStartup = null;
                         } else {
                             onErrorInternal(instance, MediaError.NETWORK_ERROR);
                         }
@@ -317,8 +322,8 @@ export function bindEventsToHlsPlayer(instance, hls, elem, onErrorFn, resolve, r
                     break;
                 case Hls.ErrorTypes.MEDIA_ERROR:
                     console.debug('fatal media error encountered, try to recover');
-                    handleHlsJsMediaError(instance, reject);
-                    reject = null;
+                    handleHlsJsMediaError(instance, rejectStartup);
+                    rejectStartup = null;
                     break;
                 default:
 
@@ -327,9 +332,9 @@ export function bindEventsToHlsPlayer(instance, hls, elem, onErrorFn, resolve, r
                     // Trigger failure differently depending on whether this is prior to start of playback, or after
                     hls.destroy();
 
-                    if (reject) {
-                        reject();
-                        reject = null;
+                    if (rejectStartup) {
+                        rejectStartup();
+                        rejectStartup = null;
                     } else {
                         onErrorInternal(instance, MediaError.FATAL_HLS_ERROR);
                     }

--- a/src/components/htmlMediaHelper.test.ts
+++ b/src/components/htmlMediaHelper.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import Events from '../utils/events';
+import { bindEventsToHlsPlayer } from './htmlMediaHelper';
+import { MediaError } from '../types/mediaError';
+
+interface FakeHls {
+    destroy: ReturnType<typeof vi.fn>
+    handlers: Map<string, (event: unknown, data: HlsErrorData) => void>
+    on: ReturnType<typeof vi.fn>
+    startLoad: ReturnType<typeof vi.fn>
+}
+
+interface HlsErrorData {
+    details?: string
+    fatal?: boolean
+    response?: { code: number }
+    type: string
+}
+
+const HLS_EVENTS = {
+    error: 'error',
+    manifestParsed: 'manifestParsed'
+};
+
+function createHls(): FakeHls {
+    const handlers = new Map<string, (event: unknown, data: HlsErrorData) => void>();
+
+    return {
+        destroy: vi.fn(),
+        handlers,
+        on: vi.fn((event: string, handler: (event: unknown, data: HlsErrorData) => void) => {
+            handlers.set(event, handler);
+        }),
+        startLoad: vi.fn()
+    };
+}
+
+describe('bindEventsToHlsPlayer', () => {
+    beforeEach(() => {
+        vi.stubGlobal('Hls', {
+            ErrorTypes: Object.fromEntries([
+                [ 'MEDIA_ERROR', 'mediaError' ],
+                [ 'NETWORK_ERROR', 'networkError' ]
+            ]),
+            Events: Object.fromEntries([
+                [ 'ERROR', HLS_EVENTS.error ],
+                [ 'MANIFEST_PARSED', HLS_EVENTS.manifestParsed ]
+            ])
+        });
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('rejects a network error during startup', () => {
+        const hls = createHls();
+        const instance = {};
+        const onError = vi.fn();
+        const resolve = vi.fn();
+        const reject = vi.fn();
+        const playbackError = vi.fn();
+        Events.on(instance, 'error', playbackError);
+
+        bindEventsToHlsPlayer(instance, hls, {} as HTMLMediaElement, onError, resolve, reject);
+        hls.handlers.get(HLS_EVENTS.error)?.(undefined, {
+            response: { code: 503 },
+            type: 'networkError'
+        });
+
+        expect(reject).toHaveBeenCalledWith(MediaError.SERVER_ERROR);
+        expect(playbackError).not.toHaveBeenCalled();
+    });
+
+    it('rejects startup only once when playback cannot start', async () => {
+        const hls = createHls();
+        const mediaElement = {
+            addEventListener: vi.fn(),
+            play: vi.fn().mockRejectedValue(new Error('playback failed'))
+        } as unknown as HTMLMediaElement;
+        const reject = vi.fn();
+
+        bindEventsToHlsPlayer(
+            {},
+            hls,
+            mediaElement,
+            vi.fn(),
+            vi.fn(),
+            reject
+        );
+
+        const manifestParsed = hls.handlers.get(HLS_EVENTS.manifestParsed);
+        manifestParsed?.(undefined, { type: '' });
+        await vi.waitFor(() => expect(reject).toHaveBeenCalledOnce());
+
+        manifestParsed?.(undefined, { type: '' });
+        await vi.waitFor(() => expect(mediaElement.play).toHaveBeenCalledTimes(2));
+        expect(reject).toHaveBeenCalledOnce();
+    });
+
+    it('emits a playback error after startup succeeds', async () => {
+        const hls = createHls();
+        const mediaElement = {
+            addEventListener: vi.fn(),
+            play: vi.fn().mockResolvedValue(undefined)
+        } as unknown as HTMLMediaElement;
+        const instance = {};
+        const onError = vi.fn();
+        const resolve = vi.fn();
+        const reject = vi.fn();
+        const playbackError = vi.fn();
+        Events.on(instance, 'error', playbackError);
+
+        bindEventsToHlsPlayer(instance, hls, mediaElement, onError, resolve, reject);
+        hls.handlers.get(HLS_EVENTS.manifestParsed)?.(undefined, { type: '' });
+        await vi.waitFor(() => expect(resolve).toHaveBeenCalledOnce());
+
+        hls.handlers.get(HLS_EVENTS.error)?.(undefined, {
+            response: { code: 503 },
+            type: 'networkError'
+        });
+
+        expect(reject).not.toHaveBeenCalled();
+        expect(playbackError).toHaveBeenCalledWith(
+            { type: 'error' },
+            { type: MediaError.SERVER_ERROR }
+        );
+    });
+
+    it.each([
+        {
+            data: {
+                fatal: true,
+                response: { code: 0 },
+                type: 'networkError'
+            },
+            name: 'a zero-status network error',
+            playbackError: MediaError.NETWORK_ERROR,
+            startupError: MediaError.NETWORK_ERROR
+        },
+        {
+            data: {
+                fatal: true,
+                type: 'unrecoverableError'
+            },
+            name: 'an unrecoverable HLS error',
+            playbackError: MediaError.FATAL_HLS_ERROR,
+            startupError: undefined
+        }
+    ])('routes $name based on startup state', async ({
+        data,
+        playbackError: expectedPlaybackError,
+        startupError
+    }) => {
+        const startupHls = createHls();
+        const startupReject = vi.fn();
+        const startupPlaybackError = vi.fn();
+        const startupInstance = {};
+        Events.on(startupInstance, 'error', startupPlaybackError);
+
+        bindEventsToHlsPlayer(
+            startupInstance,
+            startupHls,
+            {} as HTMLMediaElement,
+            vi.fn(),
+            vi.fn(),
+            startupReject
+        );
+        startupHls.handlers.get(HLS_EVENTS.error)?.(undefined, data);
+
+        expect(startupReject).toHaveBeenCalledOnce();
+        if (startupError) {
+            expect(startupReject).toHaveBeenCalledWith(startupError);
+        } else {
+            expect(startupReject.mock.calls[0]).toEqual([]);
+        }
+        expect(startupPlaybackError).not.toHaveBeenCalled();
+
+        const playbackHls = createHls();
+        const mediaElement = {
+            addEventListener: vi.fn(),
+            play: vi.fn().mockResolvedValue(undefined)
+        } as unknown as HTMLMediaElement;
+        const playbackInstance = {};
+        const playbackReject = vi.fn();
+        const playbackResolve = vi.fn();
+        const playbackError = vi.fn();
+        Events.on(playbackInstance, 'error', playbackError);
+
+        bindEventsToHlsPlayer(
+            playbackInstance,
+            playbackHls,
+            mediaElement,
+            vi.fn(),
+            playbackResolve,
+            playbackReject
+        );
+        playbackHls.handlers.get(HLS_EVENTS.manifestParsed)?.(undefined, { type: '' });
+        await vi.waitFor(() => expect(playbackResolve).toHaveBeenCalledOnce());
+
+        playbackHls.handlers.get(HLS_EVENTS.error)?.(undefined, data);
+
+        expect(playbackReject).not.toHaveBeenCalled();
+        expect(playbackError).toHaveBeenCalledWith(
+            { type: 'error' },
+            { type: expectedPlaybackError }
+        );
+    });
+});

--- a/src/components/playback/htmlVideoPlayer.test.ts
+++ b/src/components/playback/htmlVideoPlayer.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.hoisted(() => {
+    vi.stubGlobal('__PACKAGE_JSON_VERSION__', 'test');
+    vi.stubGlobal('__WEBPACK_SERVE__', false);
+});
+
+vi.mock('dompurify', () => ({ default: { sanitize: vi.fn() } }));
+vi.mock('lodash-es/debounce', () => ({ default: (callback: unknown) => callback }));
+vi.mock('screenfull', () => ({ default: { isEnabled: false } }));
+vi.mock('apps/legacy/features/playback/utils/subtitleStyles', () => ({ useCustomSubtitles: false }));
+vi.mock('components/subtitlesettings/subtitleappearancehelper', () => ({ default: {} }));
+vi.mock('constants/appFeature', () => ({ AppFeature: { HtmlVideoAutoplay: 'HtmlVideoAutoplay', PhysicalVolumeControl: 'PhysicalVolumeControl' } }));
+vi.mock('constants/pluginType', () => ({ PluginType: { MediaPlayer: 'MediaPlayer' } }));
+vi.mock('lib/jellyfin-apiclient', () => ({ ServerConnections: {} }));
+vi.mock('scripts/settings/userSettings', () => ({ currentSettings: {} }));
+vi.mock('types/mediaError', () => ({ MediaError: {} }));
+vi.mock('../../scripts/browser', () => ({ default: { supportsCssAnimation: () => false } }));
+vi.mock('../../scripts/settings/appSettings', () => ({ default: {} }));
+vi.mock('../../components/apphost', () => ({ appHost: { supports: () => false } }));
+vi.mock('../../components/loading/loading', () => ({ default: { show: vi.fn() } }));
+vi.mock('../../utils/dom', () => ({ default: {} }));
+vi.mock('../../components/playback/playbackmanager', () => ({ playbackManager: {} }));
+vi.mock('../../components/router/appRouter', () => ({ appRouter: {} }));
+vi.mock('../../components/htmlMediaHelper', () => ({
+    applySrc: vi.fn(),
+    bindEventsToHlsPlayer: vi.fn(),
+    destroyCastPlayer: vi.fn(),
+    destroyFlvPlayer: vi.fn(),
+    destroyHlsPlayer: vi.fn(),
+    enableHlsJsPlayerForCodecs: vi.fn(),
+    getBufferedRanges: vi.fn(),
+    getCrossOriginValue: vi.fn(),
+    getSavedVolume: () => 1,
+    handleHlsJsMediaError: vi.fn(),
+    isValidDuration: vi.fn(),
+    onEndedInternal: vi.fn(),
+    onErrorInternal: vi.fn(),
+    playWithPromise: vi.fn(),
+    resetSrc: vi.fn(),
+    saveVolume: vi.fn(),
+    seekOnPlaybackStart: vi.fn()
+}));
+vi.mock('../../components/itemHelper', () => ({ default: {} }));
+vi.mock('../../lib/globalize', () => ({ default: {} }));
+vi.mock('../../scripts/browserDeviceProfile', () => ({ canPlaySecondaryAudio: vi.fn(), default: vi.fn() }));
+vi.mock('../../scripts/settings/webSettings', () => ({ getIncludeCorsCredentials: vi.fn() }));
+vi.mock('../../components/backdrop/backdrop', () => ({ setBackdropTransparency: vi.fn(), ['TRANSPARENCY_LEVEL']: {} }));
+vi.mock('../../utils/events.ts', () => ({ default: { trigger: vi.fn() } }));
+vi.mock('../../utils/container.ts', () => ({ includesAny: vi.fn() }));
+vi.mock('../../utils/mediaSource.ts', () => ({ isHls: vi.fn() }));
+
+import { HtmlVideoPlayer } from '../../plugins/htmlVideoPlayer/plugin';
+
+interface TestableHtmlVideoPlayer {
+    createMediaElement(options: { fullscreen: boolean }): Promise<HTMLVideoElement>
+    currentTime(value?: number): number | undefined
+}
+
+function createPlayer(): TestableHtmlVideoPlayer {
+    return new HtmlVideoPlayer() as unknown as TestableHtmlVideoPlayer;
+}
+
+describe('HtmlVideoPlayer currentTime', () => {
+    afterEach(() => {
+        document.querySelector('.videoPlayerContainer')?.remove();
+    });
+
+    it('keeps the last playback position when the media element reports zero', async () => {
+        const player = createPlayer();
+        const mediaElement = await player.createMediaElement({ fullscreen: false });
+
+        mediaElement.currentTime = 600;
+        mediaElement.dispatchEvent(new Event('timeupdate'));
+        mediaElement.currentTime = 0;
+        mediaElement.dispatchEvent(new Event('timeupdate'));
+
+        expect(player.currentTime()).toBe(600000);
+    });
+
+    it('converts explicit seeks between milliseconds and seconds', async () => {
+        const player = createPlayer();
+        const mediaElement = await player.createMediaElement({ fullscreen: false });
+
+        mediaElement.currentTime = 6;
+        expect(player.currentTime()).toBe(6000);
+
+        player.currentTime(12000);
+        expect(mediaElement.currentTime).toBe(12);
+        expect(player.currentTime()).toBe(12000);
+
+        player.currentTime(0);
+        expect(mediaElement.currentTime).toBe(0);
+        expect(player.currentTime()).toBe(0);
+    });
+});

--- a/src/components/playback/playbackPosition.test.ts
+++ b/src/components/playback/playbackPosition.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    getPlaybackRetryStartTicks,
+    PlaybackTimeCache
+} from './playbackPosition';
+
+describe('PlaybackTimeCache', () => {
+    it('starts without a cached time', () => {
+        const cache = new PlaybackTimeCache();
+
+        expect(cache.get()).toBeNull();
+    });
+
+    it('does not cache an initial observed zero', () => {
+        const cache = new PlaybackTimeCache();
+
+        cache.update(0);
+
+        expect(cache.get()).toBeNull();
+    });
+
+    it('preserves the last playback time across a transient zero', () => {
+        const cache = new PlaybackTimeCache();
+        cache.update(600);
+
+        cache.update(0);
+
+        expect(cache.get()).toBe(600);
+    });
+
+    it('updates as playback advances', () => {
+        const cache = new PlaybackTimeCache();
+        cache.update(600);
+
+        cache.update(720);
+
+        expect(cache.get()).toBe(720);
+    });
+
+    it('accepts an explicit seek to zero', () => {
+        const cache = new PlaybackTimeCache();
+        cache.update(600);
+
+        cache.set(0);
+
+        expect(cache.get()).toBe(0);
+    });
+
+    it('clears the previous playback time on reset', () => {
+        const cache = new PlaybackTimeCache();
+        cache.update(600);
+
+        cache.reset();
+
+        expect(cache.get()).toBeNull();
+    });
+});
+
+describe('getPlaybackRetryStartTicks', () => {
+    it('uses the requested start position before playback starts', () => {
+        expect(getPlaybackRetryStartTicks(0, 300, false)).toBe(300);
+    });
+
+    it('uses the current position after playback starts', () => {
+        expect(getPlaybackRetryStartTicks(900, 300, true)).toBe(900);
+    });
+
+    it('preserves an intentional seek to zero after playback starts', () => {
+        expect(getPlaybackRetryStartTicks(0, 300, true)).toBe(0);
+    });
+
+    it('falls back to the requested start position for an invalid current position', () => {
+        expect(getPlaybackRetryStartTicks(Number.NaN, 300, true)).toBe(300);
+    });
+});

--- a/src/components/playback/playbackPosition.ts
+++ b/src/components/playback/playbackPosition.ts
@@ -1,0 +1,33 @@
+export class PlaybackTimeCache {
+    private time: number | null = null;
+
+    get(): number | null {
+        return this.time;
+    }
+
+    reset(): void {
+        this.time = null;
+    }
+
+    set(time: number): void {
+        this.time = time;
+    }
+
+    update(time: number): void {
+        if (time !== 0) {
+            this.time = time;
+        }
+    }
+}
+
+export function getPlaybackRetryStartTicks(
+    currentTicks: number,
+    playerStartPositionTicks: number | undefined,
+    playbackStarted: boolean | undefined
+): number | undefined {
+    if (playbackStarted && Number.isFinite(currentTicks)) {
+        return currentTicks;
+    }
+
+    return currentTicks || playerStartPositionTicks;
+}

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -33,6 +33,7 @@ import { OutboundWebSocketMessageType } from '@jellyfin/sdk/lib/websocket';
 import { MediaError } from 'types/mediaError';
 import { getMediaError } from 'utils/mediaError';
 import { bindSkipSegment } from './skipsegment.ts';
+import { getPlaybackRetryStartTicks } from './playbackPosition.ts';
 import * as bitrateTest from 'utils/bitrateTest';
 
 const UNLIMITED_ITEMS = -1;
@@ -3418,7 +3419,11 @@ export class PlaybackManager {
 
                 // Auto switch to transcoding
                 if (enablePlaybackRetryWithTranscoding(streamInfo, errorType, currentlyPreventsVideoStreamCopy, currentlyPreventsAudioStreamCopy)) {
-                    const startTime = getCurrentTicks(player) || streamInfo.playerStartPositionTicks;
+                    const startTime = getPlaybackRetryStartTicks(
+                        getCurrentTicks(player),
+                        streamInfo.playerStartPositionTicks,
+                        streamInfo.started
+                    );
                     const isRemoteSource = streamInfo.item.LocationType === 'Remote';
                     // force transcoding and only allow remuxing for remote source like liveTV, but only for initial trial
                     const tryVideoStreamCopy = isRemoteSource && !isAlreadyFallbacking;

--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -44,6 +44,7 @@ import { setBackdropTransparency, TRANSPARENCY_LEVEL } from '../../components/ba
 import Events from '../../utils/events.ts';
 import { includesAny } from '../../utils/container.ts';
 import { isHls } from '../../utils/mediaSource.ts';
+import { PlaybackTimeCache } from '../../components/playback/playbackPosition.ts';
 
 /**
  * Returns resolved URL.
@@ -289,10 +290,7 @@ export class HtmlVideoPlayer {
      * @type {boolean | undefined}
      */
     #timeUpdated;
-    /**
-     * @type {number | null | undefined}
-     */
-    #currentTime;
+    #currentTime = new PlaybackTimeCache();
 
     /**
      * @private (used in other files)
@@ -397,7 +395,7 @@ export class HtmlVideoPlayer {
         this.#started = false;
         this.#timeUpdated = false;
 
-        this.#currentTime = null;
+        this.#currentTime.reset();
 
         if (options.resetSubtitleOffset !== false) this.resetSubtitleOffset();
 
@@ -922,7 +920,7 @@ export class HtmlVideoPlayer {
             this.ensureValidVideo(elem);
         }
 
-        this.#currentTime = time;
+        this.#currentTime.update(time);
 
         const currentPlayOptions = this._currentPlayOptions;
         // Not sure yet how this is coming up null since we never null it out, but it is causing app crashes
@@ -1798,12 +1796,14 @@ export class HtmlVideoPlayer {
         const mediaElement = this.#mediaElement;
         if (mediaElement) {
             if (val != null) {
-                mediaElement.currentTime = val / 1000;
+                const time = val / 1000;
+                this.#currentTime.set(time);
+                mediaElement.currentTime = time;
                 return;
             }
 
-            const currentTime = this.#currentTime;
-            if (currentTime) {
+            const currentTime = this.#currentTime.get();
+            if (currentTime != null) {
                 return currentTime * 1000;
             }
 


### PR DESCRIPTION
### Background

I first noticed this at the gym, where the Wi-Fi and whatever 5G I could get inside the building were both pretty flaky. When the connection stalled, playback would sometimes seem to randomly restart.

It wasnt actually going back to the beginning. It was jumping back to the resume point the session originally started from, so any progress made during the current session was ditched.

### Changes

This keeps the last real player position when the media element briefly reports zero and uses it for the retry. An actual seek back to zero still stays at zero.

It also makes HLS errors after startup go through the normal playback error path so fallback can actually run. This doesnt change codec, transcoding, subtitle, buffering, server or UI policy.

### How it fixes it

There were two parts to the problem.

HLS errors that happened after playback had already started could still be handled like startup failures. That meant the normal playback error and fallback path didnt always run.

When the failing media element was reset it could also briefly report its position as zero. The retry would then fall back to the saved resume point from the start of the session, which is why it looked like playback had randomly restarted.

This change sends post-start HLS errors through the normal fallback path and keeps the last real playback position through that temporary zero. A deliberate seek back to zero is still kept as zero.

### Issues

This addresses the HTML player and Android WebView recovery path behind the same kind of rewind reported in:

* [jellyfin/jellyfin#14689](https://github.com/jellyfin/jellyfin/issues/14689)
* [jellyfin/jellyfin-android#1764](https://github.com/jellyfin/jellyfin-android/issues/1764)

Both issues are still open, but they also contain reports involving other players and possible media timestamp problems. I dont think this PR should automatically close either of them or claim to fix the Android TV player.

### Code assistance

I used Codex to trace the player paths, help write the patch and tests, run the local checks, and set up the controlled before and after test on my Viture Neckband. I reviewed the code, test results, recordings and proof as we worked through it.

### Testing

* `npm run lint` passed with 0 errors
* `npm run stylelint` passed
* `npm run build:check` passed
* `npm test` passed, 16 files and 186 tests
* `npm run build:es-check` passed the production build and checked 981 generated JavaScript files
* Focused Stryker run covered 30 mutants with 29 killed, 1 timeout and 0 survivors

### Before and after proof

I reproduced the flaky connection as a controlled failure using the same Viture Neckband V1231, Jellyfin Android 2.6.3, Android System WebView 150, Jellyfin server 10.10.3 and Fallout S2E7 H264/EAC3 HLS remux.

Both runs started from a five minute saved position, played past twenty minutes, then returned HTTP 503 for exactly the next HLS segment.

Before, playback was at 21:37 when the connection failed. The active session dropped to zero and paused, the app returned to the series backdrop, and there was no retry `PlaybackInfo` request.

After, playback was at 20:22 when the connection failed. The client immediately requested fallback `PlaybackInfo`, restarted near the current session position, and was still playing at 21:12.

* [Before video](https://github.com/anagnorisis2peripeteia/jellyfin-web/releases/download/proof-f7d9348f/before-sanitized.mp4)
* [After video](https://github.com/anagnorisis2peripeteia/jellyfin-web/releases/download/proof-f7d9348f/after-sanitized.mp4)
* [Redacted proof package](https://github.com/anagnorisis2peripeteia/jellyfin-web/releases/download/proof-f7d9348f/jellyfin-web-proof-f7d9348f.zip)

The public clips are pixelated and have no audio. The package contains the supporting logs, session state and checksums.

### Non-video proof

The redacted request logs and Jellyfin session snapshots show the same result as the recordings:

* [Before session state](https://github.com/anagnorisis2peripeteia/jellyfin-web/releases/download/proof-f7d9348f/before-state.json): playback went from 21:37 and playing to position zero and paused after the injected failure.
* [Before request log](https://github.com/anagnorisis2peripeteia/jellyfin-web/releases/download/proof-f7d9348f/before-proxy.log): the HLS segment received the controlled 503, but there was no fallback `PlaybackInfo` request.
* [After session state](https://github.com/anagnorisis2peripeteia/jellyfin-web/releases/download/proof-f7d9348f/after-state.json): playback went from 20:22 to 21:12 and remained playing.
* [After request log](https://github.com/anagnorisis2peripeteia/jellyfin-web/releases/download/proof-f7d9348f/after-proxy.log): the controlled 503 was immediately followed by a new `PlaybackInfo` request and fallback HLS segment requests.

Peer review: https://github.com/jellyfin/jellyfin-web/pull/8141#pullrequestreview-4678142189

Review history: https://gist.github.com/8762ab257c5bee19c29ed0e1c62568cf

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A%22merge+conflict%22+-label%3Astale+-author%3A%40me).
