### PR TITLE
Fix playbackstop listener leak on the movies page

### DIFF
--- a/src/apps/legacy/controllers/movies/moviesrecommended.js
+++ b/src/apps/legacy/controllers/movies/moviesrecommended.js
@@ -397,6 +397,7 @@ export default function (view, params) {
     });
     view.addEventListener('viewbeforehide', function () {
         inputManager.off(window, onInputCommand);
+        Events.off(playbackManager, 'playbackstop', onPlaybackStop);
     });
     for (const tabController of tabControllers) {
         if (tabController.destroy) {

--- a/src/apps/legacy/controllers/movies/moviesrecommended.js
+++ b/src/apps/legacy/controllers/movies/moviesrecommended.js
@@ -347,7 +347,9 @@ export default function (view, params) {
         }));
     }
 
-    function onPlaybackStop(e, state) {
+    function onPlaybackStop(e, stopInfo) {
+        const state = stopInfo.state;
+
         if (state.NowPlayingItem && state.NowPlayingItem.MediaType == 'Video') {
             renderedTabs = [];
             mainTabsManager.getTabsElement().triggerTabChange();

--- a/src/apps/legacy/controllers/shows/tvrecommended.js
+++ b/src/apps/legacy/controllers/shows/tvrecommended.js
@@ -316,7 +316,9 @@ export default function (view, params) {
         });
     }
 
-    function onPlaybackStop(e, state) {
+    function onPlaybackStop(e, stopInfo) {
+        const state = stopInfo.state;
+
         if (state.NowPlayingItem && state.NowPlayingItem.MediaType == 'Video') {
             renderedTabs = [];
             mainTabsManager.getTabsElement().triggerTabChange();


### PR DESCRIPTION
moviesrecommended subscribed to playbackstop in its viewshow handler but never unsubscribed, so one listener was leaked per visit to the page and accumulated without bound for the life of the session. Each stale handler ran on every playback stop and called triggerTabChange against a view that may no longer be current.



<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

### Changes
<!--
Describe your changes here in 1-5 sentences.
Please include before/after screenshots of any UI changes.
-->
Release the subscription in viewbeforehide, mirroring the symmetric pair already present in the equivalent Shows controller (tvrecommended.js).

### Issues
<!--
Tag any issues that this PR solves here.
ex. Fixes #
-->
fixes #8280 

### Code assistance
<!--
If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance.
-->
assisted by fable

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
