### PR TITLE
Add library setting to enable directory mtime pruning during scans

### DIFF
--- a/src/components/libraryoptionseditor/libraryoptionseditor.js
+++ b/src/components/libraryoptionseditor/libraryoptionseditor.js
@@ -704,6 +704,7 @@ export function getLibraryOptions(parent) {
         EnableArchiveMediaFiles: false,
         EnablePhotos: parent.querySelector('.chkEnablePhotos').checked,
         EnableRealtimeMonitor: parent.querySelector('.chkEnableRealtimeMonitor').checked,
+        EnableDirectoryMtimePruning: parent.querySelector('.chkEnableDirectoryMtimePruning').checked,
         EnableLUFSScan: parent.querySelector('.chkEnableLUFSScan').checked,
         ExtractTrickplayImagesDuringLibraryScan: parent.querySelector('.chkExtractTrickplayDuringLibraryScan').checked,
         SaveTrickplayWithMedia: parent.querySelector('.chkSaveTrickplayLocally').checked,
@@ -778,6 +779,7 @@ export function setLibraryOptions(parent, options) {
     parent.querySelector('.chkEnabled').checked = options.Enabled;
     parent.querySelector('.chkEnablePhotos').checked = options.EnablePhotos;
     parent.querySelector('.chkEnableRealtimeMonitor').checked = options.EnableRealtimeMonitor;
+    parent.querySelector('.chkEnableDirectoryMtimePruning').checked = options.EnableDirectoryMtimePruning;
     parent.querySelector('.chkEnableLUFSScan').checked = options.EnableLUFSScan;
     parent.querySelector('.chkExtractTrickplayDuringLibraryScan').checked = options.ExtractTrickplayImagesDuringLibraryScan;
     parent.querySelector('.chkExtractTrickplayImages').checked = options.EnableTrickplayImageExtraction;

--- a/src/components/libraryoptionseditor/libraryoptionseditor.template.html
+++ b/src/components/libraryoptionseditor/libraryoptionseditor.template.html
@@ -63,6 +63,14 @@
     <div class="fieldDescription checkboxFieldDescription">${LabelEnableRealtimeMonitorHelp}</div>
 </div>
 
+<div class="checkboxContainer checkboxContainer-withDescription advanced">
+    <label>
+        <input type="checkbox" is="emby-checkbox" class="chkEnableDirectoryMtimePruning" />
+        <span>${LabelEnableDirectoryMtimePruning}</span>
+    </label>
+    <div class="fieldDescription checkboxFieldDescription">${LabelEnableDirectoryMtimePruningHelp}</div>
+</div>
+
 <div class="checkboxContainer checkboxContainer-withDescription chkEnableLUFSScanContainer advanced">
     <label>
         <input type="checkbox" is="emby-checkbox" class="chkEnableLUFSScan" checked />

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -746,6 +746,8 @@
     "LabelDynamicExternalId": "{0} Id",
     "LabelEnableAudioVbr": "Enable VBR audio encoding",
     "LabelEnableAudioVbrHelp": "Variable bitrate offers better quality to average bitrate ratio, but in some rare cases may cause buffering and compatibility issues.",
+    "LabelEnableDirectoryMtimePruning": "Skip re-scanning unchanged folders",
+    "LabelEnableDirectoryMtimePruningHelp": "During a library scan, skip re-checking a folder's contents if it hasn't changed since the last scan. This can speed up scans significantly, but relies on the folder's modification time updating reliably. Leave disabled if this library is on a network share (e.g. NFS or SMB) where that isn't guaranteed.",
     "LabelEnableHardwareDecodingFor": "Enable hardware decoding for",
     "LabelEnableHttps": "Enable HTTPS",
     "LabelEnableHttpsHelp": "Listen on the configured HTTPS port. A valid certificate must also be supplied for this to take effect.",


### PR DESCRIPTION
## Dependency

Requires jellyfin/jellyfin#17600 (`LibraryOptions.EnableDirectoryMtimePruning`) to be present on the server for the setting to have any effect. The checkbox itself is inert against older servers (the field is simply ignored).

## Summary

jellyfin-server has a new library scan optimization, directory mtime pruning (jellyfin/jellyfin#17600), that lets a library skip re-listing a folder's contents from disk when its directory hasn't changed since the last scan. It's opt-in per library (`LibraryOptions.EnableDirectoryMtimePruning`, default off) since it changes scan behavior and depends on directory mtimes updating reliably, which isn't guaranteed on some network shares (NFS/SMB).

This adds the corresponding checkbox to the shared library options editor (`libraryoptionseditor`), used by both **Add New Library** and **Edit Library**, so both flows pick it up automatically. Placed under Advanced options, next to "Enable real time monitoring". Unchecked by default, matching the server-side default.

