### PR TITLE
Add combined Continue Watching & Next Up home section

### DIFF
--- a/src/components/homeScreenSettings/homeScreenSettings.template.html
+++ b/src/components/homeScreenSettings/homeScreenSettings.template.html
@@ -23,6 +23,7 @@
                 <option value="librarybuttons">${HeaderMyMediaSmall}</option>
                 <option value="activerecordings">${HeaderActiveRecordings}</option>
                 <option value="resume">${HeaderContinueWatching}</option>
+                <option value="continuewatching">${HeaderContinueWatchingAndNextUp}</option>
                 <option value="resumeaudio">${HeaderContinueListening}</option>
                 <option value="resumebook">${HeaderContinueReading}</option>
                 <option value="latestmedia">${HeaderLatestMedia}</option>
@@ -37,6 +38,7 @@
                 <option value="librarybuttons">${HeaderMyMediaSmall}</option>
                 <option value="activerecordings">${HeaderActiveRecordings}</option>
                 <option value="resume">${HeaderContinueWatching}</option>
+                <option value="continuewatching">${HeaderContinueWatchingAndNextUp}</option>
                 <option value="resumeaudio">${HeaderContinueListening}</option>
                 <option value="resumebook">${HeaderContinueReading}</option>
                 <option value="latestmedia">${HeaderLatestMedia}</option>
@@ -51,6 +53,7 @@
                 <option value="librarybuttons">${HeaderMyMediaSmall}</option>
                 <option value="activerecordings">${HeaderActiveRecordings}</option>
                 <option value="resume">${HeaderContinueWatching}</option>
+                <option value="continuewatching">${HeaderContinueWatchingAndNextUp}</option>
                 <option value="resumeaudio">${HeaderContinueListening}</option>
                 <option value="resumebook">${HeaderContinueReading}</option>
                 <option value="latestmedia">${HeaderLatestMedia}</option>
@@ -65,6 +68,7 @@
                 <option value="librarybuttons">${HeaderMyMediaSmall}</option>
                 <option value="activerecordings">${HeaderActiveRecordings}</option>
                 <option value="resume">${HeaderContinueWatching}</option>
+                <option value="continuewatching">${HeaderContinueWatchingAndNextUp}</option>
                 <option value="resumeaudio">${HeaderContinueListening}</option>
                 <option value="resumebook">${HeaderContinueReading}</option>
                 <option value="latestmedia">${HeaderLatestMedia}</option>
@@ -79,6 +83,7 @@
                 <option value="librarybuttons">${HeaderMyMediaSmall}</option>
                 <option value="activerecordings">${HeaderActiveRecordings}</option>
                 <option value="resume">${HeaderContinueWatching}</option>
+                <option value="continuewatching">${HeaderContinueWatchingAndNextUp}</option>
                 <option value="resumeaudio">${HeaderContinueListening}</option>
                 <option value="resumebook">${HeaderContinueReading}</option>
                 <option value="latestmedia">${HeaderLatestMedia}</option>
@@ -93,6 +98,7 @@
                 <option value="librarybuttons">${HeaderMyMediaSmall}</option>
                 <option value="activerecordings">${HeaderActiveRecordings}</option>
                 <option value="resume">${HeaderContinueWatching}</option>
+                <option value="continuewatching">${HeaderContinueWatchingAndNextUp}</option>
                 <option value="resumeaudio">${HeaderContinueListening}</option>
                 <option value="resumebook">${HeaderContinueReading}</option>
                 <option value="latestmedia">${HeaderLatestMedia}</option>
@@ -107,6 +113,7 @@
                 <option value="librarybuttons">${HeaderMyMediaSmall}</option>
                 <option value="activerecordings">${HeaderActiveRecordings}</option>
                 <option value="resume">${HeaderContinueWatching}</option>
+                <option value="continuewatching">${HeaderContinueWatchingAndNextUp}</option>
                 <option value="resumeaudio">${HeaderContinueListening}</option>
                 <option value="resumebook">${HeaderContinueReading}</option>
                 <option value="latestmedia">${HeaderLatestMedia}</option>
@@ -121,6 +128,7 @@
                 <option value="librarybuttons">${HeaderMyMediaSmall}</option>
                 <option value="activerecordings">${HeaderActiveRecordings}</option>
                 <option value="resume">${HeaderContinueWatching}</option>
+                <option value="continuewatching">${HeaderContinueWatchingAndNextUp}</option>
                 <option value="resumeaudio">${HeaderContinueListening}</option>
                 <option value="resumebook">${HeaderContinueReading}</option>
                 <option value="latestmedia">${HeaderLatestMedia}</option>
@@ -135,6 +143,7 @@
                 <option value="librarybuttons">${HeaderMyMediaSmall}</option>
                 <option value="activerecordings">${HeaderActiveRecordings}</option>
                 <option value="resume">${HeaderContinueWatching}</option>
