### PR TITLE
Prevent duplicate SyncPlay Ready requests after seeks

### DIFF
--- a/src/plugins/syncPlay/core/Helper.js
+++ b/src/plugins/syncPlay/core/Helper.js
@@ -17,18 +17,13 @@ export const TicksPerMillisecond = 10000.0;
  * Waits for an event to be triggered on an object. An optional timeout can specified after which the promise is rejected.
  * @param {Object} emitter Object on which to listen for events.
  * @param {string} eventType Event name to listen for.
- * @param {number} timeout Time before rejecting promise if event does not trigger, in milliseconds.
- * @param {Array} rejectEventTypes Event names to listen for and abort the waiting.
+ * @param {number} [timeout] Time before rejecting promise if event does not trigger, in milliseconds.
+ * @param {string[]} [rejectEventTypes] Event names to listen for and abort the waiting.
  * @returns {Promise} A promise that resolves when the event is triggered.
  */
 export function waitForEventOnce(emitter, eventType, timeout, rejectEventTypes) {
     return new Promise((resolve, reject) => {
         let rejectTimeout;
-        if (timeout) {
-            rejectTimeout = setTimeout(() => {
-                reject(new Error('Timed out.'));
-            }, timeout);
-        }
 
         const clearAll = () => {
             Events.off(emitter, eventType, callback);
@@ -60,6 +55,13 @@ export function waitForEventOnce(emitter, eventType, timeout, rejectEventTypes) 
             rejectEventTypes.forEach(eventName => {
                 Events.on(emitter, eventName, rejectCallback);
             });
+        }
+
+        if (timeout) {
+            rejectTimeout = setTimeout(() => {
+                clearAll();
+                reject(new Error('Timed out.'));
+            }, timeout);
         }
     });
 }

--- a/src/plugins/syncPlay/core/Helper.test.ts
+++ b/src/plugins/syncPlay/core/Helper.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { waitForEventOnce } from './Helper';
+
+describe('SyncPlay Helper', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('removes the event listener after timing out', async () => {
+        vi.useFakeTimers();
+        const emitter: { _callbacks?: Record<string, unknown[]> } = {};
+        const eventPromise = waitForEventOnce(emitter, 'ready', 100);
+        const rejection = expect(eventPromise).rejects.toThrow('Timed out.');
+
+        expect(emitter._callbacks?.ready).toHaveLength(1);
+
+        await vi.advanceTimersByTimeAsync(100);
+        await rejection;
+
+        expect(emitter._callbacks?.ready).toHaveLength(0);
+    });
+});

--- a/src/plugins/syncPlay/core/PlaybackCore.js
+++ b/src/plugins/syncPlay/core/PlaybackCore.js
@@ -8,6 +8,8 @@ import { toBoolean, toFloat } from '../../../utils/string.ts';
 import * as Helper from './Helper';
 import { getSetting } from './Settings';
 
+const SeekWaitCancelledEvent = 'seek-wait-cancelled';
+
 /**
  * Class that manages the playback of SyncPlay.
  */
@@ -26,6 +28,8 @@ class PlaybackCore {
         this.lastCommand = null; // Last scheduled playback command, might not be the latest one.
         this.scheduledCommandTimeout = null;
         this.syncTimeout = null;
+        this.seekIsPending = false;
+        this.seekWaitGeneration = 0;
 
         this.loadPreferences();
     }
