### PR TITLE
Add global localized alphabet navigation

### DIFF
--- a/src/apps/dashboard/routes/settings/index.tsx
+++ b/src/apps/dashboard/routes/settings/index.tsx
@@ -26,6 +26,11 @@ import { getSystemApi } from '@jellyfin/sdk/lib/utils/api/system-api';
 import { queryClient } from 'utils/query/queryClient';
 import { ActionData } from 'types/actionData';
 
+interface LocalizedAlphabetConfiguration {
+    EnableLocalizedAlphabetNavigation?: boolean;
+    LocalizedAlphabetAdditionalScripts?: string[] | null;
+}
+
 export const action = async ({ request }: ActionFunctionArgs) => {
     const api = ServerConnections.getApi();
     if (!api) throw new Error('No Api instance available');
@@ -35,6 +40,15 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
     config.ServerName = formData.get('ServerName')?.toString();
     config.UICulture = formData.get('UICulture')?.toString();
+    const localizedAlphabetConfig = config as typeof config & LocalizedAlphabetConfiguration;
+    localizedAlphabetConfig.EnableLocalizedAlphabetNavigation =
+        formData.get('EnableLocalizedAlphabetNavigation')?.toString() === 'on';
+    const additionalScripts = (localizedAlphabetConfig.LocalizedAlphabetAdditionalScripts ?? [])
+        .filter(script => script !== 'Latn');
+    localizedAlphabetConfig.LocalizedAlphabetAdditionalScripts =
+        formData.get('IncludeLatinAlphabet')?.toString() === 'on' ?
+            [...additionalScripts, 'Latn'] :
+            additionalScripts;
     config.CachePath = formData.get('CachePath')?.toString();
     config.MetadataPath = formData.get('MetadataPath')?.toString();
     config.QuickConnectAvailable = formData.get('QuickConnectAvailable')?.toString() === 'on';
@@ -73,6 +87,7 @@ export const Component = () => {
     const isSubmitting = navigation.state === 'submitting';
     const [ cachePath, setCachePath ] = useState<string | null | undefined>('');
     const [ metadataPath, setMetadataPath ] = useState<string | null | undefined>('');
+    const localizedAlphabetConfig = config as typeof config & LocalizedAlphabetConfiguration;
 
     const onCachePathChange = useCallback((event: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
         setCachePath(event.target.value);
@@ -176,6 +191,27 @@ export const Component = () => {
                                     <MenuItem key={language.Name} value={language.Value || ''}>{language.Name}</MenuItem>
                                 )}
                             </TextField>
+
+                            <FormControl>
+                                <FormControlLabel
+                                    control={
+                                        <Checkbox
+                                            name='EnableLocalizedAlphabetNavigation'
+                                            defaultChecked={localizedAlphabetConfig.EnableLocalizedAlphabetNavigation}
+                                        />
+                                    }
+                                    label={globalize.translate('UseLocalizedAlphabetNavigation')}
+                                />
+                                <FormControlLabel
+                                    control={
+                                        <Checkbox
+                                            name='IncludeLatinAlphabet'
+                                            defaultChecked={localizedAlphabetConfig.LocalizedAlphabetAdditionalScripts?.includes('Latn')}
+                                        />
+                                    }
+                                    label={globalize.translate('IncludeLatinAlphabet')}
+                                />
+                            </FormControl>
 
                             <Typography variant='h2'>{globalize.translate('HeaderPaths')}</Typography>
 

--- a/src/apps/modern/features/libraries/components/AlphabetPicker.tsx
+++ b/src/apps/modern/features/libraries/components/AlphabetPicker.tsx
@@ -5,18 +5,63 @@ import Paper from '@mui/material/Paper';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 
+import type { AlphabetPickerGroup } from '../utils/alphabet';
+
 import 'components/alphaPicker/style.scss';
 
 interface AlphabetPickerProps {
     value?: string | null;
     onChange: (value: string | null | undefined) => void;
+    groups?: AlphabetPickerGroup[];
 }
 
 const LETTER_VALUES = ['#', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'];
 
-const AlphabetPicker: React.FC<AlphabetPickerProps> = ({
+const AlphabetButtons = ({
+    values,
     value,
     onChange
+}: {
+    values: string[];
+    value?: string | null;
+    onChange: (event: React.MouseEvent<HTMLElement>, value: string | null | undefined) => void;
+}) => (
+    <ToggleButtonGroup
+        orientation='vertical'
+        value={value}
+        exclusive
+        color='primary'
+        size='small'
+        onChange={onChange}
+    >
+        {values.map((letter) => (
+            <ToggleButton
+                key={letter}
+                value={letter}
+                sx={{
+                    borderWidth: 0,
+                    paddingTop: {
+                        xs: 0,
+                        md: 0.25
+                    },
+                    paddingBottom: {
+                        xs: 0,
+                        md: 0.25
+                    },
+                    paddingLeft: 0.5,
+                    paddingRight: 0.5
+                }}
+            >
+                {letter}
+            </ToggleButton>
+        ))}
+    </ToggleButtonGroup>
+);
+
+const AlphabetPicker: React.FC<AlphabetPickerProps> = ({
+    value,
+    onChange,
+    groups
 }) => {
     const handleValue = useCallback(
         (
@@ -27,6 +72,8 @@ const AlphabetPicker: React.FC<AlphabetPickerProps> = ({
         },
         [onChange]
     );
+
+    const localizedGroups = groups?.length ? groups : undefined;
 
     return (
         <Box
@@ -45,48 +92,37 @@ const AlphabetPicker: React.FC<AlphabetPickerProps> = ({
                     xs: 'flex-start',
                     sm: 'center'
                 },
+                gap: localizedGroups ? 0.25 : undefined,
                 // This should render under the main AppBar if overlapping
                 zIndex: theme.zIndex.appBar - 1
             })}
         >
-            <Paper
-                elevation={0}
-                sx={{
-                    borderRadius: 1,
-                    overflow: 'hidden'
-                }}
-            >
-                <ToggleButtonGroup
-                    orientation='vertical'
-                    value={value}
-                    exclusive
-                    color='primary'
-                    size='small'
-                    onChange={handleValue}
+            {!localizedGroups ? (
+                <Paper
+                    elevation={0}
+                    sx={{
+                        borderRadius: 1,
+                        overflow: 'hidden'
+                    }}
                 >
-                    {LETTER_VALUES.map((l) => (
-                        <ToggleButton
-                            key={l}
-                            value={l}
-                            sx={{
-                                borderWidth: 0,
-                                paddingTop: {
-                                    xs: 0,
-                                    md: 0.25
-                                },
-                                paddingBottom: {
-                                    xs: 0,
-                                    md: 0.25
-                                },
-                                paddingLeft: 0.5,
-                                paddingRight: 0.5
-                            }}
-                        >
-                            {l}
-                        </ToggleButton>
-                    ))}
-                </ToggleButtonGroup>
-            </Paper>
+                    <AlphabetButtons values={LETTER_VALUES} value={value} onChange={handleValue} />
+                </Paper>
+            ) : localizedGroups.map((group, groupIndex) => (
+                <Paper
+                    key={group.id}
+                    elevation={0}
+                    sx={{
+                        borderRadius: 1,
+                        overflow: 'hidden'
+                    }}
+                >
+                    <AlphabetButtons
+                        values={groupIndex === 0 ? ['#', ...group.values] : group.values}
+                        value={value}
+                        onChange={handleValue}
+                    />
+                </Paper>
+            ))}
         </Box>
     );
 };

--- a/src/apps/modern/features/libraries/components/GenresItemsContainer.tsx
+++ b/src/apps/modern/features/libraries/components/GenresItemsContainer.tsx
@@ -6,11 +6,14 @@ import { useIntersectionObserver } from 'usehooks-ts';
 
 import NoItemsMessage from 'components/common/NoItemsMessage';
 import Loading from 'components/loading/LoadingComponent';
+import { useSystemInfo } from 'hooks/useSystemInfo';
 import type { ParentId } from 'types/library';
+import { LibraryTab } from 'types/libraryTab';
 
 import { useGenres } from '../hooks/api/useGenres';
-import GenresSectionContainer from './GenresSectionContainer';
+import { getAlphabetNavigationSettings, getLocalizedAlphabetGroups } from '../utils/alphabet';
 import AlphabetPicker from './AlphabetPicker';
+import GenresSectionContainer from './GenresSectionContainer';
 
 interface GenresItemsContainerProps {
     parentId: ParentId;
@@ -24,6 +27,15 @@ const GenresItemsContainer: FC<GenresItemsContainerProps> = ({
     itemType
 }) => {
     const [alphabet, setAlphabet] = useState<string | null>();
+    const { data: systemInfo } = useSystemInfo();
+    const alphabetNavigationSettings = useMemo(
+        () => getAlphabetNavigationSettings(systemInfo),
+        [systemInfo]
+    );
+    const alphabetGroups = useMemo(
+        () => getLocalizedAlphabetGroups(alphabetNavigationSettings, LibraryTab.Genres),
+        [alphabetNavigationSettings]
+    );
     const {
         isLoading,
         data,
@@ -33,7 +45,9 @@ const GenresItemsContainer: FC<GenresItemsContainerProps> = ({
     } = useGenres({
         parentId,
         includeItemTypes: itemType,
-        alphabet
+        alphabet,
+        alphabetNavigationSettings,
+        enabled: Boolean(systemInfo)
     });
 
     const genres = useMemo(
@@ -50,6 +64,10 @@ const GenresItemsContainer: FC<GenresItemsContainerProps> = ({
             void fetchNextPage();
         }
     }, [isIntersecting, hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+    if (!systemInfo) {
+        return <Loading />;
+    }
 
     // No genres at all (no letter filter active) - nothing to pick from
     if (!isLoading && !genres.length && alphabet == null) {
@@ -85,7 +103,11 @@ const GenresItemsContainer: FC<GenresItemsContainerProps> = ({
 
     return (
         <>
-            <AlphabetPicker value={alphabet} onChange={setAlphabet} />
+            <AlphabetPicker
+                value={alphabet}
+                onChange={setAlphabet}
+                groups={alphabetGroups}
+            />
 
             {renderGenres()}
         </>

--- a/src/apps/modern/features/libraries/components/ItemsView.tsx
+++ b/src/apps/modern/features/libraries/components/ItemsView.tsx
@@ -6,6 +6,7 @@ import React, { type FC, SetStateAction, useCallback, useMemo } from 'react';
 
 import { useLibrary } from 'apps/modern/features/libraries/hooks/useLibrary';
 import { getDefaultLibraryViewSettings } from 'apps/modern/features/libraries/utils/settings';
+import { getAlphabetNavigationSettings, getLocalizedAlphabetGroups } from 'apps/modern/features/libraries/utils/alphabet';
 import Cards from 'components/cardbuilder/Card/Cards';
 import { CardShape } from 'components/cardbuilder/utils/shape';
 import NoItemsMessage from 'components/common/NoItemsMessage';
@@ -14,6 +15,7 @@ import Loading from 'components/loading/LoadingComponent';
 import { ItemAction } from 'constants/itemAction';
 import ItemsContainer from 'elements/emby-itemscontainer/ItemsContainer';
 import { useApi } from 'hooks/useApi';
+import { useSystemInfo } from 'hooks/useSystemInfo';
 import type { CardOptions } from 'types/cardOptions';
 import { type LibraryViewSettings, ViewMode } from 'types/library';
 import { LibraryTab } from 'types/libraryTab';
@@ -49,6 +51,7 @@ const ItemsView: FC = () => {
     ].join(', '));
 
     const { __legacyApiClient__, user } = useApi();
+    const { data: systemInfo } = useSystemInfo();
 
     // The query key for all items for the current user.
     // This should be used to invalidate queries that affect multiple parents, such as collections and playlists.
@@ -192,6 +195,14 @@ const ItemsView: FC = () => {
     }, [setLibraryViewSettings]);
 
     const hasSortName = !libraryViewSettings.SortBy.includes(ItemSortBy.Random);
+    const alphabetNavigationSettings = useMemo(
+        () => getAlphabetNavigationSettings(systemInfo),
+        [systemInfo]
+    );
+    const alphabetGroups = useMemo(
+        () => getLocalizedAlphabetGroups(alphabetNavigationSettings, viewType),
+        [alphabetNavigationSettings, viewType]
+    );
 
     const itemsContainerClass = classNames(
         'padded-left padded-right',
@@ -206,6 +217,7 @@ const ItemsView: FC = () => {
                 <AlphabetPicker
                     value={libraryViewSettings.Alphabet}
                     onChange={handleAlphabetChange}
+                    groups={alphabetGroups}
                 />
             )}
 

--- a/src/apps/modern/features/libraries/hooks/api/useGenres.ts
+++ b/src/apps/modern/features/libraries/hooks/api/useGenres.ts
@@ -10,14 +10,23 @@ import type { AxiosRequestConfig } from 'axios';
 import { useApi } from 'hooks/useApi';
 import type { ItemDtoQueryResult } from 'types/base/models/item-dto-query-result';
 import type { ParentId } from 'types/library';
+import { LibraryTab } from 'types/libraryTab';
+
+import {
+    type AlphabetNavigationSettings,
+    getAlphabetFilter,
+    getAlphabetNavigationSettings
+} from '../../utils/alphabet';
 
 export const GENRES_PAGE_SIZE = 10;
 
 interface GenresParams {
     parentId?: ParentId;
     includeItemTypes?: BaseItemKind[];
-    /** Filter by the first letter of the genre name; '#' matches everything sorting before 'A'. */
+    /** Filter by the first letter of the genre name; '#' matches the Other bucket in localized mode. */
     alphabet?: string | null;
+    alphabetNavigationSettings?: AlphabetNavigationSettings;
+    enabled?: boolean;
     userId?: string;
 }
 
@@ -34,30 +43,48 @@ const fetchGenres = async (
 export const getGenresQuery = (
     api?: Api,
     params: GenresParams = {}
-) => infiniteQueryOptions({
-    queryKey: ['Genres', params.parentId, params.includeItemTypes, params.alphabet],
-    queryFn: ({ pageParam, signal }) => fetchGenres(
-        api!,
-        {
-            userId: params.userId,
-            includeItemTypes: params.includeItemTypes,
-            parentId: params.parentId ?? undefined,
-            sortBy: [ItemSortBy.SortName],
-            sortOrder: [SortOrder.Ascending],
-            nameLessThan: params.alphabet === '#' ? 'A' : undefined,
-            nameStartsWith: params.alphabet === '#' ? undefined : (params.alphabet ?? undefined),
-            enableTotalRecordCount: false,
-            startIndex: pageParam * GENRES_PAGE_SIZE,
-            limit: GENRES_PAGE_SIZE
-        },
-        { signal }
-    ),
-    initialPageParam: 0,
-    // Stop once a page returns fewer items than requested (cheaper than enabling total record count)
-    getNextPageParam: (lastPage, allPages) =>
-        (lastPage?.Items?.length ?? 0) < GENRES_PAGE_SIZE ? undefined : allPages.length,
-    enabled: !!api && !!params.userId && !!params.parentId
-});
+) => {
+    const alphabetNavigationSettings = params.alphabetNavigationSettings
+        ?? getAlphabetNavigationSettings();
+    const alphabetFilter = getAlphabetFilter(
+        params.alphabet,
+        alphabetNavigationSettings,
+        LibraryTab.Genres
+    );
+
+    return infiniteQueryOptions({
+        queryKey: [
+            'Genres',
+            params.parentId,
+            params.includeItemTypes,
+            params.alphabet,
+            alphabetNavigationSettings
+        ],
+        queryFn: ({ pageParam, signal }) => fetchGenres(
+            api!,
+            {
+                userId: params.userId,
+                includeItemTypes: params.includeItemTypes,
+                parentId: params.parentId ?? undefined,
+                sortBy: [ItemSortBy.SortName],
+                sortOrder: [SortOrder.Ascending],
+                ...alphabetFilter.query,
+                enableTotalRecordCount: false,
+                startIndex: pageParam * GENRES_PAGE_SIZE,
+                limit: GENRES_PAGE_SIZE
+            },
+            {
+                signal,
+                params: alphabetFilter.params
+            }
+        ),
+        initialPageParam: 0,
+        // Stop once a page returns fewer items than requested (cheaper than enabling total record count)
+        getNextPageParam: (lastPage, allPages) =>
+            (lastPage?.Items?.length ?? 0) < GENRES_PAGE_SIZE ? undefined : allPages.length,
+        enabled: params.enabled !== false && !!api && !!params.userId && !!params.parentId
+    });
+};
 
 /** Hook for fetching genres. */
 export const useGenres = (params?: GenresParams) => {

--- a/src/apps/modern/features/libraries/utils/alphabet.test.ts
+++ b/src/apps/modern/features/libraries/utils/alphabet.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+
+import { LibraryTab } from 'types/libraryTab';
+
+import {
+    getAlphabetFilter,
+    getAlphabetNavigationSettings,
+    getLocalizedAlphabetGroups,
+    getPrimaryAlphabetDefinition
+} from './alphabet';
+
+const russian = {
+    enabled: true,
+    locale: 'ru-RU',
+    additionalScripts: []
+};
+
+const greek = {
+    enabled: true,
+    locale: 'el-GR',
+    additionalScripts: []
+};
+
+describe('localized alphabet navigation', () => {
+    it('keeps Greek Ψ and Ω at the end of the native alphabet', () => {
+        const values = getPrimaryAlphabetDefinition('el-GR')?.values ?? [];
+        expect(values.at(-2)).toBe('Ψ');
+        expect(values.at(-1)).toBe('Ω');
+    });
+
+    it('preserves the Russian alphabet order including Ё, Ч and Я', () => {
+        const values = getPrimaryAlphabetDefinition('ru-RU')?.values ?? [];
+        expect(values.indexOf('Ё')).toBe(values.indexOf('Е') + 1);
+        expect(values.indexOf('Ч')).toBeGreaterThan(values.indexOf('Ц'));
+        expect(values.at(-1)).toBe('Я');
+    });
+
+    it('keeps legacy filters unchanged while the global feature is disabled', () => {
+        const filter = getAlphabetFilter(
+            '#',
+            { enabled: false, locale: 'ru-RU', additionalScripts: [] },
+            LibraryTab.Movies
+        );
+
+        expect(filter.params).toBeUndefined();
+        expect(filter.query).toEqual({ nameLessThan: 'A', nameStartsWith: undefined });
+    });
+
+    it('sends native initial ordering even when no bucket is selected', () => {
+        const filter = getAlphabetFilter(null, russian, LibraryTab.Movies);
+        const order = filter.params?.nameInitialSortOrder?.split(',') ?? [];
+
+        expect(order[0]).toBe('А');
+        expect(order.indexOf('Ч')).toBeGreaterThan(order.indexOf('Ц'));
+        expect(order.at(-1)).toBe('Я');
+    });
+
+    it('filters Greek titles by their native initial', () => {
+        const filter = getAlphabetFilter('Ω', greek, LibraryTab.Movies);
+        expect(filter.params?.nameInitials).toBe('Ω');
+    });
+
+    it('uses # as Other while preserving the same native sort order', () => {
+        const filter = getAlphabetFilter('#', russian, LibraryTab.Movies);
+
+        expect(filter.params?.excludeNameInitials).toBe(filter.params?.nameInitialSortOrder);
+        expect(filter.params?.excludeNameInitials).toContain('Ё');
+    });
+
+    it('appends Latin after the primary alphabet when Latn is enabled', () => {
+        const settings = { ...greek, additionalScripts: ['Latn'] };
+        const groups = getLocalizedAlphabetGroups(settings, LibraryTab.Movies);
+        const filter = getAlphabetFilter(null, settings, LibraryTab.Movies);
+        const order = filter.params?.nameInitialSortOrder?.split(',') ?? [];
+
+        expect(groups).toHaveLength(2);
+        expect(groups?.[0].values.at(-1)).toBe('Ω');
+        expect(groups?.[1].values[0]).toBe('A');
+        expect(order.indexOf('A')).toBeGreaterThan(order.indexOf('Ω'));
+    });
+
+    it('does not guess an ambiguous additional alphabet from a script code', () => {
+        const groups = getLocalizedAlphabetGroups(
+            { ...greek, additionalScripts: ['Cyrl'] },
+            LibraryTab.Movies
+        );
+        expect(groups).toHaveLength(1);
+    });
+
+    it('uses Latin only for known Latin locales', () => {
+        expect(getPrimaryAlphabetDefinition('en-US')?.id).toBe('latin');
+        expect(getPrimaryAlphabetDefinition('hy-AM')).toBeUndefined();
+        expect(getPrimaryAlphabetDefinition('ckb')).toBeUndefined();
+        expect(getPrimaryAlphabetDefinition('te-IN')).toBeUndefined();
+    });
+
+    it('falls back to the legacy API for unsupported locales', () => {
+        const filter = getAlphabetFilter(
+            'A',
+            { enabled: true, locale: 'hy-AM', additionalScripts: [] },
+            LibraryTab.Movies
+        );
+        expect(filter.params).toBeUndefined();
+        expect(filter.query.nameStartsWith).toBe('A');
+    });
+
+    it('reads the global server configuration from SystemInfo', () => {
+        expect(getAlphabetNavigationSettings({
+            EnableLocalizedAlphabetNavigation: true,
+            LocalizedAlphabetLocale: 'el-GR',
+            LocalizedAlphabetAdditionalScripts: ['Latn']
+        })).toEqual({
+            enabled: true,
+            locale: 'el-GR',
+            additionalScripts: ['Latn']
+        });
+    });
+
+    it('keeps endpoints without native-initial support on the legacy API path', () => {
+        for (const viewType of [LibraryTab.Authors, LibraryTab.Channels, LibraryTab.SeriesTimers]) {
+            const filter = getAlphabetFilter('O', russian, viewType);
+            expect(filter.params).toBeUndefined();
+            expect(filter.query.nameStartsWith).toBe('O');
+        }
+    });
+});

--- a/src/apps/modern/features/libraries/utils/alphabet.ts
+++ b/src/apps/modern/features/libraries/utils/alphabet.ts
@@ -1,0 +1,230 @@
+import { LibraryTab } from 'types/libraryTab';
+
+export interface AlphabetPickerGroup {
+    id: string;
+    values: string[];
+}
+
+interface AlphabetDefinition extends AlphabetPickerGroup {
+    localePrefixes: string[];
+    script: string;
+}
+
+export interface AlphabetNavigationSettings {
+    enabled: boolean;
+    locale: string;
+    additionalScripts: string[];
+}
+
+interface AlphabetNavigationSystemInfo {
+    EnableLocalizedAlphabetNavigation?: boolean;
+    LocalizedAlphabetLocale?: string | null;
+    LocalizedAlphabetAdditionalScripts?: string[] | null;
+}
+
+interface LegacyAlphabetQuery {
+    nameLessThan?: string;
+    nameStartsWith?: string;
+}
+
+interface AlphabetFilter {
+    query: LegacyAlphabetQuery;
+    params?: Record<string, string>;
+}
+
+const LATIN: AlphabetDefinition = {
+    id: 'latin',
+    script: 'Latn',
+    localePrefixes: [],
+    values: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('')
+};
+
+const GREEK: AlphabetDefinition = {
+    id: 'greek',
+    script: 'Grek',
+    localePrefixes: ['el'],
+    values: 'ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΤΥΦΧΨΩ'.split('')
+};
+
+const CYRILLIC_RU: AlphabetDefinition = {
+    id: 'cyrillic-ru',
+    script: 'Cyrl',
+    localePrefixes: ['ru'],
+    values: 'АБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ'.split('')
+};
+
+const CYRILLIC_UK: AlphabetDefinition = {
+    id: 'cyrillic-uk',
+    script: 'Cyrl',
+    localePrefixes: ['uk'],
+    values: 'АБВГҐДЕЄЖЗИІЇЙКЛМНОПРСТУФХЦЧШЩЬЮЯ'.split('')
+};
+
+const CYRILLIC_BE: AlphabetDefinition = {
+    id: 'cyrillic-be',
+    script: 'Cyrl',
+    localePrefixes: ['be'],
+    values: 'АБВГДЕЁЖЗІЙКЛМНОПРСТУЎФХЦЧШЫЬЭЮЯ'.split('')
+};
+
+const CYRILLIC_BG: AlphabetDefinition = {
+    id: 'cyrillic-bg',
+    script: 'Cyrl',
+    localePrefixes: ['bg'],
+    values: 'АБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЬЮЯ'.split('')
+};
+
+const DEFINITIONS = [GREEK, CYRILLIC_RU, CYRILLIC_UK, CYRILLIC_BE, CYRILLIC_BG, LATIN];
+
+// Only locales whose alphabet can be represented safely by A-Z should use the
+// Latin picker implicitly. Unknown locales remain on the legacy picker until a
+// proper alphabet definition is added.
+const LATIN_LOCALE_PREFIXES = new Set([
+    'af', 'az', 'br', 'bs', 'ca', 'ch', 'cs', 'cy', 'da', 'de', 'en', 'eo',
+    'es', 'et', 'eu', 'fi', 'fil', 'fo', 'fr', 'ga', 'gl', 'hr', 'hu', 'id',
+    'is', 'it', 'lb', 'lt', 'lv', 'ms', 'mt', 'nb', 'nl', 'nn', 'pl', 'pt',
+    'ro', 'sk', 'sl', 'sq', 'sv', 'sw', 'tr', 'uz', 'vi'
+]);
+
+// Additional scripts need a single unambiguous alphabet definition. Some
+// scripts (for example Cyrillic) differ by locale, so they should not be
+// guessed here until the UI can select a concrete alphabet definition.
+const ADDITIONAL_DEFINITIONS: Record<string, AlphabetDefinition> = {
+    Latn: LATIN
+};
+
+const LOCALIZED_ALPHABET_VIEW_TYPES = new Set<LibraryTab>([
+    LibraryTab.Albums,
+    LibraryTab.AlbumArtists,
+    LibraryTab.Artists,
+    LibraryTab.Books,
+    LibraryTab.Collections,
+    LibraryTab.Episodes,
+    LibraryTab.Favorites,
+    LibraryTab.Folders,
+    LibraryTab.Genres,
+    LibraryTab.Mixed,
+    LibraryTab.Movies,
+    LibraryTab.MusicVideos,
+    LibraryTab.PhotoAlbums,
+    LibraryTab.Photos,
+    LibraryTab.Playlists,
+    LibraryTab.Series,
+    LibraryTab.Songs,
+    LibraryTab.Studios,
+    LibraryTab.Videos
+]);
+
+const normalizeLocale = (locale: string) => locale.replace(/_/g, '-').toLowerCase();
+
+const getLegacyAlphabetQuery = (alphabet?: string | null): LegacyAlphabetQuery => ({
+    nameLessThan: alphabet === '#' ? 'A' : undefined,
+    nameStartsWith: alphabet === '#' ? undefined : (alphabet ?? undefined)
+});
+
+export const getAlphabetNavigationSettings = (
+    systemInfo?: unknown
+): AlphabetNavigationSettings => {
+    const info = systemInfo as AlphabetNavigationSystemInfo | undefined;
+    return {
+        enabled: Boolean(info?.EnableLocalizedAlphabetNavigation),
+        locale: info?.LocalizedAlphabetLocale ?? '',
+        additionalScripts: info?.LocalizedAlphabetAdditionalScripts ?? []
+    };
+};
+
+export const getPrimaryAlphabetDefinition = (locale: string): AlphabetPickerGroup | undefined => {
+    const normalizedLocale = normalizeLocale(locale);
+    const definition = DEFINITIONS.find(candidate =>
+        candidate.localePrefixes.some(prefix =>
+            normalizedLocale === prefix || normalizedLocale.startsWith(`${prefix}-`)
+        )
+    );
+
+    if (definition) {
+        return definition;
+    }
+
+    const localeParts = normalizedLocale.split('-');
+    if (localeParts.includes('latn') || LATIN_LOCALE_PREFIXES.has(localeParts[0])) {
+        return LATIN;
+    }
+
+    return undefined;
+};
+
+export const supportsLocalizedAlphabetNavigation = (
+    viewType: LibraryTab,
+    settings: AlphabetNavigationSettings
+) => LOCALIZED_ALPHABET_VIEW_TYPES.has(viewType)
+    && Boolean(getPrimaryAlphabetDefinition(settings.locale));
+
+const getEnabledAlphabets = (
+    settings: AlphabetNavigationSettings,
+    viewType: LibraryTab
+): AlphabetDefinition[] => {
+    if (!settings.enabled || !supportsLocalizedAlphabetNavigation(viewType, settings)) {
+        return [];
+    }
+
+    const primary = getPrimaryAlphabetDefinition(settings.locale);
+    if (!primary) {
+        return [];
+    }
+
+    const primaryDefinition = DEFINITIONS.find(definition => definition.id === primary.id);
+    if (!primaryDefinition) {
+        return [];
+    }
+
+    const definitions = [primaryDefinition];
+    for (const script of settings.additionalScripts) {
+        const definition = ADDITIONAL_DEFINITIONS[script];
+        if (definition && !definitions.some(candidate => candidate.id === definition.id)) {
+            definitions.push(definition);
+        }
+    }
+
+    return definitions;
+};
+
+export const getLocalizedAlphabetGroups = (
+    settings: AlphabetNavigationSettings,
+    viewType: LibraryTab
+): AlphabetPickerGroup[] | undefined => {
+    const enabled = getEnabledAlphabets(settings, viewType);
+    return enabled.length > 0 ?
+        enabled.map(({ id, values }) => ({ id, values })) :
+        undefined;
+};
+
+export const getAlphabetFilter = (
+    selectedAlphabet: string | null | undefined,
+    settings: AlphabetNavigationSettings,
+    viewType: LibraryTab
+): AlphabetFilter => {
+    const enabled = getEnabledAlphabets(settings, viewType);
+    if (enabled.length === 0) {
+        return { query: getLegacyAlphabetQuery(selectedAlphabet) };
+    }
+
+    const orderedInitials = [...new Set(enabled.flatMap(alphabet => alphabet.values))];
+    const params: Record<string, string> = {
+        nameInitialSortOrder: orderedInitials.join(',')
+    };
+
+    if (!selectedAlphabet) {
+        return { query: {}, params };
+    }
+
+    if (selectedAlphabet === '#') {
+        params.excludeNameInitials = orderedInitials.join(',');
+        return { query: {}, params };
+    }
+
+    if (orderedInitials.includes(selectedAlphabet)) {
+        params.nameInitials = selectedAlphabet;
+    }
+
+    return { query: {}, params };
+};

--- a/src/hooks/useFetchItems.ts
+++ b/src/hooks/useFetchItems.ts
@@ -21,7 +21,9 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 import datetime from 'scripts/datetime';
 
 import { type JellyfinApiContext, useApi } from './useApi';
-import { getAlphaPickerQuery, getFieldsQuery, getFiltersQuery, getLimitQuery } from 'utils/items';
+import { useSystemInfo } from './useSystemInfo';
+import { getFieldsQuery, getFiltersQuery, getLimitQuery } from 'utils/items';
+import { getAlphabetFilter, getAlphabetNavigationSettings, type AlphabetNavigationSettings } from 'apps/modern/features/libraries/utils/alphabet';
 import { getProgramSections, getSuggestionSections } from 'utils/sections';
 
 import type { LibraryViewSettings, ParentId } from 'types/library';
@@ -192,10 +194,20 @@ const fetchGetItemsViewByType = async (
     parentId: ParentId,
     itemType: BaseItemKind[],
     libraryViewSettings: LibraryViewSettings,
+    alphabetNavigationSettings: AlphabetNavigationSettings,
     options?: AxiosRequestConfig
 ) => {
     const { api, user } = currentApi;
     if (api && user?.Id && viewType) {
+        const alphabetFilter = getAlphabetFilter(
+            libraryViewSettings.Alphabet,
+            alphabetNavigationSettings,
+            viewType
+        );
+        const requestOptions: AxiosRequestConfig = {
+            signal: options?.signal,
+            params: alphabetFilter.params
+        };
         const isFavorite = libraryViewSettings.Filters?.Status?.includes(ItemFilter.IsFavorite) || undefined;
         let response;
         switch (viewType) {
@@ -208,15 +220,13 @@ const fetchGetItemsViewByType = async (
                         ...getFieldsQuery(viewType, libraryViewSettings),
                         ...getFiltersQuery(viewType, libraryViewSettings),
                         ...getLimitQuery(),
-                        ...getAlphaPickerQuery(libraryViewSettings),
+                        ...alphabetFilter.query,
                         sortBy: libraryViewSettings.SortBy,
                         sortOrder: [libraryViewSettings.SortOrder],
                         includeItemTypes: itemType,
                         startIndex: libraryViewSettings.StartIndex
                     },
-                    {
-                        signal: options?.signal
-                    }
+                    requestOptions
                 );
                 break;
             }
@@ -229,15 +239,13 @@ const fetchGetItemsViewByType = async (
                         ...getFieldsQuery(viewType, libraryViewSettings),
                         ...getFiltersQuery(viewType, libraryViewSettings),
                         ...getLimitQuery(),
-                        ...getAlphaPickerQuery(libraryViewSettings),
+                        ...alphabetFilter.query,
                         sortBy: libraryViewSettings.SortBy,
                         sortOrder: [libraryViewSettings.SortOrder],
                         includeItemTypes: itemType,
                         startIndex: libraryViewSettings.StartIndex
                     },
-                    {
-                        signal: options?.signal
-                    }
+                    requestOptions
                 );
                 break;
             }
@@ -250,13 +258,11 @@ const fetchGetItemsViewByType = async (
                         fields: [ItemFields.PrimaryImageAspectRatio],
                         filters: libraryViewSettings?.Filters?.Status,
                         ...getLimitQuery(),
-                        ...getAlphaPickerQuery(libraryViewSettings),
+                        ...alphabetFilter.query,
                         personTypes: [PersonKind.Author],
                         startIndex: libraryViewSettings.StartIndex
                     },
-                    {
-                        signal: options?.signal
-                    }
+                    requestOptions
                 );
                 break;
             }
@@ -267,15 +273,13 @@ const fetchGetItemsViewByType = async (
                         parentId: parentId ?? undefined,
                         ...getFieldsQuery(viewType, libraryViewSettings),
                         ...getLimitQuery(),
-                        ...getAlphaPickerQuery(libraryViewSettings),
+                        ...alphabetFilter.query,
                         includeItemTypes: itemType,
                         isFavorite,
                         enableImageTypes: [ImageType.Thumb],
                         startIndex: libraryViewSettings.StartIndex
                     },
-                    {
-                        signal: options?.signal
-                    }
+                    requestOptions
                 );
                 break;
             case LibraryTab.Channels: {
@@ -287,9 +291,7 @@ const fetchGetItemsViewByType = async (
                         isFavorite,
                         enableImageTypes: [ImageType.Primary]
                     },
-                    {
-                        signal: options?.signal
-                    }
+                    requestOptions
                 );
                 break;
             }
@@ -304,15 +306,13 @@ const fetchGetItemsViewByType = async (
                         ...getFieldsQuery(viewType, libraryViewSettings),
                         ...getFiltersQuery(viewType, libraryViewSettings),
                         ...getLimitQuery(),
-                        ...getAlphaPickerQuery(libraryViewSettings),
+                        ...alphabetFilter.query,
                         sortBy: libraryViewSettings.SortBy,
                         sortOrder: [libraryViewSettings.SortOrder],
                         includeItemTypes: itemType,
                         startIndex: libraryViewSettings.StartIndex
                     },
-                    {
-                        signal: options?.signal
-                    }
+                    requestOptions
                 );
                 break;
             }
@@ -322,9 +322,7 @@ const fetchGetItemsViewByType = async (
                         sortBy: 'SortName',
                         sortOrder: SortOrder.Ascending
                     },
-                    {
-                        signal: options?.signal
-                    }
+                    requestOptions
                 );
                 break;
             default: {
@@ -338,16 +336,14 @@ const fetchGetItemsViewByType = async (
                         ...getFieldsQuery(viewType, libraryViewSettings),
                         ...getFiltersQuery(viewType, libraryViewSettings),
                         ...getLimitQuery(),
-                        ...getAlphaPickerQuery(libraryViewSettings),
+                        ...alphabetFilter.query,
                         isFavorite: viewType === LibraryTab.Favorites ? true : undefined,
                         sortBy: libraryViewSettings.SortBy,
                         sortOrder: [libraryViewSettings.SortOrder],
                         includeItemTypes: itemType,
                         startIndex: libraryViewSettings.StartIndex
                     },
-                    {
-                        signal: options?.signal
-                    }
+                    requestOptions
                 );
                 break;
             }
@@ -365,6 +361,8 @@ export const useGetItemsViewByType = (
     libraryViewSettings: LibraryViewSettings
 ) => {
     const currentApi = useApi();
+    const { data: systemInfo } = useSystemInfo();
+    const alphabetNavigationSettings = getAlphabetNavigationSettings(systemInfo);
     return useQuery({
         queryKey: [
             'User',
@@ -375,7 +373,8 @@ export const useGetItemsViewByType = (
             viewType,
             {
                 itemType,
-                libraryViewSettings
+                libraryViewSettings,
+                alphabetNavigationSettings
             }
         ],
         queryFn: ({ signal }) =>
@@ -385,10 +384,11 @@ export const useGetItemsViewByType = (
                 parentId,
                 itemType,
                 libraryViewSettings!,
+                alphabetNavigationSettings,
                 { signal }
             ),
         refetchOnWindowFocus: false,
-        enabled: !!currentApi.api && !!currentApi.user?.Id
+        enabled: !!currentApi.api && !!currentApi.user?.Id && !!systemInfo
             && viewType
             && [
                 LibraryTab.Movies,

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1945,5 +1945,7 @@
     "LabelPlayerSizes": "Player sizes",
     "LabelPlaybackQuality": "Frame dropped / corrupted",
     "AudioLanguages": "Audio languages",
-    "SubtitleLanguages": "Subtitle languages"
+    "SubtitleLanguages": "Subtitle languages",
+    "UseLocalizedAlphabetNavigation": "Use localized alphabet navigation",
+    "IncludeLatinAlphabet": "Include Latin alphabet (A–Z)"
 }


### PR DESCRIPTION
### Changes

Adds the Jellyfin Web client-side implementation for localized alphabet navigation described in jellyfin/jellyfin#17733.

This depends on the corresponding server-side API changes in:

jellyfin/jellyfin#<SERVER_PR_NUMBER>

The feature is opt-in and disabled by default.

When disabled, the existing alphabet picker and legacy `# / A-Z` filtering behavior remain unchanged.

When enabled, Jellyfin Web:

- selects the primary alphabet from the server UI locale;
- displays the locale's native alphabet instead of forcing navigation through transliterated `A-Z`;
- keeps `#` as the `Other` bucket;
- optionally displays an additional Latin `A-Z` alphabet;
- sends the native alphabet order to the server so groups remain in their actual alphabet order rather than the order produced by transliterated `SortName`;
- applies the same localized navigation to the separate Genres view;
- falls back to the existing legacy picker for unsupported locales and API paths.

For example, with Greek as the UI locale:

```text
# Α Β Γ Δ Ε Ζ Η Θ Ι Κ Λ Μ Ν Ξ Ο Π Ρ Σ Τ Υ Φ Χ Ψ Ω
```

A Greek title such as:

```text
Ωμέγα
```

is navigated through:

```text
Ω
```

instead of only through its transliterated `SortName`:

```text
omega → O
```

If Latin is additionally enabled, a second alphabet is displayed:

```text
Greek:
# Α Β Γ ... Ψ Ω

Latin:
A B C ... Y Z
```

so:

```text
Ωμέγα → Ω
Omega → O
```

The localized `#` button represents items whose native initial does not belong to any enabled alphabet.

#### Configuration

Two global controls are added to Dashboard → General, directly below the existing display-language setting:

- `Use localized alphabet navigation`
- `Include Latin alphabet (A–Z)`

These settings are server-wide rather than stored separately for each media library.

The primary alphabet follows the existing Jellyfin `UICulture`.

Changing the Latin option only adds or removes the `Latn` script and preserves any other configured additional-script values.

#### Supported alphabets

The client currently defines native alphabets for:

- Greek
- Russian
- Ukrainian
- Belarusian
- Bulgarian
- Latin

For locales whose alphabet is not explicitly supported, Jellyfin Web retains the existing legacy alphabet navigation instead of guessing an incorrect alphabet.

#### API behavior

The Web client uses the new server query primitives:

```text
nameInitials
excludeNameInitials
nameInitialSortOrder
```

`nameInitialSortOrder` is sent even when no individual letter is selected so the complete item list is grouped in native alphabet order.

Selecting a native letter sends `nameInitials`.

Selecting `#` sends `excludeNameInitials` for all enabled alphabet initials.

The existing `nameStartsWith` / `nameLessThan` behavior is preserved for the legacy path.

Authors and other endpoints that do not support the new server primitives continue to use the existing legacy behavior.

#### SDK compatibility

All API requests continue to use the Jellyfin TypeScript SDK endpoint clients.

The currently published generated SDK does not yet expose the new server fields and query parameters from the companion server PR, so this change temporarily:

- uses narrow local interfaces for the new configuration/SystemInfo properties;
- passes the new query parameters through the SDK method's `AxiosRequestConfig.params`.

These compatibility bridges can be removed once a generated SDK containing the companion server API changes is available.

#### Localization

Only the source-language `en-us` translation file is changed in this PR.

Translations for other languages should be added through Weblate according to the Jellyfin Web contribution guidelines.

#### Testing

Validated with the same quality checks used by Jellyfin Web CI:

```text
npm run lint
npm run stylelint
npm run build:check
npm run test
npm run build:es-check
```

The tests cover:

- legacy behavior while the feature is disabled;
- Greek alphabet ordering;
- localized `#` / `Other`;
- additional Latin navigation;
- native initial ordering without a selected letter;
- Cyrillic alphabet ordering, including locale-specific letters;
- unsupported-locale fallback;
- SystemInfo configuration mapping;
- unsupported API paths remaining on the legacy behavior.

The implementation was also manually tested against a mixed-script media library together with the companion server changes.

### Issues

Related to jellyfin/jellyfin#17733

Depends on jellyfin/jellyfin#17742

### Code assistance

OpenAI Codex was used to assist with implementation, codebase analysis, debugging, test generation, and review of the changes.

The resulting changes were manually reviewed and validated with the Jellyfin Web lint, type-check, test, production-build, and browser-compatibility checks.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A%22merge+conflict%22+-label%3Astale+-author%3A%40me).