### PR TITLE
Enable horizontal mouse wheel scrolling in the modern layout

### DIFF
--- a/src/elements/emby-scroller/Scroller.tsx
+++ b/src/elements/emby-scroller/Scroller.tsx
@@ -26,7 +26,7 @@ export interface ScrollerProps {
 const Scroller: FC<PropsWithChildren<ScrollerProps>> = ({
     className,
     isHorizontalEnabled = true,
-    isMouseWheelEnabled = false,
+    isMouseWheelEnabled = true,
     isCenterFocusEnabled = false,
     isScrollButtonsEnabled = true,
     isSkipFocusWhenVisibleEnabled = false,


### PR DESCRIPTION
Horizontal mouse wheel scrolling is set to off by [default](https://github.com/jellyfin/jellyfin-web/blob/ec2622a5ad124dc32f730df9ca89d4f0597708df/src/elements/emby-scroller/Scroller.tsx#L29), and none of the modern pages were passing it in. This led to legacy pages working with mouse scrolling, while none of the modern pages did. 

### Changes
 ~~Added `scrollerProps={{ isMouseWheelEnabled: true }}` to sections in the modern layout pages (Genres, Programs, Suggestions, Upcoming) where horizontal mouse wheel scrolling should be enabled.~~ 
 
 Set `isMouseWheelEnabled` to true.

### Issues
N/A

### Code assistance
N/A

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
