### PR TITLE
stop playback upon logout

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -99,6 +99,9 @@ function reportPlayback(playbackManagerInstance, state, player, reportPlaylist, 
     // Notify that report has been sent
     reportPlaybackPromise.then(() => {
         Events.trigger(playbackManagerInstance, 'reportplayback', [true]);
+    }, () => {
+        // Session may already be gone (e.g. stop() during sign out), nothing to report to
+        Events.trigger(playbackManagerInstance, 'reportplayback', [false]);
     });
 }
 
@@ -3756,6 +3759,7 @@ export class PlaybackManager {
                 });
                 Events.on(ServerConnections, 'localusersignedout', () => {
                     _unsubscribeRemoteControl?.();
+                    self.stop();
                 });
             });
         }


### PR DESCRIPTION
### Changes
Playback of audio will now stop upon logging out of the user's account

### Issues
Fixes: #4917

### Code assistance
Claude Code was used to assist me in solving the issue, but any code written by it was reviewed and refined by me, and I stand behind it as my own code.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