+                <option value="continuewatching">${HeaderContinueWatchingAndNextUp}</option>
                 <option value="resumeaudio">${HeaderContinueListening}</option>
                 <option value="resumebook">${HeaderContinueReading}</option>
                 <option value="latestmedia">${HeaderLatestMedia}</option>
@@ -149,6 +158,7 @@
                 <option value="librarybuttons">${HeaderMyMediaSmall}</option>
                 <option value="activerecordings">${HeaderActiveRecordings}</option>
                 <option value="resume">${HeaderContinueWatching}</option>
+                <option value="continuewatching">${HeaderContinueWatchingAndNextUp}</option>
                 <option value="resumeaudio">${HeaderContinueListening}</option>
                 <option value="resumebook">${HeaderContinueReading}</option>
                 <option value="latestmedia">${HeaderLatestMedia}</option>

--- a/src/components/homesections/homesections.js
+++ b/src/components/homesections/homesections.js
@@ -10,6 +10,7 @@ import { loadRecordings } from './sections/activeRecordings';
 import { loadLibraryButtons } from './sections/libraryButtons';
 import { loadLibraryTiles } from './sections/libraryTiles';
 import { loadLiveTV } from './sections/liveTv';
+import { loadContinueWatching } from './sections/continueWatching';
 import { loadNextUp } from './sections/nextUp';
 import { loadRecentlyAdded } from './sections/recentlyAdded';
 import { loadResume } from './sections/resume';
