### PR TITLE
Fix native shell selectServer not used when signing out

### DIFF
--- a/src/utils/dashboard.js
+++ b/src/utils/dashboard.js
@@ -107,8 +107,12 @@ export function logout() {
         queryClient.clear();
         // Reset cached views
         viewContainer.reset();
-        appHost.supports(AppFeature.MultiServer) ?
-            navigate('selectserver') : navigate('login');
+
+        if (appHost.supports(AppFeature.MultiServer)) {
+            selectServer();
+        } else {
+            navigate('login');
+        }
     });
 }
 


### PR DESCRIPTION
### Changes

The Android app (and iOS probably too?) implements the selectServer function in the native shell to show native UI for server selection. Due to an oversight the sign out button did not use this, instead it would always redirect to the selectserver route if the multi-server feature is enabled.

This change fixes that, making sure the native shell is used for server selection.

### Issues
<!--
Tag any issues that this PR solves here.
ex. Fixes #
-->

### Code assistance
<!--
If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance.
-->

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
