### PR TITLE
Reduce calls to getApiClients

### DIFF
--- a/src/elements/emby-itemrefreshindicator/emby-itemrefreshindicator.js
+++ b/src/elements/emby-itemrefreshindicator/emby-itemrefreshindicator.js
@@ -38,9 +38,9 @@ EmbyItemRefreshIndicatorPrototype.createdCallback = function () {
         if (unsub) this._wsUnsubscribers.push(unsub);
     };
 
-    this._wsUnsubscribers = ServerConnections.getApiClients()
-        .map(apiClient => apiClient.subscribe([OutboundWebSocketMessageType.RefreshProgress], handler))
-        .filter(Boolean);
+    const serverId = dom.parentWithAttribute(this, 'data-serverid').getAttribute('data-serverid');
+    this._wsUnsubscribers = ServerConnections.getApiClient(serverId)
+        .subscribe([OutboundWebSocketMessageType.RefreshProgress], handler);
 };
 
 EmbyItemRefreshIndicatorPrototype.attachedCallback = function () {
@@ -72,4 +72,3 @@ document.registerElement('emby-itemrefreshindicator', {
     prototype: EmbyItemRefreshIndicatorPrototype,
     extends: 'div'
 });
-

--- a/src/elements/emby-itemrefreshindicator/emby-itemrefreshindicator.js
+++ b/src/elements/emby-itemrefreshindicator/emby-itemrefreshindicator.js
@@ -39,8 +39,8 @@ EmbyItemRefreshIndicatorPrototype.createdCallback = function () {
     };
 
     const serverId = dom.parentWithAttribute(this, 'data-serverid').getAttribute('data-serverid');
-    this._wsUnsubscribers = ServerConnections.getApiClient(serverId)
-        .subscribe([OutboundWebSocketMessageType.RefreshProgress], handler);
+    this._wsUnsubscribers = [ServerConnections.getApiClient(serverId)
+        .subscribe([OutboundWebSocketMessageType.RefreshProgress], handler)];
 };
 
 EmbyItemRefreshIndicatorPrototype.attachedCallback = function () {

--- a/src/elements/emby-itemrefreshindicator/emby-itemrefreshindicator.js
+++ b/src/elements/emby-itemrefreshindicator/emby-itemrefreshindicator.js
@@ -33,11 +33,6 @@ EmbyItemRefreshIndicatorPrototype.createdCallback = function () {
 
     const handler = ({ Data }) => onRefreshProgress(this, Data);
 
-    this._wsApiClientCreatedHandler = (e, newApiClient) => {
-        const unsub = newApiClient.subscribe([OutboundWebSocketMessageType.RefreshProgress], handler);
-        if (unsub) this._wsUnsubscribers.push(unsub);
-    };
-
     const serverId = dom.parentWithAttribute(this, 'data-serverid')?.getAttribute('data-serverid');
     const apiClient = serverId ? ServerConnections.getApiClient(serverId) : ServerConnections.currentApiClient();
     this._wsUnsubscribers = [];
@@ -63,10 +58,6 @@ EmbyItemRefreshIndicatorPrototype.detachedCallback = function () {
         unsub();
     });
     this._wsUnsubscribers = [];
-
-    if (this._wsApiClientCreatedHandler) {
-        this._wsApiClientCreatedHandler = null;
-    }
 
     this.itemId = null;
 };

--- a/src/elements/emby-itemrefreshindicator/emby-itemrefreshindicator.js
+++ b/src/elements/emby-itemrefreshindicator/emby-itemrefreshindicator.js
@@ -38,9 +38,12 @@ EmbyItemRefreshIndicatorPrototype.createdCallback = function () {
         if (unsub) this._wsUnsubscribers.push(unsub);
     };
 
