### PR TITLE
Fix remote control queue not refreshing

### DIFF
--- a/src/plugins/sessionPlayer/plugin.js
+++ b/src/plugins/sessionPlayer/plugin.js
@@ -133,7 +133,10 @@ function updateCurrentQueue(instance, session) {
         instance.isPlaylistRendered = true;
     };
 
-    updatePlaylist(instance, current).then(finish, finish);
+    updatePlaylist(instance, current).then(() => {
+        finish();
+        Events.trigger(instance, 'playlistitemadd');
+    }, finish);
 }
 
 function processUpdatedSessions(instance, sessions, apiClient) {


### PR DESCRIPTION
### Changes
Notify queue consumers after the session player's asynchronous playlist refresh completes. Previously, `statechange` could be handled before the playlist was populated, leaving the controlling client's queue empty.

### Issues
Fixes #8182.

### Code assistance
Use of LLM for codebase navigation.

---

- [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
- [x] I have tested these changes.
- [x] I have verified that this is not duplicating changes in an existing PR.
- [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A%22merge+conflict%22+-label%3Astale+-author%3A%40me).
