### PR TITLE
Fix default styling when themes are not loaded

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="preload" dir="ltr">
+<html dir="ltr">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover">
@@ -53,8 +53,9 @@
             cursor: none !important;
         }
 
-        .preload {
+        html {
             background-color: #101010;
+            color: rgba(255, 255, 255, 0.7);
         }
 
         .hide,


### PR DESCRIPTION
### Changes
Fixes the default styles when themes fail to load. This is most noticeable when the app crashes and the error boundary screen shows the page has the default dark background and the browser default (black) text. Adding the text color while keeping the `preload` class caused it to override the theme color since the themes target `html` directly. This is the only usage of the class so it was easiest to just remove the `preload` class entirely so the theme overrides work properly.

(For reference the screenshot here demonstrates the issue: https://github.com/jellyfin/jellyfin-web/issues/8301#issuecomment-5408987035)

### Issues
None

### Code assistance
Zed autocomplete maybe

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
