### PR TITLE
Use measured bitrate for local connections

### DIFF
--- a/src/utils/bitrateTest.test.ts
+++ b/src/utils/bitrateTest.test.ts
@@ -1,0 +1,129 @@
+import type { Api } from '@jellyfin/sdk';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const endpoint = vi.hoisted(() => ({
+    isInNetwork: false
+}));
+
+vi.mock('@jellyfin/sdk/lib/utils/api/system-api', () => ({
+    getSystemApi: () => ({
+        getEndpointInfo: () => Promise.resolve({
+            data: {
+                IsInNetwork: endpoint.isInNetwork
+            }
+        })
+    })
+}));
+
+const api = {
+    authorizationHeader: 'MediaBrowser Client="test"',
+    basePath: 'http://localhost:8096'
+} as unknown as Api;
+
+let currentTime: number;
+let downloadSpeeds: number[];
+let failRequest: boolean;
+let reportHeadersReceived: boolean;
+let requestedSizes: number[];
+
+class MockXMLHttpRequest {
+    onabort: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    onload: (() => void) | null = null;
+    onreadystatechange: (() => void) | null = null;
+    ontimeout: (() => void) | null = null;
+    readyState = 0;
+    response = { size: 0 };
+    responseType = '';
+    status = 200;
+    timeout = 0;
+    url = '';
+
+    open(_method: string, url: string) {
+        this.url = url;
+    }
+
+    setRequestHeader() {
+        // No-op for tests.
+    }
+
+    send() {
+        const size = Number(new URL(this.url).searchParams.get('Size'));
+        requestedSizes.push(size);
+
+        if (failRequest) {
+            this.onerror?.();
+            return;
+        }
+
+        const speed = downloadSpeeds.shift();
+        if (!speed) {
+            throw new Error('Missing mocked download speed');
+        }
+
+        if (reportHeadersReceived) {
+            this.readyState = 2;
+            this.onreadystatechange?.();
+        }
+
+        currentTime += size * 8 / speed * 1000;
+        this.response = { size };
+        this.onload?.();
+    }
+}
+
+describe('detectBitrate', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        Object.defineProperty(MockXMLHttpRequest, 'HEADERS_RECEIVED', { value: 2 });
+        vi.stubGlobal('XMLHttpRequest', MockXMLHttpRequest);
+        vi.spyOn(performance, 'now').mockImplementation(() => currentTime);
+
+        currentTime = 0;
+        downloadSpeeds = [];
+        endpoint.isInNetwork = false;
+        failRequest = false;
+        reportHeadersReceived = true;
+        requestedSizes = [];
+    });
+
+    it('uses a measured low bitrate on a local network', async () => {
+        endpoint.isInNetwork = true;
+        downloadSpeeds = [ 8_000_000, 8_000_000 ];
+        const { detectBitrate } = await import('./bitrateTest');
+
+        const bitrate = await detectBitrate(api, true);
+
+        expect(bitrate).toBe(5_600_000);
+        expect(requestedSizes).toEqual([ 500_000, 1_000_000 ]);
+    });
+
+    it('measures speed when an older webview omits the headers event', async () => {
+        downloadSpeeds = [ 8_000_000, 8_000_000 ];
+        reportHeadersReceived = false;
+        const { detectBitrate } = await import('./bitrateTest');
+
+        const bitrate = await detectBitrate(api, true);
+
+        expect(bitrate).toBe(5_600_000);
+    });
+
+    it('falls back to the LAN estimate when no speed can be measured', async () => {
+        endpoint.isInNetwork = true;
+        failRequest = true;
+        const { detectBitrate } = await import('./bitrateTest');
+
+        const bitrate = await detectBitrate(api, true);
+
+        expect(bitrate).toBe(140_000_000);
+    });
+
+    it('does not assume LAN speed for a failed remote test', async () => {
+        failRequest = true;
+        const { detectBitrate } = await import('./bitrateTest');
+
+        const bitrate = await detectBitrate(api, true);
+
+        expect(bitrate).toBe(0);
+    });
+});

--- a/src/utils/bitrateTest.ts
+++ b/src/utils/bitrateTest.ts
@@ -4,8 +4,8 @@ import { getSystemApi } from '@jellyfin/sdk/lib/utils/api/system-api';
 
 /** Maximum bitrate (Int32) */
 const MAX_BITRATE = 2147483647;
-/** Approximate LAN bitrate */
-const LAN_BITRATE = 140000000;
+/** Fallback bitrate when a LAN speed test cannot produce a result */
+const LAN_FALLBACK_BITRATE = 140000000;
 /** Bitrate test timeout in milliseconds */
 const BITRATETEST_TIMEOUT = 5000;
 /** Bitrate cache time in milliseconds */
@@ -64,7 +64,9 @@ const getDownloadSpeed = (api: Api, bytes: number) => {
             xhr.setRequestHeader(key, headers[key as keyof typeof headers]);
         }
 
-        let startTime: number;
+        // Some older webviews do not reliably report HEADERS_RECEIVED. Starting
+        // the timer here gives them a conservative measurement instead of NaN.
+        let startTime = performance.now();
 
         xhr.onreadystatechange = () => {
             if (xhr.readyState == XMLHttpRequest.HEADERS_RECEIVED) {
@@ -183,14 +185,19 @@ const detectBitrateWithEndpointInfo = (api: Api, endpointInfo: EndPointInfo) => 
         0,
         undefined
     ).then(result => {
-        const bitrateInMbps = (result / 1048576).toFixed(2);
-        console.debug(`[bitratetest] bitrate detected as ${bitrateInMbps} Mbps`);
-        if (endpointInfo.IsInNetwork) {
-            result = Math.max(result || 0, LAN_BITRATE);
+        // A local connection can still be bandwidth constrained by Wi-Fi, a
+        // powerline adapter, or a VPN. Trust a successful measurement and only
+        // use the historical LAN estimate if the test failed before measuring
+        // any data.
+        if (!result && endpointInfo.IsInNetwork) {
+            result = LAN_FALLBACK_BITRATE;
 
             lastDetectedBitrate = result;
             lastDetectedBitrateTime = Date.now();
         }
+
+        const bitrateInMbps = (result / 1048576).toFixed(2);
+        console.debug(`[bitratetest] bitrate detected as ${bitrateInMbps} Mbps`);
         return result;
     });
 };


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

### Changes
<!--
Describe your changes here in 1-5 sentences.
Please include before/after screenshots of any UI changes.
-->

When using Jellyfin client from my Samsung TV, and streaming from a Jellyfin server that is on my old MacBook Air (Intel chip stuck on macos12, also on a bad wifi router that might be the bottleneck). I notice that when using "Automatic" quality, the streaming often gets stuck and has to load before playback can resume in short segments, when manually adjusting to 6 mbps quality it works flawlessly,

### Issues
<!--
Tag any issues that this PR solves here.
ex. Fixes #
-->

Related to https://github.com/jellyfin/jellyfin-web/pull/7915.

### Code assistance
<!--
If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance.
-->

Codex wrote the code.

---

* [ ] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [ ] I have tested these changes.
* [ ] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
