### PR TITLE
Open external password reset link on different provider

### DIFF
--- a/src/apps/legacy/routes/session/forgotPassword/index.tsx
+++ b/src/apps/legacy/routes/session/forgotPassword/index.tsx
@@ -10,6 +10,7 @@ import Input from 'elements/emby-input/Input';
 import globalize from 'lib/globalize';
 import ServerConnections from 'lib/jellyfin-apiclient/ServerConnections';
 import { getAuthenticationApi } from 'utils/sdk/authentication-api';
+import { isValidUrl } from 'utils/url';
 
 export const ForgotPasswordPage = () => {
     const navigate = useNavigate();
@@ -41,13 +42,19 @@ export const ForgotPasswordPage = () => {
                     msg = globalize.translate('MessageForgotPasswordInNetworkRequired');
                     break;
                 case ForgotPasswordAction.PinCode:
-                    msg = globalize.translate('MessageForgotPasswordFileCreated');
-                    msg += '<br/><br/>';
-                    msg += globalize.translate('MessageForgotPasswordPinReset');
-                    msg += '<br/><br/>';
-                    msg += result.PinFile;
-                    msg += '<br/>';
-                    callback = () => navigate('/forgotpasswordpin');
+                    if (result.PinFile && isValidUrl(result.PinFile)) {
+                        msg += globalize.translate('MessageForgotPasswordRedirect');
+                        window.open(result.PinFile, '_blank', 'noopener,noreferrer');
+                        callback = () => navigate('/login');
+                    } else {
+                        msg = globalize.translate('MessageForgotPasswordFileCreated');
+                        msg += '<br/><br/>';
+                        msg += globalize.translate('MessageForgotPasswordPinReset');
+                        msg += '<br/><br/>';
+                        msg += result.PinFile;
+                        msg += '<br/>';
+                        callback = () => navigate('/forgotpasswordpin');
+                    }
                     break;
                 default:
                     return;

--- a/src/apps/legacy/routes/session/forgotPassword/index.tsx
+++ b/src/apps/legacy/routes/session/forgotPassword/index.tsx
@@ -11,6 +11,7 @@ import globalize from 'lib/globalize';
 import ServerConnections from 'lib/jellyfin-apiclient/ServerConnections';
 import { getAuthenticationApi } from 'utils/sdk/authentication-api';
 import { isValidUrl } from 'utils/url';
+import shell from 'scripts/shell';
 
 export const ForgotPasswordPage = () => {
     const navigate = useNavigate();
@@ -43,8 +44,8 @@ export const ForgotPasswordPage = () => {
                     break;
                 case ForgotPasswordAction.PinCode:
                     if (result.PinFile && isValidUrl(result.PinFile)) {
-                        msg += globalize.translate('MessageForgotPasswordRedirect');
-                        window.open(result.PinFile, '_blank', 'noopener,noreferrer');
+                        msg = globalize.translate('MessageForgotPasswordRedirect');
+                        shell.openUrl(result.PinFile);
                         callback = () => navigate('/login');
                     } else {
                         msg = globalize.translate('MessageForgotPasswordFileCreated');

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1186,7 +1186,7 @@
     "MessageFileReadError": "There was an error reading the file. Please try again.",
     "MessageForgotPasswordFileCreated": "The following file has been created on your server and contains instructions on how to proceed",
     "MessageForgotPasswordPinReset": "Enter PIN here to finish Password reset",
-    "MessageForgotPasswordRedirect": "You've been redirected to an external provider for the password reset.",
+    "MessageForgotPasswordRedirect": "You have been redirected to an external provider for the password reset.",
     "MessageForgotPasswordInNetworkRequired": "Please try again within your home network to initiate the password reset process.",
     "MessageGetInstalledPluginsError": "An error occurred while getting the list of currently installed plugins.",
     "MessageImageFileTypeAllowed": "Only JPEG and PNG files are supported.",

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1186,6 +1186,7 @@
     "MessageFileReadError": "There was an error reading the file. Please try again.",
     "MessageForgotPasswordFileCreated": "The following file has been created on your server and contains instructions on how to proceed",
     "MessageForgotPasswordPinReset": "Enter PIN here to finish Password reset",
+    "MessageForgotPasswordRedirect": "You've been redirected to an external provider for the password reset.",
     "MessageForgotPasswordInNetworkRequired": "Please try again within your home network to initiate the password reset process.",
     "MessageGetInstalledPluginsError": "An error occurred while getting the list of currently installed plugins.",
     "MessageImageFileTypeAllowed": "Only JPEG and PNG files are supported.",

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -53,3 +53,20 @@ export const safeDecodeURIComponent = (value: string) => {
         return value;
     }
 };
+
+/**
+ * Test if a string is a valid http or https URL.
+ * @param value The value to test.
+ * @returns Whether the value is a URL or not.
+ */
+export const isValidUrl = (value: string) => {
+    let url;
+
+    try {
+        url = new URL(value);
+    } catch {
+        return false;
+    }
+
+    return url.protocol === 'http:' || url.protocol === 'https:';
+};


### PR DESCRIPTION
In cases when using an external provider (like LDAP) for password resets, the "PinFile" can be a url to an external password reset link. To avoid incorrectly asking for a pin, this PR allows instead to redirect to that provider and then return to the login page.

Ideally this should be sent as a separate action from the server.

### Changes
Redirect to external password reset provider when it's detected as a URL

### Issues
Fixes https://github.com/jellyfin/jellyfin-plugin-ldapauth/issues/22

### Code assistance
None

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
