### PR TITLE
Add subtitle editing to the video OSD

### DIFF
--- a/src/apps/legacy/controllers/playback/video/index.js
+++ b/src/apps/legacy/controllers/playback/video/index.js
@@ -211,13 +211,8 @@ export default function (view) {
         btnFastForward.disabled = false;
         btnRewind.disabled = false;
 
-        if (playbackManager.subtitleTracks(player).length) {
-            view.querySelector('.btnSubtitles').classList.remove('hide');
-            toggleSubtitleSync();
-        } else {
-            view.querySelector('.btnSubtitles').classList.add('hide');
-            toggleSubtitleSync('forceToHide');
-        }
+        refreshSubtitleEditingPermission(item);
+        updateSubtitleButton(player);
 
         if (playbackManager.audioTracks(player).length > 1) {
             view.querySelector('.btnAudio').classList.remove('hide');
@@ -232,6 +227,41 @@ export default function (view) {
             view.querySelector('.btnPreviousChapter').classList.add('hide');
             view.querySelector('.btnNextChapter').classList.add('hide');
         }
+    }
+
+    function updateSubtitleButton(player) {
+        const subtitleTracks = playbackManager.subtitleTracks(player).length > 0;
+
+        if (subtitleTracks || canEditSubtitles) {
+            view.querySelector('.btnSubtitles').classList.remove('hide');
+        } else {
+            view.querySelector('.btnSubtitles').classList.add('hide');
+        }
+
+        toggleSubtitleSync(subtitleTracks ? undefined : 'forceToHide');
+    }
+
+    function refreshSubtitleEditingPermission(item) {
+        if (subtitleEditingItemId === item.Id) {
+            return;
+        }
+
+        subtitleEditingItemId = item.Id;
+        canEditSubtitles = false;
+
+        if (!item.ServerId) {
+            return;
+        }
+
+        ServerConnections.getApiClient(item.ServerId).getCurrentUser().then(function (user) {
+            canEditSubtitles = itemHelper.canEditSubtitles(user, item);
+
+            if (currentPlayer) {
+                updateSubtitleButton(currentPlayer);
+            }
+        }).catch(function (err) {
+            console.error('[videoosd] failed to read subtitle permissions', err);
+        });
     }
 
     function setTitle(item, parentName) {
@@ -1130,13 +1160,13 @@ export default function (view) {
         });
 
         /**
-            * Only show option if:
-            * - player has support
-            * - has more than 1 subtitle track
-            * - has valid secondary tracks
-            * - primary subtitle is not off
-            * - primary subtitle has support
-            */
+         * Only show option if:
+         * - player has support
+         * - has more than 1 subtitle track
+         * - has valid secondary tracks
+         * - primary subtitle is not off
+         * - primary subtitle has support
+         */
         const currentTrackCanAddSecondarySubtitle = playbackManager.playerHasSecondarySubtitleSupport(player)
                 && streams.length > 1
                 && secondaryStreams.length > 0
@@ -1149,6 +1179,16 @@ export default function (view) {
                 id: 'secondarysubtitle'
             };
             menuItems.unshift(secondarySubtitleMenuItem);
+        }
+
+        if (canEditSubtitles) {
+            menuItems.push({
+                divider: true
+            }, {
+                name: globalize.translate('EditSubtitles'),
+                id: 'editsubtitles',
+                icon: 'closed_caption'
+            });
         }
 
         const positionTo = this;
@@ -1165,6 +1205,8 @@ export default function (view) {
                     } catch (e) {
                         console.error(e);
                     }
+                } else if (id === 'editsubtitles') {
+                    showSubtitleEditor();
                 } else {
                     const index = parseInt(id, 10);
 
@@ -1180,6 +1222,31 @@ export default function (view) {
 
             setTimeout(resetIdle, 0);
         });
