### PR TITLE
Fix Live TV default landing tab

### DIFF
--- a/src/hooks/useCurrentTab.ts
+++ b/src/hooks/useCurrentTab.ts
@@ -11,7 +11,7 @@ const useCurrentTab = () => {
     const activeTab: number =
         searchParamsTab !== null ?
             parseInt(searchParamsTab, 10) :
-            getDefaultViewIndex(location.pathname, libraryId);
+            getDefaultViewIndex(location.pathname, settingsKey);
 
     return {
         searchParams,


### PR DESCRIPTION
Changing `libraryId` to `settingsKey`  in `useCurrentTab `seems to have been missed in #8299

### Changes
Use `settingsKey` instead of `libraryId`

### Issues
Fixes: #8350

### Code assistance
N/A

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
