### PR TITLE
Fix card footer padding

### DIFF
--- a/src/components/cardbuilder/Card/CardFooterText.tsx
+++ b/src/components/cardbuilder/Card/CardFooterText.tsx
@@ -1,4 +1,4 @@
-import React, { type FC } from 'react';
+import React, { type FC, type PropsWithChildren } from 'react';
 import Box from '@mui/material/Box';
 import useCardText from './useCardText';
 import layoutManager from 'components/layoutManager';
@@ -20,6 +20,28 @@ const shouldShowDetailsMenu = (
         && cardOptions.cardFooterAside !== 'none'
     );
 };
+
+interface CardFooterWrapperProps {
+    cardOptions: CardOptions;
+    footerClass?: string;
+    isOuterFooter: boolean;
+    logoUrl?: string;
+}
+
+/** Component that conditionally wraps the footer content based on the card options and presence of a logo. */
+const CardFooterWrapper: FC<PropsWithChildren<CardFooterWrapperProps>> = ({
+    cardOptions,
+    footerClass,
+    isOuterFooter,
+    logoUrl,
+    children
+}) => (
+    (!isOuterFooter || logoUrl || cardOptions.cardLayout) ? (
+        <Box className={footerClass}>
+            {children}
+        </Box>
+    ) : children
+);
 
 interface LogoComponentProps {
     logoUrl: string;
@@ -72,7 +94,12 @@ const CardFooterText: FC<CardFooterTextProps> = ({
     });
 
     return (
-        <Box className={footerClass}>
+        <CardFooterWrapper
+            cardOptions={cardOptions}
+            footerClass={footerClass}
+            isOuterFooter={isOuterFooter}
+            logoUrl={logoUrl}
+        >
             {logoUrl && <LogoComponent logoUrl={logoUrl} />}
             {shouldShowDetailsMenu(cardOptions, isOuterFooter) && (
                 <MoreVertIconButton className='itemAction btnCardOptions' />
@@ -81,7 +108,7 @@ const CardFooterText: FC<CardFooterTextProps> = ({
             {cardTextLines}
 
             {progressBar}
-        </Box>
+        </CardFooterWrapper>
     );
 };
 

--- a/src/components/cardbuilder/card.scss
+++ b/src/components/cardbuilder/card.scss
@@ -299,7 +299,7 @@ button::-moz-focus-inner {
 }
 
 .cardText {
-    padding: 0.06em 0.5em;
+    padding: 0.06em 2px; // 2px horizontal padding to avoid touching multiselect border
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
### Changes
- Fixes the card footer wrapper logic in the modern app so it is only included under the same conditions as the legacy app. This prevents some extra padding from being added to the footer.
- Reduces the horizontal padding on card (footer) text so the text can go to the edge of the card with only a small adjustment for the multiselect border.

**Before**
<img width="1072" height="695" alt="IMG_8896" src="https://github.com/user-attachments/assets/3f0e6a40-0bb4-4356-b85e-16e652775f44" />

**After**
<img width="1058" height="603" alt="IMG_8895" src="https://github.com/user-attachments/assets/ebf0f8a3-5b71-4843-bce2-879d555b9e4f" />

### Issues
N/A

### Code assistance
Zed autocomplete

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
