### PR TITLE
Clear the query cache on server restart

### DIFF
--- a/src/apps/dashboard/routes/index.tsx
+++ b/src/apps/dashboard/routes/index.tsx
@@ -1,29 +1,36 @@
-import React, { useCallback, useMemo, useState } from 'react';
-import Page from 'components/Page';
-import globalize from 'lib/globalize';
+import { TaskState } from '@jellyfin/sdk/lib/generated-client/models/task-state';
+import { OutboundWebSocketMessageType } from '@jellyfin/sdk/lib/websocket';
 import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
+import Stack from '@mui/material/Stack';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+
+import ConfirmDialog from 'components/ConfirmDialog';
+import Page from 'components/Page';
+import { useApi } from 'hooks/useApi';
+import globalize from 'lib/globalize';
+
 import ServerPathWidget from '../components/widgets/ServerPathWidget';
 import ServerInfoWidget from '../components/widgets/ServerInfoWidget';
 import ActivityLogWidget from '../components/widgets/ActivityLogWidget';
 import AlertsLogWidget from '../components/widgets/AlertsLogWidget';
-import Stack from '@mui/material/Stack';
 import useShutdownServer from '../features/system/api/useShutdownServer';
 import useRestartServer from '../features/system/api/useRestartServer';
-import ConfirmDialog from 'components/ConfirmDialog';
 import useLiveTasks from '../features/tasks/hooks/useLiveTasks';
 import RunningTasksWidget from '../components/widgets/RunningTasksWidget';
 import DevicesWidget from '../components/widgets/DevicesWidget';
 import { useStartTask } from '../features/tasks/api/useStartTask';
 import ItemCountsWidget from '../components/widgets/ItemCountsWidget';
-import { TaskState } from '@jellyfin/sdk/lib/generated-client/models/task-state';
 
 export const Component = () => {
+    const { api } = useApi();
     const [ isRestartConfirmDialogOpen, setIsRestartConfirmDialogOpen ] = useState(false);
     const [ isShutdownConfirmDialogOpen, setIsShutdownConfirmDialogOpen ] = useState(false);
     const startTask = useStartTask();
     const restartServer = useRestartServer();
     const shutdownServer = useShutdownServer();
+    const queryClient = useQueryClient();
 
     const { data: tasks } = useLiveTasks({ isHidden: false });
 
@@ -65,7 +72,14 @@ export const Component = () => {
     const onShutdownConfirm = useCallback(() => {
         shutdownServer.mutate();
         setIsShutdownConfirmDialogOpen(false);
-    }, [ shutdownServer ]);
+    }, [shutdownServer]);
+
+    // Clear the query client when the server restarts or shuts down
+    useEffect(() => {
+        return api?.subscribe([OutboundWebSocketMessageType.ServerRestarting, OutboundWebSocketMessageType.ServerShuttingDown], () => {
+            queryClient.clear();
+        });
+    }, [ api, queryClient ]);
 
     return (
         <Page


### PR DESCRIPTION
### Changes
Clears the query cache on server restart or shutdown

### Issues
Fixes #8319 

### Code assistance
Zed autocomplete

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
