### PR TITLE
Add helper text clarifying subtitle sync slider direction

### DIFF
--- a/src/components/subtitlesync/subtitlesync.js
+++ b/src/components/subtitlesync/subtitlesync.js
@@ -1,6 +1,7 @@
 
 import { playbackManager } from '../playback/playbackmanager';
 import layoutManager from '../layoutManager';
+import globalize from 'lib/globalize';
 import template from './subtitlesync.template.html';
 import './subtitlesync.scss';
 
@@ -9,6 +10,7 @@ let subtitleSyncSlider;
 let subtitleSyncTextField;
 let subtitleSyncCloseButton;
 let subtitleSyncContainer;
+let subtitleSyncHelpText;
 
 function init(instance) {
     const parent = document.createElement('div');
@@ -19,6 +21,9 @@ function init(instance) {
     subtitleSyncTextField = parent.querySelector('.subtitleSyncTextField');
     subtitleSyncCloseButton = parent.querySelector('.subtitleSync-closeButton');
     subtitleSyncContainer = parent.querySelector('.subtitleSyncContainer');
+    subtitleSyncHelpText = parent.querySelector('.subtitleSyncHelpText');
+
+    subtitleSyncHelpText.textContent = globalize.translate('SubtitleOffsetHelp');
 
     if (layoutManager.tv) {
         subtitleSyncSlider.classList.add('focusable');

--- a/src/components/subtitlesync/subtitlesync.scss
+++ b/src/components/subtitlesync/subtitlesync.scss
@@ -9,7 +9,7 @@
     min-width: 18em;
     margin-left: auto;
     margin-right: auto;
-    height: 4.2em;
+    height: 6.3em;
     background: rgba(28, 28, 28, 0.8);
     border-radius: 0.3em;
     color: #fff;
@@ -50,4 +50,15 @@
     flex-grow: 1;
     border-radius: 0.3em;
     z-index: 1;
+}
+
+.subtitleSyncHelpText {
+    position: absolute;
+    left: 0;
+    width: 100%;
+    top: 4.6em;
+    text-align: center;
+    font-size: 0.9em;
+    color: #ccc;
+    z-index: 2;
 }

--- a/src/components/subtitlesync/subtitlesync.template.html
+++ b/src/components/subtitlesync/subtitlesync.template.html
@@ -5,5 +5,6 @@
         <div class="sliderContainer subtitleSyncSliderContainer">
             <input is="emby-slider" type="range" step="0.1" min="-30" max="30" value="0" class="subtitleSyncSlider" data-slider-keep-progress="true" />
         </div>
+        <div class="subtitleSyncHelpText"></div>
     </div>
 </div>

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1636,6 +1636,7 @@
     "SubtitleLightGray": "Light Gray",
     "SubtitleMagenta": "Magenta",
     "SubtitleOffset": "Subtitle Offset",
+    "SubtitleOffsetHelp": "Increase the delay if subtitles are too early, decrease if too late",
     "SubtitleRed": "Red",
     "Subtitles": "Subtitles",
     "SubtitleVerticalPositionHelp": "Line number where text appears. Positive numbers indicate top down. Negative numbers indicate bottom up.",


### PR DESCRIPTION
### Changes

Adds a short helper text below the subtitle sync slider clarifying which direction increases/decreases the delay. Previously the slider only showed an arbitrary +/- number with no indication of what it meant or how to use it.

**Screenshot after the change:**
<img width="924" height="116" alt="Screenshot 2026-07-22 at 14 22 13" src="https://github.com/user-attachments/assets/c1e4c02a-13f4-45c7-9191-98b143ddce9b" />


### Issues
Fixes #8021

### Code assistance

I used an LLM to help identify the relevant component and plan the change, I wrote&applied the actual code changes manually and tested them locally on my own Jellyfin server.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
