### PR TITLE
Fix connecting to wrong server when servers exist in config

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -15,6 +15,7 @@ import { appRouter } from './components/router/appRouter';
 import { AppFeature } from 'constants/appFeature';
 import globalize from './lib/globalize';
 import { loadCoreDictionary } from 'lib/globalize/loader';
+import getServerAddress from 'lib/jellyfin-apiclient/utils/getServerAddress';
 import { initialize as initializeAutoCast } from 'scripts/autocast';
 import browser from './scripts/browser';
 import keyboardNavigation from './scripts/keyboardNavigation';
@@ -69,11 +70,16 @@ build: ${__JF_BUILD_VERSION__}`);
     // Initialize app host
     await appHost.init();
 
-    // Initialize the api client
-    const serverUrl = await serverAddress();
-    if (serverUrl) {
-        ServerConnections.initApiClient(serverUrl);
+    // Find the correct server URL
+    const lastServer = ServerConnections.getLastUsedServer();
+    let serverUrl;
+    if (lastServer) {
+        serverUrl = getServerAddress(lastServer);
+    } else {
+        serverUrl = await serverAddress();
     }
+    // Initialize the api client
+    if (serverUrl) ServerConnections.initApiClient(serverUrl);
 
     // Initialize automatic (default) cast target
     initializeAutoCast();

--- a/src/lib/jellyfin-apiclient/connectionManager.js
+++ b/src/lib/jellyfin-apiclient/connectionManager.js
@@ -6,28 +6,16 @@ import { compareVersions } from '@jellyfin/sdk/lib/utils/versioning';
 
 import events from 'utils/events';
 import { ajax } from 'utils/fetch';
+import { toApi } from 'utils/jellyfin-apiclient/compat';
 import { createApiClient } from 'utils/jellyfin-apiclient/createApiClient';
 import { equalsIgnoreCase } from 'utils/string';
+import { safeDecodeURIComponent } from 'utils/url';
 
 import { ConnectionMode } from './connectionMode';
 import { ConnectionState } from './connectionState';
-import { toApi } from 'utils/jellyfin-apiclient/compat';
-import { safeDecodeURIComponent } from 'utils/url';
+import getServerAddress from './utils/getServerAddress';
 
 const DEFAULT_CONNECTION_TIMEOUT = 20000;
-
-function getServerAddress(server, mode) {
-    switch (mode) {
-        case ConnectionMode.Local:
-            return server.LocalAddress;
-        case ConnectionMode.Manual:
-            return server.ManualAddress;
-        case ConnectionMode.Remote:
-            return server.RemoteAddress;
-        default:
-            return server.ManualAddress || server.LocalAddress || server.RemoteAddress;
-    }
-}
 
 function updateServerInfo(server, systemInfo) {
     server.Name = systemInfo.ServerName;
@@ -167,7 +155,7 @@ export default class ConnectionManager {
 
             const server = servers[0];
 
-            return self._getOrAddApiClient(server, getServerAddress(server, server.LastConnectionMode));
+            return self._getOrAddApiClient(server, getServerAddress(server));
         };
 
         function onAuthenticated(apiClient, result, options, saveCredentials) {
@@ -783,7 +771,7 @@ export default class ConnectionManager {
         for (let i = 0, length = servers.length; i < length; i++) {
             const server = servers[i];
             if (server.Id) {
-                this._getOrAddApiClient(server, getServerAddress(server, server.LastConnectionMode));
+                this._getOrAddApiClient(server, getServerAddress(server));
             }
         }
 

--- a/src/lib/jellyfin-apiclient/utils/getServerAddress.ts
+++ b/src/lib/jellyfin-apiclient/utils/getServerAddress.ts
@@ -1,0 +1,22 @@
+import { ConnectionMode } from 'lib/jellyfin-apiclient/connectionMode';
+
+interface ServerInfo {
+    LastConnectionMode: ConnectionMode;
+    LocalAddress?: string;
+    ManualAddress?: string;
+    RemoteAddress?: string;
+}
+
+/** Returns the best server address based on the connection mode. */
+export default function getServerAddress(server: ServerInfo) {
+    switch (server.LastConnectionMode) {
+        case ConnectionMode.Local:
+            return server.LocalAddress;
+        case ConnectionMode.Manual:
+            return server.ManualAddress;
+        case ConnectionMode.Remote:
+            return server.RemoteAddress;
+        default:
+            return server.ManualAddress || server.LocalAddress || server.RemoteAddress;
+    }
+}


### PR DESCRIPTION
### Changes
Fixes an issue where servers in the config.json file would always be used instead of the last used server

### Issues
Reported in matrix (apparently)

### Code assistance
Zed autocomplete

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
