### PR TITLE
Fix SyncPlay ping never being reported to the server

### DIFF
--- a/src/plugins/syncPlay/core/Manager.js
+++ b/src/plugins/syncPlay/core/Manager.js
@@ -61,7 +61,7 @@ class Manager {
 
         Events.on(this.timeSyncCore, 'time-sync-server-update', (event, timeOffset, ping) => {
             // Report ping back to server.
-            if (this.syncEnabled) {
+            if (this.isSyncPlayEnabled()) {
                 this.getApiClient().sendSyncPlayPing({
                     Ping: ping
                 });

--- a/src/plugins/syncPlay/core/timeSync/TimeSync.js
+++ b/src/plugins/syncPlay/core/timeSync/TimeSync.js
@@ -49,7 +49,7 @@ class Measurement {
      * Get ping time, in milliseconds.
      */
     getPing() {
-        return this.getDelay() / 2;
+        return Math.round(this.getDelay() / 2);
     }
 }
 


### PR DESCRIPTION
### Fix SyncPlay ping never being reported to the server

Hello there! I started poking around some of the syncplay functionality to learn more about the subsystem, and hopefully make some improvements to the desync/laggy behavior my friends and I experience when using syncplay for movie nights. I found an unreachable code path as part of that learning experience. Upfront I want to mention I used Claude to help with this investigation, and I welcome any corrections to my understanding of this feature since I actively want to learn more about it. I am also working on a server side change to improve the latency compensation and debug logs for syncplay which is what let me get this test output. I provide below 

[jellyfin server PR](https://github.com/jellyfin/jellyfin/pull/17309)

### Changes
The server's SyncPlay latency compensation depends on clients periodically reporting their measured ping via `POST /SyncPlay/Ping`. That never actually happened: the guard in `Manager.js` checked `this.syncEnabled`, a property that is never set on `Manager` (only on `PlaybackCore`, and whether SyncPlay is active at all is already exposed via `isSyncPlayEnabled()`). The condition was always false, so `sendSyncPlayPing` never fired and server-side compensation silently ran on its hardcoded default for every session, for everyone, regardless of real network conditions.

Separately, `Measurement.getPing()` in `TimeSync.js` divides an integer delay by two, which can produce a fractional-millisecond value (e.g. `12.5`). The server's `Ping` field is a plain integer and rejects non-integer values with a 400, so even after fixing the first bug, some all ping reports (whenever the round-trip delay happened to be odd) would silently fail depending on network timing. This function doesn't appear to be used outside of syncplay so this was never caught due to the code path not being executed.

Using `isSyncPlayEnabled()` instead of `this.PlaybackCore.syncEnabled` also fixes another issue. Because syncEnabled won't be set till around 1.5 seconds in after joining a group, the three initial pings used to gauge latency wouldn't fire if we use syncEnabled . Using the Group method isSyncPlayEnabled which is flipped to true as soon as the group is created, allows those three baseline pings actually get sent out as expected.

### Issues
<!-- None filed; found while investigating SyncPlay desync reports and testing an unrelated server-side change. -->
I was not able to find any issues related to this specific problem.

### Code assistance
Both bugs were found/investigated with Claude Code. While testing a server-side SyncPlay change against a local deployment, ping reports were expected in the server logs but never appeared. Claude traced the client-side event-handler chain (`TimeSync.js` → `TimeSyncCore.js` → `Manager.js`) to find the `this.syncEnabled` scoping bug. While testing this update on a local deployment of jellyfin-web in a container, I noticed that these pings that previously were not firing could potentially return an intermittent 400 when inspecting the network requests. Claude separately diagnosed the intermittent 400s by tracing the ping value's computation back to the unrounded division. I reviewed and understood both root causes before applying the fixes, and validated the corrected behavior against a real running server.

### Testing
I am working on server side improvement to the latency compensation where this new debug information is coming from. That pull request can be found [here](https://github.com/jellyfin/jellyfin/pull/17309)
```
[2026-07-12 02:24:57.354 +00:00] [INF] [7] Emby.Server.Implementations.SyncPlay.Group: Session "c51c928ffc7d8b72fe3c2d70d9fcb40b" requested Ping in group "2ba3b99a-6494-4d7f-a0b0-c0a0c4414e8b" that is Paused.
[2026-07-12 02:24:57.364 +00:00] [DBG] [7] Emby.Server.Implementations.SyncPlay.Group: [SyncPlayMetrics] Session "c51c928ffc7d8b72fe3c2d70d9fcb40b" reported ping 12ms, smoothed 12ms -> 12ms.
[2026-07-12 02:25:57.458 +00:00] [INF] [47] Emby.Server.Implementations.SyncPlay.Group: Session "c51c928ffc7d8b72fe3c2d70d9fcb40b" requested Ping in group "2ba3b99a-6494-4d7f-a0b0-c0a0c4414e8b" that is Paused.
[2026-07-12 02:25:57.459 +00:00] [DBG] [47] Emby.Server.Implementations.SyncPlay.Group: [SyncPlayMetrics] Session "c51c928ffc7d8b72fe3c2d70d9fcb40b" reported ping 12ms, smoothed 12ms -> 12ms.
```

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [X] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A%22merge+conflict%22+-label%3Astale+-author%3A%40me) 
I am working on this part, but am new to the project and didn't know about this part until I had my changes ready.

