### PR TITLE
Bugfix: mouse falling off volume slider knob

### DIFF
--- a/src/elements/emby-slider/emby-slider.js
+++ b/src/elements/emby-slider/emby-slider.js
@@ -389,9 +389,8 @@ EmbySliderPrototype.attachedCallback = function () {
 
     /* eslint-disable-next-line compat/compat */
     dom.addEventListener(this, (window.PointerEvent ? 'pointermove' : 'mousemove'), function (e) {
-        if (this.activePointerId === e.pointerId) {
-            const fraction = mapClientToFraction(this, e.clientX);
-            const value = mapFractionToValue(this, fraction);
+        if (this.activePointerId !== undefined && this.activePointerId === e.pointerId) {
+            const value = mapFractionToValue(this, mapClientToFraction(this, e.clientX));
 
             if (parseFloat(this.value) !== value) {
                 this.value = value;
@@ -682,4 +681,3 @@ document.registerElement('emby-slider', {
     prototype: EmbySliderPrototype,
     extends: 'input'
 });
-

--- a/src/elements/emby-slider/emby-slider.js
+++ b/src/elements/emby-slider/emby-slider.js
@@ -392,7 +392,7 @@ EmbySliderPrototype.attachedCallback = function () {
         if (this.activePointerId !== undefined && this.activePointerId === e.pointerId) {
             const value = mapFractionToValue(this, mapClientToFraction(this, e.clientX));
 
-            if (parseFloat(this.value) !== value) {
+            if (Number.parseFloat(this.value) !== value) {
                 this.value = value;
                 this.dispatchEvent(new Event('input', {
                     bubbles: true,

--- a/src/elements/emby-slider/emby-slider.js
+++ b/src/elements/emby-slider/emby-slider.js
@@ -370,8 +370,38 @@ EmbySliderPrototype.attachedCallback = function () {
         passive: true
     });
 
+    if (window.PointerEvent && !browser.iOS) {
+        dom.addEventListener(this, 'pointerdown', function (e) {
+            this.activePointerId = e.pointerId;
+            this.setPointerCapture(e.pointerId);
+        }, {
+            passive: true
+        });
+
+        ['pointerup', 'pointercancel'].forEach((event) => {
+            dom.addEventListener(this, event, function () {
+                this.activePointerId = undefined;
+            }, {
+                passive: true
+            });
+        });
+    }
+
     /* eslint-disable-next-line compat/compat */
     dom.addEventListener(this, (window.PointerEvent ? 'pointermove' : 'mousemove'), function (e) {
+        if (this.activePointerId === e.pointerId) {
+            const fraction = mapClientToFraction(this, e.clientX);
+            const value = mapFractionToValue(this, fraction);
+
+            if (parseFloat(this.value) !== value) {
+                this.value = value;
+                this.dispatchEvent(new Event('input', {
+                    bubbles: true,
+                    cancelable: false
+                }));
+            }
+        }
+
         if (!this.dragging) {
             const fraction = mapClientToFraction(this, e.clientX);
             const percent = fraction * 100;

--- a/src/elements/emby-slider/emby-slider.js
+++ b/src/elements/emby-slider/emby-slider.js
@@ -372,6 +372,10 @@ EmbySliderPrototype.attachedCallback = function () {
 
     if (window.PointerEvent && !browser.iOS) {
         dom.addEventListener(this, 'pointerdown', function (e) {
+            if (this.activePointerId !== undefined) {
+                return;
+            }
+
             this.activePointerId = e.pointerId;
             this.setPointerCapture(e.pointerId);
         }, {
@@ -379,7 +383,17 @@ EmbySliderPrototype.attachedCallback = function () {
         });
 
         ['pointerup', 'pointercancel'].forEach((event) => {
-            dom.addEventListener(this, event, function () {
+            dom.addEventListener(this, event, function (e) {
+                if (this.activePointerId !== e.pointerId) {
+                    return;
+                }
+
+                try {
+                    this.releasePointerCapture(e.pointerId);
+                } catch {
+                    // already released
+                }
+
                 this.activePointerId = undefined;
             }, {
                 passive: true
@@ -392,7 +406,7 @@ EmbySliderPrototype.attachedCallback = function () {
         if (this.activePointerId !== undefined && this.activePointerId === e.pointerId) {
             const value = mapFractionToValue(this, mapClientToFraction(this, e.clientX));
 
-            if (Number.parseFloat(this.value) !== value) {
+            if (parseFloat(this.value) !== value) {
                 this.value = value;
                 this.dispatchEvent(new Event('input', {
                     bubbles: true,


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

### Changes

Hey all,

This is my first Jellyfin contribution so I tried my best to keep the changes simple. This has been driving me nuts for ages and I finally got around to poking at it.

On jellyfin's web client if you moved your mouse too quickly while adjusting the volume it'd slip right off the volume knob and it'd stop moving. So I made it just track the pointer until you let go of it. Tested with both mouse and touch events (well, touch events emulated with firefox's devtools)

Tested in Firefox developer edition and Chrome (which I believe should also cover MS Edge) on Windows.

Cheers

Austin

### Issues

Possibly fixes #7107 - the description is a bit different from my issue, but the attached video seems to show the mouse slipping off the slider

### Code assistance
I tracked down emby-slider and made the changes myself but asked chatty g to trace the other places emby-slider are used so i could spot check them for regressions. The playback scrubber seems fine, subtitle offset time controller seems fine, so I'm calling it good.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).

The item is a little confusing, I haven't done any reviews of other contributor's PRs before. But I did go and look at a couple to see how they usually went. 
