### PR TITLE
Fix still watching prompt being unreachable by remote on TV

### DIFF
--- a/src/apps/legacy/controllers/playback/video/index.js
+++ b/src/apps/legacy/controllers/playback/video/index.js
@@ -410,6 +410,9 @@ export default function (view) {
     function onInputCommand(e) {
         const player = currentPlayer;
 
+        // Ignore commands when some dialog is opened
+        if (getOpenedDialog()) return;
+
         switch (e.detail.command) {
             case 'left':
                 if (currentVisibleMenu === 'osd') {
@@ -464,8 +467,7 @@ export default function (view) {
                 break;
 
             case 'back':
-                // Ignore command when some dialog is opened
-                if (currentVisibleMenu === 'osd' && !getOpenedDialog()) {
+                if (currentVisibleMenu === 'osd') {
                     hideOsd();
                     e.preventDefault();
                 }
@@ -1222,6 +1224,9 @@ export default function (view) {
         // Skip modified keys
         if (isKeyModified) return;
 
+        // Ignore keys when some dialog is opened
+        if (getOpenedDialog()) return;
+
         const key = keyboardnavigation.getKeyName(e);
 
         const btnPlayPause = osdBottomElement.querySelector('.btnPause');
@@ -1280,8 +1285,7 @@ export default function (view) {
                 break;
             case 'Escape':
             case 'Back':
-                // Ignore key when some dialog is opened
-                if (currentVisibleMenu === 'osd' && !getOpenedDialog()) {
+                if (currentVisibleMenu === 'osd') {
                     hideOsd();
                     e.stopPropagation();
                 }


### PR DESCRIPTION
### Changes

On TV layout the "Still watching?" prompt cannot be operated with a remote. The video OSD handles keys on `document` and input commands on `window` without checking for an open dialog, so while the OSD is hidden the arrow keys take the TV branch that focuses the seek slider behind the dialog and calls `preventDefault()` — focus leaves the prompt and navigation never reaches it again.

This guards both handlers with `getOpenedDialog()`, the check the file already uses in `resetIdle` and `onWheel` to stop the player reacting behind an open dialog, and drops the now-unreachable check in the `back` and `Escape` cases.

### Issues

None — I could not find an existing report.

### Code assistance

LLM-assisted. I hit the bug on my own TV and described the symptom; the assistant traced the event chain through the code to the cause, proposed the guard and wrote the change. I checked the diagnosis against the source, built it on `master`, and tested it on my LG C4: the prompt works, and the subtitle and audio menus still navigate and close normally.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
