### PR TITLE
Change subtitle text size setting to a continuous slider

### DIFF
--- a/src/components/subtitlesettings/subtitleappearancehelper.js
+++ b/src/components/subtitlesettings/subtitleappearancehelper.js
@@ -3,30 +3,44 @@
  * @module components/subtitleSettings/subtitleAppearanceHelper
  */
 
+/**
+ * Multipliers equivalent to the legacy discrete text size options,
+ * expressed as a scale factor relative to 1em.
+ */
+export const LEGACY_TEXT_SIZE_SCALES = {
+    smaller: 0.8,
+    small: 1,
+    medium: 1.36,
+    large: 1.72,
+    larger: 2,
+    extralarge: 2.2
+};
+
+export const DEFAULT_TEXT_SCALE = LEGACY_TEXT_SIZE_SCALES.medium;
+
+const MIN_TEXT_SCALE = 0.1;
+const MAX_TEXT_SCALE = 10;
+
+/**
+ * Resolves the effective text scale factor from appearance settings.
+ * Prefers the continuous textScale value; falls back to legacy discrete values.
+ * @param {object} settings - Subtitle appearance settings.
+ * @returns {number} Text scale factor in em units.
+ */
+export function resolveTextScale(settings) {
+    const scale = Number(settings?.textScale);
+
+    if (Number.isFinite(scale) && scale > 0) {
+        return Math.min(Math.max(scale, MIN_TEXT_SCALE), MAX_TEXT_SCALE);
+    }
+
+    return LEGACY_TEXT_SIZE_SCALES[settings?.textSize || 'medium'] ?? DEFAULT_TEXT_SCALE;
+}
+
 function getTextStyles(settings, preview) {
     const list = [];
 
-    switch (settings.textSize || '') {
-        case 'smaller':
-            list.push({ name: 'font-size', value: '.8em' });
-            break;
-        case 'small':
-            list.push({ name: 'font-size', value: 'inherit' });
-            break;
-        case 'larger':
-            list.push({ name: 'font-size', value: '2em' });
-            break;
-        case 'extralarge':
-            list.push({ name: 'font-size', value: '2.2em' });
-            break;
-        case 'large':
-            list.push({ name: 'font-size', value: '1.72em' });
-            break;
-        case 'medium':
-        default:
-            list.push({ name: 'font-size', value: '1.36em' });
-            break;
-    }
+    list.push({ name: 'font-size', value: `${resolveTextScale(settings)}em` });
 
     switch (settings.textWeight || '') {
         case 'bold':

--- a/src/components/subtitlesettings/subtitleappearancehelper.test.js
+++ b/src/components/subtitlesettings/subtitleappearancehelper.test.js
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
     DEFAULT_TEXT_SCALE,
-    LEGACY_TEXT_SIZE_SCALES,
     resolveTextScale,
     getStyles
 } from './subtitleappearancehelper';
@@ -9,10 +8,6 @@ import {
 describe('resolveTextScale', () => {
     it('uses the continuous textScale value when present', () => {
         expect(resolveTextScale({ textScale: 1.65 })).toBe(1.65);
-    });
-
-    it('accepts string values that parse to a number', () => {
-        expect(resolveTextScale({ textScale: '1.2' })).toBe(1.2);
     });
 
     it('clamps extreme continuous values', () => {
@@ -25,7 +20,16 @@ describe('resolveTextScale', () => {
         expect(resolveTextScale({ textScale: -2 })).toBe(DEFAULT_TEXT_SCALE);
     });
 
-    it.each(Object.entries(LEGACY_TEXT_SIZE_SCALES))('maps legacy size "%s" to %s', (legacy, expected) => {
+    // Pinned to literals: this mapping is the compatibility contract that keeps
+    // existing users' saved sizes rendering identically after the upgrade.
+    it.each([
+        ['smaller', 0.8],
+        ['small', 1],
+        ['medium', 1.36],
+        ['large', 1.72],
+        ['larger', 2],
+        ['extralarge', 2.2]
+    ])('maps legacy size "%s" to %s', (legacy, expected) => {
         expect(resolveTextScale({ textSize: legacy })).toBe(expected);
     });
 

--- a/src/components/subtitlesettings/subtitleappearancehelper.test.js
+++ b/src/components/subtitlesettings/subtitleappearancehelper.test.js
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import {
+    DEFAULT_TEXT_SCALE,
+    LEGACY_TEXT_SIZE_SCALES,
+    resolveTextScale,
+    getStyles
+} from './subtitleappearancehelper';
+
+describe('resolveTextScale', () => {
+    it('uses the continuous textScale value when present', () => {
+        expect(resolveTextScale({ textScale: 1.65 })).toBe(1.65);
+    });
+
+    it('accepts string values that parse to a number', () => {
+        expect(resolveTextScale({ textScale: '1.2' })).toBe(1.2);
+    });
+
+    it('clamps extreme continuous values', () => {
+        expect(resolveTextScale({ textScale: 0.01 })).toBe(0.1);
+        expect(resolveTextScale({ textScale: 100 })).toBe(10);
+    });
+
+    it('ignores non-finite and negative values', () => {
+        expect(resolveTextScale({ textScale: Number.NaN })).toBe(DEFAULT_TEXT_SCALE);
+        expect(resolveTextScale({ textScale: -2 })).toBe(DEFAULT_TEXT_SCALE);
+    });
+
+    it.each(Object.entries(LEGACY_TEXT_SIZE_SCALES))('maps legacy size "%s" to %s', (legacy, expected) => {
+        expect(resolveTextScale({ textSize: legacy })).toBe(expected);
+    });
+
+    it('maps an unset legacy size to the previous default', () => {
+        expect(resolveTextScale({})).toBe(1.36);
+        expect(resolveTextScale({ textSize: '' })).toBe(1.36);
+    });
+
+    it('falls back to the default for unknown legacy sizes', () => {
+        expect(resolveTextScale({ textSize: 'gigantic' })).toBe(DEFAULT_TEXT_SCALE);
+    });
+
+    it('prefers textScale over legacy textSize', () => {
+        expect(resolveTextScale({ textScale: 2, textSize: 'smaller' })).toBe(2);
+    });
+});
+
+describe('getStyles text sizing', () => {
+    function getFontSize(settings) {
+        const styles = getStyles(settings).text;
+        return styles.find((style) => style.name === 'font-size').value;
+    }
+
+    it('emits the continuous scale as em units', () => {
+        expect(getFontSize({ textScale: 0.9 })).toBe('0.9em');
+    });
+
+    it('emits legacy sizes as equivalent em units', () => {
+        expect(getFontSize({ textSize: 'extralarge' })).toBe('2.2em');
+        expect(getFontSize({})).toBe('1.36em');
+    });
+});

--- a/src/components/subtitlesettings/subtitlesettings.js
+++ b/src/components/subtitlesettings/subtitlesettings.js
@@ -30,7 +30,7 @@ function getSubtitleAppearanceObject(context) {
     return {
         aspectMode: context.querySelector('#selectBitmapSubtitleAspectMode').value,
         subtitleStyling: context.querySelector('#selectSubtitleStyling').value,
-        textScale: parseFloat(context.querySelector('#sliderTextSize').value),
+        textScale: Number.parseFloat(context.querySelector('#sliderTextSize').value),
         textWeight: context.querySelector('#selectTextWeight').value,
         dropShadow: context.querySelector('#selectDropShadow').value,
         font: context.querySelector('#selectFont').value,

--- a/src/components/subtitlesettings/subtitlesettings.js
+++ b/src/components/subtitlesettings/subtitlesettings.js
@@ -6,7 +6,7 @@ import appSettings from '../../scripts/settings/appSettings';
 import focusManager from '../focusManager';
 import layoutManager from '../layoutManager';
 import loading from '../loading/loading';
-import subtitleAppearanceHelper from './subtitleappearancehelper';
+import subtitleAppearanceHelper, { resolveTextScale } from './subtitleappearancehelper';
 import settingsHelper from '../settingshelper';
 import dom from '../../utils/dom';
 import Events from '../../utils/events.ts';
@@ -30,7 +30,7 @@ function getSubtitleAppearanceObject(context) {
     return {
         aspectMode: context.querySelector('#selectBitmapSubtitleAspectMode').value,
         subtitleStyling: context.querySelector('#selectSubtitleStyling').value,
-        textSize: context.querySelector('#selectTextSize').value,
+        textScale: parseFloat(context.querySelector('#sliderTextSize').value),
         textWeight: context.querySelector('#selectTextWeight').value,
         dropShadow: context.querySelector('#selectDropShadow').value,
         font: context.querySelector('#selectFont').value,
@@ -66,7 +66,7 @@ function loadForm(context, user, userSettings, appearanceSettings, apiClient) {
 
         context.querySelector('#selectSubtitleStyling').value = appearanceSettings.subtitleStyling || 'Auto';
         context.querySelector('#selectSubtitleStyling').dispatchEvent(new CustomEvent('change', {}));
-        context.querySelector('#selectTextSize').value = appearanceSettings.textSize || '';
+        context.querySelector('#sliderTextSize').value = resolveTextScale(appearanceSettings);
         context.querySelector('#selectTextWeight').value = appearanceSettings.textWeight || 'normal';
         context.querySelector('#selectDropShadow').value = appearanceSettings.dropShadow || '';
         context.querySelector('#inputTextBackground').value = appearanceSettings.textBackground || 'transparent';
@@ -84,7 +84,7 @@ function loadForm(context, user, userSettings, appearanceSettings, apiClient) {
         context.querySelector('#chkAlwaysBurnInSubtitleWhenTranscoding').checked = appSettings.alwaysBurnInSubtitleWhenTranscoding();
 
         onAppearanceFieldChange({
-            target: context.querySelector('#selectTextSize')
+            target: context.querySelector('#sliderTextSize')
         });
 
         loading.hide();
@@ -216,7 +216,6 @@ function embed(options, self) {
     options.element.querySelector('#selectSubtitleStyling').addEventListener('change', onSubtitleStyleChange);
     options.element.querySelector('#selectSubtitleBurnIn').addEventListener('change', onSubtitleBurnInChange);
     options.element.querySelector('#chkSubtitleRenderPgs').addEventListener('change', onSubtitleRenderPgsChange);
-    options.element.querySelector('#selectTextSize').addEventListener('change', onAppearanceFieldChange);
     options.element.querySelector('#selectTextWeight').addEventListener('change', onAppearanceFieldChange);
     options.element.querySelector('#selectDropShadow').addEventListener('change', onAppearanceFieldChange);
     options.element.querySelector('#selectFont').addEventListener('change', onAppearanceFieldChange);
@@ -238,6 +237,10 @@ function embed(options, self) {
         const sliderVerticalPosition = options.element.querySelector('#sliderVerticalPosition');
         sliderVerticalPosition.addEventListener('input', onAppearanceFieldChange);
         sliderVerticalPosition.addEventListener('input', () => showSubtitlePreview.call(self));
+
+        const sliderTextSize = options.element.querySelector('#sliderTextSize');
+        sliderTextSize.addEventListener('input', onAppearanceFieldChange);
+        sliderTextSize.addEventListener('input', () => showSubtitlePreview.call(self));
 
         const eventPrefix = window.PointerEvent ? 'pointer' : 'mouse';
         sliderVerticalPosition.addEventListener(`${eventPrefix}enter`, () => showSubtitlePreview.call(self, true));

--- a/src/components/subtitlesettings/subtitlesettings.template.html
+++ b/src/components/subtitlesettings/subtitlesettings.template.html
@@ -97,15 +97,11 @@
             <div class="fieldDescription subtitleStylingNativeHelp subtitleStylingHelp hide">${NativeSubtitleStylingHelp}</div>
         </div>
 
-        <div class="selectContainer">
-            <select is="emby-select" id="selectTextSize" label="${LabelTextSize}">
-                <option value="smaller">${Smaller}</option>
-                <option value="small">${Small}</option>
-                <option value="">${Normal}</option>
-                <option value="large">${Large}</option>
-                <option value="larger">${Larger}</option>
-                <option value="extralarge">${ExtraLarge}</option>
-            </select>
+        <div class="sliderContainer-settings">
+            <div class="sliderContainer">
+                <input is="emby-slider" id="sliderTextSize" label="${LabelTextSize}" type="range" min="0.25" max="2.5" step="0.05" />
+            </div>
+            <div class="fieldDescription">${LabelTextSizeHelp}</div>
         </div>
 
         <div class="selectContainer">

--- a/src/components/subtitlesettings/subtitlesettings.template.html
+++ b/src/components/subtitlesettings/subtitlesettings.template.html
@@ -99,7 +99,7 @@
 
         <div class="sliderContainer-settings">
             <div class="sliderContainer">
-                <input is="emby-slider" id="sliderTextSize" label="${LabelTextSize}" type="range" min="0.25" max="2.5" step="0.05" />
+                <input is="emby-slider" id="sliderTextSize" label="${LabelTextSize}" aria-label="${LabelTextSize}" type="range" min="0.25" max="2.5" step="0.05" />
             </div>
             <div class="fieldDescription">${LabelTextSizeHelp}</div>
         </div>

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1019,6 +1019,7 @@
     "LabelTextBackgroundColor": "Text background color",
     "LabelTextColor": "Text color",
     "LabelTextSize": "Text size",
+    "LabelTextSizeHelp": "Scale of subtitle text relative to the video. 1.36 approximates the previous default.",
     "LabelTextWeight": "Text weight",
     "Bold": "Bold",
     "LabelTheme": "Theme",


### PR DESCRIPTION
### Changes
Replaces the six discrete subtitle Text size options with a continuous slider (0.25–2.5, step 0.05). The selected scale is stored as a `textScale` float in the existing subtitle appearance settings JSON, so previously saved discrete values keep working and resolve to their equivalent position automatically ("Large" → 1.72)  no reset or migration needed for current users, and older clients are unaffected since the legacy keys are untouched. Rendering is unchanged (same em-based styling through `subtitleAppearanceHelper`), only the granularity differs. Includes unit tests for the scale resolution/migration mapping.

<img width="1268" height="560" alt="image" src="https://github.com/user-attachments/assets/7c7567ab-9cef-4f5c-bec8-514df71dda81" />


### Issues
Related to #3794 (continuous sizing request, closed stale) and #558. Same UX Android TV shipped in jhttps://github.com/jellyfin/jellyfin-androidtv/pull/4175 

### Code assistance
Implemented with the help of an LLM coding assistant (design exploration, implementation of slider/migration/tests). All changes reviewed and tested locally by me: unit suite (`vitest`, 177 passing incl. 15 new tests), `eslint`, `tsc --noEmit`, production build, and manual playback testing in Chrome/Firefox.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
