### PR TITLE
Fix stale position in SyncPlay ready report after seek

### DIFF
--- a/src/plugins/htmlVideoPlayer/plugin.js
+++ b/src/plugins/htmlVideoPlayer/plugin.js
@@ -1989,6 +1989,9 @@ export class HtmlVideoPlayer {
         if (mediaElement) {
             if (val != null) {
                 mediaElement.currentTime = val / 1000;
+                // Update the cached position immediately so readers such as the
+                // SyncPlay ready report see the seek target, not the pre-seek time.
+                this.#currentTime = val / 1000;
                 return;
             }
 


### PR DESCRIPTION
### Changes

`HtmlVideoPlayer.currentTime(val)` sets `mediaElement.currentTime` but leaves the cached `#currentTime` at the pre-seek value until the next `timeupdate` event. SyncPlay reads that cache when it sends its ready report after a seek. When the seek lands in unbuffered data (typical for direct play of a large file over WAN), the report goes out before the first `timeupdate` at the new position and carries the old position. The server then computes a delay equal to the seek distance and schedules the group to resume that far in the future, so a five minute skip freezes the group for five minutes.

This updates the cached position in the setter so the ready report carries the seek target.

Before (Jellyfin 10.11.11 server log, two web clients, one skip forward of about five minutes during playback):

```
Group ... switching from Playing to Waiting.
Session ... got lost in time, correcting.
Session ... will pause when ready in 304.8158268 seconds. Group ... is waiting for all ready events.
Session ... is recovering, group ... will resume in 304.8100486 seconds.
```

After, same setup and same skips:

```
Group ... switching from Playing to Waiting.
Session ... will pause when ready in -0.0519125 seconds. Group ... is waiting for all ready events.
Session ... resumed playback, group ... has 1 seconds to recover.
Group ... switching from Waiting to Playing.
```

Repro: create a SyncPlay group with two web clients playing a direct-play MP4, skip forward several minutes while playing, and watch the server log for the `will resume in` / `will pause when ready in` values.

### Issues

Related: jellyfin/jellyfin#16241 (erratic SyncPlay playback, auto-pauses and skips after seeking).

### Code assistance

The diagnosis (reading the server log, tracing the ready report to the cached position in `HtmlVideoPlayer`) and this patch were produced with an AI coding assistant (Claude Code). The change was built into jellyfin-web 10.11.11 and tested manually against a Jellyfin 10.11.11 server with two web clients before and after.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
