### PR TITLE
Declare npm package manager version

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Web interface for Jellyfin",
   "repository": "https://github.com/jellyfin/jellyfin-web",
   "license": "GPL-2.0-or-later",
+  "packageManager": "npm@11.17.0",
   "devDependencies": {
     "@babel/core": "7.29.7",
     "@babel/plugin-transform-modules-umd": "7.29.7",


### PR DESCRIPTION
## Changes
- Adds packageManager metadata for npm 11.17.0, matching the repository's Node 24/npm 11 engine requirement.

## Why
This helps Corepack-aware environments and contributors select the expected package manager version instead of accidentally using npm from an older Node install.

## Validation
- env PATH="/opt/homebrew/opt/node@24/bin:$PATH" npm install --package-lock-only --ignore-scripts
- env PATH="/opt/homebrew/opt/node@24/bin:$PATH" npm run build:check
- git diff --check
