### PR TITLE
Refresh cached resume positions for EPUB books and comics

### DIFF
--- a/src/plugins/bookPlayer/plugin.js
+++ b/src/plugins/bookPlayer/plugin.js
@@ -1,3 +1,4 @@
+import { getBookResumePosition } from '../../utils/bookPlayerResume';
 import { getLibraryApi } from '@jellyfin/sdk/lib/utils/api/library-api';
 
 import { PluginType } from 'constants/pluginType';
@@ -55,7 +56,11 @@ export class BookPlayer {
         this.toggleFullscreen = this.toggleFullscreen.bind(this);
     }
 
-    play(options) {
+    async play(options) {
+        const item = options.items[0];
+        const startPositionTicks = await getBookResumePosition(
+            ServerConnections.getApiClient(item.ServerId), item, options.startPositionTicks
+        );
         this.progress = 0;
         this.cancellationToken = false;
         this.loaded = false;
@@ -63,7 +68,7 @@ export class BookPlayer {
         screenSaverManager.block();
         loading.show();
         const elem = this.createMediaElement(options);
-        return this.setCurrentSrc(elem, options);
+        return this.setCurrentSrc(elem, { ...options, startPositionTicks });
     }
 
     stop() {

--- a/src/plugins/comicsPlayer/plugin.js
+++ b/src/plugins/comicsPlayer/plugin.js
@@ -1,3 +1,4 @@
+import { getBookResumePosition } from '../../utils/bookPlayerResume';
 import { getLibraryApi } from '@jellyfin/sdk/lib/utils/api/library-api';
 import { Archive } from 'libarchive.js';
 
@@ -40,7 +41,11 @@ export class ComicsPlayer {
         this.toggleFullscreen = this.toggleFullscreen.bind(this);
     }
 
-    play(options) {
+    async play(options) {
+        const item = options.items[0];
+        const startPositionTicks = await getBookResumePosition(
+            ServerConnections.getApiClient(item.ServerId), item, options.startPositionTicks
+        );
         this.currentPage = 0;
         this.pageCount = 0;
 
@@ -49,7 +54,7 @@ export class ComicsPlayer {
 
         screenSaverManager.block();
         const elem = this.createMediaElement(options);
-        return this.setCurrentSrc(elem, options);
+        return this.setCurrentSrc(elem, { ...options, startPositionTicks });
     }
 
     stop() {

--- a/src/utils/bookPlayerResume.test.ts
+++ b/src/utils/bookPlayerResume.test.ts
@@ -1,0 +1,58 @@
+import type { BaseItemDto } from '@jellyfin/sdk/lib/generated-client/models/base-item-dto';
+import type { ApiClient } from 'jellyfin-apiclient';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getBookResumePosition } from './bookPlayerResume';
+
+const { getItem } = vi.hoisted(() => ({ getItem: vi.fn() }));
+vi.mock('@jellyfin/sdk/lib/utils/api/library-api', () => ({
+    getLibraryApi: () => ({ getItem })
+}));
+vi.mock('./jellyfin-apiclient/compat', () => ({ toApi: vi.fn() }));
+
+const apiClient = { getCurrentUserId: () => 'reader' } as ApiClient;
+const item: BaseItemDto = {
+    Id: 'comic',
+    UserData: { Key: 'comic', PlaybackPositionTicks: 8360000 }
+};
+
+describe('book resume after a missed progress notification', () => {
+    beforeEach(() => {
+        getItem.mockReset();
+    });
+
+    it('uses the saved page instead of a stale details-screen position', async () => {
+        getItem.mockResolvedValue({ data: { UserData: { PlaybackPositionTicks: 9600000 } } });
+        expect(await getBookResumePosition(apiClient, item, 8360000)).toBe(9600000);
+        expect(getItem).toHaveBeenCalledWith({ itemId: 'comic', userId: 'reader' });
+    });
+
+    it('preserves a deliberate start from the beginning', async () => {
+        expect(await getBookResumePosition(apiClient, item, 0)).toBe(0);
+        expect(getItem).not.toHaveBeenCalled();
+    });
+
+    it('preserves an explicit position that is not the cached resume value', async () => {
+        expect(await getBookResumePosition(apiClient, item, 4200000)).toBe(4200000);
+        expect(getItem).not.toHaveBeenCalled();
+    });
+
+    it('allows the latest saved page to move backwards', async () => {
+        getItem.mockResolvedValue({ data: { UserData: { PlaybackPositionTicks: 7000000 } } });
+        expect(await getBookResumePosition(apiClient, item, 8360000)).toBe(7000000);
+    });
+
+    it('respects progress cleared on the server', async () => {
+        getItem.mockResolvedValue({ data: { UserData: { PlaybackPositionTicks: 0 } } });
+        expect(await getBookResumePosition(apiClient, item, 8360000)).toBe(0);
+    });
+
+    it('does not silently resume stale progress when the lookup fails', async () => {
+        getItem.mockRejectedValue(new Error('Server unavailable'));
+        await expect(getBookResumePosition(apiClient, item, 8360000)).rejects.toThrow('Server unavailable');
+    });
+
+    it('does not fetch progress for a new book', async () => {
+        expect(await getBookResumePosition(apiClient, { Id: 'new-book' })).toBe(0);
+        expect(getItem).not.toHaveBeenCalled();
+    });
+});

--- a/src/utils/bookPlayerResume.ts
+++ b/src/utils/bookPlayerResume.ts
@@ -1,0 +1,23 @@
+import type { BaseItemDto } from '@jellyfin/sdk/lib/generated-client/models/base-item-dto';
+import { getLibraryApi } from '@jellyfin/sdk/lib/utils/api/library-api';
+import type { ApiClient } from 'jellyfin-apiclient';
+import { toApi } from './jellyfin-apiclient/compat';
+
+/** Resolve Resume against current user data, preserving explicit start positions. */
+export async function getBookResumePosition(
+    apiClient: ApiClient,
+    item: BaseItemDto,
+    startPositionTicks = 0
+): Promise<number> {
+    if (!item.Id || !startPositionTicks
+        || startPositionTicks !== item.UserData?.PlaybackPositionTicks) {
+        return startPositionTicks;
+    }
+
+    // Restored details views can miss the stop notification and retain an old page.
+    const { data } = await getLibraryApi(toApi(apiClient)).getItem({
+        itemId: item.Id,
+        userId: apiClient.getCurrentUserId()
+    });
+    return data.UserData?.PlaybackPositionTicks ?? 0;
+}


### PR DESCRIPTION
### Changes

Resuming an EPUB book or comic from a cached details screen can reuse an outdated saved position when a progress notification is missed. Reusing that position can overwrite newer progress already saved on the server. When the requested resume position matches the cached nonzero value, this change fetches the latest user progress before opening the reader. Starts from the beginning and other explicit positions are preserved, and the latest saved position may move backwards. A failed progress lookup stops the resume attempt instead of reusing stale progress.

### Issues

Related to #3575.

### Code assistance

Codex was used to investigate the bug, implement the fix, and write and run regression tests.

---

* [ ] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls).