-    const serverId = dom.parentWithAttribute(this, 'data-serverid').getAttribute('data-serverid');
-    this._wsUnsubscribers = [ServerConnections.getApiClient(serverId)
-        .subscribe([OutboundWebSocketMessageType.RefreshProgress], handler)];
+    const serverId = dom.parentWithAttribute(this, 'data-serverid')?.getAttribute('data-serverid');
+    const apiClient = serverId ? ServerConnections.getApiClient(serverId) : ServerConnections.currentApiClient();
+    this._wsUnsubscribers = [];
+    if (apiClient) {
+        this._wsUnsubscribers.push(apiClient.subscribe([OutboundWebSocketMessageType.RefreshProgress], handler));
+    }
 };
 
 EmbyItemRefreshIndicatorPrototype.attachedCallback = function () {

--- a/src/elements/emby-itemscontainer/emby-itemscontainer.js
+++ b/src/elements/emby-itemscontainer/emby-itemscontainer.js
@@ -302,7 +302,7 @@ ItemsContainerPrototype.attachedCallback = function () {
     this._wsApiClientCreatedHandler = (e, newApiClient) => {
         this._wsUnsubscribers = (this._wsUnsubscribers ?? []).concat(subscribeToApiClient(newApiClient));
     };
-    this._wsUnsubscribers = ServerConnections.getApiClients().flatMap(subscribeToApiClient);
+    this._wsUnsubscribers = [subscribeToApiClient(ServerConnections.currentApiClient())];
 
     addNotificationEvent(this, 'playbackstop', onPlaybackStopped, playbackManager);
 

--- a/src/elements/emby-itemscontainer/emby-itemscontainer.js
+++ b/src/elements/emby-itemscontainer/emby-itemscontainer.js
@@ -302,7 +302,7 @@ ItemsContainerPrototype.attachedCallback = function () {
     this._wsApiClientCreatedHandler = (e, newApiClient) => {
         this._wsUnsubscribers = (this._wsUnsubscribers ?? []).concat(subscribeToApiClient(newApiClient));
     };
-    this._wsUnsubscribers = [subscribeToApiClient(ServerConnections.currentApiClient())];
+    this._wsUnsubscribers = subscribeToApiClient(ServerConnections.currentApiClient());
 
     addNotificationEvent(this, 'playbackstop', onPlaybackStopped, playbackManager);
 

--- a/src/elements/emby-itemscontainer/emby-itemscontainer.js
+++ b/src/elements/emby-itemscontainer/emby-itemscontainer.js
@@ -299,12 +299,7 @@ ItemsContainerPrototype.attachedCallback = function () {
         apiClient.subscribe([OutboundWebSocketMessageType.LibraryChanged], (msg) => onLibraryChanged(msg, this))
     ].filter(Boolean) : [];
 
-    this._wsUnsubscribers = [];
-    this._wsApiClientCreatedHandler = (e, newApiClient) => {
-        this._wsUnsubscribers.push(...subscribeToApiClient(newApiClient));
-    };
-
-    this._wsUnsubscribers.push(...subscribeToApiClient(ServerConnections.currentApiClient()));
+    this._wsUnsubscribers = subscribeToApiClient(ServerConnections.currentApiClient());
 
     addNotificationEvent(this, 'playbackstop', onPlaybackStopped, playbackManager);
 
@@ -328,9 +323,6 @@ ItemsContainerPrototype.detachedCallback = function () {
         unsub();
     });
     this._wsUnsubscribers = [];
-    if (this._wsApiClientCreatedHandler) {
-        this._wsApiClientCreatedHandler = null;
-    }
 
     removeNotificationEvent(this, 'playbackstop', playbackManager);
 

--- a/src/elements/emby-itemscontainer/emby-itemscontainer.js
+++ b/src/elements/emby-itemscontainer/emby-itemscontainer.js
@@ -290,19 +290,21 @@ ItemsContainerPrototype.attachedCallback = function () {
 
     itemShortcuts.on(this, getShortcutOptions());
 
-    const subscribeToApiClient = (apiClient) => [
+    const subscribeToApiClient = apiClient => apiClient ? [
         apiClient.subscribe([OutboundWebSocketMessageType.UserDataChanged], (msg) => onUserDataChanged(msg, this)),
         apiClient.subscribe([OutboundWebSocketMessageType.TimerCreated], (msg) => onTimerCreated(msg, this)),
         apiClient.subscribe([OutboundWebSocketMessageType.SeriesTimerCreated], (msg) => onSeriesTimerCreated(msg, this)),
         apiClient.subscribe([OutboundWebSocketMessageType.TimerCancelled], (msg) => onTimerCancelled(msg, this)),
         apiClient.subscribe([OutboundWebSocketMessageType.SeriesTimerCancelled], (msg) => onSeriesTimerCancelled(msg, this)),
         apiClient.subscribe([OutboundWebSocketMessageType.LibraryChanged], (msg) => onLibraryChanged(msg, this))
-    ].filter(Boolean);
+    ].filter(Boolean) : [];
 
+    this._wsUnsubscribers = [];
     this._wsApiClientCreatedHandler = (e, newApiClient) => {
-        this._wsUnsubscribers = (this._wsUnsubscribers ?? []).concat(subscribeToApiClient(newApiClient));
+        this._wsUnsubscribers.push(...subscribeToApiClient(newApiClient));
     };
-    this._wsUnsubscribers = subscribeToApiClient(ServerConnections.currentApiClient());
+
+    this._wsUnsubscribers.push(...subscribeToApiClient(ServerConnections.currentApiClient()));
 
     addNotificationEvent(this, 'playbackstop', onPlaybackStopped, playbackManager);
 


### PR DESCRIPTION
### Changes
I noticed when debugging something else that we are making hundreds of calls to `_getOrAddApiClient` now due to the items containers and refresh indicators subscribing on all apiClients instead of only the relevant one.

This needs testing to verify it still works as expected.

### Issues
N/A

### Code assistance
Zed autocomplete

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [ ] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
