### PR TITLE
Add: slider markers now jump to chapter timecodes when clicked

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -110,6 +110,7 @@
 - [austinhardaway](https://github.com/austinhardaway)
 - [Alex Dickens](https://github.com/alex-dicko)
 - [shindouj](https://github.com/shindouj)
+- [LuisTheOne](https://github.com/LuisThe0ne)
 
 ## Emby Contributors
 

--- a/src/apps/legacy/controllers/playback/video/index.html
+++ b/src/apps/legacy/controllers/playback/video/index.html
@@ -21,7 +21,7 @@
             <div class="flex flex-direction-row align-items-center" dir="ltr">
                 <div class="osdTextContainer startTimeText osdPositionText" style="margin: 0 .25em 0 0;"></div>
                 <div class="sliderContainer flex-grow" style="margin: .5em 0 .25em;">
-                    <div class="sliderMarkerContainer"></div>
+                    <div class="sliderMarkerOuterContainer"></div>
                     <input type="range" step=".01" min="0" max="100" value="0" is="emby-slider" class="osdPositionSlider" data-slider-keep-progress="true" />
                 </div>
                 <div class="osdTextContainer endTimeText osdDurationText" style="margin: 0 0 0 .25em;"></div>

--- a/src/apps/legacy/controllers/playback/video/index.js
+++ b/src/apps/legacy/controllers/playback/video/index.js
@@ -148,8 +148,8 @@ export default function (view) {
             const maxWidth = window.screen.width * window.devicePixelRatio * 0.2;
             for (const [, info] of Object.entries(trickplayResolutions)) {
                 if (!bestWidth
-                        || (info.Width < bestWidth && bestWidth > maxWidth) // Objects not guaranteed to be sorted in any order, first width might be > maxWidth.
-                        || (info.Width > bestWidth && info.Width <= maxWidth)) {
+                    || (info.Width < bestWidth && bestWidth > maxWidth) // Objects not guaranteed to be sorted in any order, first width might be > maxWidth.
+                    || (info.Width > bestWidth && info.Width <= maxWidth)) {
                     bestWidth = info.Width;
                 }
             }
@@ -964,7 +964,7 @@ export default function (view) {
 
                 // show subtitle offset feature only if player and media support it
                 const showSubOffset = playbackManager.supportSubtitleOffset(player)
-                        && playbackManager.canHandleOffsetOnCurrentSubtitle(player);
+                    && playbackManager.canHandleOffsetOnCurrentSubtitle(player);
 
                 playerSettingsMenu.show({
                     mediaType: 'Video',
@@ -1138,10 +1138,10 @@ export default function (view) {
             * - primary subtitle has support
             */
         const currentTrackCanAddSecondarySubtitle = playbackManager.playerHasSecondarySubtitleSupport(player)
-                && streams.length > 1
-                && secondaryStreams.length > 0
-                && currentIndex !== -1
-                && playbackManager.trackHasSecondarySubtitleSupport(playbackManager.getSubtitleStream(player, currentIndex), player);
+            && streams.length > 1
+            && secondaryStreams.length > 0
+            && currentIndex !== -1
+            && playbackManager.trackHasSecondarySubtitleSupport(playbackManager.getSubtitleStream(player, currentIndex), player);
 
         if (currentTrackCanAddSecondarySubtitle) {
             const secondarySubtitleMenuItem = {
@@ -1926,10 +1926,15 @@ export default function (view) {
 
     nowPlayingPositionSlider.getMarkerInfo = function () {
         // use markers based on chapters
-        return currentItem?.Chapters?.map(currentChapter => ({
+        return currentItem?.Chapters?.map((currentChapter, index) => ({
             name: currentChapter.Name,
-            progress: currentChapter.StartPositionTicks / currentItem.RunTimeTicks
+            progress: currentChapter.StartPositionTicks / currentItem.RunTimeTicks,
+            index: index
         })) || [];
+    };
+
+    nowPlayingPositionSlider.seekToChapter = function (index) {
+        playbackManager.seek(currentItem?.Chapters[index].StartPositionTicks, currentPlayer);
     };
 
     view.querySelector('.btnPreviousTrack').addEventListener('click', function () {

--- a/src/apps/legacy/controllers/playback/video/index.js
+++ b/src/apps/legacy/controllers/playback/video/index.js
@@ -1927,9 +1927,9 @@ export default function (view) {
     nowPlayingPositionSlider.getMarkerInfo = function () {
         // use markers based on chapters
         return currentItem?.Chapters?.map((currentChapter, index) => ({
+            id: index,
             name: currentChapter.Name,
-            progress: currentChapter.StartPositionTicks / currentItem.RunTimeTicks,
-            id: index
+            progress: currentChapter.StartPositionTicks / currentItem.RunTimeTicks
         })) || [];
     };
 

--- a/src/apps/legacy/controllers/playback/video/index.js
+++ b/src/apps/legacy/controllers/playback/video/index.js
@@ -1929,12 +1929,12 @@ export default function (view) {
         return currentItem?.Chapters?.map((currentChapter, index) => ({
             name: currentChapter.Name,
             progress: currentChapter.StartPositionTicks / currentItem.RunTimeTicks,
-            index: index
+            id: index
         })) || [];
     };
 
-    nowPlayingPositionSlider.seekToChapter = function (index) {
-        playbackManager.seek(currentItem?.Chapters[index].StartPositionTicks, currentPlayer);
+    nowPlayingPositionSlider.onMarkerClicked = function (id) {
+        playbackManager.seek(currentItem?.Chapters[id].StartPositionTicks, currentPlayer);
     };
 
     view.querySelector('.btnPreviousTrack').addEventListener('click', function () {

--- a/src/elements/emby-slider/emby-slider.js
+++ b/src/elements/emby-slider/emby-slider.js
@@ -260,12 +260,20 @@ function updateMarkers(range, currentValue) {
             range.markerInfo = newMarkerInfo;
 
             let markersHtml = '';
-            range.markerInfo.forEach(() => {
-                markersHtml += '<span class="sliderMarker" aria-hidden="true"></span>';
+            range.markerInfo.forEach((marker) => {
+                markersHtml += `<span id="sliderMarker-${marker.index}" class="sliderMarker" aria-hidden="true"></span>`;
             });
             range.markerContainerElement.innerHTML = markersHtml;
 
             range.markerElements = range.markerContainerElement.querySelectorAll('.sliderMarker');
+
+            range.markerElements.forEach(element => {
+                element.addEventListener('click', event => {
+                    const index = event.currentTarget.id.replace('sliderMarker-', '');
+                    range.seekToChapter(index);
+                    return true;
+                });
+            });
         }
     }
 

--- a/src/elements/emby-slider/emby-slider.js
+++ b/src/elements/emby-slider/emby-slider.js
@@ -190,7 +190,7 @@ function updateValues(isValueSet) {
             backgroundLower.style.width = fraction + '%';
         }
 
-        if (range.markerContainerElement) {
+        if (range.markerOuterContainerElement) {
             updateMarkers(range, value);
         }
     });
@@ -230,17 +230,19 @@ function updateBubble(range, percent, value, bubble) {
     });
 }
 
-function setMarker(range, valueMarker, marker, valueProgress) {
+function setMarker(range, valueMarker, markerContainer, valueProgress) {
     requestAnimationFrame(function () {
         const bubbleTrackRect = range.sliderBubbleTrack.getBoundingClientRect();
-        const markerRect = marker.getBoundingClientRect();
+        const markerRect = markerContainer.getBoundingClientRect();
 
         if (!bubbleTrackRect.width || !markerRect.width) {
             // width is not set, most probably because the OSD is currently hidden
             return;
         }
 
-        marker.style.left = `calc(${valueMarker}% - ${markerRect.width / 2}px)`;
+        markerContainer.style.left = `calc(${valueMarker}% - ${markerRect.width / 2}px)`;
+
+        const marker = markerContainer.getElementsByClassName('sliderMarker')[0];
 
         if (valueProgress >= valueMarker) {
             marker.classList.remove('unwatched');
@@ -261,26 +263,27 @@ function updateMarkers(range, currentValue) {
 
             let markersHtml = '';
             range.markerInfo.forEach((marker) => {
-                markersHtml += `<span id="sliderMarker-${marker.index}" class="sliderMarker" aria-hidden="true"></span>`;
+                markersHtml += `<div class="sliderMarkerContainer" aria-hidden="true"><span data-id="${marker.id}" class="sliderMarker" aria-hidden="true"></span></div>`;
             });
-            range.markerContainerElement.innerHTML = markersHtml;
+            range.markerOuterContainerElement.innerHTML = markersHtml;
 
-            range.markerElements = range.markerContainerElement.querySelectorAll('.sliderMarker');
+            range.markerContainers = range.markerOuterContainerElement.querySelectorAll('.sliderMarkerContainer');
+            range.markerElements = range.markerOuterContainerElement.querySelectorAll('.sliderMarker');
 
             range.markerElements.forEach(element => {
                 element.addEventListener('click', event => {
-                    const index = event.currentTarget.id.replace('sliderMarker-', '');
-                    range.seekToChapter(index);
+                    const id = event.currentTarget.dataset.id;
+                    range.onMarkerClicked(id);
                     return true;
                 });
             });
         }
     }
 
-    if (range.markerInfo?.length && range.markerElements?.length) {
-        for (let i = 0, length = range.markerElements.length; i < length; i++) {
+    if (range.markerInfo?.length && range.markerContainers?.length) {
+        for (let i = 0, length = range.markerContainers.length; i < length; i++) {
             if (range.markerInfo.length > i) {
-                setMarker(range, mapFractionToValue(range, range.markerInfo[i].progress), range.markerElements[i], currentValue);
+                setMarker(range, mapFractionToValue(range, range.markerInfo[i].progress), range.markerContainers[i], currentValue);
             }
         }
     }
@@ -345,7 +348,7 @@ EmbySliderPrototype.attachedCallback = function () {
 
     let hasHideBubbleClass = sliderBubble.classList.contains('hide');
 
-    this.markerContainerElement = containerElement.querySelector('.sliderMarkerContainer');
+    this.markerOuterContainerElement = containerElement.querySelector('.sliderMarkerOuterContainer');
 
     dom.addEventListener(this, 'input', function () {
         this.dragging = true;

--- a/src/elements/emby-slider/emby-slider.js
+++ b/src/elements/emby-slider/emby-slider.js
@@ -263,7 +263,7 @@ function updateMarkers(range, currentValue) {
 
             let markersHtml = '';
             range.markerInfo.forEach((marker) => {
-                markersHtml += `<div class="sliderMarkerContainer" aria-hidden="true"><span data-id="${marker.id}" class="sliderMarker" aria-hidden="true"></span></div>`;
+                markersHtml += `<div class="sliderMarkerContainer"><span data-id="${marker.id}" class="sliderMarker" aria-hidden="true"></span></div>`;
             });
             range.markerOuterContainerElement.innerHTML = markersHtml;
 

--- a/src/elements/emby-slider/emby-slider.js
+++ b/src/elements/emby-slider/emby-slider.js
@@ -270,13 +270,16 @@ function updateMarkers(range, currentValue) {
             range.markerContainers = range.markerOuterContainerElement.querySelectorAll('.sliderMarkerContainer');
             range.markerElements = range.markerOuterContainerElement.querySelectorAll('.sliderMarker');
 
-            range.markerElements.forEach(element => {
-                element.addEventListener('click', event => {
-                    const id = event.currentTarget.dataset.id;
-                    range.onMarkerClicked(id);
-                    return true;
+            if (typeof (range.onMarkerClicked) === typeof (Function)) {
+                range.markerElements.forEach(element => {
+                    element.classList.add('clickable');
+                    element.addEventListener('click', event => {
+                        const id = event.currentTarget.dataset.id;
+                        range.onMarkerClicked(id);
+                        return true;
+                    });
                 });
-            });
+            }
         }
     }
 

--- a/src/elements/emby-slider/emby-slider.js
+++ b/src/elements/emby-slider/emby-slider.js
@@ -242,7 +242,7 @@ function setMarker(range, valueMarker, markerContainer, valueProgress) {
 
         markerContainer.style.left = `calc(${valueMarker}% - ${markerRect.width / 2}px)`;
 
-        const marker = markerContainer.getElementsByClassName('sliderMarker')[0];
+        const marker = markerContainer.querySelector('.sliderMarker');
 
         if (valueProgress >= valueMarker) {
             marker.classList.remove('unwatched');

--- a/src/elements/emby-slider/emby-slider.scss
+++ b/src/elements/emby-slider/emby-slider.scss
@@ -253,19 +253,26 @@
     margin-bottom: 0.25em;
 }
 
-.sliderMarkerContainer {
+.sliderMarkerOuterContainer {
     position: absolute;
     left: 0;
     right: 0;
     margin: 0 0.54em; /* half of slider thumb size */
 }
 
-.sliderMarker {
+.sliderMarkerContainer {
     z-index:10;
     position: absolute;
-    width: 2px;
+    width: 10px;
     height: 12px;
     transform: translate3d(0, 25%, 0);
+}
+
+.sliderMarker {
+    width: 100%;
+    height: 100%;
+    cursor: pointer;
+    display: block;
 }
 
 .sliderMarker:hover {

--- a/src/elements/emby-slider/emby-slider.scss
+++ b/src/elements/emby-slider/emby-slider.scss
@@ -261,7 +261,7 @@
 }
 
 .sliderMarkerContainer {
-    z-index:10;
+    z-index: 10;
     position: absolute;
     width: 2px;
     height: 12px;

--- a/src/elements/emby-slider/emby-slider.scss
+++ b/src/elements/emby-slider/emby-slider.scss
@@ -271,7 +271,6 @@
 .sliderMarker {
     width: 100%;
     height: 100%;
-    cursor: pointer;
     display: block;
 }
 
@@ -285,4 +284,8 @@
 
 .sliderMarker.watched {
     background-color: #00a4dc;
+}
+
+.sliderMarker.clickable {
+    cursor: pointer;
 }

--- a/src/elements/emby-slider/emby-slider.scss
+++ b/src/elements/emby-slider/emby-slider.scss
@@ -261,10 +261,15 @@
 }
 
 .sliderMarker {
+    z-index:10;
     position: absolute;
     width: 2px;
     height: 12px;
     transform: translate3d(0, 25%, 0);
+}
+
+.sliderMarker:hover {
+    transform: scale(1.5);
 }
 
 .sliderMarker.unwatched {

--- a/src/elements/emby-slider/emby-slider.scss
+++ b/src/elements/emby-slider/emby-slider.scss
@@ -263,7 +263,7 @@
 .sliderMarkerContainer {
     z-index:10;
     position: absolute;
-    width: 10px;
+    width: 2px;
     height: 12px;
     transform: translate3d(0, 25%, 0);
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

### Changes
<!--
Describe your changes here in 1-5 sentences.
Please include before/after screenshots of any UI changes.
-->
Slider markers in the player progress bar now jump to their associated timecode when clicked and get larger when hovered over.
Hovered:
<img width="112" height="131" alt="image" src="https://github.com/user-attachments/assets/6c541820-1045-4fd6-b6cd-eba12b8e5f56" />


### Issues
<!--
Tag any issues that this PR solves here.
ex. Fixes #
-->
none
### Code assistance
<!--
If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance.
-->
Used ChatGPT for research

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
