### PR TITLE
Pass the card server id when building the card link

### DIFF
--- a/src/components/cardbuilder/cardBuilder.js
+++ b/src/components/cardbuilder/cardBuilder.js
@@ -865,7 +865,13 @@ function buildCard(index, item, apiClient, options) {
     } else {
         const cardImageContainerAriaLabelAttribute = ` aria-label="${escapeHtml(item.Name)}" role="img"`;
 
-        const url = appRouter.getRouteUrl(item);
+        /*
+         * Items that are embedded in a parent item (people, for example) do not carry
+         * a ServerId, so the card's serverId option has to be passed along - otherwise
+         * the link ends up with "serverId=undefined". This matches the fallback already
+         * used for the card's data-serverid attribute.
+         */
+        const url = appRouter.getRouteUrl(item, { serverId: options.serverId });
         // Don't use the IMG tag with safari because it puts a white border around it
         cardImageContainerOpen = imgUrl ? ('<a href="' + url + '" data-action="' + action + '" class="' + cardImageContainerClasses + ' ' + cardContentClass + ' itemAction lazy" data-src="' + imgUrl + '" ' + blurhashAttrib + cardImageContainerAriaLabelAttribute + '>') : ('<a href="' + url + '" data-action="' + action + '" class="' + cardImageContainerClasses + ' ' + cardContentClass + ' itemAction"' + cardImageContainerAriaLabelAttribute + '>');
 


### PR DESCRIPTION
### Changes

Cast/crew cards link to `serverId=undefined`. `buildCard()` builds the card image link with `appRouter.getRouteUrl(item)` and passes no options, but people are embedded in their parent item and carry no `ServerId` of their own, so `getRouteUrl` resolves `item.ServerId || options.serverId` to `undefined`.

The card's own markup already handles this — the same `buildCard()` call sets `data-serverid="${item.ServerId || options.serverId}"`, and the text link path resolves the server id before building the link. Only the image `href` missed it, so the card works when clicked but has a broken URL when hovered, copied, or opened in a new tab.

`getRouteUrl` already accepts `options.serverId` as the fallback, so this just passes the card's `serverId` option along — the same thing `renderArtistLinks()` in the item details controller does for artists (`getRouteUrl(artist, { context, itemType, serverId })`). Items that carry their own `ServerId` are unaffected.

Before: `#/details?id=<personId>&serverId=undefined`
After: `#/details?id=<personId>&serverId=<serverId>`

### Issues

Fixes #7854

### Code assistance

Used Claude to help trace the link-building path (`renderCast` → `buildPeopleCards` → `cardBuilder.buildCard` → `appRouter.getRouteUrl`) and to confirm that `getRouteUrl` already supports the `serverId` option and that the same fallback is applied elsewhere in `buildCard`. The change itself is a one-line fix that I reviewed against the surrounding code.
