### PR TITLE
Fix flex alignment for JMP

### DIFF
--- a/src/apps/dashboard/routes/plugins/index.tsx
+++ b/src/apps/dashboard/routes/plugins/index.tsx
@@ -133,7 +133,7 @@ export const Component = () => {
                         <Box
                             sx={{
                                 display: 'flex',
-                                justifyContent: 'end',
+                                justifyContent: 'flex-end',
                                 marginTop: {
                                     xs: 2,
                                     sm: 0

--- a/src/apps/modern/features/libraries/components/AlphabetPicker.tsx
+++ b/src/apps/modern/features/libraries/components/AlphabetPicker.tsx
@@ -42,7 +42,7 @@ const AlphabetPicker: React.FC<AlphabetPickerProps> = ({
                 fontSize: '80%',
                 display: 'flex',
                 alignItems: {
-                    xs: 'start',
+                    xs: 'flex-start',
                     sm: 'center'
                 },
                 // This should render under the main AppBar if overlapping

--- a/src/apps/modern/features/libraries/components/LibraryToolbar.tsx
+++ b/src/apps/modern/features/libraries/components/LibraryToolbar.tsx
@@ -128,7 +128,7 @@ const LibraryToolbar: FC = () => {
                     sx={{
                         justifyContent: {
                             xs: 'auto',
-                            sm: 'end'
+                            sm: 'flex-end'
                         },
                         flexBasis: {
                             xs: '100%',


### PR DESCRIPTION
### Changes
Layout in JMP is a bit broken in places because it does not support the flex alignment properties that exclude the `flex-` prefix

### Issues
None (reported in matrix)

### Code assistance
Zed autocomplete

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
