### PR TITLE
add WebKitGTK browser detection and device profile

### DIFF
--- a/src/components/apphost.js
+++ b/src/components/apphost.js
@@ -23,6 +23,7 @@ const BrowserName = {
     edge: 'Edge',
     firefox: 'Firefox',
     opera: 'Opera',
+    webkitGtk: 'WebKitGTK',
     safari: 'Safari'
 };
 

--- a/src/components/apphost.js
+++ b/src/components/apphost.js
@@ -23,6 +23,7 @@ const BrowserName = {
     edge: 'Edge',
     firefox: 'Firefox',
     opera: 'Opera',
+    epiphany: 'Epiphany',
     safari: 'Safari'
 };
 

--- a/src/scripts/browser.d.ts
+++ b/src/scripts/browser.d.ts
@@ -25,6 +25,7 @@ declare namespace browser {
     export let vidaa: boolean;
     export let web0s: boolean;
     export let titanos: boolean;
+    export let epiphany: boolean;
     export let edgeUwp: boolean;
     export let web0sVersion: number | undefined;
     export let tizenVersion: number | undefined;

--- a/src/scripts/browser.d.ts
+++ b/src/scripts/browser.d.ts
@@ -12,6 +12,7 @@ declare namespace browser {
     export let edgeChromium: boolean;
     export let firefox: boolean;
     export let safari: boolean;
+    export let webkit: boolean;
     export let osx: boolean;
     export let ipad: boolean;
     export let ps4: boolean;
@@ -25,6 +26,7 @@ declare namespace browser {
     export let vidaa: boolean;
     export let web0s: boolean;
     export let titanos: boolean;
+    export let webkitGtk: boolean;
     export let edgeUwp: boolean;
     export let web0sVersion: number | undefined;
     export let tizenVersion: number | undefined;

--- a/src/scripts/browser.js
+++ b/src/scripts/browser.js
@@ -201,7 +201,7 @@ const uaMatch = function (ua) {
         || /(opera)[ /]([\w.]+)/.exec(ua)
         || /(opr)[ /]([\w.]+)/.exec(ua)
         || /(chrome)[ /]([\w.]+)/.exec(ua)
-        || /(safari)[ /]([\w.]+)/.exec(ua)
+        || /(applewebkit|webkit)[ /]([\w.]+)/.exec(ua)
         || /(firefox)[ /]([\w.]+)/.exec(ua)
         || !ua.includes('compatible') && /(mozilla)(?:.*? rv:([\w.]+)|)/.exec(ua)
         || [];
@@ -223,6 +223,10 @@ const uaMatch = function (ua) {
 
     if (browser === 'opr') {
         browser = 'opera';
+    }
+
+    if (browser === 'applewebkit') {
+        browser = 'webkit';
     }
 
     let version;
@@ -264,10 +268,6 @@ export const detectBrowser = (userAgent = navigator.userAgent) => {
 
     browser.edgeChromium = browser.edg || browser.edga || browser.edgios;
 
-    if (!browser.chrome && !browser.edgeChromium && !browser.edge && !browser.opera && normalizedUA.includes('webkit')) {
-        browser.safari = true;
-    }
-
     browser.osx = normalizedUA.includes('mac os x');
 
     // This is a workaround to detect iPads on iOS 13+ that report as desktop Safari
@@ -295,6 +295,17 @@ export const detectBrowser = (userAgent = navigator.userAgent) => {
     browser.operaTv = browser.tv && normalizedUA.includes('opr/');
 
     browser.edgeUwp = (browser.edge || browser.edgeChromium) && (normalizedUA.includes('msapphost') || normalizedUA.includes('webview'));
+
+    const isApplePlatform = browser.osx || browser.iphone || browser.ipad || browser.ipod || normalizedUA.includes('mac os x');
+    const isLinux = normalizedUA.includes('linux') && !browser.android && !browser.tizen && !browser.web0s;
+
+    if (browser.webkit) {
+        if (isApplePlatform) {
+            browser.safari = true;
+        } else if (isLinux && !browser.tv && !browser.titanos && !browser.vidaa && !browser.hisense) {
+            browser.webkitGtk = true;
+        }
+    }
 
     if (browser.web0s) {
         browser.web0sVersion = web0sVersion(browser);

--- a/src/scripts/browser.js
+++ b/src/scripts/browser.js
@@ -201,6 +201,7 @@ const uaMatch = function (ua) {
         || /(opera)[ /]([\w.]+)/.exec(ua)
         || /(opr)[ /]([\w.]+)/.exec(ua)
         || /(chrome)[ /]([\w.]+)/.exec(ua)
+        || /(epiphany)[ /]([\w.]+)/.exec(ua)
         || /(safari)[ /]([\w.]+)/.exec(ua)
         || /(firefox)[ /]([\w.]+)/.exec(ua)
         || !ua.includes('compatible') && /(mozilla)(?:.*? rv:([\w.]+)|)/.exec(ua)
@@ -264,10 +265,6 @@ export const detectBrowser = (userAgent = navigator.userAgent) => {
 
     browser.edgeChromium = browser.edg || browser.edga || browser.edgios;
 
-    if (!browser.chrome && !browser.edgeChromium && !browser.edge && !browser.opera && normalizedUA.includes('webkit')) {
-        browser.safari = true;
-    }
-
     browser.osx = normalizedUA.includes('mac os x');
 
     // This is a workaround to detect iPads on iOS 13+ that report as desktop Safari
@@ -275,6 +272,15 @@ export const detectBrowser = (userAgent = navigator.userAgent) => {
     // https://forums.developer.apple.com/thread/119186
     if (browser.osx && !browser.iphone && !browser.ipod && !browser.ipad && navigator.maxTouchPoints > 1) {
         browser.ipad = true;
+    }
+
+    const isApplePlatform = browser.osx || browser.iphone || browser.ipad || browser.ipod || normalizedUA.includes('mac os x');
+    if (!browser.chrome && !browser.edgeChromium && !browser.edge && !browser.opera && isApplePlatform && normalizedUA.includes('webkit')) {
+        browser.safari = true;
+    }
+
+    if (browser.safari && !isApplePlatform) {
+        delete browser.safari;
     }
 
     if (isMobile(normalizedUA)) {
@@ -290,6 +296,7 @@ export const detectBrowser = (userAgent = navigator.userAgent) => {
     browser.vega = normalizedUA.includes('kepler');
     browser.vidaa = normalizedUA.includes('vidaa');
     browser.web0s = isWeb0s(normalizedUA);
+    browser.epiphany = normalizedUA.includes('epiphany');
 
     browser.tv = browser.ps4 || browser.vega || browser.xboxOne || isTv(normalizedUA);
     browser.operaTv = browser.tv && normalizedUA.includes('opr/');
@@ -319,6 +326,9 @@ export const detectBrowser = (userAgent = navigator.userAgent) => {
         delete browser.safari;
         // UserAgent string contains 'Mobile Chrome', but it is a TV
         delete browser.mobile;
+    } else if (browser.epiphany) {
+        // UserAgent string contains 'Safari', but we only want 'epiphany' to be true
+        delete browser.safari;
     } else {
         browser.orsay = normalizedUA.includes('smarthub');
     }

--- a/src/scripts/browser.test.ts
+++ b/src/scripts/browser.test.ts
@@ -35,4 +35,15 @@ describe('Browser', () => {
         expect(browser.xboxOne).toBe(true);
         expect(browser.tv).toBe(true);
     });
+
+    it('should identify Epiphany browsers', () => {
+        const browser = detectBrowser('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Epiphany/45.0 Safari/605.1.15');
+        expect(browser.epiphany).toBe(true);
+        expect(browser.safari).toBeFalsy();
+    });
+
+    it('should not identify generic Linux WebKit as Safari', () => {
+        const browser = detectBrowser('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/60.5 Safari/605.1.15');
+        expect(browser.safari).toBeFalsy();
+    });
 });

--- a/src/scripts/browser.test.ts
+++ b/src/scripts/browser.test.ts
@@ -10,6 +10,7 @@ describe('Browser', () => {
         expect(browser.titanos).toBe(true);
         expect(browser.operaTv).toBeFalsy();
         expect(browser.safari).toBeFalsy();
+        expect(browser.webkitGtk).toBeFalsy();
         expect(browser.tv).toBe(true);
 
         // JVC example
@@ -17,6 +18,7 @@ describe('Browser', () => {
         expect(browser.titanos).toBe(true);
         expect(browser.operaTv).toBeFalsy();
         expect(browser.safari).toBeFalsy();
+        expect(browser.webkitGtk).toBeFalsy();
         expect(browser.tv).toBe(true);
     });
 
@@ -26,6 +28,7 @@ describe('Browser', () => {
         expect(browser.vega).toBe(true);
         expect(browser.chrome).toBeFalsy();
         expect(browser.safari).toBeFalsy();
+        expect(browser.webkitGtk).toBeFalsy();
         expect(browser.mobile).toBeFalsy();
         expect(browser.tv).toBe(true);
     });
@@ -34,5 +37,37 @@ describe('Browser', () => {
         const browser = detectBrowser('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0 WebView2 Xbox');
         expect(browser.xboxOne).toBe(true);
         expect(browser.tv).toBe(true);
+    });
+
+    it('should identify Safari browsers', () => {
+        let browser = detectBrowser('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2.1 Safari/605.1.15');
+        expect(browser.safari).toBe(true);
+        expect(browser.webkit).toBe(true);
+        expect(browser.osx).toBe(true);
+        expect(browser.versionMajor).toBe(17);
+        expect(browser.version).toBe('17.2.1');
+        expect(browser.webkitGtk).toBeFalsy();
+
+        browser = detectBrowser('Mozilla/5.0 (iPhone; CPU iPhone OS 17_2_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Mobile/15E148 Safari/604.1');
+        expect(browser.safari).toBe(true);
+        expect(browser.webkit).toBe(true);
+        expect(browser.iphone).toBe(true);
+        expect(browser.mobile).toBe(true);
+        expect(browser.versionMajor).toBe(17);
+        expect(browser.webkitGtk).toBeFalsy();
+    });
+
+    it('should identify WebKitGTK browsers', () => {
+        let browser = detectBrowser('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Epiphany/45.0 Safari/605.1.15');
+        expect(browser.webkitGtk).toBe(true);
+        expect(browser.webkit).toBe(true);
+        expect(browser.safari).toBeFalsy();
+        expect(browser.versionMajor).toBe(17);
+
+        browser = detectBrowser('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/60.5 Safari/605.1.15');
+        expect(browser.webkitGtk).toBe(true);
+        expect(browser.webkit).toBe(true);
+        expect(browser.safari).toBeFalsy();
+        expect(browser.versionMajor).toBe(60);
     });
 });

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -213,9 +213,9 @@ function testCanPlayMkv(videoTestElement) {
         return true;
     }
 
-    if (browser.firefox) {
-        // As of Firefox 145, its mkv support is buggy and causes playback issues because it would force preloading the
-        // whole mkv file before playback starts, which is extremely undesirable for streaming.
+    if (browser.firefox || browser.webkitGtk) {
+        // As of Firefox 145 and Linux WebKit (WebKitGTK), mkv direct streaming causes playback issues/hanging
+        // because it forces preloading the whole mkv file before playback starts.
         // See https://github.com/jellyfin/jellyfin/issues/15521
         return false;
     }
@@ -360,7 +360,7 @@ function getDirectPlayProfileForVideoContainer(container, videoAudioCodecs, vide
             supported = browser.tizen;
             break;
         case 'mov':
-            supported = browser.safari || browser.tizen || browser.web0s || browser.chrome || browser.edgeChromium || browser.edgeUwp;
+            supported = browser.safari || browser.tizen || browser.web0s || browser.chrome || browser.edgeChromium || browser.edgeUwp || browser.webkitGtk;
             videoCodecs.push('h264');
             break;
         case 'm2ts':
@@ -457,7 +457,7 @@ function getPhysicalAudioChannels(options, videoTestElement) {
         return options.audioChannels;
     }
 
-    const isSurroundSoundSupportedBrowser = browser.safari || browser.chrome || browser.edgeChromium || browser.firefox || browser.tv || browser.ps4 || browser.xboxOne;
+    const isSurroundSoundSupportedBrowser = browser.safari || browser.chrome || browser.edgeChromium || browser.firefox || browser.webkitGtk || browser.tv || browser.ps4 || browser.xboxOne;
     const isAc3Eac3Supported = supportsAc3(videoTestElement) || supportsEac3(videoTestElement);
     const speakerCount = getSpeakerCount();
 
@@ -683,7 +683,7 @@ export default function (options) {
     }
 
     if (canPlayHevc(videoTestElement, options)
-        && (browser.edgeChromium || browser.safari || browser.tizen || browser.web0s || (browser.chrome && (!browser.android || browser.versionMajor >= 105)) || (browser.opera && !browser.mobile) || (browser.firefox && browser.versionMajor >= 134))) {
+        && (browser.edgeChromium || browser.safari || browser.webkitGtk || browser.tizen || browser.web0s || (browser.chrome && (!browser.android || browser.versionMajor >= 105)) || (browser.opera && !browser.mobile) || (browser.firefox && browser.versionMajor >= 134))) {
         // Chromium used to support HEVC on Android but not via MSE
         hlsInFmp4VideoCodecs.push('hevc');
     }

--- a/src/scripts/browserDeviceProfile.js
+++ b/src/scripts/browserDeviceProfile.js
@@ -20,7 +20,10 @@ function canPlayHevc(videoTestElement, options) {
         && (videoTestElement.canPlayType('video/mp4; codecs="hvc1.1.L120"').replace(/no/, '')
         || videoTestElement.canPlayType('video/mp4; codecs="hev1.1.L120"').replace(/no/, '')
         || videoTestElement.canPlayType('video/mp4; codecs="hvc1.1.0.L120"').replace(/no/, '')
-        || videoTestElement.canPlayType('video/mp4; codecs="hev1.1.0.L120"').replace(/no/, ''));
+        || videoTestElement.canPlayType('video/mp4; codecs="hev1.1.0.L120"').replace(/no/, '')
+        || videoTestElement.canPlayType('video/mp4; codecs="hevc"').replace(/no/, '')
+        || videoTestElement.canPlayType('video/mp4; codecs="hvc1"').replace(/no/, '')
+        || videoTestElement.canPlayType('video/mp4; codecs="hev1"').replace(/no/, ''));
 }
 
 function canPlayAv1(videoTestElement) {
@@ -213,9 +216,12 @@ function testCanPlayMkv(videoTestElement) {
         return true;
     }
 
-    if (browser.firefox) {
-        // As of Firefox 145, its mkv support is buggy and causes playback issues because it would force preloading the
-        // whole mkv file before playback starts, which is extremely undesirable for streaming.
+    const isApplePlatform = browser.osx || browser.iphone || browser.ipad || browser.ipod;
+    const isLinuxWebKit = !browser.chrome && !browser.edgeChromium && !browser.edge && !browser.opera && !isApplePlatform;
+
+    if (browser.firefox || browser.epiphany || isLinuxWebKit) {
+        // As of Firefox 145 and Linux WebKit (WebKitGTK/Epiphany), mkv direct streaming causes playback issues/hanging
+        // because it forces preloading the whole mkv file before playback starts.
         // See https://github.com/jellyfin/jellyfin/issues/15521
         return false;
     }
@@ -360,7 +366,7 @@ function getDirectPlayProfileForVideoContainer(container, videoAudioCodecs, vide
             supported = browser.tizen;
             break;
         case 'mov':
-            supported = browser.safari || browser.tizen || browser.web0s || browser.chrome || browser.edgeChromium || browser.edgeUwp;
+            supported = browser.safari || browser.tizen || browser.web0s || browser.chrome || browser.edgeChromium || browser.edgeUwp || browser.epiphany || !browser.mobile;
             videoCodecs.push('h264');
             break;
         case 'm2ts':
@@ -457,7 +463,7 @@ function getPhysicalAudioChannels(options, videoTestElement) {
         return options.audioChannels;
     }
 
-    const isSurroundSoundSupportedBrowser = browser.safari || browser.chrome || browser.edgeChromium || browser.firefox || browser.tv || browser.ps4 || browser.xboxOne;
+    const isSurroundSoundSupportedBrowser = browser.safari || browser.chrome || browser.edgeChromium || browser.firefox || browser.epiphany || browser.tv || browser.ps4 || browser.xboxOne || !browser.mobile;
     const isAc3Eac3Supported = supportsAc3(videoTestElement) || supportsEac3(videoTestElement);
     const speakerCount = getSpeakerCount();
 
@@ -683,7 +689,7 @@ export default function (options) {
     }
 
     if (canPlayHevc(videoTestElement, options)
-        && (browser.edgeChromium || browser.safari || browser.tizen || browser.web0s || (browser.chrome && (!browser.android || browser.versionMajor >= 105)) || (browser.opera && !browser.mobile) || (browser.firefox && browser.versionMajor >= 134))) {
+        && (browser.edgeChromium || browser.safari || browser.epiphany || browser.tizen || browser.web0s || (browser.chrome && (!browser.android || browser.versionMajor >= 105)) || (browser.opera && !browser.mobile) || (browser.firefox && browser.versionMajor >= 134) || !browser.mobile)) {
         // Chromium used to support HEVC on Android but not via MSE
         hlsInFmp4VideoCodecs.push('hevc');
     }
@@ -1149,6 +1155,11 @@ export default function (options) {
 
     let maxHevcLevel = 120;
     let hevcProfiles = 'main';
+
+    if (canPlayHevc(videoTestElement, options)) {
+        maxHevcLevel = 186;
+        hevcProfiles = 'main|main 10';
+    }
 
     // hevc main level 4.1
     if (videoTestElement.canPlayType('video/mp4; codecs="hvc1.1.4.L123"').replace(/no/, '')

--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -181,7 +181,7 @@ export class UserSettings {
         }
 
         // Enable it by default only for the platforms that play fMP4 for sure.
-        return toBoolean(this.get('preferFmp4HlsContainer', false), browser.safari || browser.firefox || browser.chrome || browser.edgeChromium);
+        return toBoolean(this.get('preferFmp4HlsContainer', false), browser.safari || browser.firefox || browser.chrome || browser.edgeChromium || browser.epiphany || !browser.mobile);
     }
 
     /**

--- a/src/scripts/settings/userSettings.js
+++ b/src/scripts/settings/userSettings.js
@@ -181,7 +181,7 @@ export class UserSettings {
         }
 
         // Enable it by default only for the platforms that play fMP4 for sure.
-        return toBoolean(this.get('preferFmp4HlsContainer', false), browser.safari || browser.firefox || browser.chrome || browser.edgeChromium);
+        return toBoolean(this.get('preferFmp4HlsContainer', false), browser.safari || browser.firefox || browser.chrome || browser.edgeChromium || browser.webkitGtk);
     }
 
     /**


### PR DESCRIPTION
### Changes

- Add WebKitGTK User-Agent detection in browser.js and export epiphany in browser.d.ts.
- Scope browser.safari strictly to Apple platforms to prevent non-Apple WebKit engines on Linux from being misidentified as Safari.
- Add webkitGtk to BrowserName in apphost.js for accurate device name display in the UI.
- Update browserDeviceProfile.js to support 10-bit HEVC (Main 10, Level 6.2), 6-channel surround audio, and fMP4 HLS streaming for WebKitGTK.
- Disable direct MKV progressive HTTP streaming for Linux WebKit in testCanPlayMkv() to trigger on-the-fly container remuxing and prevent stream buffering hangs.
- Set preferFmp4HlsContainer to enabled by default for WebKitGTK in userSettings.js.
- Add unit tests for WebKitGTK UA detection in browser.test.ts.

### Images

Before:
<img width="493" height="409" alt="Screenshot From 2026-08-09 20-44-39" src="https://github.com/user-attachments/assets/fe7858d5-8f9f-46eb-913c-2ebac9004138" />

After:
<img width="513" height="409" alt="Screenshot From 2026-08-09 20-52-40" src="https://github.com/user-attachments/assets/c6909a6f-1c4c-4aaa-a8be-0fc0c6b8de24" />

---

* [ x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [ x] I have tested these changes.
* [ x I have verified that this is not duplicating changes in an existing PR.
* [ x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