@@ -113,8 +117,11 @@ class PlaybackCore {
      */
     onReady() {
         this.playerIsBuffering = false;
-        this.sendBufferingRequest(false);
+        const seekIsPending = this.seekIsPending;
         Events.trigger(this.manager, 'ready');
+        if (!seekIsPending) {
+            this.sendBufferingRequest(false);
+        }
     }
 
     /**
@@ -386,16 +393,34 @@ class PlaybackCore {
         const seekAtTimeLocal = this.timeSyncCore.remoteDateToLocal(seekAtTime);
 
         const callback = () => {
-            this.localUnpause();
-            this.localSeek(positionTicks);
+            const seekWaitGeneration = this.seekWaitGeneration;
+            this.seekIsPending = true;
 
-            Helper.waitForEventOnce(this.manager, 'ready', Helper.WaitForEventDefaultTimeout).then(() => {
+            Helper.waitForEventOnce(
+                this.manager,
+                'ready',
+                Helper.WaitForEventDefaultTimeout,
+                [SeekWaitCancelledEvent]
+            ).then(() => {
+                if (this.seekWaitGeneration !== seekWaitGeneration) {
+                    return;
+                }
+
+                this.seekIsPending = false;
                 this.localPause();
                 this.sendBufferingRequest(false);
             }).catch((error) => {
+                if (error === SeekWaitCancelledEvent || this.seekWaitGeneration !== seekWaitGeneration) {
+                    return;
+                }
+
+                this.seekIsPending = false;
                 console.error(`Timed out while waiting for 'ready' event! Seeking to ${positionTicks}.`, error);
                 this.localSeek(positionTicks);
             });
+
+            this.localUnpause();
+            this.localSeek(positionTicks);
         };
 
         if (seekAtTimeLocal > currentTime) {
@@ -415,6 +440,9 @@ class PlaybackCore {
     clearScheduledCommand() {
         clearTimeout(this.scheduledCommandTimeout);
         clearTimeout(this.syncTimeout);
+        this.seekIsPending = false;
+        this.seekWaitGeneration++;
+        Events.trigger(this.manager, SeekWaitCancelledEvent);
 
         this.syncEnabled = false;
         const playerWrapper = this.manager.getPlayerWrapper();

--- a/src/plugins/syncPlay/core/PlaybackCore.test.ts
+++ b/src/plugins/syncPlay/core/PlaybackCore.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import PlaybackCore from './PlaybackCore';
+
+vi.mock('./Settings', () => ({
+    getSetting: vi.fn()
+}));
+
+function createPlaybackCore() {
+    let isPlaying = false;
+    const requestSyncPlayReady = vi.fn();
+    const playerWrapper = {
+        currentTime: vi.fn(() => 10),
+        hasPlaybackRate: vi.fn(() => false),
+        isPlaying: vi.fn(() => isPlaying),
+        localPause: vi.fn(() => {
+            isPlaying = false;
+        }),
+        localSeek: vi.fn(),
+        localUnpause: vi.fn(() => {
+            isPlaying = true;
+        })
+    };
+    const timeSyncCore = {
+        localDateToRemote: vi.fn((date: Date) => date),
+        remoteDateToLocal: vi.fn((date: Date) => date)
+    };
+    const manager: Record<string, unknown> & {
+        _callbacks?: Record<string, unknown[]>
+    } = {
+        clearSyncIcon: vi.fn(),
+        getApiClient: vi.fn(() => ({ requestSyncPlayReady })),
+        getPlayerWrapper: vi.fn(() => playerWrapper),
+        getQueueCore: vi.fn(() => ({
+            getCurrentPlaylistItemId: vi.fn(() => 'playlist-item')
+        })),
+        getTimeSyncCore: vi.fn(() => timeSyncCore),
+        isPlaybackActive: vi.fn(() => true)
+    };
+    const playbackCore = new PlaybackCore();
+    playbackCore.init(manager);
+
+    return {
+        manager,
+        playbackCore,
+        playerWrapper,
+        requestSyncPlayReady
+    };
+}
+
+describe('SyncPlay PlaybackCore', () => {
+    it('reports ready only once when a seek completes', async () => {
+        const {
+            playbackCore,
+            playerWrapper,
+            requestSyncPlayReady
+        } = createPlaybackCore();
+
+        playbackCore.scheduleSeek(new Date(0), 100_000);
+        playbackCore.onReady();
+        await Promise.resolve();
+
+        expect(playerWrapper.localPause).toHaveBeenCalledOnce();
+        expect(requestSyncPlayReady).toHaveBeenCalledOnce();
+        expect(requestSyncPlayReady).toHaveBeenCalledWith(expect.objectContaining({
+            IsPlaying: false
+        }));
+    });
+
+    it('keeps only the latest seek ready listener', async () => {
+        const { manager, playbackCore, playerWrapper } = createPlaybackCore();
+
+        playbackCore.scheduleSeek(new Date(0), 100_000);
+        playbackCore.scheduleSeek(new Date(0), 200_000);
+
+        expect(manager._callbacks?.ready).toHaveLength(1);
+
+        playbackCore.onReady();
+        await Promise.resolve();
+
+        expect(playerWrapper.localPause).toHaveBeenCalledOnce();
+    });
+
+    it('ignores a completed seek wait that is superseded before settling', async () => {
+        const {
+            playbackCore,
+            playerWrapper,
+            requestSyncPlayReady
+        } = createPlaybackCore();
+
+        playbackCore.scheduleSeek(new Date(0), 100_000);
+        playbackCore.onReady();
+        playbackCore.scheduleSeek(new Date(0), 200_000);
+        await Promise.resolve();
+
+        expect(playerWrapper.localPause).not.toHaveBeenCalled();
+        expect(requestSyncPlayReady).not.toHaveBeenCalled();
+
+        playbackCore.onReady();
+        await Promise.resolve();
+
+        expect(playerWrapper.localPause).toHaveBeenCalledOnce();
+        expect(requestSyncPlayReady).toHaveBeenCalledOnce();
+    });
+});


### PR DESCRIPTION
### Changes

Prevents SyncPlay seeks from sending duplicate `Ready` requests. Superseded seek listeners are cancelled using a generation guard, while `waitForEventOnce` now removes its event listeners after a timeout. Regression tests cover duplicate requests, stale listeners, superseded seeks, and timeout cleanup.

### Issues

Related to jellyfin/jellyfin#16241

### Code assistance

OpenAI Codex was used to review and explain the SyncPlay event flow and to verify the change with tests, linting, and TypeScript checks and writes the code based on my instructions

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A%22merge+conflict%22+-label%3Astale+-author%3A%40me).
