### PR TITLE
Favorite albums shuffle fix

### DIFF
--- a/src/apps/legacy/controllers/list.js
+++ b/src/apps/legacy/controllers/list.js
@@ -793,7 +793,8 @@ class ItemsView {
                 getItems(self, self.params, currentItem, 'Random', 0, 300).then(function (result) {
                     playbackManager.play({
                         items: result.Items,
-                        autoplay: true
+                        autoplay: true,
+                        shuffle: true
                     });
                 });
             }

--- a/src/apps/legacy/controllers/music/musicalbums.js
+++ b/src/apps/legacy/controllers/music/musicalbums.js
@@ -22,9 +22,14 @@ export default function (view, params, tabContent) {
     }
 
     function shuffle() {
-        ApiClient.getItem(ApiClient.getCurrentUserId(), params.topParentId).then(function (item) {
-            getQuery();
-            playbackManager.shuffle(item);
+        const query = { ...getQuery(), SortBy: 'Random', StartIndex: 0, Limit: 300 };
+
+        ApiClient.getItems(ApiClient.getCurrentUserId(), query).then(function (result) {
+            playbackManager.play({
+                items: result.Items,
+                autoplay: true,
+                shuffle: true
+            });
         });
     }
 

--- a/src/apps/modern/features/libraries/components/LibraryToolbar.tsx
+++ b/src/apps/modern/features/libraries/components/LibraryToolbar.tsx
@@ -176,7 +176,6 @@ const LibraryToolbar: FC = () => {
                                     collectionType={collectionType}
                                     hasFilters={hasFilters}
                                     isTextVisible={isSmallScreen && !isBtnPlayAllEnabled}
-                                    libraryViewSettings={libraryViewSettings}
                                 />
                             )}
 

--- a/src/apps/modern/features/libraries/components/ShuffleButton.tsx
+++ b/src/apps/modern/features/libraries/components/ShuffleButton.tsx
@@ -1,5 +1,4 @@
 import { CollectionType } from '@jellyfin/sdk/lib/generated-client/models/collection-type';
-import { ItemSortBy } from '@jellyfin/sdk/lib/generated-client/models/item-sort-by';
 import React, { FC, useCallback } from 'react';
 import Shuffle from '@mui/icons-material/Shuffle';
 import Button from '@mui/material/Button';
@@ -7,8 +6,6 @@ import Button from '@mui/material/Button';
 import { useLibrary } from 'apps/modern/features/libraries/hooks/useLibrary';
 import { playbackManager } from 'components/playback/playbackmanager';
 import globalize from 'lib/globalize';
-import { getFiltersQuery } from 'utils/items';
-import { LibraryViewSettings } from 'types/library';
 import { LibraryTab } from 'types/libraryTab';
 import type { ItemDto } from 'types/base/models/item-dto';
 
@@ -19,7 +16,6 @@ interface ShuffleButtonProps {
     collectionType: CollectionType | undefined
     hasFilters: boolean
     isTextVisible: boolean
-    libraryViewSettings: LibraryViewSettings
 }
 
 const ShuffleButton: FC<ShuffleButtonProps> = ({
@@ -28,8 +24,7 @@ const ShuffleButton: FC<ShuffleButtonProps> = ({
     viewType,
     collectionType,
     hasFilters,
-    isTextVisible,
-    libraryViewSettings
+    isTextVisible
 }) => {
     const { itemsResult } = useLibrary();
     const isPending = itemsResult?.isPending ?? true;
@@ -42,19 +37,17 @@ const ShuffleButton: FC<ShuffleButtonProps> = ({
         if (item && !hasFilters && !(viewType === LibraryTab.Videos && collectionType === CollectionType.Homevideos)) {
             playbackManager.shuffle(item);
         } else {
+            // items is already scoped to the active filters, so pass it through directly
+            // rather than re-deriving a query (which previously reapplied list filters to the wrong item type)
             playbackManager.play({
                 items,
                 autoplay: true,
-                queryOptions: {
-                    ParentId: item?.Id ?? undefined,
-                    ...getFiltersQuery(viewType, libraryViewSettings),
-                    SortBy: [ItemSortBy.Random]
-                }
+                shuffle: true
             }).catch(err => {
                 console.error('[ShuffleButton] failed to play', err);
             });
         }
-    }, [collectionType, hasFilters, item, items, libraryViewSettings, viewType]);
+    }, [collectionType, hasFilters, item, items, viewType]);
 
     return (
         <Button

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -1864,6 +1864,20 @@ export class PlaybackManager {
                         ].join(','),
                         MediaTypes: MediaType.Audio
                     }, queryOptions));
+                case BaseItemKind.MusicAlbum:
+
+                    return getItemsForPlayback(serverId, mergePlaybackQueries({
+                        // Use every passed-in album, not just the first, so a shuffled/filtered list of albums plays through all of them
+                        AlbumIds: items.map(albumItem => albumItem.Id).join(','),
+                        Recursive: true,
+                        SortBy: options.shuffle ? SortBy : [
+                            ItemSortBy.Album,
+                            ItemSortBy.ParentIndexNumber,
+                            ItemSortBy.IndexNumber,
+                            ItemSortBy.SortName
+                        ].join(','),
+                        MediaTypes: MediaType.Audio
+                    }, queryOptions));
                 case BaseItemKind.PhotoAlbum:
                     return getItemsForPlayback(serverId, mergePlaybackQueries({
                         ParentId: firstItem.Id,


### PR DESCRIPTION
### Changes
Fixes the shuffle in the favorites for both movies and music, as issue #6955 specifies.

I have tested the fix for both favorite movies, and favorite music. It works perfectly for both.

### Issues
Fixes #6955

### Code assistance
Claude Code was used to assist me in solving the issue, but any code written by it was reviewed and refined by me, and I stand behind it as my own code.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
