### PR TITLE
Enable iOS background play when screen is turned off

### DIFF
--- a/src/plugins/htmlAudioPlayer/plugin.js
+++ b/src/plugins/htmlAudioPlayer/plugin.js
@@ -164,6 +164,11 @@ class HtmlAudioPlayer {
                 elem.crossOrigin = crossOrigin;
             }
 
+            // This avoids the AudioContext being suspended when Safari is put into background
+            if ('audioSession' in navigator) {
+               navigator.audioSession.type = 'playback';
+            }
+
             return enableHlsPlayer(val, options.item, options.mediaSource, 'Audio').then(function () {
                 return new Promise(function (resolve, reject) {
                     requireHlsPlayer(async () => {

--- a/src/plugins/htmlAudioPlayer/plugin.js
+++ b/src/plugins/htmlAudioPlayer/plugin.js
@@ -166,7 +166,7 @@ class HtmlAudioPlayer {
 
             // This avoids the AudioContext being suspended when Safari is put into background
             if ('audioSession' in navigator) {
-               navigator.audioSession.type = 'playback';
+                navigator.audioSession.type = 'playback';
             }
 
             return enableHlsPlayer(val, options.item, options.mediaSource, 'Audio').then(function () {


### PR DESCRIPTION
### Changes
Set background play on iOS when Normalization is turned off

### Issues
https://github.com/jellyfin/jellyfin-web/issues/6113
https://github.com/jellyfin/jellyfin-ios/issues/799
https://github.com/jellyfin/jellyfin-ios/issues/19
https://github.com/jellyfin/jellyfin-ios/issues/487

### Code assistance
None

---

* [X] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [X] I have tested these changes.
* [X] I have verified that this is not duplicating changes in an existing PR.
* [X] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
