### PR TITLE
Add missing 'alttwo' series order option for TheTVDB plugin

### DIFF
--- a/src/components/metadataEditor/metadataEditor.js
+++ b/src/components/metadataEditor/metadataEditor.js
@@ -748,6 +748,7 @@ function setFieldVisibilities(context, item) {
         html += '<option value="production">' + globalize.translate('Production') + '</option>';
         html += '<option value="tv">TV</option>';
         html += '<option value="alternate">' + globalize.translate('Alternate') + '</option>';
+        html += '<option value="alttwo">' + globalize.translate('AlternateTwo') + '</option>';
         html += '<option value="regional">' + globalize.translate('Regional') + '</option>';
         html += '<option value="altdvd">' + globalize.translate('AlternateDVD') + '</option>';
 

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -35,6 +35,7 @@
     "AllowStreamSharingHelp": "Allow Jellyfin to duplicate the mpegts stream from tuner and share this duplicated stream to its clients. This is useful when the tuner has total stream count limit but may also cause playback issues.",
     "Alternate" : "Alternate",
     "AlternateDVD" : "Alternate DVD",
+    "AlternateTwo" : "Alternate 2",
     "AlwaysBurnInSubtitleWhenTranscoding": "Always burn in subtitle when transcoding",
     "AlwaysBurnInSubtitleWhenTranscodingHelp": "Burn in all subtitles when transcoding is triggered. This ensures subtitle synchronization after transcoding at the cost of reduced transcoding speed.",
     "LabelThrottleDelaySeconds": "Throttle after",


### PR DESCRIPTION
### Changes
Adds the missing `alttwo` "Alternate Order 2" series order type from TheTVDB to the metadata editor.

### Issues
https://github.com/jellyfin/jellyfin-plugin-tvdb/issues/226#issuecomment-5284122494

### Code assistance
none

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
