### PR TITLE
Invalidate packages when adding a repository

### DIFF
--- a/src/apps/dashboard/features/plugins/api/useSetRepositories.ts
+++ b/src/apps/dashboard/features/plugins/api/useSetRepositories.ts
@@ -16,6 +16,12 @@ export const useSetRepositories = () => {
             void queryClient.invalidateQueries({
                 queryKey: [ QueryKey.Repositories ]
             });
+            void queryClient.invalidateQueries({
+                queryKey: [ QueryKey.Plugins ]
+            });
+            void queryClient.invalidateQueries({
+                queryKey: [ QueryKey.Packages ]
+            });
         }
     });
 };


### PR DESCRIPTION
When adding a new repository, the new plugins won't show up until the cache goes stale.

### Changes
Invalidate packages and plugins when a new repository is added

### Issues
N/A

### Code assistance
None

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
