### PR TITLE
Cover empty media segment input

### DIFF
--- a/src/apps/legacy/features/playback/utils/mediaSegments.test.ts
+++ b/src/apps/legacy/features/playback/utils/mediaSegments.test.ts
@@ -65,4 +65,8 @@ describe('findCurrentSegment()', () => {
         segmentDetails = findCurrentSegment(TEST_SEGMENTS, 100);
         expect(segmentDetails).toBeUndefined();
     });
+
+    it('Should return undefined for empty segments', () => {
+        expect(findCurrentSegment([], 0)).toBeUndefined();
+    });
 });

--- a/src/apps/legacy/features/playback/utils/mediaSegments.ts
+++ b/src/apps/legacy/features/playback/utils/mediaSegments.ts
@@ -20,6 +20,8 @@ export const isInSegment = (segment: MediaSegmentDto, time: number) => (
 );
 
 export const findCurrentSegment = (segments: MediaSegmentDto[], time: number, lastIndex = 0) => {
+    if (!segments.length) return;
+
     const lastSegment = segments[lastIndex];
     if (isInSegment(lastSegment, time)) {
         return { index: lastIndex, segment: lastSegment };


### PR DESCRIPTION
### Changes
- Add focused regression coverage for `findCurrentSegment([])`.
- Return `undefined` immediately when no media segments are available, preventing an empty-input TypeError.

### Issues
None.

### Code assistance
Code assistance was used to inspect the existing helper and test fixtures, identify the empty-input dereference, and validate the focused test in the repository's pinned Node.js 24 container.

---

* [x] I have read and followed the contributing guidelines.
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a substantive review of another web PR.

<!-- repo-agent-case:e26366a1-eac7-46bd-a90f-3b441b90d505 -->