### PR TITLE
Fix false-positive MPEG2/VC-1 direct play on Xbox WebView2

### DIFF
--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -237,10 +237,20 @@ function testCanPlayTs() {
 }
 
 function supportsMpeg2Video() {
+    if (browser.xboxOne) {
+        // webview2 on xbox matches the edgeUwp check but cannot actually decode mpeg2
+        return false;
+    }
+
     return browser.tizen || browser.web0s || browser.edgeUwp;
 }
 
 function supportsVc1(videoTestElement) {
+    if (browser.xboxOne) {
+        // webview2 on xbox matches the edgeUwp check but cannot actually decode vc-1
+        return false;
+    }
+
     return browser.tizen || browser.web0s || browser.edgeUwp || videoTestElement.canPlayType('video/mp4; codecs="vc-1"').replace(/no/, '');
 }
 


### PR DESCRIPTION
## Root cause

`browser.edgeUwp` in `src/scripts/browser.js` is computed as:

```js
(browser.edge || browser.edgeChromium) && (ua.includes('msapphost') || ua.includes('webview'))
```

This flag was originally intended for the old **EdgeHTML/UWP** Xbox host, which used Windows Media Foundation and could genuinely hardware-decode MPEG2 and VC-1.

The new Chromium/WebView2-based Xbox client (jellyfin-xbox) sends a user agent that also contains both `Edg/` and `WebView2`, so it **also** matches `browser.edgeUwp = true` -- even though Chromium/WebView2 cannot decode MPEG2 or VC-1 at all.

In `src/scripts/browserDeviceProfile.js`, `supportsMpeg2Video()` and `supportsVc1()` gated purely on this flag, so the server was told the WebView2 Xbox client could direct-play MPEG2/VC-1. Direct play was attempted, WebView2 failed to decode it, and playback fell back to transcoding -- producing the "there was an error starting direct playback" symptom reported in jellyfin/jellyfin-xbox#113 for MPEG2 files.

This is the exact same class of bug already worked around in `canPlayAv1()`, which special-cases `browser.xboxOne` because "webview2 on xbox may falsely report AV1 as supported".

## Fix

Add an early `if (browser.xboxOne) { return false; }` guard to both `supportsMpeg2Video()` and `supportsVc1()`, mirroring the existing `canPlayAv1()` workaround. Tizen/webOS support and the VC-1 `canPlayType` fallback for other platforms are unchanged.

## Notes

- Node.js/npm were not available in the environment this change was authored in, so `npm run lint` / tests could not be executed locally. The change is a minimal, style-consistent mirror of the existing `canPlayAv1()` guard in the same file -- please run CI/lint on this PR.
- Opened as a **draft** since this fix addresses a client-side symptom reported against a different repo and needs maintainer/community review before merging.

Refs jellyfin/jellyfin-xbox#113
