### PR TITLE
Per-library progress indicators in the library dashboard

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -110,6 +110,7 @@
 - [austinhardaway](https://github.com/austinhardaway)
 - [Alex Dickens](https://github.com/alex-dicko)
 - [shindouj](https://github.com/shindouj)
+- [Mumbolio85](https://github.com/Mumbolio85)
 
 ## Emby Contributors
 

--- a/src/apps/dashboard/features/libraries/components/LibraryCard.tsx
+++ b/src/apps/dashboard/features/libraries/components/LibraryCard.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import type { VirtualFolderInfo } from '@jellyfin/sdk/lib/generated-client/models/virtual-folder-info';
+import Box from '@mui/material/Box';
 import BaseCard from 'apps/dashboard/components/BaseCard';
+import RefreshIndicator from 'elements/emby-itemrefreshindicator/RefreshIndicator';
 import getCollectionTypeOptions from '../utils/collectionTypeOptions';
 import globalize from 'lib/globalize';
 import Icon from '@mui/material/Icon';
@@ -179,17 +181,22 @@ const LibraryCard = ({ virtualFolder }: LibraryCardProps) => {
                 onCancel={onCancelDeleteLibrary}
             />
 
-            <BaseCard
-                title={virtualFolder.Name || ''}
-                text={typeName}
-                image={imageUrl}
-                icon={<Icon sx={{ fontSize: 70 }}>{getLibraryIcon(virtualFolder.CollectionType)}</Icon>}
-                action={true}
-                actionRef={actionRef}
-                onActionClick={onActionClick}
-                onClick={showMediaLibraryEditor}
-                height={260}
-            />
+            <Box sx={{ position: 'relative' }}>
+                <BaseCard
+                    title={virtualFolder.Name || ''}
+                    text={typeName}
+                    image={imageUrl}
+                    icon={<Icon sx={{ fontSize: 70 }}>{getLibraryIcon(virtualFolder.CollectionType)}</Icon>}
+                    action={true}
+                    actionRef={actionRef}
+                    onActionClick={onActionClick}
+                    onClick={showMediaLibraryEditor}
+                    height={260}
+                />
+                <Box sx={{ position: 'absolute', top: 8, right: 8 }}>
+                    <RefreshIndicator item={{ Id: virtualFolder.ItemId }} />
+                </Box>
+            </Box>
             <Menu
                 anchorEl={anchorEl}
                 open={isMenuOpen}

--- a/src/elements/emby-itemrefreshindicator/emby-itemrefreshindicator.js
+++ b/src/elements/emby-itemrefreshindicator/emby-itemrefreshindicator.js
@@ -33,11 +33,12 @@ EmbyItemRefreshIndicatorPrototype.createdCallback = function () {
 
     const handler = ({ Data }) => onRefreshProgress(this, Data);
 
-    const serverId = dom.parentWithAttribute(this, 'data-serverid')?.getAttribute('data-serverid');
-    const apiClient = serverId ? ServerConnections.getApiClient(serverId) : ServerConnections.currentApiClient();
+    const serverId = dom.parentWithAttribute(this, 'data-serverid')?.getAttribute('data-serverid')
+        || ServerConnections.currentApiClient()?.serverId();
+    const api = serverId ? ServerConnections.getApi(serverId) : undefined;
     this._wsUnsubscribers = [];
-    if (apiClient) {
-        this._wsUnsubscribers.push(apiClient.subscribe([OutboundWebSocketMessageType.RefreshProgress], handler));
+    if (api) {
+        this._wsUnsubscribers.push(api.subscribe([OutboundWebSocketMessageType.RefreshProgress], handler));
     }
 };
 


### PR DESCRIPTION
### Changes
I added per library progress indicators to the library dashboard.

In this picture, both libraries were refreshed at the same time to demonstrate.
<img width="1434" height="890" alt="jellyfin-issue-7944-fix-dashboard" src="https://github.com/user-attachments/assets/709e6575-fe47-4904-8caa-6ab3248b0a5f" />

### Issues
Fixes: https://github.com/jellyfin/jellyfin-web/issues/7944

### Code assistance
Claude Code was used to assist me in solving the issue, but any code written by it was reviewed and refined by me, and I stand behind it as my own code.


---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
