### PR TITLE
Add bundle size reporting script

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,6 +163,7 @@
     "build:analyze": "cross-env NODE_ENV=\"production\" webpack --config webpack.analyze.js",
     "build:development": "webpack --config webpack.dev.js",
     "build:production": "cross-env NODE_ENV=\"production\" webpack --config webpack.prod.js",
+    "build:report": "node scripts/report-bundle-size.mjs",
     "build:check": "tsc --noEmit",
     "build:es-check": "npm run build:production && npm run escheck",
     "escheck": "es-check",

--- a/scripts/report-bundle-size.mjs
+++ b/scripts/report-bundle-size.mjs
@@ -1,0 +1,61 @@
+import { readdir, stat } from 'node:fs/promises';
+import path from 'node:path';
+
+const root = process.argv[2] || 'dist';
+const limit = Number.parseInt(process.env.BUNDLE_REPORT_LIMIT || '25', 10);
+
+async function walk(dir) {
+    const entries = await readdir(dir, { withFileTypes: true });
+    const files = [];
+
+    for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name);
+
+        if (entry.isDirectory()) {
+            files.push(...await walk(fullPath));
+        } else if (entry.isFile()) {
+            const fileStat = await stat(fullPath);
+            files.push({
+                path: path.relative(root, fullPath),
+                size: fileStat.size
+            });
+        }
+    }
+
+    return files;
+}
+
+function formatBytes(bytes) {
+    const units = ['B', 'KiB', 'MiB', 'GiB'];
+    let size = bytes;
+    let unitIndex = 0;
+
+    while (size >= 1024 && unitIndex < units.length - 1) {
+        size /= 1024;
+        unitIndex++;
+    }
+
+    return `${size.toFixed(unitIndex === 0 ? 0 : 1)} ${units[unitIndex]}`;
+}
+
+try {
+    const files = await walk(root);
+    const total = files.reduce((sum, file) => sum + file.size, 0);
+    const largest = files
+        .sort((a, b) => b.size - a.size)
+        .slice(0, limit);
+
+    console.log(`Bundle root: ${root}`);
+    console.log(`Total files: ${files.length}`);
+    console.log(`Total size: ${formatBytes(total)}`);
+    console.log('');
+    console.log(`Largest ${largest.length} files:`);
+
+    for (const file of largest) {
+        console.log(`${formatBytes(file.size).padStart(10)}  ${file.path}`);
+    }
+} catch (err) {
+    console.error(`Unable to read bundle output from ${root}. Run a build first.`);
+    console.error(err instanceof Error ? err.message : err);
+    process.exitCode = 1;
+}


### PR DESCRIPTION
## Changes
- Adds npm run build:report to summarize built asset counts, total size, and largest files in dist.
- Uses a dependency-free Node script so it works with the current Webpack output and can continue to work during a future Vite migration.

## Why
Jellyfin Web already emits Webpack size warnings, but modernization work needs a repeatable summary that can be copied into PRs or CI logs.

## Validation
- env PATH="/opt/homebrew/opt/node@24/bin:$PATH" npm run build:report
- env PATH="/opt/homebrew/opt/node@24/bin:$PATH" node --check scripts/report-bundle-size.mjs
- env PATH="/opt/homebrew/opt/node@24/bin:$PATH" npm run build:check
- git diff --check