@@ -154,6 +155,9 @@ function loadSection(page, apiClient, user, userSettings, userViews, section, in
             break;
         case HomeSectionType.LiveTv:
             return loadLiveTV(elem, apiClient, user, options);
+        case HomeSectionType.ContinueWatching:
+            loadContinueWatching(elem, apiClient, userSettings, options);
+            break;
         case HomeSectionType.NextUp:
             loadNextUp(elem, apiClient, userSettings, options);
             break;

--- a/src/components/homesections/sections/continueWatching.ts
+++ b/src/components/homesections/sections/continueWatching.ts
@@ -1,0 +1,134 @@
+import type { BaseItemDto } from '@jellyfin/sdk/lib/generated-client/models/base-item-dto';
+import { ImageType } from '@jellyfin/sdk/lib/generated-client/models/image-type';
+import { ItemFields } from '@jellyfin/sdk/lib/generated-client/models/item-fields';
+import type { ApiClient } from 'jellyfin-apiclient';
+
+import { getNextUpQuery } from 'apps/legacy/features/libraries/api/useNextUp';
+import { getResumeItemsQuery } from 'apps/legacy/features/libraries/api/useResumeItems';
+import cardBuilder from 'components/cardbuilder/cardBuilder';
+import { getBackdropShape } from 'components/cardbuilder/utils/shape';
+import globalize from 'lib/globalize';
+import ServerConnections from 'lib/jellyfin-apiclient/ServerConnections';
+import type { UserSettings } from 'scripts/settings/userSettings';
+import { toIsoDateOnlyString } from 'utils/date';
+import { queryClient } from 'utils/query/queryClient';
+
+import type { SectionContainerElement, SectionOptions } from './section';
+
+function getItemsFn(
+    apiClient: ApiClient,
+    userSettings: UserSettings,
+    { enableOverflow }: SectionOptions
+) {
+    return function () {
+        const api = ServerConnections.getApi(apiClient.serverId());
+        const userId = apiClient.getCurrentUserId();
+        const limit = enableOverflow ? 12 : 5;
+        const oldestDateForNextUp = new Date();
+        oldestDateForNextUp.setDate(oldestDateForNextUp.getDate() - userSettings.maxDaysForNextUp());
+
+        const resumeItems = queryClient.fetchQuery(getResumeItemsQuery(api, {
+            userId,
+            limit,
+            fields: [ ItemFields.PrimaryImageAspectRatio ],
+            imageTypeLimit: 1,
+            enableImageTypes: [
+                ImageType.Primary,
+                ImageType.Backdrop,
+                ImageType.Thumb
+            ],
+            enableTotalRecordCount: false,
+            mediaTypes: [ 'Video' ]
+        }));
+
+        // Requesting Next Up without resumable episodes makes it exactly complementary
+        // to the resume list: a series whose next episode is partially watched surfaces
+        // in the resume part instead, so concatenating both never produces duplicates.
+        const nextUpItems = queryClient.fetchQuery(getNextUpQuery(api, {
+            userId,
+            limit,
+            fields: [
+                ItemFields.PrimaryImageAspectRatio,
+                ItemFields.DateCreated,
+                ItemFields.Path,
+                ItemFields.MediaSourceCount
+            ],
+            imageTypeLimit: 1,
+            enableImageTypes: [
+                ImageType.Primary,
+                ImageType.Backdrop,
+                ImageType.Thumb
+            ],
+            enableTotalRecordCount: false,
+            nextUpDateCutoff: toIsoDateOnlyString(oldestDateForNextUp),
+            enableResumable: false,
+            enableRewatching: userSettings.enableRewatchingInNextUp()
+        }));
+
+        return Promise.all([ resumeItems, nextUpItems ])
+            .then(([ resumeResult, nextUpResult ]) => ({
+                Items: [
+                    ...(resumeResult.Items ?? []),
+                    ...(nextUpResult.Items ?? [])
+                ]
+            }));
+    };
+}
+
+function getItemsHtmlFn(
+    useEpisodeImages: boolean,
+    { enableOverflow }: SectionOptions
+) {
+    return function (items: BaseItemDto[]) {
+        const cardLayout = false;
+        return cardBuilder.getCardsHtml({
+            items: items,
+            preferThumb: true,
+            inheritThumb: !useEpisodeImages,
+            shape: getBackdropShape(enableOverflow),
+            overlayText: false,
+            showTitle: true,
+            showParentTitle: true,
+            lazy: true,
+            showDetailsMenu: true,
+            overlayPlayButton: true,
+            context: 'home',
+            centerText: !cardLayout,
+            allowBottomPadding: false,
+            cardLayout: cardLayout,
+            showYear: true,
+            lines: 2
+        });
+    };
+}
+
+export function loadContinueWatching(
+    elem: HTMLElement,
+    apiClient: ApiClient,
+    userSettings: UserSettings,
+    options: SectionOptions
+) {
+    let html = '';
+
+    html += '<h2 class="sectionTitle sectionTitle-cards padded-left">' + globalize.translate('HeaderContinueWatchingAndNextUp') + '</h2>';
+    if (options.enableOverflow) {
+        html += '<div is="emby-scroller" class="padded-top-focusscale padded-bottom-focusscale" data-centerfocus="true">';
+        html += '<div is="emby-itemscontainer" class="itemsContainer scrollSlider focuscontainer-x" data-monitor="videoplayback,markplayed">';
+    } else {
+        html += '<div is="emby-itemscontainer" class="itemsContainer padded-left padded-right vertical-wrap focuscontainer-x" data-monitor="videoplayback,markplayed">';
+    }
+
+    if (options.enableOverflow) {
+        html += '</div>';
+    }
+    html += '</div>';
+
+    elem.classList.add('hide');
+    elem.innerHTML = html;
+
+    const itemsContainer: SectionContainerElement | null = elem.querySelector('.itemsContainer');
+    if (!itemsContainer) return;
+    itemsContainer.fetchData = getItemsFn(apiClient, userSettings, options);
+    itemsContainer.getItemsHtml = getItemsHtmlFn(userSettings.useEpisodeImagesInNextUpAndResume(), options);
+    itemsContainer.parentContainer = elem;
+}

--- a/src/constants/homeSectionType.ts
+++ b/src/constants/homeSectionType.ts
@@ -5,6 +5,7 @@ export enum HomeSectionType {
     SmallLibraryTiles = 'smalllibrarytiles',
     LibraryButtons = 'librarybuttons',
     ActiveRecordings = 'activerecordings',
+    ContinueWatching = 'continuewatching',
     Resume = 'resume',
     ResumeAudio = 'resumeaudio',
     LatestMedia = 'latestmedia',

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -432,6 +432,7 @@
     "HeaderConnectToServer": "Connect to Server",
     "HeaderContinueListening": "Continue Listening",
     "HeaderContinueWatching": "Continue Watching",
+    "HeaderContinueWatchingAndNextUp": "Continue Watching & Next Up",
     "HeaderContinueReading": "Continue Reading",
     "HeaderDateIssued": "Date Issued",
     "HeaderDefaultRecordingSettings": "Default Recording Settings",


### PR DESCRIPTION
**Changes**

Adds a new opt-in home section "Continue Watching & Next Up" that merges the resume list and Next Up into a single row: in-progress movies and episodes first (most recently played), followed by each series' next unwatched episode. The trick that keeps it simple: requesting Next Up with `enableResumable: false` makes the two lists exactly complementary — a series whose next episode is partially watched surfaces in the resume part instead — so the section just concatenates two parallel queries and never needs a dedup pass. Selectable in the home screen section settings; defaults are unchanged.

**Code assistance**

LLM-assisted (mapping the section registry/settings plumbing and drafting the section module, modeled on the existing resume/nextUp sections). I reviewed the changes and verified the behavior on my own server (12.0 preview, 175k-item library): the merged row renders movies in progress, episodes in progress and upcoming episodes together, with no duplicate items; `tsc --noEmit`, eslint and a production webpack build pass.

**Issues**

None filed — happy to open a feature request first if preferred.



The section module mirrors the existing resume/nextUp sections; happy to extract a shared section-shell helper (also covering those two) in a follow-up if preferred.
