### PR TITLE
Disable Audio Normalization in iOS to fix pitch and speed issues

### DIFF
--- a/src/components/playbackSettings/playbackSettings.js
+++ b/src/components/playbackSettings/playbackSettings.js
@@ -259,6 +259,7 @@ function loadForm(context, user, userSettings, systemInfo, apiClient) {
     context.querySelector('.chkEnableHi10p').checked = appSettings.enableHi10p();
     context.querySelector('.chkEnableCinemaMode').checked = userSettings.enableCinemaMode();
     context.querySelector('#selectAudioNormalization').value = userSettings.selectAudioNormalization();
+    context.querySelector('.fldAudioNormalization').classList.toggle('hide', browser.iOS);
     context.querySelector('.chkEnableNextVideoOverlay').checked = userSettings.enableNextVideoInfoOverlay();
     context.querySelector('.chkRememberAudioSelections').checked = user.Configuration.RememberAudioSelections || false;
     context.querySelector('.chkRememberSubtitleSelections').checked = user.Configuration.RememberSubtitleSelections || false;

--- a/src/components/playbackSettings/playbackSettings.template.html
+++ b/src/components/playbackSettings/playbackSettings.template.html
@@ -231,7 +231,7 @@
             ${HeaderAudioAdvanced}
         </h2>
 
-        <div class="selectContainer">
+        <div class="selectContainer fldAudioNormalization">
             <select is="emby-select" id="selectAudioNormalization" label="${LabelSelectAudioNormalization}">
                 <option value="Off">${Off}</option>
                 <option value="TrackGain">${LabelTrackGain}</option>

--- a/src/plugins/htmlAudioPlayer/plugin.js
+++ b/src/plugins/htmlAudioPlayer/plugin.js
@@ -115,6 +115,11 @@ class HtmlAudioPlayer {
             let val = options.url;
             console.debug('playing url: ' + val);
             import('../../scripts/settings/userSettings').then((userSettings) => {
+                if (browser.iOS) {
+                    // createMediaElementSource breaks playbackRate and pitch on iOS WebKit
+                    return;
+                }
+
                 let normalizationGain;
                 if (userSettings.selectAudioNormalization() == 'TrackGain') {
                     normalizationGain = options.item.NormalizationGain


### PR DESCRIPTION
### Changes
- Hide Audio Normalization setting in iOS platform
- Early return from the Audio Normalization settings block when iOS client to ignore Audio Normalization

### Issues
- Pitch issues in iOS discovered while testing out https://github.com/jellyfin/jellyfin-web/pull/7681 and continued in https://github.com/jellyfin/jellyfin-web/pull/8201 determined to be because of Audio Normalization
- Not a current issue, but also currently blocking me from adding html's playbackRate (audio speed) for Audiobooks. I have a server fix for this using Atempo but makes the feature much more complex. playbackRate is currently only broken on iOS when Audio Normalization is turned on

### Code assistance
None

---

* [X] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [X] I have tested these changes.
* [X] I have verified that this is not duplicating changes in an existing PR.
* [X] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
