### PR TITLE
Fix Now Playing page not following player switches after browser back

### DIFF
--- a/src/components/remotecontrol/remotecontrol.js
+++ b/src/components/remotecontrol/remotecontrol.js
@@ -895,7 +895,6 @@ export default function () {
         bindEvents(context);
         context.querySelector('.sendMessageForm').addEventListener('submit', onMessageSubmit);
         context.querySelector('.typeTextForm').addEventListener('submit', onSendStringSubmit);
-        Events.on(playbackManager, 'playerchange', onPlayerChange);
 
         if (layoutManager.tv) {
             const positionSlider = context.querySelector('.nowPlayingPositionSlider');
@@ -911,6 +910,9 @@ export default function () {
     }
 
     function onShow(context) {
+        // Subscribe here, not in init(): init runs once per node but hide/show repeat.
+        Events.off(playbackManager, 'playerchange', onPlayerChange);
+        Events.on(playbackManager, 'playerchange', onPlayerChange);
         bindToPlayer(context, playbackManager.getCurrentPlayer());
     }
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

### Changes
<!--
Describe your changes here in 1-5 sentences.
Please include before/after screenshots of any UI changes.
-->

remoteControl.init() runs once per view node, but destroy() runs on every
viewbeforehide. Since init() was the only place subscribing to playerchange
and destroy() unsubscribes it, a cached view restored by the browser back
button was left unsubscribed for good: onShow() re-binds the per-player
events but never re-established the playbackManager-level subscription.

Move the subscription to onShow(), pairing it with the Events.off already
in onDialogClosed(). Events.off first so a repeated show cannot stack
duplicate subscriptions.

Verified against a second browser session acting as a real cast target:
before, casting while on a restored Now Playing page left the page bound
to the old player; after, it re-binds. No duplicated volume control or
form handlers across repeated show/hide cycles.


### Issues
<!--
Tag any issues that this PR solves here.
ex. Fixes #
-->
Fixes #8283 

### Code assistance
<!--
If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance.
-->
Assisted by Fable

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
