### PR TITLE
Fix invalid request for all items on page load

### DIFF
--- a/src/hooks/useFetchItems.ts
+++ b/src/hooks/useFetchItems.ts
@@ -187,14 +187,14 @@ export const useGetQueryFiltersLegacy = (
 
 const fetchGetItemsViewByType = async (
     currentApi: JellyfinApiContext,
-    viewType: LibraryTab,
+    viewType: LibraryTab | undefined,
     parentId: ParentId,
     itemType: BaseItemKind[],
     libraryViewSettings: LibraryViewSettings,
     options?: AxiosRequestConfig
 ) => {
     const { api, user } = currentApi;
-    if (api && user?.Id) {
+    if (api && user?.Id && viewType) {
         const isFavorite = libraryViewSettings.Filters?.Status?.includes(ItemFilter.IsFavorite) || undefined;
         let response;
         switch (viewType) {
@@ -380,7 +380,7 @@ export const useGetItemsViewByType = (
         queryFn: ({ signal }) =>
             fetchGetItemsViewByType(
                 currentApi,
-                viewType!,
+                viewType,
                 parentId,
                 itemType,
                 libraryViewSettings!,


### PR DESCRIPTION
### Changes
For reasons unknown, this query was being called with an `undefined` view type even though the `enabled` check should prevent that. I did not find a clear reason for this in testing and somehow even changing the enabled expression to `!!viewType` seemed to prevent it, so I believe it is a strange edge case. Adding a guarding check in the fetch function itself seems like the safest approach to prevent unwanted queries.

### Issues
Fixes #8172

### Code assistance
Zed autocomplete

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
