### PR TITLE
Fix library button styling

### DIFF
--- a/src/components/homesections/homesections.scss
+++ b/src/components/homesections/homesections.scss
@@ -1,16 +1,23 @@
+.homeLibraryButtonContainer {
+    margin-left: -0.5em;
+    margin-right: -0.5em;
+}
+
 .homeLibraryButton {
     min-width: 18%;
     margin: 0.5em !important;
-}
 
-@media all and (max-width: 50em) {
-    .homeLibraryButton {
-        width: 46% !important;
+    @media all and (max-width: 50em) {
+        width: 45% !important;
+        width: calc(50% - 1em) !important;
+    }
+
+    @media all and (max-width: 18em) {
+        width: 100% !important;
     }
 }
 
 .homeLibraryIcon {
-    margin-left: 0.5em;
     margin-right: 0.5em;
     flex-shrink: 0;
 }

--- a/src/components/homesections/sections/libraryButtons.ts
+++ b/src/components/homesections/sections/libraryButtons.ts
@@ -12,7 +12,7 @@ function getLibraryButtonsHtml(items: BaseItemDto[]) {
     html += '<div class="verticalSection verticalSection-extrabottompadding">';
     html += '<h2 class="sectionTitle sectionTitle-cards padded-left">' + globalize.translate('HeaderMyMedia') + '</h2>';
 
-    html += '<div is="emby-itemscontainer" class="itemsContainer padded-left padded-right vertical-wrap focuscontainer-x" data-multiselect="false">';
+    html += '<div is="emby-itemscontainer" class="homeLibraryButtonContainer itemsContainer padded-left padded-right vertical-wrap focuscontainer-x" data-multiselect="false">';
 
     // library card background images
     for (let i = 0, length = items.length; i < length; i++) {


### PR DESCRIPTION
### Changes
Fixes some styling issues for the library button home screen section
- buttons were inset due to the margin buttons
- half width sizing was too large so buttons failed to be two columns
- added full width buttons for really small screens
- removed some extra padding in front of the icons

### Issues
Reported in chat

### Code assistance
Zed autocomplete

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
