### PR TITLE
Show the server-provided name for plugin tuner types

### DIFF
--- a/src/apps/dashboard/features/livetv/api/useTunerHostTypes.ts
+++ b/src/apps/dashboard/features/livetv/api/useTunerHostTypes.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { useApi } from 'hooks/useApi';
+import { getLiveTvApi } from '@jellyfin/sdk/lib/utils/api/live-tv-api';
+
+export const useTunerHostTypes = () => {
+    const { api } = useApi();
+
+    return useQuery({
+        queryKey: [ 'TunerHostTypes' ],
+        queryFn: async () => (await getLiveTvApi(api!).getTunerHostTypes()).data,
+        enabled: !!api
+    });
+};

--- a/src/apps/dashboard/features/livetv/components/TunerDeviceCard.tsx
+++ b/src/apps/dashboard/features/livetv/components/TunerDeviceCard.tsx
@@ -13,6 +13,7 @@ import globalize from 'lib/globalize';
 import { useNavigate } from 'react-router-dom';
 import ConfirmDialog from 'components/ConfirmDialog';
 import { useDeleteTuner } from '../api/useDeleteTuner';
+import { useTunerHostTypes } from '../api/useTunerHostTypes';
 
 interface TunerDeviceCardProps {
     tunerHost: TunerHostInfo;
@@ -25,6 +26,11 @@ const TunerDeviceCard = ({ tunerHost }: TunerDeviceCardProps) => {
     const [ isMenuOpen, setIsMenuOpen ] = useState(false);
     const [ isConfirmDeleteDialogOpen, setIsConfirmDeleteDialogOpen ] = useState(false);
     const deleteTuner = useDeleteTuner();
+    const { data: tunerTypes } = useTunerHostTypes();
+
+    // Prefer the name the server reports for this tuner type; this covers plugin-provided tuners that the
+    // static getTunerName() list does not know about. getTunerName is kept as a fallback while it loads.
+    const typeName = tunerTypes?.find(type => type.Id === tunerHost.Type)?.Name;
 
     const navigateToEditPage = useCallback(() => {
         navigate(`/dashboard/livetv/tuner?id=${tunerHost.Id}`);
@@ -75,7 +81,7 @@ const TunerDeviceCard = ({ tunerHost }: TunerDeviceCardProps) => {
             />
 
             <BaseCard
-                title={tunerHost.FriendlyName || getTunerName(tunerHost.Type) || ''}
+                title={tunerHost.FriendlyName || typeName || getTunerName(tunerHost.Type) || ''}
                 text={tunerHost.Url || ''}
                 icon={<DvrIcon sx={{ fontSize: 70 }} />}
                 action={true}


### PR DESCRIPTION
### Changes

The tuner device card resolves its title from a hardcoded type list (`getTunerName`) and shows "Unknown" for any type not in it, including plugin-provided tuners. This uses the display name returned by the `TunerHosts/Types` endpoint via a small `useTunerHostTypes` hook, keeping `getTunerName` as a fallback while the query loads.

A plugin can register an `ITunerHost`; it shows up by name in the "Add Tuner Device" dropdown, but once added the device card reads "Unknown". This makes the card match the dropdown.

Motivating case: https://github.com/vk496/jellyfin-htsp-tuner

### Issues

Part of jellyfin/jellyfin#17372. The guide provider list has the same limitation but needs a new API, proposed in jellyfin/jellyfin#17371.

### Code assistance

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [ ] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A%22merge+conflict%22+-label%3Astale+-author%3A%40me).
