### PR TITLE
Fix invalid livetv items request

### DIFF
--- a/src/apps/modern/features/libraries/components/PageTabContent.tsx
+++ b/src/apps/modern/features/libraries/components/PageTabContent.tsx
@@ -34,7 +34,6 @@ const PageTabContent: FC<PageTabContentProps> = ({ parentId, currentTab }) => {
     if (currentTab.viewType === LibraryTab.Programs || currentTab.viewType === LibraryTab.Recordings || currentTab.viewType === LibraryTab.Schedule) {
         return (
             <ProgramsSectionView
-                parentId={parentId}
                 sectionType={
                     currentTab.sectionsView?.programSections ?? []
                 }

--- a/src/apps/modern/features/libraries/components/ProgramsSectionView.tsx
+++ b/src/apps/modern/features/libraries/components/ProgramsSectionView.tsx
@@ -9,22 +9,19 @@ import { ItemAction } from 'constants/itemAction';
 import { useApi } from 'hooks/useApi';
 import { useGetProgramsSectionsWithItems, useGetTimers } from 'hooks/useFetchItems';
 import globalize from 'lib/globalize';
-import type { ParentId } from 'types/library';
 import type { Section, SectionType } from 'types/sections';
 
 interface ProgramsSectionViewProps {
-    parentId: ParentId;
     sectionType: SectionType[];
     isUpcomingRecordingsEnabled: boolean | undefined
 }
 
 const ProgramsSectionView: FC<ProgramsSectionViewProps> = ({
-    parentId,
     sectionType,
     isUpcomingRecordingsEnabled = false
 }) => {
     const { __legacyApiClient__ } = useApi();
-    const { isLoading, data: sectionsWithItems, refetch } = useGetProgramsSectionsWithItems(parentId, sectionType);
+    const { isLoading, data: sectionsWithItems, refetch } = useGetProgramsSectionsWithItems(sectionType);
     const {
         isLoading: isUpcomingRecordingsLoading,
         data: upcomingRecordings

--- a/src/apps/modern/features/libraries/hooks/useLibrary.tsx
+++ b/src/apps/modern/features/libraries/hooks/useLibrary.tsx
@@ -35,7 +35,7 @@ export const useLibrary = () => useContext(LibraryContext);
 
 export const LibraryProvider: FC<PropsWithChildren<unknown>> = ({ children }) => {
     const { pathname } = useLocation();
-    const { libraryId, activeTab } = useCurrentTab();
+    const { libraryId, activeTab, settingsKey } = useCurrentTab();
 
     const route = useMemo(() => LibraryRoutes.find(({ path }) => path === pathname), [pathname]);
     const collectionType = route?.type;
@@ -48,7 +48,7 @@ export const LibraryProvider: FC<PropsWithChildren<unknown>> = ({ children }) =>
     // Local storage requires the view type to be known upfront so default to movies if unknown
     const settingsViewType = viewType ?? LibraryTab.Movies;
     const [viewSettings, setViewSettings] = useLocalStorage<LibraryViewSettings>(
-        getSettingsKey(settingsViewType, libraryId),
+        getSettingsKey(settingsViewType, settingsKey),
         getDefaultLibraryViewSettings(settingsViewType)
     );
 

--- a/src/hooks/useCurrentTab.ts
+++ b/src/hooks/useCurrentTab.ts
@@ -6,10 +6,8 @@ const useCurrentTab = () => {
     const location = useLocation();
     const [searchParams, setSearchParams] = useSearchParams();
     const searchParamsTab = searchParams.get('tab');
-    const libraryId =
-        location.pathname === '/livetv' ?
-            'livetv' :
-            searchParams.get('topParentId');
+    const libraryId = searchParams.get('topParentId');
+    const settingsKey = location.pathname === '/livetv' ? 'livetv' : libraryId;
     const activeTab: number =
         searchParamsTab !== null ?
             parseInt(searchParamsTab, 10) :
@@ -19,6 +17,7 @@ const useCurrentTab = () => {
         searchParams,
         setSearchParams,
         libraryId,
+        settingsKey,
         activeTab
     };
 };

--- a/src/hooks/useFetchItems.ts
+++ b/src/hooks/useFetchItems.ts
@@ -954,14 +954,13 @@ export const useGetSuggestionSectionsWithItems = (
 };
 
 export const useGetProgramsSectionsWithItems = (
-    parentId: ParentId,
     programSectionType: SectionType[]
 ) => {
     const currentApi = useApi();
     const sections = getProgramSections();
     return useQuery({
         queryKey: ['ProgramSectionWithItems', { programSectionType }],
-        queryFn: ({ signal }) => getSectionsWithItems(currentApi, parentId, sections, programSectionType, { signal }),
+        queryFn: ({ signal }) => getSectionsWithItems(currentApi, undefined, sections, programSectionType, { signal }),
         enabled: !!currentApi.api && !!currentApi.user?.Id
     });
 };


### PR DESCRIPTION
### Changes
Fixes the invalid items requests with "livetv" as the item id by separating the settings key from the library id and removes some unnecessary passing of the "livetv" id as props/params

### Issues
Fixes #8168 
Closes #8170 

### Code assistance
Zed autocomplete

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
