### PR TITLE
Keep same origin login disclaimer links on the same tab

### DIFF
--- a/src/apps/legacy/controllers/session/login/index.js
+++ b/src/apps/legacy/controllers/session/login/index.js
@@ -306,8 +306,10 @@ export default function (view, params) {
             loginDisclaimer.innerHTML = domPurify.sanitize(markdownIt({ html: true }).render(options.LoginDisclaimer || ''));
 
             for (const elem of loginDisclaimer.querySelectorAll('a')) {
-                elem.rel = 'noopener noreferrer';
-                elem.target = '_blank';
+                if (new URL(elem.href).origin !== window.location.origin) {
+                    elem.rel = 'noopener noreferrer';
+                    elem.target = '_blank';
+                }
                 elem.classList.add('button-link');
                 elem.setAttribute('is', 'emby-linkbutton');
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues page.
-->

### Changes
<!--
Describe your changes here in 1-5 sentences.
Please include before/after screenshots of any UI changes.
-->
Previously, same-origin links living in the login disclaimer would be opened in a new tab, regardless of the fact it's same-origin, in-app navigation. This skips links whose origin matches the current page's.

### Issues
Fixes #8357

### Code assistance
<!--
If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance.
-->

No LLMs were used in any way, shape, or form.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
