### PR TITLE
Fix dashboard "Scan All Libraries" button disabled without feedback

### DIFF
--- a/src/apps/dashboard/routes/index.tsx
+++ b/src/apps/dashboard/routes/index.tsx
@@ -113,7 +113,7 @@ export const Component = () => {
                                 onScanLibrariesClick={onScanLibraries}
                                 onRestartClick={promptRestart}
                                 onShutdownClick={promptShutdown}
-                                isScanning={librariesTask?.State !== TaskState.Idle}
+                                isScanning={librariesTask && librariesTask.State !== TaskState.Idle}
                             />
                             <ItemCountsWidget />
                             <RunningTasksWidget tasks={tasks} />

--- a/src/apps/dashboard/routes/index.tsx
+++ b/src/apps/dashboard/routes/index.tsx
@@ -8,6 +8,7 @@ import { useQueryClient } from '@tanstack/react-query';
 
 import ConfirmDialog from 'components/ConfirmDialog';
 import Page from 'components/Page';
+import Toast from 'apps/dashboard/components/Toast';
 import { useApi } from 'hooks/useApi';
 import globalize from 'lib/globalize';
 
@@ -27,6 +28,7 @@ export const Component = () => {
     const { api } = useApi();
     const [ isRestartConfirmDialogOpen, setIsRestartConfirmDialogOpen ] = useState(false);
     const [ isShutdownConfirmDialogOpen, setIsShutdownConfirmDialogOpen ] = useState(false);
+    const [ isScanUnavailableToastOpen, setIsScanUnavailableToastOpen ] = useState(false);
     const startTask = useStartTask();
     const restartServer = useRestartServer();
     const shutdownServer = useShutdownServer();
@@ -61,8 +63,14 @@ export const Component = () => {
             startTask.mutate({
                 taskId: scanLibrariesTask.Id
             });
+        } else {
+            setIsScanUnavailableToastOpen(true);
         }
     }, [ startTask, tasks ]);
+
+    const handleScanUnavailableToastClose = useCallback(() => {
+        setIsScanUnavailableToastOpen(false);
+    }, []);
 
     const onRestartConfirm = useCallback(() => {
         restartServer.mutate();
@@ -95,6 +103,11 @@ export const Component = () => {
                 onCancel={closeRestartDialog}
                 confirmButtonText={globalize.translate('Restart')}
                 confirmButtonColor='error'
+            />
+            <Toast
+                open={isScanUnavailableToastOpen}
+                onClose={handleScanUnavailableToastClose}
+                message={globalize.translate('MessageUnableToScanLibraries')}
             />
             <ConfirmDialog
                 open={isShutdownConfirmDialogOpen}

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1241,6 +1241,7 @@
     "MessageSyncPlayUserLeft": "{0} has left the group.",
     "MessageTheFollowingLocationWillBeRemovedFromLibrary": "The following media locations will be removed from your library",
     "MessageUnableToConnectToServer": "We're unable to connect to the selected server right now. Please ensure it is running and try again.",
+    "MessageUnableToScanLibraries": "Unable to start the library scan. Please refresh the page and try again.",
     "MessageUnauthorizedUser": "You are not authorized to access the server at this time. Please contact your server administrator for more information.",
     "MessageUnsetContentHelp": "Content will be displayed as plain folders. For best results use the metadata manager to set the content types of sub-folders.",
     "MessageWaitingForServer": "Waiting for server...",


### PR DESCRIPTION
### Changes
Fixing `isScanning` condition with a proper guard before the check so it does not return also true when the `librariesTask` is undefined.

### Issues
n/a

### Code assistance
I debugged this because I am an user of jellyfin web in brave and for a while the button was disabled, so with the help of pi-coding-agent (GLM 5.2) I cloned the repo in a /tmp repository to quickly check what could be the issue. Then I did check myself that the report made sense and implemented the fix manually.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] Review another web PR: #8162 