### PR TITLE
add security improvements to npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,7 @@
+allow-remote=root
 engine-strict=true
 fund=false
+ignore-scripts=true
+min-release-age=7
+min-release-age-exclude[]=@jellyfin/*
 save-exact=true


### PR DESCRIPTION
### Changes

allow-remote: Setting "none" would be better but we have a single remote package. The default on new NPM versions is none so this also fixes installs in modern environments.

ignore-scripts: I ran a search and I don't think any of our dependencies use irregular scripts?

min-release-age: Requires that a package exist for at least two weeks before it can be added to our builds by default.

### Issues

None

### Code Assistance

None