### PR TITLE
Add toast when subtitle upload/add fails

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -173,6 +173,7 @@
 - [tikuf](https://github.com/tikuf/)
 - [Tim Hobbs](https://github.com/timhobbs)
 - [SvenVandenbrande](https://github.com/SvenVandenbrande)
+- [FredMcAwesome](https://github.com/FredMcAwesome)
 <!--
     NOTE: This is the end of the list of past Emby Contributors.
     New Jellyfin contributors should add their name to the end

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -110,6 +110,7 @@
 - [austinhardaway](https://github.com/austinhardaway)
 - [Alex Dickens](https://github.com/alex-dicko)
 - [shindouj](https://github.com/shindouj)
+- [FredMcAwesome](https://github.com/FredMcAwesome)
 
 ## Emby Contributors
 
@@ -173,7 +174,6 @@
 - [tikuf](https://github.com/tikuf/)
 - [Tim Hobbs](https://github.com/timhobbs)
 - [SvenVandenbrande](https://github.com/SvenVandenbrande)
-- [FredMcAwesome](https://github.com/FredMcAwesome)
 <!--
     NOTE: This is the end of the list of past Emby Contributors.
     New Jellyfin contributors should add their name to the end

--- a/src/components/subtitleuploader/subtitleuploader.js
+++ b/src/components/subtitleuploader/subtitleuploader.js
@@ -17,6 +17,8 @@ import '../formdialog.scss';
 import './style.scss';
 import { readFileAsBase64 } from 'utils/file';
 
+const VALID_SUBTITLE_EXTENSIONS = ['.sub', '.srt', '.vtt', '.ass', '.ssa', '.mks'];
+
 let currentItemId;
 let currentServerId;
 let currentFile;
@@ -32,7 +34,7 @@ function onFileReaderError(evt) {
 }
 
 function isValidSubtitleFile(file) {
-    return file && ['.sub', '.srt', '.vtt', '.ass', '.ssa', '.mks']
+    return file && VALID_SUBTITLE_EXTENSIONS
         .some(function(ext) {
             return file.name.endsWith(ext);
         });
@@ -46,6 +48,7 @@ function setFiles(page, files) {
         page.querySelector('#fldUpload').classList.add('hide');
         page.querySelector('#labelDropSubtitle').classList.remove('hide');
         currentFile = null;
+        toast(globalize.translate('MessageSubtitleFileTypeAllowed', file?.name, VALID_SUBTITLE_EXTENSIONS.join(', ')));
         return;
     }
 
@@ -84,7 +87,7 @@ async function onSubmit(e) {
     const file = currentFile;
 
     if (!isValidSubtitleFile(file)) {
-        toast(globalize.translate('MessageSubtitleFileTypeAllowed'));
+        toast(globalize.translate('MessageSubtitleFileTypeAllowed', file?.name, VALID_SUBTITLE_EXTENSIONS.join(', ')));
         return;
     }
 

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1240,6 +1240,7 @@
     "MessageSyncPlayPlaybackPermissionRequired": "Playback permission required.",
     "MessageSyncPlayUserJoined": "{0} has joined the group.",
     "MessageSyncPlayUserLeft": "{0} has left the group.",
+    "MessageSubtitleFileTypeAllowed": "The file \"{0}\" is not a supported subtitle type. Supported types are: {1}",
     "MessageTheFollowingLocationWillBeRemovedFromLibrary": "The following media locations will be removed from your library",
     "MessageUnableToConnectToServer": "We're unable to connect to the selected server right now. Please ensure it is running and try again.",
     "MessageUnauthorizedUser": "You are not authorized to access the server at this time. Please contact your server administrator for more information.",


### PR DESCRIPTION
Currently when a subtitle file is selected to be uploaded but has an invalid/unsupported extension the selection fails silently. This PR adds a toast message clearly showing the filename that was selected for upload. This is useful when the name is correctly displayed in windows but encounters [MS-DOS 8.3](https://en.wikipedia.org/wiki/8.3_filename) issues when uploading (name gets shortened and the suffix may be capitalised so it doesn't pass extension check anymore).

### Changes
Add a toast when a subtitle add (when dragged or selected from file browser) fails to pass the isValidSubtitleFile extension check and related missing message to en-us.json.

### Issues
Fixes #8367

### Code assistance
Code was generated by Opus 4.6 and subsequently cleaned up manually.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
