### PR TITLE
Migrate datetime to typescript

### DIFF
--- a/src/apps/dashboard/features/logs/components/LogItemList.tsx
+++ b/src/apps/dashboard/features/logs/components/LogItemList.tsx
@@ -12,7 +12,8 @@ type LogItemProps = {
 
 const LogItemList: FunctionComponent<LogItemProps> = ({ logs }: LogItemProps) => {
     const getDate = (logFile: LogFile) => {
-        const date = datetime.parseISO8601Date(logFile.DateModified, true);
+        // If DateModified is undefined or null, then this will throw an Error
+        const date = datetime.parseISO8601Date(logFile.DateModified as string, true);
         return datetime.toLocaleDateString(date) + ' ' + datetime.getDisplayTime(date);
     };
 

--- a/src/components/cardbuilder/Card/cardHelper.ts
+++ b/src/components/cardbuilder/Card/cardHelper.ts
@@ -488,7 +488,8 @@ function getSeriesTimerTime(item: ItemDto) {
     if (item.RecordAnyTime) {
         return globalize.translate('Anytime');
     } else {
-        return datetime.getDisplayTime(item.StartDate);
+        // If StartDate is undefined or null, this will throw an Error
+        return datetime.getDisplayTime(item.StartDate as string);
     }
 }
 

--- a/src/components/common/textLines/useTextLines.tsx
+++ b/src/components/common/textLines/useTextLines.tsx
@@ -75,8 +75,9 @@ function useTextLines({ item, textLineOpts = {} }: UseTextLinesProps) {
     const addProgramDateTime = () => {
         if (showProgramDateTime) {
             const programDateTime = datetime.toLocaleString(
-                datetime.parseISO8601Date(item.StartDate),
+                datetime.parseISO8601Date(item.StartDate as string),
                 {
+                    // @ts-expect-error: these arguments don't match what toLocaleString expects
                     weekday: 'long',
                     month: 'short',
                     day: 'numeric',
@@ -91,7 +92,8 @@ function useTextLines({ item, textLineOpts = {} }: UseTextLinesProps) {
     const addProgramTime = () => {
         if (showProgramTime) {
             const programTime = datetime.getDisplayTime(
-                datetime.parseISO8601Date(item.StartDate)
+                // If StartDate is null, this will throw an Error
+                datetime.parseISO8601Date(item.StartDate as string)
             );
             addTextLine({ title: programTime });
         }

--- a/src/components/indicators/useIndicator.tsx
+++ b/src/components/indicators/useIndicator.tsx
@@ -223,8 +223,9 @@ const useIndicator = (item: ItemDto) => {
             let endDate = 1;
 
             try {
-                startDate = datetime.parseISO8601Date(item.StartDate).getTime();
-                endDate = datetime.parseISO8601Date(item.EndDate).getTime();
+                // If either StartDate or EndDate are null or undefined, this will throw an Error
+                startDate = datetime.parseISO8601Date(item.StartDate as string).getTime();
+                endDate = datetime.parseISO8601Date(item.EndDate as string).getTime();
             } catch (err) {
                 console.error(err);
             }

--- a/src/components/mediainfo/usePrimaryMediaInfo.tsx
+++ b/src/components/mediainfo/usePrimaryMediaInfo.tsx
@@ -99,7 +99,8 @@ function addSeriesTimerInfo(
         if (itemRecordAnyTime) {
             addMiscInfo({ text: globalize.translate('Anytime') });
         } else {
-            addMiscInfo({ text: datetime.getDisplayTime(itemStartDate) });
+            // If itemStartDate is ever null, then getDisplayTime will throw an Error
+            addMiscInfo({ text: datetime.getDisplayTime(itemStartDate as string) });
         }
 
         if (itemRecordAnyChannel) {
@@ -288,6 +289,9 @@ function addproductionYearWithEndDate(
                 { useGrouping: false }
             );
             /* At this point, text will contain only the start year */
+            // @ts-expect-error: this appears to be an error. Since, toLocaleString() returns a `string` it can never equal itemProductionYear since it's a number.
+            // This is either a logic error or the typing on BaseItemDto is incorrect.
+            // eslint-disable-next-line sonarjs/different-types-comparison
             if (endYear !== itemProductionYear) {
                 productionYear += `-${endYear}`;
             }

--- a/src/scripts/datetime.ts
+++ b/src/scripts/datetime.ts
@@ -1,13 +1,14 @@
 import globalize from 'lib/globalize';
 
-export function parseISO8601Date(s, toLocal) {
+export function parseISO8601Date(s: string, toLocal?: boolean) {
     // parenthese matches:
     // year month day    hours minutes seconds
     // dotmilliseconds
     // tzstring plusminus hours minutes
     const re = /(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(\.\d+)?(Z|([+-])(\d{2}):(\d{2}))?/;
 
-    const d = s.match(re);
+    // eslint-disable-next-line sonarjs/prefer-regexp-exec
+    const d = s.match(re) as (string | number)[];
 
     // "2010-12-07T11:00:00.000-09:00" parses to:
     //  ["2010-12-07T11:00:00.000-09:00", "2010", "12", "07", "11",
@@ -23,14 +24,14 @@ export function parseISO8601Date(s, toLocal) {
     // parse strings, leading zeros into proper ints
     const a = [1, 2, 3, 4, 5, 6, 10, 11];
     for (const i in a) {
-        d[a[i]] = parseInt(d[a[i]], 10);
+        d[a[i]] = parseInt(d[a[i]] as string, 10);
     }
-    d[7] = parseFloat(d[7]);
+    d[7] = parseFloat(d[7] as string);
 
     // Date.UTC(year, month[, date[, hrs[, min[, sec[, ms]]]]])
     // note that month is 0-11, not 1-12
     // see https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Date/UTC
-    let ms = Date.UTC(d[1], d[2] - 1, d[3], d[4], d[5], d[6]);
+    let ms = Date.UTC(d[1] as number, d[2] as number - 1, d[3] as number, d[4] as number, d[5] as number, d[6] as number);
 
     // if there are milliseconds, add them
     if (d[7] > 0) {
@@ -39,9 +40,9 @@ export function parseISO8601Date(s, toLocal) {
 
     // if there's a timezone, calculate it
     if (d[8] !== 'Z' && d[10]) {
-        let offset = d[10] * 60 * 60 * 1000;
+        let offset = d[10] as number * 60 * 60 * 1000;
         if (d[11]) {
-            offset += d[11] * 60 * 1000;
+            offset += d[11] as number * 60 * 1000;
         }
         if (d[9] === '-') {
             ms -= offset;
@@ -57,9 +58,9 @@ export function parseISO8601Date(s, toLocal) {
 
 /**
      * Return a string in '{}h {}m' format for duration.
-     * @param {number} ticks - Duration in ticks.
+     * @param ticks - Duration in ticks.
      */
-export function getDisplayDuration(ticks) {
+export function getDisplayDuration(ticks: number): string {
     const totalMinutes = Math.round(ticks / 600000000) || 1;
     const totalHours = Math.floor(totalMinutes / 60);
     const remainderMinutes = totalMinutes % 60;
@@ -71,7 +72,7 @@ export function getDisplayDuration(ticks) {
     return result.join(' ');
 }
 
-export function getDisplayRunningTime(ticks) {
+export function getDisplayRunningTime(ticks: number) {
     const ticksPerHour = 36000000000;
     const ticksPerMinute = 600000000;
     const ticksPerSecond = 10000000;
@@ -87,7 +88,7 @@ export function getDisplayRunningTime(ticks) {
 
     ticks -= (hours * ticksPerHour);
 
-    let minutes = ticks / ticksPerMinute;
+    let minutes: string | number = ticks / ticksPerMinute;
     minutes = Math.floor(minutes);
 
     ticks -= (minutes * ticksPerMinute);
@@ -99,7 +100,7 @@ export function getDisplayRunningTime(ticks) {
     }
     parts.push(minutes);
 
-    let seconds = ticks / ticksPerSecond;
+    let seconds: string | number = ticks / ticksPerSecond;
     seconds = Math.floor(seconds);
 
     if (seconds < 10) {
@@ -117,12 +118,13 @@ const toLocaleTimeStringSupportsLocales = function () {
         // eslint-disable-next-line sonarjs/no-ignored-return
         new Date().toLocaleTimeString('i');
     } catch (e) {
+        // @ts-expect-error: type of e is not specified
         return e.name === 'RangeError';
     }
     return false;
 }();
 
-function getOptionList(options) {
+function getOptionList<T>(options: Record<string, T>): { name: string; value: T }[] {
     const list = [];
 
     for (const i in options) {
@@ -135,7 +137,7 @@ function getOptionList(options) {
     return list;
 }
 
-export function toLocaleString(date, options) {
+export function toLocaleString(date: Date | number, options?: Intl.NumberFormatOptions) {
     if (!date) {
         throw new Error('date cannot be null');
     }
@@ -153,7 +155,7 @@ export function toLocaleString(date, options) {
     return date.toLocaleString();
 }
 
-export function toLocaleDateString(date, options) {
+export function toLocaleDateString(date: Date, options?: Intl.DateTimeFormatOptions) {
     if (!date) {
         throw new Error('date cannot be null');
     }
@@ -169,6 +171,7 @@ export function toLocaleDateString(date, options) {
     }
 
     // This is essentially a hard-coded polyfill
+    // @ts-expect-error: the typing here is rather complex
     const optionList = getOptionList(options);
     if (optionList.length === 1 && optionList[0].name === 'weekday') {
         const weekday = [];
@@ -185,7 +188,7 @@ export function toLocaleDateString(date, options) {
     return date.toLocaleDateString();
 }
 
-export function toLocaleTimeString(date, options) {
+export function toLocaleTimeString(date: Date, options?: Intl.DateTimeFormatOptions) {
     if (!date) {
         throw new Error('date cannot be null');
     }
@@ -203,7 +206,7 @@ export function toLocaleTimeString(date, options) {
     return date.toLocaleTimeString();
 }
 
-export function getDisplayDateTime(date) {
+export function getDisplayDateTime(date: Date | string): string {
     if (!date) {
         throw new Error('date cannot be null');
     }
@@ -212,14 +215,14 @@ export function getDisplayDateTime(date) {
         try {
             date = parseISO8601Date(date, true);
         } catch {
-            return date;
+            return date as string;
         }
     }
 
     return toLocaleString(date);
 }
 
-export function getDisplayTime(date) {
+export function getDisplayTime(date: Date | string): string {
     if (!date) {
         throw new Error('date cannot be null');
     }
@@ -228,13 +231,12 @@ export function getDisplayTime(date) {
         try {
             date = parseISO8601Date(date, true);
         } catch {
-            return date;
+            return date as string;
         }
     }
 
     if (toLocaleTimeStringSupportsLocales) {
         return toLocaleTimeString(date, {
-
             hour: 'numeric',
             minute: '2-digit'
 
@@ -251,7 +253,7 @@ export function getDisplayTime(date) {
         if (!hour) {
             hour = 12;
         }
-        let minutes = date.getMinutes();
+        let minutes: number | string = date.getMinutes();
 
         if (minutes < 10) {
             minutes = '0' + minutes;
@@ -273,7 +275,7 @@ export function getDisplayTime(date) {
     return time;
 }
 
-export function isRelativeDay(date, offsetInDays) {
+export function isRelativeDay(date: Date, offsetInDays: number) {
     if (!date) {
         throw new Error('date cannot be null');
     }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

### Changes
<!--
Describe your changes here in 1-5 sentences.
Please include before/after screenshots of any UI changes.
-->

### Issues
<!--
Tag any issues that this PR solves here.
ex. Fixes #
-->

### Code assistance
<!--
If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance.
-->

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [ ] I have tested these changes.
    * dates look the same in:
        * [x] in admin dashboard logs
            * `7/17/2026 12:19 PM`
        * [ ] card series time
            * This code path is only hit if `showSeriesTimerChannel` is `true` which seems to only be true in the `livetv` case. (I didn't know that jellyfin supported live tv streams, so I'm not really sure how to test this one)
        * [ ] useTextLines
            * These changes also seem to only apply to live tv
        * [ ] useIndicator (wherever that's used)
        * [ ] usePrimaryMediaInfo (wherever that's usd
* [ ] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