+    }
+
+    function showSubtitleEditor() {
+        if (!currentPlayer || !currentItem) {
+            return;
+        }
+
+        import('components/subtitleeditor/subtitleeditor')
+            .then(({ default: subtitleEditor }) => subtitleEditor.show(currentItem.Id, currentItem.ServerId))
+            .then(() => refreshSubtitleTracks(currentPlayer))
+            // The editor rejects when it is closed without changes
+            .catch(() => { /* no changes */ })
+            .finally(resetIdle);
+    }
+
+    /**
+     * The player holds the media source it started with, so a subtitle added during playback
+     * is only listed after the source is read again
+     */
+    async function refreshSubtitleTracks(player) {
+        try {
+            await playbackManager.refreshMediaSource(player);
+        } catch (err) {
+            console.error('[videoosd] failed to refresh the subtitle tracks', err);
+        }
     }
 
     function toggleSubtitleSync(action) {
@@ -1199,9 +1266,9 @@ export default function (view) {
     }
 
     /**
-         * Clicked element.
-         * To skip 'click' handling on Firefox/Edge.
-         */
+     * Clicked element.
+     * To skip 'click' handling on Firefox/Edge.
+     */
     let clickedElement;
 
     function onClickCapture(e) {
@@ -1635,6 +1702,8 @@ export default function (view) {
     let programEndDateMs = 0;
     let playbackStartTimeTicks = 0;
     let subtitleSyncOverlay;
+    let canEditSubtitles = false;
+    let subtitleEditingItemId = null;
     let trickplayResolution = null;
     const nowPlayingVolumeSlider = view.querySelector('.osdVolumeSlider');
     const nowPlayingVolumeSliderContainer = view.querySelector('.osdVolumeSliderContainer');

--- a/src/apps/legacy/controllers/playback/video/index.js
+++ b/src/apps/legacy/controllers/playback/video/index.js
@@ -1231,22 +1231,14 @@ export default function (view) {
 
         import('components/subtitleeditor/subtitleeditor')
             .then(({ default: subtitleEditor }) => subtitleEditor.show(currentItem.Id, currentItem.ServerId))
-            .then(() => refreshSubtitleTracks(currentPlayer))
+            .then(() => playbackManager.refreshMediaSource(currentPlayer)
+                .catch(
+                    (err) => {
+                        console.error('[videoosd] failed to refresh the subtitle tracks', err)
+                    }))
             // The editor rejects when it is closed without changes
             .catch(() => { /* no changes */ })
             .finally(resetIdle);
-    }
-
-    /**
-     * The player holds the media source it started with, so a subtitle added during playback
-     * is only listed after the source is read again
-     */
-    async function refreshSubtitleTracks(player) {
-        try {
-            await playbackManager.refreshMediaSource(player);
-        } catch (err) {
-            console.error('[videoosd] failed to refresh the subtitle tracks', err);
-        }
     }
 
     function toggleSubtitleSync(action) {

--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -748,6 +748,53 @@ export class PlaybackManager {
             return data.streamInfo ? data.streamInfo.mediaSource : null;
         };
 
+        self.refreshMediaSource = function (player) {
+            player = player || self._currentPlayer;
+
+            if (!player || !enableLocalPlaylistManagement(player)) {
+                return Promise.resolve(null);
+            }
+
+            const streamInfo = getPlayerData(player).streamInfo;
+            const mediaSource = streamInfo?.mediaSource;
+            const item = self.currentItem(player);
+
+            if (!mediaSource || !item?.ServerId) {
+                return Promise.resolve(null);
+            }
+
+            const apiClient = ServerConnections.getApiClient(item.ServerId);
+
+            return player.getDeviceProfile(item).then(function (deviceProfile) {
+                return getPlaybackInfo(player, apiClient, item, deviceProfile, mediaSource.Id, streamInfo.liveStreamId, {
+                    isPlayback: false,
+                    maxBitrate: self.getMaxStreamingBitrate(player),
+                    audioStreamIndex: getPlayerData(player).audioStreamIndex,
+                    subtitleStreamIndex: getPlayerData(player).subtitleStreamIndex
+                });
+            }).then(function (result) {
+                const refreshed = result?.MediaSources?.find(function (source) {
+                    return source.Id === mediaSource.Id;
+                });
+
+                if (!refreshed) {
+                    return null;
+                }
+
+                mediaSource.MediaStreams = refreshed.MediaStreams;
+
+                const subtitleIndex = getPlayerData(player).subtitleStreamIndex;
+                if (subtitleIndex != null && subtitleIndex !== -1 && !self.getSubtitleStream(player, subtitleIndex)) {
+                    getPlayerData(player).subtitleStreamIndex = -1;
+                    player.setSubtitleStreamIndex(-1);
+                }
+
+                Events.trigger(player, PlayerEvent.MediaStreamsChange);
+
+                return mediaSource;
+            });
+        };
+
         self.playMethod = function (player) {
             if (!player) {
                 throw new Error('player cannot be null');

--- a/src/components/subtitleeditor/subtitleeditor.js
+++ b/src/components/subtitleeditor/subtitleeditor.js
@@ -30,6 +30,8 @@ function downloadRemoteSubtitles(context, id) {
     const url = 'Items/' + currentItem.Id + '/RemoteSearch/Subtitles/' + id;
 
     const apiClient = ServerConnections.getApiClient(currentItem.ServerId);
+    loading.show();
+
     apiClient.ajax({
 
         type: 'POST',
@@ -41,6 +43,10 @@ function downloadRemoteSubtitles(context, id) {
         toast(globalize.translate('MessageDownloadQueued'));
 
         focusManager.autoFocus(context);
+        reload(context, apiClient, currentItem.Id);
+    }).catch(function (err) {
+        loading.hide();
+        console.error('[subtitleeditor] failed to download the subtitle', err);
     });
 }
 


### PR DESCRIPTION
### Changes
I've created this pr to open up the road for editing subtitles within the OSD without leaving playback, for [1713](https://features.jellyfin.org/posts/1713/search-for-subtitles-from-within-ui) and [3385](https://features.jellyfin.org/posts/3385/on-demand-subtitle-search). It adds a subtitle editor to the player so you can search, download and switch tracks while the video keeps running.

It reuses the current subtitle edit modal and works, however the core has a bug that shifts stream indexes on a refresh, which puts the client and the server out of sync. https://github.com/jellyfin/jellyfin/issues/17681 has been created to resolve that, so I would not merge this yet.

### Issues
[1713](https://features.jellyfin.org/posts/1713/search-for-subtitles-from-within-ui) and [3385](https://features.jellyfin.org/posts/3385/on-demand-subtitle-search)

### Code assistance
None

[x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
[x] I have tested these changes.
[x] I have verified that this is not duplicating changes in an existing PR.
[x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).

https://github.com/user-attachments/assets/ba480d5c-3eb2-413a-a286-276a994e9545

