### PR TITLE
Add version restore warning

### DIFF
--- a/src/apps/dashboard/features/backups/components/RestoreConfirmationDialog.tsx
+++ b/src/apps/dashboard/features/backups/components/RestoreConfirmationDialog.tsx
@@ -26,7 +26,7 @@ const RestoreConfirmationDialog: FunctionComponent<IProps> = ({ open, onClose, o
             </DialogTitle>
 
             <DialogContent>
-                <DialogContentText>
+                <DialogContentText sx={{ whiteSpace: 'pre-line' }}>
                     {globalize.translate('MessageRestoreDisclaimer')}
                 </DialogContentText>
             </DialogContent>

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1208,7 +1208,7 @@
     "MessageReenableUser": "See below to reenable",
     "MessageRenameMediaFolder": "Renaming a media library will cause all metadata to be lost, proceed with caution.",
     "MessageRepositoryInstallDisclaimer": "WARNING: Installing a third party plugin repository carries risks. It may contain unstable or malicious code, and may change at any time. Only install repositories from authors that you trust.",
-    "MessageRestoreDisclaimer": "WARNING: You are about to restore from a previous backup. Your server will be rendered unusable for the duration of the process and any new data created since the backup will be lost.",
+    "MessageRestoreDisclaimer": "WARNING: You are about to restore from a previous backup. Your server will be rendered unusable for the duration of the process and any new data created since the backup will be lost.\n\nBackups should only be restored to the same version they were created on. Restoring a backup to a different version is unsupported and may render the server unusable.",
     "MessageRestoreInProgress": "Restore in progress",
     "MessageRestoreSuccess": "Restore successfully completed",
     "MessageSent": "Message sent.",


### PR DESCRIPTION
Backups should only be restored to the same server version they were created on. Restoring to a newer version may cause the server to be unusable. 

### Changes
Add a warning to relay this when initiating a restore. 

### Issues
N/A

### Code assistance
N/A

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
