### PR TITLE
modify eslint and webpack config files

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -94,7 +94,6 @@ export default tseslint.config(
             '@typescript-eslint/no-useless-constructor': 'error',
             'no-var': 'error',
             'no-void': ['error', { 'allowAsStatement': true }],
-            'no-warning-comments': ['warn', { 'terms': ['hack', 'xxx'] }],
             'one-var': ['error', 'never'],
             'prefer-const': ['error', { 'destructuring': 'all' }],
             'prefer-promise-reject-errors': ['warn', { 'allowEmptyReject': true }],
@@ -102,7 +101,7 @@ export default tseslint.config(
             'radix': 'error',
             'yoda': 'error',
 
-            'sonarjs/fixme-tag': 'warn',
+            'sonarjs/fixme-tag': 'off',
             'sonarjs/todo-tag': 'off',
             'sonarjs/deprecation': 'off',
             'sonarjs/no-alphabetical-sort': 'warn',
@@ -389,7 +388,6 @@ export default tseslint.config(
         },
         rules: {
             'react/jsx-filename-extension': ['error', { 'extensions': ['.jsx', '.tsx'] }],
-            'react/jsx-no-bind': 'error',
             'react/jsx-no-useless-fragment': 'error',
             'react/no-array-index-key': 'error',
             'react-hooks/rules-of-hooks': 'error',

--- a/package.json
+++ b/package.json
@@ -173,7 +173,6 @@
   },
   "engines": {
     "node": ">=24.0.0",
-    "npm": ">=11.0.0",
-    "yarn": "YARN NO LONGER USED - use npm instead."
+    "npm": ">=11.0.0"
   }
 }

--- a/src/apps/dashboard/routes/devices/index.tsx
+++ b/src/apps/dashboard/routes/devices/index.tsx
@@ -221,7 +221,6 @@ export const Component = () => {
                 >
                     <Tooltip title={globalize.translate('Edit')}>
                         <IconButton
-                            // eslint-disable-next-line react/jsx-no-bind
                             onClick={() => table.setEditingRow(row)}
                         >
                             <Edit />

--- a/src/apps/dashboard/routes/keys/index.tsx
+++ b/src/apps/dashboard/routes/keys/index.tsx
@@ -94,7 +94,6 @@ export const Component = () => {
                     <Tooltip title={globalize.translate('ButtonRevoke')}>
                         <IconButton
                             color='error'
-                            // eslint-disable-next-line react/jsx-no-bind
                             onClick={() => row.original?.AccessToken && onRevokeKey(row.original.AccessToken)}
                         >
                             <DeleteIcon />

--- a/src/apps/dashboard/routes/plugins/index.tsx
+++ b/src/apps/dashboard/routes/plugins/index.tsx
@@ -183,21 +183,18 @@ export const Component = () => {
                                 >
                                     <Chip
                                         color={status === PluginStatusOption.All ? 'primary' : undefined}
-                                        // eslint-disable-next-line react/jsx-no-bind
                                         onClick={() => setStatus(PluginStatusOption.All)}
                                         label={globalize.translate('All')}
                                     />
 
                                     <Chip
                                         color={status === PluginStatusOption.Available ? 'primary' : undefined}
-                                        // eslint-disable-next-line react/jsx-no-bind
                                         onClick={() => setStatus(PluginStatusOption.Available)}
                                         label={globalize.translate('LabelAvailable')}
                                     />
 
                                     <Chip
                                         color={status === PluginStatusOption.Installed ? 'primary' : undefined}
-                                        // eslint-disable-next-line react/jsx-no-bind
                                         onClick={() => setStatus(PluginStatusOption.Installed)}
                                         label={globalize.translate('LabelInstalled')}
                                     />
@@ -206,7 +203,6 @@ export const Component = () => {
 
                                     <Chip
                                         color={!category ? 'primary' : undefined}
-                                        // eslint-disable-next-line react/jsx-no-bind
                                         onClick={() => setCategory('')}
                                         label={globalize.translate('All')}
                                     />
@@ -215,7 +211,6 @@ export const Component = () => {
                                         <Chip
                                             key={c}
                                             color={category === c.toLowerCase() ? 'primary' : undefined}
-                                            // eslint-disable-next-line react/jsx-no-bind
                                             onClick={() => setCategory(c.toLowerCase())}
                                             label={globalize.translate(CATEGORY_LABELS[c as PluginCategory])}
                                         />

--- a/src/apps/dashboard/routes/tasks/task.tsx
+++ b/src/apps/dashboard/routes/tasks/task.tsx
@@ -126,7 +126,6 @@ export const Component = () => {
                     <Tooltip disableInteractive title={globalize.translate('ButtonRemove')}>
                         <IconButton
                             color='error'
-                            // eslint-disable-next-line react/jsx-no-bind
                             onClick={() => onDeleteTrigger(row.original)}
                         >
                             <RemoveCircleIcon />

--- a/src/apps/modern/components/AppToolbar/RemotePlayButton.tsx
+++ b/src/apps/modern/components/AppToolbar/RemotePlayButton.tsx
@@ -69,7 +69,6 @@ const RemotePlayButton = () => {
                             aria-haspopup='true'
                             onClick={onRemotePlayActiveButtonClick}
                             color='inherit'
-                            // eslint-disable-next-line react/jsx-no-bind
                             sx={(theme) => ({
                                 color: theme.vars.palette.primary.main
                             })}

--- a/src/apps/modern/components/AppToolbar/menus/RemotePlayMenu.tsx
+++ b/src/apps/modern/components/AppToolbar/menus/RemotePlayMenu.tsx
@@ -83,8 +83,6 @@ const RemotePlayMenu: FC<RemotePlayMenuProps> = ({
             {playbackTargets.map(target => (
                 <MenuItem
                     key={target.id}
-                    // Since we are looping over targets there is no good way to avoid creating a new function here
-                    // eslint-disable-next-line react/jsx-no-bind
                     onClick={() => onPlayTargetClick(target)}
                 >
                     <ListItemIcon>

--- a/src/apps/modern/features/libraries/components/AlphabetPicker.tsx
+++ b/src/apps/modern/features/libraries/components/AlphabetPicker.tsx
@@ -38,7 +38,6 @@ const AlphabetPicker: React.FC<AlphabetPickerProps> = ({
     return (
         <Box
             className='alphaPicker-fixed-right'
-            // eslint-disable-next-line react/jsx-no-bind
             sx={theme => ({
                 position: 'fixed',
                 top: {

--- a/src/apps/modern/features/libraries/components/LibraryViewMenu.tsx
+++ b/src/apps/modern/features/libraries/components/LibraryViewMenu.tsx
@@ -60,7 +60,6 @@ const LibraryViewMenu: FC = () => {
                 {currentRoute?.views.map(tab => (
                     <MenuItem
                         key={tab.view}
-                        // eslint-disable-next-line react/jsx-no-bind
                         onClick={() => {
                             searchParams.set('tab', `${tab.index}`);
                             setSearchParams(searchParams);

--- a/src/apps/modern/features/libraries/components/SortButton.tsx
+++ b/src/apps/modern/features/libraries/components/SortButton.tsx
@@ -237,7 +237,6 @@ const SortButton: FC<SortButtonProps> = ({
                         .map((option) => (
                             <MenuItem
                                 key={option.value.join(',')}
-                                // eslint-disable-next-line react/jsx-no-bind
                                 onClick={() => onMenuItemClick(option.value)}
                             >
                                 <ListItemText>

--- a/src/apps/modern/features/libraries/components/ViewSettingsButton.tsx
+++ b/src/apps/modern/features/libraries/components/ViewSettingsButton.tsx
@@ -177,7 +177,6 @@ const ViewSettingsButton: FC<ViewSettingsButtonProps> = ({
                                 {imageTypesOptions.map((imageType) => (
                                     <MenuItem
                                         key={imageType.value}
-                                        // eslint-disable-next-line react/jsx-no-bind
                                         onClick={() => setImageType(imageType.value)}
                                     >
                                         <ListItemIcon>

--- a/src/components/UserAvatar.tsx
+++ b/src/components/UserAvatar.tsx
@@ -24,7 +24,6 @@ const UserAvatar: FC<UserAvatarProps> = ({
                     `${api.basePath}/Users/${user.Id}/Images/Primary?tag=${user.PrimaryImageTag}` :
                     undefined
             }
-            // eslint-disable-next-line react/jsx-no-bind
             sx={(theme) => ({
                 bgcolor: api && user.Id && user.PrimaryImageTag ?
                     theme.vars.palette.background.paper :

--- a/src/components/mediainfo/StarIcons.tsx
+++ b/src/components/mediainfo/StarIcons.tsx
@@ -20,7 +20,6 @@ const StarIcons: FC<StarIconsProps> = ({ className, communityRating }) => {
         <Box className={cssClass}>
             <StarIcon
                 fontSize={'small'}
-                // eslint-disable-next-line react/jsx-no-bind
                 sx={(theme) => ({
                     color: theme.vars.palette.starIcon.main
                 })}

--- a/src/elements/emby-progressbar/AutoTimeProgressBar.tsx
+++ b/src/elements/emby-progressbar/AutoTimeProgressBar.tsx
@@ -66,7 +66,6 @@ const AutoTimeProgressBar: FC<AutoTimeProgressBarProps> = ({
             className={progressBarClass}
             variant='determinate'
             value={progress}
-            // eslint-disable-next-line react/jsx-no-bind
             sx={(theme) => ({
                 [`& .${linearProgressClasses.bar}`]: {
                     borderRadius: 5,

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -276,7 +276,8 @@ const config = {
                     {
                         loader: 'ts-loader',
                         options: {
-                            transpileOnly: true
+                            transpileOnly: true,
+                            compilerOptions: { sourceMap: DEV_MODE }
                         }
                     }
                 ]
@@ -287,7 +288,8 @@ const config = {
                 use: [{
                     loader: 'ts-loader',
                     options: {
-                        transpileOnly: true
+                        transpileOnly: true,
+                        compilerOptions: { sourceMap: DEV_MODE }
                     }
                 }]
             },


### PR DESCRIPTION
### Changes

eslint: Disable the rule that rejects arrow functions in JSX properties. Obviously we don't want complex arrow functions living in JSX components but sometimes it's nice to add a quick inline event handler. Also removed the TODO warnings.

webpack: TS and TSX files were not getting built with source maps in development builds. JavaScript files have always worked fine since they're handled in a different location.

### Issues

None

### Code Assistance

None