### PR TITLE
unify progress indicator across book players

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -2266,15 +2266,27 @@ export class PlaybackManager {
         // Only used internally
         self.getCurrentTicks = getCurrentTicks;
 
-        function playOther(items, options) {
+        async function playOther(items, options) {
             const playStartIndex = options.startIndex || 0;
             const player = getPlayer(items[playStartIndex], options);
+
+            if (self._currentPlayer) {
+                await onPlaybackChanging(self._currentPlayer, player, items[playStartIndex]);
+            }
 
             loading.hide();
 
             options.items = items;
 
-            return player.play(options);
+            self._playQueueManager.setPlaylist(items);
+            setPlaylistState(items[playStartIndex].PlaylistItemId, playStartIndex);
+
+            await player.play(options);
+
+            if (items[playStartIndex].MediaType === 'Book') {
+                // books use progress reporting to track position through listeners in other components
+                onPlaybackStarted(player, options, player.streamInfo, player.streamInfo?.mediaSource);
+            }
         }
 
         const getAdditionalParts = async (items, mediaSourceId, startIndex) => {
@@ -3694,9 +3706,9 @@ export class PlaybackManager {
 
             if (state.NowPlayingItem) {
                 const serverId = state.NowPlayingItem.ServerId;
-
                 const streamInfo = getPlayerData(player).streamInfo;
 
+                Events.trigger(player, 'statechange', [state]);
                 if (streamInfo?.started && !streamInfo.ended) {
                     reportPlayback(self, state, player, reportPlaylist, serverId, 'reportPlaybackProgress', progressEventName);
                 }

--- a/src/plugins/bookPlayer/BookOsd/BookOsd.scss
+++ b/src/plugins/bookPlayer/BookOsd/BookOsd.scss
@@ -32,6 +32,16 @@
     flex: 1;
 }
 
+.bookOsdProgressRow {
+    height: 3vh;
+    margin-top: auto;
+}
+
+.bookOsdProgressText {
+    min-width: 4rem;
+    text-align: center;
+}
+
 .bookOsdTitle {
     font-size: 1.1rem;
     margin-left: 0.35rem;

--- a/src/plugins/bookPlayer/BookOsd/BookOsd.tsx
+++ b/src/plugins/bookPlayer/BookOsd/BookOsd.tsx
@@ -6,6 +6,13 @@ import globalize from 'lib/globalize';
 import * as userSettings from '../../../scripts/settings/userSettings';
 import type { BaseItemDto } from '@jellyfin/sdk/lib/generated-client';
 import Screenfull from 'screenfull';
+import LinearProgress from '@mui/material/LinearProgress';
+import { PlayerEvent } from 'apps/legacy/features/playback/constants/playerEvent';
+import { playbackManager } from 'components/playback/playbackmanager';
+import Events, { type Event } from 'utils/events';
+import { PlaybackManagerEvent } from 'apps/legacy/features/playback/constants/playbackManagerEvent';
+import type { PlayerState } from 'types/playbackStopInfo';
+import type { PlayerPlugin } from 'types/plugin';
 
 interface BookOsdProps {
     item: BaseItemDto;
@@ -42,10 +49,15 @@ const BookOsd: FC<BookOsdProps> = ({
     const settings = userSettings.getComicsPlayerSettings(item.Id!) as ComicsPlayerSettings;
     const timeout = useRef<ReturnType<typeof setTimeout>>();
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const player = useRef<any>(undefined);
+
     const [direction, setDirection] = useState(settings.langDir === 'rtl');
     const [layout, setLayout] = useState(settings.pagesPerView === 2);
     const [fullscreen, setFullscreen] = useState(false);
     const [visible, setVisible] = useState(true);
+    const [position, setPosition] = useState(-1);
+    const [duration, setDuration] = useState(100);
 
     const scheduleHide = useCallback(() => {
         clearTimeout(timeout.current);
@@ -104,11 +116,48 @@ const BookOsd: FC<BookOsdProps> = ({
         };
     }, [scheduleHide, updateFullscreen]);
 
+    useEffect(() => {
+        const onStateChange = (_e: Event, _newState: PlayerState) => {
+            // special case to handle EPUB progress as percentage value
+            if (_newState.NowPlayingItem?.Path?.endsWith('.epub')) {
+                setPosition(Math.floor(player.current?.currentTime() / 10));
+                setDuration(100);
+            } else {
+                setPosition(player.current?.currentTime());
+                setDuration(player.current?.duration());
+            }
+        };
+
+        const onPlaybackStart = (_e: Event, _player: PlayerPlugin, _state?: PlayerState) => {
+            player.current = _player;
+
+            Events.on(player.current, PlayerEvent.StateChange, onStateChange);
+            onStateChange(_e, _state!);
+        };
+
+        Events.on(playbackManager, PlaybackManagerEvent.PlaybackStart, onPlaybackStart);
+
+        return () => {
+            Events.off(playbackManager, PlaybackManagerEvent.PlaybackStart, onPlaybackStart);
+            Events.off(player.current, PlayerEvent.StateChange, onStateChange);
+        };
+    }, []);
+
     return (
         <div className='bookOsd'>
             <div className='bookOsdRow' style={{ paddingTop: 'env(safe-area-inset-top)', ...(!visible && { opacity: 0, pointerEvents: 'none' }) }}>
                 <IconButton onClick={onExit} icon='arrow_back' title={globalize.translate('ButtonBack')} />
                 <span className='bookOsdTitle'>{item.Name}</span>
+            </div>
+
+            <div className='bookOsdRow bookOsdProgressRow' style={{ ...(!visible && { opacity: 0, pointerEvents: 'none' }) }}>
+                <span className='bookOsdProgressText'>{position + 1}</span>
+                <LinearProgress
+                    variant='determinate'
+                    value={position !== 0 ? position / (duration - 1) * 100 : 0}
+                    style={{ flex: 1 }}
+                />
+                <span className='bookOsdProgressText'>{duration}</span>
             </div>
 
             <div className='bookOsdRow' style={{ paddingBottom: 'env(safe-area-inset-bottom)', ...(!visible && { opacity: 0, pointerEvents: 'none' }) }}>

--- a/src/plugins/bookPlayer/plugin.js
+++ b/src/plugins/bookPlayer/plugin.js
@@ -367,7 +367,7 @@ export class BookPlayer {
                         epubElem.style.opacity = '';
                         rendition.on('relocated', (locations) => {
                             this.progress = book.locations.percentageFromCfi(locations.start.cfi);
-                            Events.trigger(this, 'pause');
+                            Events.trigger(this, 'timeupdate');
                         });
 
                         this.setTheme(this.theme, this.fontSize);

--- a/src/plugins/comicsPlayer/plugin.js
+++ b/src/plugins/comicsPlayer/plugin.js
@@ -221,7 +221,6 @@ export class ComicsPlayer {
             elem.classList.add('slideshowDialog');
             elem.innerHTML = `<div id="bookOsdMount"></div><div dir=${this.comicsPlayerSettings.langDir} class="slideshowSwiperContainer">
                                 <div class="swiper-wrapper"></div>
-                                <div class="swiper-pagination"></div>
                             </div>`;
 
             dialogHelper.open(elem);
@@ -300,11 +299,6 @@ export class ComicsPlayer {
                     slidesPerGroup: this.comicsPlayerSettings.pagesPerView,
                     slidesPerColumn: 1,
                     initialSlide: this.currentPage,
-                    pagination: {
-                        el: '.swiper-pagination',
-                        clickable: true,
-                        type: 'fraction'
-                    },
                     // reduces memory consumption for large libraries while allowing preloading of images
                     virtual: {
                         slides: this.archiveSource.urls,
@@ -318,7 +312,7 @@ export class ComicsPlayer {
                 // save current page ( a page is an image file inside the archive )
                 this.swiperInstance.on('slideChange', () => {
                     this.currentPage = this.swiperInstance.activeIndex;
-                    Events.trigger(this, 'pause');
+                    Events.trigger(this, 'timeupdate');
                 });
             });
     }

--- a/src/plugins/comicsPlayer/style.scss
+++ b/src/plugins/comicsPlayer/style.scss
@@ -21,14 +21,4 @@
         width: 100%;
         object-fit: contain;
     }
-
-    .swiper-pagination {
-        width: max-content;
-        background: #fff;
-        color: #000;
-        padding: 2px 5px 2px 5px;
-        left: 50%;
-        transform: translate(-50%, 0%);
-        text-shadow: 0 0 20px #fff;
-    }
 }

--- a/src/plugins/pdfPlayer/plugin.js
+++ b/src/plugins/pdfPlayer/plugin.js
@@ -242,7 +242,7 @@ export class PdfPlayer {
         this.loadPage(this.progress + 2);
         this.progress = this.progress + 1;
 
-        Events.trigger(this, 'pause');
+        Events.trigger(this, 'timeupdate');
     }
 
     previous() {
@@ -250,7 +250,7 @@ export class PdfPlayer {
         this.loadPage(this.progress);
         this.progress = this.progress - 1;
 
-        Events.trigger(this, 'pause');
+        Events.trigger(this, 'timeupdate');
     }
 
     loadPage(number) {

--- a/src/themes/_base/_theme.scss
+++ b/src/themes/_base/_theme.scss
@@ -605,11 +605,6 @@ a[data-role="button"],
     background-color: var(--jf-palette-background-default, $background-default);
 }
 
-#comicsPlayer .swiper-pagination {
-    background-color: var(--jf-palette-background-default, $background-default);
-    color: var(--jf-palette-text-primary, $text-primary);
-}
-
 #dialogToc {
     background-color: var(--jf-palette-background-default, $background-default);
 }


### PR DESCRIPTION
### Changes

Previously, the comic player used a Swiper feature to show current position from local state. This pull request removes that implementation and replaces it with a ProgressIndicator element in BookOsd that hooks into playback events for all updates.

@jordanmichaelrushing I technically "fixed" the audio + book playback issue along with the photo playback issue from your previous review comments. However, I consider the former an unintentional feature and have removed it to avoid edge cases. Simultaneous playback in a single browser tab doesn't seem like something we want to support but I'll defer to @thornbill for the decision.

### Issues

None

### Code Assistance

None