### PR TITLE
Add setting to include episodes in progress in Next Up

### DIFF
--- a/src/apps/legacy/controllers/list.js
+++ b/src/apps/legacy/controllers/list.js
@@ -261,6 +261,7 @@ function getItems(instance, params, item, sortBy, startIndex, limit) {
             EnableImageTypes: 'Primary,Backdrop,Thumb',
             EnableTotalRecordCount: false,
             SortBy: sortBy,
+            EnableResumable: userSettings.enableResumableInNextUp(),
             EnableRewatching: userSettings.enableRewatchingInNextUp()
         }));
     }

--- a/src/apps/modern/features/preferences/components/NextUpPreferences.tsx
+++ b/src/apps/modern/features/preferences/components/NextUpPreferences.tsx
@@ -47,6 +47,23 @@ export function NextUpPreferences({ onChange, values }: Readonly<NextUpPreferenc
 
             <FormControl fullWidth>
                 <FormControlLabel
+                    aria-describedby='display-settings-next-up-resumable-description'
+                    control={
+                        <Checkbox
+                            checked={values.enableResumableInNextUp}
+                            onChange={onChange}
+                        />
+                    }
+                    label={globalize.translate('EnableResumableNextUp')}
+                    name='enableResumableInNextUp'
+                />
+                <FormHelperText id='display-settings-next-up-resumable-description'>
+                    {globalize.translate('EnableResumableNextUpHelp')}
+                </FormHelperText>
+            </FormControl>
+
+            <FormControl fullWidth>
+                <FormControlLabel
                     aria-describedby='display-settings-next-up-rewatching-description'
                     control={
                         <Checkbox

--- a/src/apps/modern/features/preferences/hooks/useDisplaySettings.ts
+++ b/src/apps/modern/features/preferences/hooks/useDisplaySettings.ts
@@ -95,6 +95,7 @@ async function loadDisplaySettings({
         enableLibraryBackdrops: Boolean(settings.enableBackdrops()),
         enableLibraryThemeSongs: Boolean(settings.enableThemeSongs()),
         enableLibraryThemeVideos: Boolean(settings.enableThemeVideos()),
+        enableResumableInNextUp: Boolean(settings.enableResumableInNextUp()),
         enableRewatchingInNextUp: Boolean(settings.enableRewatchingInNextUp()),
         episodeImagesInNextUp: Boolean(settings.useEpisodeImagesInNextUpAndResume()),
         language: settings.language() || 'auto',
@@ -142,6 +143,7 @@ async function saveDisplaySettings({
     userSettings.enableBackdrops(newDisplaySettings.enableLibraryBackdrops);
     userSettings.enableThemeSongs(newDisplaySettings.enableLibraryThemeSongs);
     userSettings.enableThemeVideos(newDisplaySettings.enableLibraryThemeVideos);
+    userSettings.enableResumableInNextUp(newDisplaySettings.enableResumableInNextUp);
     userSettings.enableRewatchingInNextUp(newDisplaySettings.enableRewatchingInNextUp);
     userSettings.useEpisodeImagesInNextUpAndResume(newDisplaySettings.episodeImagesInNextUp);
     userSettings.libraryPageSize(newDisplaySettings.libraryPageSize);

--- a/src/apps/modern/features/preferences/types/displaySettingsValues.ts
+++ b/src/apps/modern/features/preferences/types/displaySettingsValues.ts
@@ -10,6 +10,7 @@ export interface DisplaySettingsValues {
     enableLibraryBackdrops: boolean;
     enableLibraryThemeSongs: boolean;
     enableLibraryThemeVideos: boolean;
+    enableResumableInNextUp: boolean;
     enableRewatchingInNextUp: boolean;
     episodeImagesInNextUp: boolean;
     language: string;

--- a/src/components/displaySettings/displaySettings.js
+++ b/src/components/displaySettings/displaySettings.js
@@ -139,6 +139,7 @@ function loadForm(context, user, userSettings) {
     context.querySelector('#txtLibraryPageSize').value = userSettings.libraryPageSize();
 
     context.querySelector('#txtMaxDaysForNextUp').value = userSettings.maxDaysForNextUp();
+    context.querySelector('#chkResumableNextUp').checked = userSettings.enableResumableInNextUp();
     context.querySelector('#chkRewatchingNextUp').checked = userSettings.enableRewatchingInNextUp();
     context.querySelector('#chkUseEpisodeImagesInNextUp').checked = userSettings.useEpisodeImagesInNextUpAndResume();
 
@@ -170,6 +171,7 @@ function saveUser(context, user, userSettingsInstance, apiClient) {
     userSettingsInstance.libraryPageSize(context.querySelector('#txtLibraryPageSize').value);
 
     userSettingsInstance.maxDaysForNextUp(context.querySelector('#txtMaxDaysForNextUp').value);
+    userSettingsInstance.enableResumableInNextUp(context.querySelector('#chkResumableNextUp').checked);
     userSettingsInstance.enableRewatchingInNextUp(context.querySelector('#chkRewatchingNextUp').checked);
     userSettingsInstance.useEpisodeImagesInNextUpAndResume(context.querySelector('#chkUseEpisodeImagesInNextUp').checked);
 

--- a/src/components/displaySettings/displaySettings.template.html
+++ b/src/components/displaySettings/displaySettings.template.html
@@ -286,6 +286,14 @@
 
     <div class="checkboxContainer checkboxContainer-withDescription">
         <label>
+            <input type="checkbox" is="emby-checkbox" id="chkResumableNextUp" />
+            <span>${EnableResumableNextUp}</span>
+        </label>
+        <div class="fieldDescription checkboxFieldDescription">${EnableResumableNextUpHelp}</div>
+    </div>
+
+    <div class="checkboxContainer checkboxContainer-withDescription">
+        <label>
             <input type="checkbox" is="emby-checkbox" id="chkRewatchingNextUp" />
             <span>${EnableRewatchingNextUp}</span>
         </label>

--- a/src/components/homesections/sections/nextUp.ts
+++ b/src/components/homesections/sections/nextUp.ts
@@ -43,7 +43,7 @@ function getNextUpFetchFn(
                 ],
                 enableTotalRecordCount: false,
                 nextUpDateCutoff: toIsoDateOnlyString(oldestDateForNextUp),
-                enableResumable: false,
+                enableResumable: userSettings.enableResumableInNextUp(),
                 enableRewatching: userSettings.enableRewatchingInNextUp()
             }));
     };

--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -561,6 +561,19 @@ export class UserSettings {
     }
 
     /**
+     * Get or set resumable episodes in next up.
+     * @param {boolean|undefined} [val] - If episodes in progress should be included in next up.
+     * @returns {boolean} Resumable episodes in next up state.
+     */
+    enableResumableInNextUp(val) {
+        if (val !== undefined) {
+            return this.set('enableResumableInNextUp', val.toString(), false);
+        }
+
+        return toBoolean(this.get('enableResumableInNextUp', false), false);
+    }
+
+    /**
      * Get or set sound effects.
      * @param {string|undefined} val - Sound effects.
      * @return {string} Sound effects.

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -320,6 +320,8 @@
     "EnablePhotos": "Display the photos",
     "EnablePhotosHelp": "Images will be detected and displayed alongside other media files.",
     "EnableCardLayout": "Display visual CardBox",
+    "EnableResumableNextUp": "Enable Episodes in Progress in Next Up",
+    "EnableResumableNextUpHelp": "Enable showing episodes in progress in 'Next Up' sections.",
     "EnableRewatchingNextUp": "Enable Rewatching in Next Up",
     "EnableRewatchingNextUpHelp": "Enable showing already watched episodes in 'Next Up' sections.",
     "EnableQuickConnect": "Enable Quick Connect on this server",


### PR DESCRIPTION
### Changes

The Next Up home section calls the API with a hardcoded `enableResumable: false`, and no user setting exists for it, so a series drops out of Next Up entirely while one of its episodes is only partially watched. Users who disable the Continue Watching home section then lose those in-progress episodes with no way to get them back. This adds an "Enable Episodes in Progress in Next Up" display setting, following the existing rewatching option (legacy + modern settings UI, home section and Next Up list view). Defaults to off, so nothing changes unless opted in.

### Issues

None filed.

### Code assistance

LLM-assisted: locating where the flag is consumed and drafting the patch, modeled on the existing `enableRewatchingInNextUp` implementation. I reviewed the changes and verified the behavior on my own server (12.0); `tsc --noEmit` and eslint pass.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of another web PR.
