### PR TITLE
Fix too large video osd header padding

### DIFF
--- a/src/apps/modern/routes/video/index.tsx
+++ b/src/apps/modern/routes/video/index.tsx
@@ -70,7 +70,7 @@ const VideoPage: FC = () => {
                                 <RemotePlayButton />
                             </>
                         }
-                        className='padded-left padded-right'
+                        className='videoOsd-appBar'
                     >
                         <Typography>{videoTitle}</Typography>
                     </AppToolbar>

--- a/src/styles/videoosd.scss
+++ b/src/styles/videoosd.scss
@@ -1,4 +1,11 @@
-@use 'mixins' as *;
+@use "mixins" as *;
+
+.videoOsd-appBar {
+    margin-left: env(safe-area-inset-left);
+    margin-right: env(safe-area-inset-right);
+    padding-left: 1em;
+    padding-right: 1em;
+}
 
 .chapterThumbTextContainer,
 .videoOsdBottom {


### PR DESCRIPTION
### Changes
Fixes the video player osd header/appBar using too large of padding in comparison to the footer

This is a small regression from a recent change I made to make the app bar padding consistent with the page content

### Issues
N/A

### Code assistance
Zed autocomplete

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
