### PR TITLE
Enforce global parseFloat/parseInt over Number counterparts

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -75,6 +75,16 @@ export default tseslint.config(
                 {
                     property: 'replaceChildren',
                     message: 'replaceChildren is not supported in all target browsers'
+                },
+                {
+                    object: 'Number',
+                    property: 'parseFloat',
+                    message: 'Use the global parseFloat to match the rest of the codebase'
+                },
+                {
+                    object: 'Number',
+                    property: 'parseInt',
+                    message: 'Use the global parseInt to match the rest of the codebase'
                 }
             ],
             'no-return-assign': 'error',

--- a/src/elements/emby-itemrefreshindicator/RefreshIndicator.tsx
+++ b/src/elements/emby-itemrefreshindicator/RefreshIndicator.tsx
@@ -56,7 +56,7 @@ const RefreshIndicator: FC<RefreshIndicatorProps> = ({ item, className }) => {
 
     const onRefreshProgress = useCallback(({ Data }: RefreshProgressMessage) => {
         if (Data?.ItemId === item?.Id) {
-            const pct = Number.parseFloat(Data?.Progress ?? '0');
+            const pct = parseFloat(Data?.Progress ?? '0');
 
             if (pct && pct < 100) {
                 setShowProgressBar(true);


### PR DESCRIPTION
Closes #8251

Standardizes numeric parsing on the global `parseFloat`/`parseInt`, which is what the overwhelming majority of the codebase already uses, and makes the choice self-enforcing via lint.

**Changes**
- `RefreshIndicator.tsx`: `Number.parseFloat` → `parseFloat`
- `eslint.config.mjs`: extend the existing `no-restricted-properties` rule to reject `Number.parseFloat` and `Number.parseInt`

**On the scope**

The issue describes the split as widespread, but the actual counts on current master are lopsided enough that no codemod is warranted:

| form | occurrences |
|---|---|
| global `parseFloat` | 37 |
| `Number.parseFloat` | 1 |
| global `parseInt` | 126 |
| `Number.parseInt` | 0 |

So this is a one-line change plus enforcement rather than a repository-wide migration. Worth noting that `src/elements/emby-slider/emby-slider.js`, cited in the issue as a `Number.parseFloat` user, actually uses the global form throughout — `RefreshIndicator.tsx` was the only outlier.

**Verification**
- Confirmed the new rule fires on both `Number.parseFloat` and `Number.parseInt` (scratch file, since no real occurrences remain)
- `npx eslint src/`: 0 errors (98 pre-existing warnings, untouched)