### PR TITLE
fix:  Episode lists not refreshing after deleting a episode

### DIFF
--- a/src/apps/legacy/controllers/itemDetails/index.js
+++ b/src/apps/legacy/controllers/itemDetails/index.js
@@ -1088,22 +1088,22 @@ function renderMoreFromSeason(view, item, apiClient) {
         }
 
         const userId = apiClient.getCurrentUserId();
-        apiClient.getEpisodes(item.SeriesId, {
-            SeasonId: item.SeasonId,
-            UserId: userId,
-            Fields: 'ItemCounts,PrimaryImageAspectRatio,CanDelete,MediaSourceCount'
-        }).then(function (result) {
-            if (result.Items.length < 2) {
-                section.classList.add('hide');
-                return;
+        const itemsContainer = section.querySelector('.itemsContainer');
+        let hasScrolled = false;
+
+        itemsContainer.fetchData = function () {
+            return apiClient.getEpisodes(item.SeriesId, {
+                SeasonId: item.SeasonId,
+                UserId: userId,
+                Fields: 'ItemCounts,PrimaryImageAspectRatio,CanDelete,MediaSourceCount'
+            });
+        };
+        itemsContainer.getItemsHtml = function (items) {
+            if (items.length < 2) {
+                return '';
             }
 
-            section.classList.remove('hide');
-            section.querySelector('h2').innerText = globalize.translate('MoreFromValue', item.SeasonName);
-            const itemsContainer = section.querySelector('.itemsContainer');
-            cardBuilder.buildCards(result.Items, {
-                parentContainer: section,
-                itemsContainer: itemsContainer,
+            return cardBuilder.getCardsHtml(items, {
                 shape: 'overflowBackdrop',
                 sectionTitleTagName: 'h2',
                 scalable: true,
@@ -1113,14 +1113,25 @@ function renderMoreFromSeason(view, item, apiClient) {
                 includeParentInfoInTitle: false,
                 allowBottomPadding: false
             });
+        };
+        itemsContainer.afterRefresh = function (result) {
+            if (result.Items.length < 2) {
+                section.classList.add('hide');
+                return;
+            }
+
+            section.classList.remove('hide');
+            section.querySelector('h2').innerText = globalize.translate('MoreFromValue', item.SeasonName);
             const card = itemsContainer.querySelector('.card[data-id="' + item.Id + '"]');
 
-            if (card) {
+            if (card && !hasScrolled) {
+                hasScrolled = true;
                 setTimeout(function () {
                     section.querySelector('.emby-scroller').toStart(card.previousSibling || card, true);
                 }, 100);
             }
-        });
+        };
+        itemsContainer.refreshItems();
     }
 }
 
@@ -1354,18 +1365,18 @@ function renderChildren(page, item) {
         query.SortBy = 'SortName';
     }
 
-    let promise;
+    let fetchData;
     const apiClient = ServerConnections.getApiClient(item.ServerId);
     const userId = apiClient.getCurrentUserId();
 
     if (item.Type == 'Series') {
-        promise = apiClient.getSeasons(item.Id, {
+        fetchData = () => apiClient.getSeasons(item.Id, {
             userId: userId,
             Fields: fields
         });
     } else if (item.Type == 'Season') {
         fields += ',Overview';
-        promise = apiClient.getEpisodes(item.SeriesId, {
+        fetchData = () => apiClient.getEpisodes(item.SeriesId, {
             seasonId: item.Id,
             userId: userId,
             Fields: fields
@@ -1374,23 +1385,23 @@ function renderChildren(page, item) {
         query.SortBy = 'PremiereDate,ProductionYear,SortName';
     }
 
-    promise = promise || apiClient.getItems(apiClient.getCurrentUserId(), query);
-    promise.then(function (result) {
+    childrenItemsContainer.fetchData = fetchData || (() => apiClient.getItems(userId, query));
+    childrenItemsContainer.getItemsHtml = function (items) {
         let html = '';
         let scrollX = false;
         let isList = false;
 
         if (item.Type == 'MusicAlbum') {
             let showArtist = false;
-            for (const track of result.Items) {
+            for (const track of items) {
                 if (!isEqual(track.ArtistItems.map(x => x.Id).sort(), track.AlbumArtists.map(x => x.Id).sort())) {
                     showArtist = true;
                     break;
                 }
             }
-            const discNumbers = result.Items.map(x => x.ParentIndexNumber);
+            const discNumbers = items.map(x => x.ParentIndexNumber);
             html = listView.getListViewHtml({
-                items: result.Items,
+                items: items,
                 smallIcon: true,
                 showIndex: new Set(discNumbers).size > 1 || (discNumbers.length >= 1 && discNumbers[0] > 1),
                 index: 'disc',
@@ -1405,7 +1416,7 @@ function renderChildren(page, item) {
         } else if (item.Type == 'Series') {
             scrollX = enableScrollX();
             html = cardBuilder.getCardsHtml({
-                items: result.Items,
+                items: items,
                 shape: 'overflowPortrait',
                 showTitle: true,
                 centerText: true,
@@ -1418,13 +1429,13 @@ function renderChildren(page, item) {
                 isList = true;
             }
             scrollX = item.Type == 'Episode';
-            if (result.Items.length < 2 && item.Type === 'Episode') {
-                return;
+            if (items.length < 2 && item.Type === 'Episode') {
+                return '';
             }
 
             if (item.Type === 'Episode') {
                 html = cardBuilder.getCardsHtml({
-                    items: result.Items,
+                    items: items,
                     shape: 'overflowBackdrop',
                     showTitle: true,
                     displayAsSpecial: item.Type == 'Season' && item.IndexNumber,
@@ -1438,7 +1449,7 @@ function renderChildren(page, item) {
                 });
             } else if (item.Type === 'Season') {
                 html = listView.getListViewHtml({
-                    items: result.Items,
+                    items: items,
                     showIndexNumber: false,
                     enableOverview: true,
                     enablePlayedButton: !layoutManager.mobile,
@@ -1476,8 +1487,9 @@ function renderChildren(page, item) {
         if (layoutManager.mobile) {
             childrenItemsContainer.classList.remove('padded-right');
         }
-        childrenItemsContainer.innerHTML = html;
-        imageLoader.lazyChildren(childrenItemsContainer);
+        return html;
+    };
+    childrenItemsContainer.afterRefresh = function (result) {
         if (item.Type == 'BoxSet') {
             const collectionItemTypes = [{
                 name: globalize.translate('Movies'),
@@ -1503,7 +1515,8 @@ function renderChildren(page, item) {
             }];
             renderCollectionItems(page, item, collectionItemTypes, result.Items);
         }
-    });
+    };
+    childrenItemsContainer.refreshItems();
 
     let childrenTitle = globalize.translate('Items');
     if (item.Type == 'Season') {

--- a/src/apps/legacy/controllers/itemDetails/index.js
+++ b/src/apps/legacy/controllers/itemDetails/index.js
@@ -122,7 +122,7 @@ function getContextMenuOptions(item, user, button) {
 
 function getProgramScheduleHtml(items, action = 'none') {
     return listView.getListViewHtml({
-        items: items,
+        items,
         enableUserDataButtons: false,
         image: true,
         imageSource: 'channel',
@@ -1091,18 +1091,16 @@ function renderMoreFromSeason(view, item, apiClient) {
         const itemsContainer = section.querySelector('.itemsContainer');
         let hasScrolled = false;
 
+        itemsContainer.parentContainer = section;
+
         itemsContainer.fetchData = function () {
             return apiClient.getEpisodes(item.SeriesId, {
                 SeasonId: item.SeasonId,
                 UserId: userId,
                 Fields: 'ItemCounts,PrimaryImageAspectRatio,CanDelete,MediaSourceCount'
-            });
+            }).then(result => (result.Items.length < 2 ? { ...result, Items: [] } : result));
         };
         itemsContainer.getItemsHtml = function (items) {
-            if (items.length < 2) {
-                return '';
-            }
-
             return cardBuilder.getCardsHtml(items, {
                 shape: 'overflowBackdrop',
                 sectionTitleTagName: 'h2',
@@ -1115,12 +1113,8 @@ function renderMoreFromSeason(view, item, apiClient) {
             });
         };
         itemsContainer.afterRefresh = function (result) {
-            if (result.Items.length < 2) {
-                section.classList.add('hide');
-                return;
-            }
+            if (!result.Items.length) return;
 
-            section.classList.remove('hide');
             section.querySelector('h2').innerText = globalize.translate('MoreFromValue', item.SeasonName);
             const card = itemsContainer.querySelector('.card[data-id="' + item.Id + '"]');
 
@@ -1352,6 +1346,34 @@ function renderTags(page, item) {
 function renderChildren(page, item) {
     const childrenCollapsible = page.querySelector(LIST_VIEW_TYPES.includes(item.Type) ? '#listChildrenCollapsible' : '#childrenCollapsible');
     const childrenItemsContainer = childrenCollapsible.querySelector('.itemsContainer');
+    const isList = item.Type == 'MusicAlbum' || item.Type == 'Season';
+    const scrollX = item.Type == 'Series' ? enableScrollX() : item.Type == 'Episode';
+
+    if (scrollX) {
+        childrenItemsContainer.classList.add('scrollX');
+        childrenItemsContainer.classList.add('hiddenScrollX');
+        childrenItemsContainer.classList.remove('vertical-wrap');
+        childrenItemsContainer.classList.remove('vertical-list');
+    } else {
+        childrenItemsContainer.classList.remove('scrollX');
+        childrenItemsContainer.classList.remove('hiddenScrollX');
+        childrenItemsContainer.classList.remove('smoothScrollX');
+        if (isList) {
+            childrenItemsContainer.classList.add('vertical-list');
+            childrenItemsContainer.classList.remove('vertical-wrap');
+        } else {
+            childrenItemsContainer.classList.add('vertical-wrap');
+            childrenItemsContainer.classList.remove('vertical-list');
+        }
+    }
+
+    if (layoutManager.mobile) {
+        childrenItemsContainer.classList.remove('padded-right');
+    }
+
+    if (item.Type !== 'BoxSet') {
+        childrenItemsContainer.parentContainer = childrenCollapsible;
+    }
 
     let fields = 'ItemCounts,PrimaryImageAspectRatio,CanDelete,MediaSourceCount';
     const query = {
@@ -1388,8 +1410,6 @@ function renderChildren(page, item) {
     childrenItemsContainer.fetchData = fetchData || (() => apiClient.getItems(userId, query));
     childrenItemsContainer.getItemsHtml = function (items) {
         let html = '';
-        let scrollX = false;
-        let isList = false;
 
         if (item.Type == 'MusicAlbum') {
             let showArtist = false;
@@ -1401,7 +1421,7 @@ function renderChildren(page, item) {
             }
             const discNumbers = items.map(x => x.ParentIndexNumber);
             html = listView.getListViewHtml({
-                items: items,
+                items,
                 smallIcon: true,
                 showIndex: new Set(discNumbers).size > 1 || (discNumbers.length >= 1 && discNumbers[0] > 1),
                 index: 'disc',
@@ -1412,11 +1432,9 @@ function renderChildren(page, item) {
                 artist: showArtist,
                 containerAlbumArtists: item.AlbumArtists
             });
-            isList = true;
         } else if (item.Type == 'Series') {
-            scrollX = enableScrollX();
             html = cardBuilder.getCardsHtml({
-                items: items,
+                items,
                 shape: 'overflowPortrait',
                 showTitle: true,
                 centerText: true,
@@ -1424,69 +1442,35 @@ function renderChildren(page, item) {
                 overlayPlayButton: true,
                 allowBottomPadding: !scrollX
             });
-        } else if (item.Type == 'Season' || item.Type == 'Episode') {
-            if (item.Type !== 'Episode') {
-                isList = true;
-            }
-            scrollX = item.Type == 'Episode';
-            if (items.length < 2 && item.Type === 'Episode') {
-                return '';
-            }
-
-            if (item.Type === 'Episode') {
-                html = cardBuilder.getCardsHtml({
-                    items: items,
-                    shape: 'overflowBackdrop',
-                    showTitle: true,
-                    displayAsSpecial: item.Type == 'Season' && item.IndexNumber,
-                    playFromHere: true,
-                    overlayText: true,
-                    lazy: true,
-                    showDetailsMenu: true,
-                    overlayPlayButton: true,
-                    allowBottomPadding: !scrollX,
-                    includeParentInfoInTitle: false
-                });
-            } else if (item.Type === 'Season') {
-                html = listView.getListViewHtml({
-                    items: items,
-                    showIndexNumber: false,
-                    enableOverview: true,
-                    enablePlayedButton: !layoutManager.mobile,
-                    infoButton: !layoutManager.mobile,
-                    imageSize: 'large',
-                    enableSideMediaInfo: false,
-                    highlight: false,
-                    action: !layoutManager.desktop ? 'link' : 'none',
-                    imagePlayButton: true,
-                    includeParentInfoInTitle: false
-                });
-            }
+        } else if (item.Type == 'Episode') {
+            html = cardBuilder.getCardsHtml({
+                items,
+                shape: 'overflowBackdrop',
+                showTitle: true,
+                playFromHere: true,
+                overlayText: true,
+                lazy: true,
+                showDetailsMenu: true,
+                overlayPlayButton: true,
+                allowBottomPadding: !scrollX,
+                includeParentInfoInTitle: false
+            });
+        } else if (item.Type == 'Season') {
+            html = listView.getListViewHtml({
+                items,
+                showIndexNumber: false,
+                enableOverview: true,
+                enablePlayedButton: !layoutManager.mobile,
+                infoButton: !layoutManager.mobile,
+                imageSize: 'large',
+                enableSideMediaInfo: false,
+                highlight: false,
+                action: !layoutManager.desktop ? 'link' : 'none',
+                imagePlayButton: true,
+                includeParentInfoInTitle: false
+            });
         }
 
-        if (item.Type !== 'BoxSet') {
-            childrenCollapsible.classList.remove('hide');
-        }
-        if (scrollX) {
-            childrenItemsContainer.classList.add('scrollX');
-            childrenItemsContainer.classList.add('hiddenScrollX');
-            childrenItemsContainer.classList.remove('vertical-wrap');
-            childrenItemsContainer.classList.remove('vertical-list');
-        } else {
-            childrenItemsContainer.classList.remove('scrollX');
-            childrenItemsContainer.classList.remove('hiddenScrollX');
-            childrenItemsContainer.classList.remove('smoothScrollX');
-            if (isList) {
-                childrenItemsContainer.classList.add('vertical-list');
-                childrenItemsContainer.classList.remove('vertical-wrap');
-            } else {
-                childrenItemsContainer.classList.add('vertical-wrap');
-                childrenItemsContainer.classList.remove('vertical-list');
-            }
-        }
-        if (layoutManager.mobile) {
-            childrenItemsContainer.classList.remove('padded-right');
-        }
         return html;
     };
     childrenItemsContainer.afterRefresh = function (result) {
@@ -1757,7 +1741,7 @@ function renderCollectionItemType(page, parentItem, type, items) {
     html += '<div is="emby-itemscontainer" class="itemsContainer collectionItemsContainer vertical-wrap padded-left padded-right">';
     const shape = type.type == 'MusicAlbum' ? getSquareShape(false) : getPortraitShape(false);
     html += cardBuilder.getCardsHtml({
-        items: items,
+        items,
         shape: shape,
         showTitle: true,
         showYear: type.mediaType === 'Video' || type.type === 'Series' || type.type === 'Movie',
@@ -1837,7 +1821,7 @@ function renderScenes(page, item) {
 
 function getVideosHtml(items) {
     return cardBuilder.getCardsHtml({
-        items: items,
+        items,
         shape: 'autooverflow',
         showTitle: true,
         action: 'play',

--- a/src/apps/legacy/controllers/itemDetails/index.js
+++ b/src/apps/legacy/controllers/itemDetails/index.js
@@ -1403,6 +1403,9 @@ function renderChildren(page, item) {
             userId: userId,
             Fields: fields
         });
+    } else if (item.Type == 'Episode') {
+        fetchData = () => apiClient.getItems(userId, query)
+            .then(result => (result.Items.length < 2 ? { ...result, Items: [] } : result));
     } else if (item.Type == 'MusicArtist') {
         query.SortBy = 'PremiereDate,ProductionYear,SortName';
     }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

### Changes
<!--
Describe your changes here in 1-5 sentences.
Please include before/after screenshots of any UI changes.
-->
The children list on a Season/Series page and the "More from this Season" carousel on an Episode page never refresh after an item is deleted. `shortcuts.js` calls `notifyRefreshNeeded()` on the `emby-itemscontainer`, but neither container sets `fetchData`, so `ItemsContainerPrototype.refreshItems` no-ops and the deleted item stays visible until the page is reloaded.

Per @dmitrylyzo's suggestion, both containers now use the `fetchData` / `getItemsHtml`
pattern already used by `movies.js` and `playlistViewer.js`, rather than overriding
`notifyRefreshNeeded`:

- `renderChildren` — the endpoint selection becomes a `fetchData` thunk, the HTML branches
  become `getItemsHtml`, and the BoxSet `renderCollectionItems` call moves to `afterRefresh`.
- `renderMoreFromSeason` — `cardBuilder.buildCards` becomes `getItemsHtml` +
  `cardBuilder.getCardsHtml`; section visibility and the title move to `afterRefresh`.
  Scroll-to-current-episode now runs only on the first render, so a background refresh
  does not move the carousel.

before:
https://photos.jagadam97.uk/s/8343%2Fbefore

after:
https://photos.jagadam97.uk/s/s%2F8343-after

### Issues
<!--
Tag any issues that this PR solves here.
ex. Fixes #
-->
Fixes #8317

### Code assistance
<!--
If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance.
-->

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
