### PR TITLE
Use pointer type to toggle scroll buttons instead of only touch

### DIFF
--- a/src/elements/emby-scroller/Scroller.tsx
+++ b/src/elements/emby-scroller/Scroller.tsx
@@ -1,6 +1,8 @@
 import React, { type FC, type PropsWithChildren, useCallback, useEffect, useRef, useState } from 'react';
 import classNames from 'classnames';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import useElementSize from 'hooks/useElementSize';
+import { FINE_POINTER_MEDIA_QUERY } from 'utils/pointer';
 import layoutManager from '../../components/layoutManager';
 import dom from '../../utils/dom';
 import browser from '../../scripts/browser';
@@ -34,6 +36,7 @@ const Scroller: FC<PropsWithChildren<ScrollerProps>> = ({
     children
 }) => {
     const [scrollRef, size] = useElementSize();
+    const hasFinePointer = useMediaQuery(FINE_POINTER_MEDIA_QUERY);
 
     const [showControls, setShowControls] = useState(false);
     const [scrollState, setScrollState] = useState({
@@ -158,7 +161,7 @@ const Scroller: FC<PropsWithChildren<ScrollerProps>> = ({
             return;
         }
 
-        const enableScrollButtons = layoutManager.desktop && !browser.touch && isHorizontalEnabled && isScrollButtonsEnabled;
+        const enableScrollButtons = layoutManager.desktop && hasFinePointer && isHorizontalEnabled && isScrollButtonsEnabled;
 
         const options = {
             horizontal: isHorizontalEnabled,
@@ -195,8 +198,9 @@ const Scroller: FC<PropsWithChildren<ScrollerProps>> = ({
                 capture: false,
                 passive: true
             });
-            setShowControls(true);
         }
+
+        setShowControls(enableScrollButtons);
 
         return () => {
             if (scrollerFactoryRef.current) {
@@ -211,6 +215,7 @@ const Scroller: FC<PropsWithChildren<ScrollerProps>> = ({
         };
     }, [
         addScrollEventListener,
+        hasFinePointer,
         initCenterFocus,
         isAllowNativeSmoothScrollEnabled,
         isCenterFocusEnabled,

--- a/src/elements/emby-scroller/emby-scroller.js
+++ b/src/elements/emby-scroller/emby-scroller.js
@@ -4,6 +4,7 @@ import layoutManager from '../../components/layoutManager';
 import inputManager from '../../scripts/inputManager';
 import focusManager from '../../components/focusManager';
 import browser from '../../scripts/browser';
+import { hasFinePointer } from '../../utils/pointer';
 import 'webcomponents.js/webcomponents-lite';
 import './emby-scroller.scss';
 
@@ -116,7 +117,7 @@ ScrollerPrototype.attachedCallback = function () {
     }
 
     const scrollFrame = this;
-    const enableScrollButtons = layoutManager.desktop && !browser.touch && horizontal && this.getAttribute('data-scrollbuttons') !== 'false';
+    const enableScrollButtons = layoutManager.desktop && hasFinePointer() && horizontal && this.getAttribute('data-scrollbuttons') !== 'false';
 
     const options = {
         horizontal: horizontal,

--- a/src/utils/pointer.ts
+++ b/src/utils/pointer.ts
@@ -1,0 +1,6 @@
+/**
+ * Matches when the primary pointing device is precise (mouse/trackpad).
+ */
+export const FINE_POINTER_MEDIA_QUERY = '(pointer: fine)';
+
+export const hasFinePointer = () => window.matchMedia(FINE_POINTER_MEDIA_QUERY).matches;


### PR DESCRIPTION
### Changes
* Use pointer type to toggle scroll buttons instead of relying on just touch capability

### Issues
Fixes https://github.com/jellyfin/jellyfin-web/issues/7976

### Code assistance
None

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [ ] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
