### PR TITLE
default overlayMoreButton for mobile cards

### DIFF
--- a/src/apps/legacy/controllers/itemDetails/index.js
+++ b/src/apps/legacy/controllers/itemDetails/index.js
@@ -1830,7 +1830,8 @@ function getVideosHtml(items) {
         action: 'play',
         overlayText: false,
         centerText: true,
-        showRuntime: true
+        showRuntime: true,
+        overlayMoreButton: true
     });
 }
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

### Changes
<!--
Describe your changes here in 1-5 sentences.
Please include before/after screenshots of any UI changes.
-->
Users have requested both the Download on `Additional Parts` and on `special features`.
This PR changes the default card options for `getVideosHtml` to set enable `overlayMoreButton`.
How I see  it, the cardBuilder exclusively uses `options.overlayMoreButton` for mobile layout, so setting it to true will not affect TV or desktop layouts.

I decided to directly modify the `getVideosHtml` instead of only the card options for both `specialsContent` and `additionalPartsContent`, necause `getVideosHtml` seems to be only used 3 times:
- `specialsContent`
- `additionalPartsContent`
- `musicVideosContent`

In my opinion it is sensible to just modify the default, especially since I see no reason not to allow downloading of Music Videos on mobile too.

I am aware this DOES remove the `overlayPlayButton` from those types of mini-cards, however since it is not needed this should be fine. If the UX now is "too akward", I guess enabling `centerPlayButton` would be a ?good? alternative?

Anyways...

| Before | After |
| - | - |
| <img width="188" height="306" alt="grafik" src="https://github.com/user-attachments/assets/72230d90-4290-4df6-8c11-4890f02c875a" /> | <img width="188" height="306" alt="grafik" src="https://github.com/user-attachments/assets/ac341181-1aeb-4540-a5a1-18f360ea2f0d" /> |

### Issues
<!--
Tag any issues that this PR solves here.
ex. Fixes #
-->
Should fix:
- [Download Action on "Additional Parts" list container in mobile web view](https://github.com/jellyfin/jellyfin-web/issues/3300)
- [download of special features](https://github.com/jellyfin/jellyfin-android/issues/636)

### Code assistance
<!--
If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance.
-->
ChatGPT was used to find alternative solutions. However it just suggested garbage and its output was not used.

---

* [X] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [X] I have tested these changes.
* [X] I have verified that this is not duplicating changes in an existing PR. (At least couldn't find one)
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me). (I wish I could :moyai: )