### PR TITLE
Reduce EPUB startup time with background location indexing

### DIFF
--- a/src/plugins/bookPlayer/plugin.js
+++ b/src/plugins/bookPlayer/plugin.js
@@ -15,6 +15,8 @@ import { translateHtml } from '../../lib/globalize';
 import * as userSettings from '../../scripts/settings/userSettings';
 import Events from '../../utils/events.ts';
 import { renderComponent } from '../../utils/reactUtils';
+import { createEpubLocationCache } from '../../utils/bookPlayerLocationCache';
+import { prepareEpubLocations } from '../../utils/bookPlayerLocations';
 
 import 'material-design-icons-iconfont';
 import '../../elements/emby-button/paper-icon-button-light';
@@ -56,7 +58,8 @@ export class BookPlayer {
     }
 
     play(options) {
-        this.progress = 0;
+        this.locationPreparation?.cancel();
+        this.progress = (options.startPositionTicks || 0) / 10000000;
         this.cancellationToken = false;
         this.loaded = false;
 
@@ -67,6 +70,8 @@ export class BookPlayer {
     }
 
     stop() {
+        this.cancellationToken = true;
+        this.locationPreparation?.cancel();
         this.unbindEvents();
         this.unmountBookOsd();
         screenSaverManager.unblock();
@@ -97,7 +102,6 @@ export class BookPlayer {
 
         // hide loader in case player was not fully loaded yet
         loading.hide();
-        this.cancellationToken = true;
     }
 
     destroy() {
@@ -316,7 +320,7 @@ export class BookPlayer {
         return elem;
     }
 
-    setCurrentSrc(elem, options) {
+    async setCurrentSrc(elem, options) {
         const item = options.items[0];
         this.item = item;
         this.streamInfo = {
@@ -328,58 +332,53 @@ export class BookPlayer {
             }
         };
 
-        return new Promise((resolve, reject) => {
-            import('epubjs').then(({ default: epubjs }) => {
-                const api = ServerConnections.getApi(item.ServerId);
-                if (!api) {
-                    console.error('[BookPlayer] no Api instance available for server', item.ServerId);
-                    return;
-                }
-                const downloadHref = getLibraryApi(api).getDownloadUrl({ itemId: item.Id });
-                const book = epubjs(downloadHref, { openAs: 'epub' });
+        try {
+            const { default: epubjs } = await import('epubjs');
+            if (this.cancellationToken || this.mediaElement !== elem || this.item !== item) return;
 
-                const rendition = book.renderTo('bookPlayerContainer', {
-                    width: '100%',
-                    height: '100%',
-                    // TODO: Add option for scrolled-doc
-                    flow: 'paginated'
-                });
-
-                this.currentSrc = () => downloadHref;
-                this.rendition = rendition;
-
-                return rendition.display().then(() => {
-                    const epubElem = document.querySelector('.epub-container');
-                    epubElem.style.opacity = '0';
-
-                    this.bindEvents();
-
-                    return this.rendition.book.locations.generate(1024).then(async () => {
-                        if (this.cancellationToken) reject();
-
-                        const percentageTicks = options.startPositionTicks / 10000000;
-                        if (percentageTicks !== 0.0) {
-                            const resumeLocation = book.locations.cfiFromPercentage(percentageTicks);
-                            await rendition.display(resumeLocation);
-                        }
-
-                        this.loaded = true;
-                        epubElem.style.opacity = '';
-                        rendition.on('relocated', (locations) => {
-                            this.progress = book.locations.percentageFromCfi(locations.start.cfi);
-                            Events.trigger(this, 'pause');
-                        });
-
-                        this.setTheme(this.theme, this.fontSize);
-                        loading.hide();
-                        return resolve();
-                    });
-                }, () => {
-                    console.error('failed to display epub');
-                    return reject();
-                });
+            const api = ServerConnections.getApi(item.ServerId);
+            if (!api) throw new Error('[BookPlayer] no Api instance available');
+            const downloadHref = getLibraryApi(api).getDownloadUrl({ itemId: item.Id });
+            const book = epubjs(downloadHref, { openAs: 'epub' });
+            const rendition = book.renderTo('bookPlayerContainer', {
+                width: '100%',
+                height: '100%',
+                // TODO: Add option for scrolled-doc
+                flow: 'paginated'
             });
-        });
+            this.currentSrc = () => downloadHref;
+            this.rendition = rendition;
+
+            await rendition.display();
+            if (this.cancellationToken || this.rendition !== rendition) return;
+
+            this.bindEvents();
+            this.loaded = true;
+            this.setTheme(this.theme, this.fontSize);
+            loading.hide();
+
+            const cache = createEpubLocationCache(item, book);
+            this.locationPreparation = prepareEpubLocations({
+                locations: book.locations,
+                rendition,
+                startPercentage: (options.startPositionTicks || 0) / 10000000,
+                onProgress: percentage => {
+                    this.progress = percentage;
+                    Events.trigger(this, 'pause');
+                },
+                beforeIndexing: () => new Promise(resolve => {
+                    requestAnimationFrame(() => requestAnimationFrame(resolve));
+                }),
+                loadLocations: cache.load,
+                saveLocations: cache.save
+            });
+            this.locationsReady = this.locationPreparation.ready.catch(error => {
+                console.error('[BookPlayer] failed to prepare EPUB locations', error);
+            });
+        } catch (error) {
+            if (!this.cancellationToken && this.mediaElement === elem && this.item === item) loading.hide();
+            throw error;
+        }
     }
 
     canPlayMediaType(mediaType) {

--- a/src/utils/bookPlayerLocationCache.test.ts
+++ b/src/utils/bookPlayerLocationCache.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { get, set } from 'idb-keyval';
+
+import { createEpubLocationCache, createLocationCacheKey } from './bookPlayerLocationCache';
+
+vi.mock('idb-keyval', () => ({
+    createStore: vi.fn(),
+    get: vi.fn(),
+    set: vi.fn()
+}));
+
+const item = { ServerId: 'server', Id: 'book', Size: 12345 };
+// eslint-disable-next-line @typescript-eslint/naming-convention -- EPUB metadata uses modified_date.
+const book = { packaging: { metadata: { identifier: 'edition', modified_date: '2026-01-01' }, spine: [{}] } };
+
+beforeEach(() => {
+    vi.mocked(get).mockReset();
+    vi.mocked(set).mockReset();
+});
+
+describe('EPUB location cache', () => {
+    it('reuses the key for an unchanged book', () => {
+        expect(createLocationCacheKey(item, book)).toBe(createLocationCacheKey({ ...item }, { packaging: { metadata: { ...book.packaging.metadata }, spine: [...book.packaging.spine] } }));
+    });
+
+    it.each([
+        { ServerId: 'other server' }, { Id: 'other book' }, { Size: 54321 }
+    ])('separates indexes for different items and file sizes: %j', change => {
+        expect(createLocationCacheKey({ ...item, ...change }, book)).not.toBe(createLocationCacheKey(item, book));
+    });
+
+    it.each([
+        { identifier: 'other edition' },
+        // eslint-disable-next-line @typescript-eslint/naming-convention -- EPUB metadata uses modified_date.
+        { modified_date: '2026-02-01' }
+    ])('invalidates an index when publication metadata changes: %j', change => {
+        const changed = { packaging: { metadata: { ...book.packaging.metadata }, spine: [...book.packaging.spine] } };
+        Object.assign(changed.packaging.metadata, change);
+        expect(createLocationCacheKey(item, changed)).not.toBe(createLocationCacheKey(item, book));
+    });
+
+    it('invalidates an index when the spine changes', () => {
+        const changed = { packaging: { metadata: { ...book.packaging.metadata }, spine: [...book.packaging.spine] } };
+        changed.packaging.spine.push({});
+        expect(createLocationCacheKey(item, changed)).not.toBe(createLocationCacheKey(item, book));
+    });
+
+    it('uses the media source size when the item size is absent', () => {
+        expect(createLocationCacheKey({ ...item, Size: undefined, MediaSources: [{ Size: item.Size }] }, book))
+            .toBe(createLocationCacheKey(item, book));
+    });
+
+    it('loads a previously saved index', async () => {
+        const cache = createEpubLocationCache(item, book);
+        await cache.save('["epubcfi(saved)"]');
+        vi.mocked(get).mockResolvedValue(vi.mocked(set).mock.calls[0][1]);
+        expect(await cache.load()).toBe('["epubcfi(saved)"]');
+    });
+
+    it.each([undefined, { schemaVersion: 0 }, { schemaVersion: 1, breakSize: 512, locations: '[]' }])('treats missing or incompatible records as a cache miss: %j', async record => {
+        vi.mocked(get).mockResolvedValue(record);
+        expect(await createEpubLocationCache(item, book).load()).toBeNull();
+    });
+
+    it('allows reading when browser storage is unavailable or full', async () => {
+        vi.mocked(get).mockRejectedValue(new Error('storage unavailable'));
+        vi.mocked(set).mockRejectedValue(new Error('quota exceeded'));
+        const cache = createEpubLocationCache(item, book);
+        expect(await cache.load()).toBeNull();
+        await expect(cache.save('[]')).resolves.toBeUndefined();
+    });
+});

--- a/src/utils/bookPlayerLocationCache.ts
+++ b/src/utils/bookPlayerLocationCache.ts
@@ -1,0 +1,66 @@
+import type { BaseItemDto } from '@jellyfin/sdk/lib/generated-client/models/base-item-dto';
+import type { PackagingMetadataObject } from 'epubjs/types/packaging';
+import { createStore, get, set } from 'idb-keyval';
+
+import { LOCATION_BREAK_SIZE } from './bookPlayerLocations';
+
+const CACHE_SCHEMA_VERSION = 1;
+const store = createStore('jellyfin-reader-cache', 'epubLocations');
+
+type CacheItem = Pick<BaseItemDto, 'ServerId' | 'Id' | 'MediaSources'> & { Size?: number | null };
+interface CacheBook {
+    packaging?: {
+        metadata?: Partial<Pick<PackagingMetadataObject, 'identifier' | 'modified_date'>>;
+        spine?: unknown[];
+    };
+}
+
+interface CacheRecord {
+    schemaVersion: number;
+    breakSize: number;
+    locations: string;
+}
+
+export function createLocationCacheKey(item: CacheItem, book: CacheBook) {
+    const metadata = book.packaging?.metadata;
+    return JSON.stringify([
+        CACHE_SCHEMA_VERSION,
+        LOCATION_BREAK_SIZE,
+        item.ServerId || '',
+        item.Id || '',
+        item.Size || item.MediaSources?.[0]?.Size || '',
+        metadata?.identifier || '',
+        metadata?.modified_date || '',
+        book.packaging?.spine?.length || ''
+    ]);
+}
+
+export function createEpubLocationCache(item: CacheItem, book: CacheBook) {
+    const key = createLocationCacheKey(item, book);
+    return {
+        async load() {
+            try {
+                const record = await get<CacheRecord>(key, store);
+                if (record?.schemaVersion === CACHE_SCHEMA_VERSION
+                    && record.breakSize === LOCATION_BREAK_SIZE
+                    && typeof record.locations === 'string') {
+                    return record.locations;
+                }
+            } catch {
+                // Private browsing or storage errors must not prevent reading.
+            }
+            return null;
+        },
+        async save(locations: string) {
+            try {
+                await set(key, {
+                    schemaVersion: CACHE_SCHEMA_VERSION,
+                    breakSize: LOCATION_BREAK_SIZE,
+                    locations
+                }, store);
+            } catch {
+                // The next open can regenerate the index if storage is full.
+            }
+        }
+    };
+}

--- a/src/utils/bookPlayerLocations.test.ts
+++ b/src/utils/bookPlayerLocations.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { LOCATION_BREAK_SIZE, prepareEpubLocations } from './bookPlayerLocations';
+
+function deferred() {
+    let resolve!: (value: string[]) => void;
+    const promise = new Promise<string[]>(complete => {
+        resolve = complete;
+    });
+    return { promise, resolve };
+}
+
+function reader() {
+    type Location = { start: { cfi: string } };
+    const listeners = new Set<(location: Location) => void>();
+    const locations = {
+        pause: 100,
+        generate: vi.fn(async () => ['epubcfi(generated)']),
+        load: vi.fn(),
+        save: vi.fn(() => '["epubcfi(generated)"]'),
+        cfiFromPercentage: vi.fn(() => 'epubcfi(resume)'),
+        percentageFromCfi: vi.fn((cfi: string): number => cfi === 'epubcfi(resume)' ? 0.35 : 0.42)
+    };
+    const rendition = {
+        location: { start: { cfi: 'epubcfi(initial)' } },
+        display: vi.fn(async (cfi?: string | number) => {
+            rendition.location = { start: { cfi: String(cfi) } };
+            listeners.forEach(listener => {
+                listener(rendition.location);
+            });
+        }),
+        on: vi.fn((_event: string, callback: (location: Location) => void) => { listeners.add(callback); }),
+        off: vi.fn((_event: string, callback: (location: Location) => void) => { listeners.delete(callback); })
+    };
+    const options = {
+        locations, rendition, startPercentage: 0,
+        onProgress: vi.fn(),
+        loadLocations: vi.fn(async (): Promise<string | null> => null),
+        saveLocations: vi.fn<(locations: string) => Promise<void>>(() => Promise.resolve())
+    };
+    return { ...options, options, listeners };
+}
+
+describe('prepareEpubLocations', () => {
+    it('leaves the reader available while indexing and removes the per-section delay', async () => {
+        const { options, locations, onProgress } = reader();
+        const generation = deferred();
+        locations.generate.mockReturnValue(generation.promise);
+        const preparation = prepareEpubLocations(options);
+
+        await vi.waitFor(() => expect(locations.generate).toHaveBeenCalledWith(LOCATION_BREAK_SIZE));
+        expect(locations.pause).toBe(0);
+        expect(onProgress).not.toHaveBeenCalled();
+        generation.resolve(['epubcfi(generated)']);
+        await preparation.ready;
+        expect(options.saveLocations).toHaveBeenCalledWith('["epubcfi(generated)"]');
+    });
+
+    it('uses a cached index without parsing the chapters again', async () => {
+        const { options, locations } = reader();
+        options.loadLocations.mockResolvedValue('["epubcfi(cached)"]');
+        await prepareEpubLocations(options).ready;
+        expect(locations.load).toHaveBeenCalledWith('["epubcfi(cached)"]');
+        expect(locations.generate).not.toHaveBeenCalled();
+        expect(options.saveLocations).not.toHaveBeenCalled();
+    });
+
+    it.each(['broken json', '[]', '{}', '[null]', '["not a CFI"]'])('regenerates an unusable cache: %s', async cached => {
+        const { options, locations } = reader();
+        options.loadLocations.mockResolvedValue(cached);
+        await prepareEpubLocations(options).ready;
+        expect(locations.generate).toHaveBeenCalled();
+    });
+
+    it('regenerates if epub.js cannot load the cached index', async () => {
+        const { options, locations } = reader();
+        options.loadLocations.mockResolvedValue('["epubcfi(cached)"]');
+        locations.load.mockImplementation(() => {
+            throw new Error('invalid index');
+        });
+        await prepareEpubLocations(options).ready;
+        expect(locations.generate).toHaveBeenCalled();
+    });
+
+    it('restores the saved percentage and reports subsequent page turns', async () => {
+        const { options, rendition, locations, onProgress } = reader();
+        options.startPercentage = 0.35;
+        await prepareEpubLocations(options).ready;
+        expect(locations.cfiFromPercentage).toHaveBeenCalledWith(0.35);
+        expect(rendition.display).toHaveBeenCalledWith('epubcfi(resume)');
+        expect(onProgress).toHaveBeenLastCalledWith(0.35);
+        await rendition.display('epubcfi(next)');
+        expect(onProgress).toHaveBeenLastCalledWith(0.42);
+    });
+
+    it('does not report the old page when display resolves before the resumed location event', async () => {
+        const { options, rendition, onProgress, listeners } = reader();
+        options.startPercentage = 0.35;
+        rendition.display.mockResolvedValue(undefined);
+        await prepareEpubLocations(options).ready;
+        expect(onProgress).not.toHaveBeenCalled();
+        listeners.forEach(listener => {
+            listener({ start: { cfi: 'epubcfi(resume)' } });
+        });
+        expect(onProgress).toHaveBeenCalledExactlyOnceWith(0.35);
+    });
+
+    it('keeps a page chosen during indexing instead of jumping back to the resume position', async () => {
+        const { options, locations, rendition, onProgress } = reader();
+        options.startPercentage = 0.35;
+        const generation = deferred();
+        locations.generate.mockReturnValue(generation.promise);
+        const preparation = prepareEpubLocations(options);
+        await vi.waitFor(() => expect(locations.generate).toHaveBeenCalled());
+        await rendition.display('epubcfi(chosen)');
+        expect(onProgress).not.toHaveBeenCalled();
+        generation.resolve(['epubcfi(generated)']);
+        await preparation.ready;
+        expect(locations.cfiFromPercentage).not.toHaveBeenCalled();
+        expect(rendition.location.start.cfi).toBe('epubcfi(chosen)');
+        expect(onProgress).toHaveBeenLastCalledWith(0.42);
+    });
+
+    it('does not start indexing after the reader is closed before its first paint', async () => {
+        const { options, locations, listeners } = reader();
+        const preparation = prepareEpubLocations(options);
+        preparation.cancel();
+        await preparation.ready;
+        expect(locations.generate).not.toHaveBeenCalled();
+        expect(options.loadLocations).not.toHaveBeenCalled();
+        expect(listeners.size).toBe(0);
+    });
+
+    it('does not resume, save progress or retain listeners when closed during indexing', async () => {
+        const { options, locations, rendition, onProgress, listeners } = reader();
+        options.startPercentage = 0.35;
+        const generation = deferred();
+        locations.generate.mockReturnValue(generation.promise);
+        const preparation = prepareEpubLocations(options);
+        await vi.waitFor(() => expect(locations.generate).toHaveBeenCalled());
+        preparation.cancel();
+        generation.resolve(['epubcfi(generated)']);
+        await preparation.ready;
+        expect(rendition.display).not.toHaveBeenCalled();
+        expect(onProgress).not.toHaveBeenCalled();
+        expect(listeners.size).toBe(0);
+    });
+
+    it('removes its listener if chapter parsing fails', async () => {
+        const { options, locations, listeners } = reader();
+        locations.generate.mockRejectedValue(new Error('chapter missing'));
+        await expect(prepareEpubLocations(options).ready).rejects.toThrow('chapter missing');
+        expect(listeners.size).toBe(0);
+    });
+
+    it('ignores invalid progress values', async () => {
+        const { options, locations, onProgress } = reader();
+        locations.percentageFromCfi.mockReturnValue(NaN);
+        await prepareEpubLocations(options).ready;
+        expect(onProgress).not.toHaveBeenCalled();
+    });
+});

--- a/src/utils/bookPlayerLocations.ts
+++ b/src/utils/bookPlayerLocations.ts
@@ -1,0 +1,100 @@
+import type Locations from 'epubjs/types/locations';
+import type Rendition from 'epubjs/types/rendition';
+
+export const LOCATION_BREAK_SIZE = 1024;
+
+type LocationMap = Pick<Locations, 'generate' | 'load' | 'save' | 'cfiFromPercentage' | 'percentageFromCfi'> & {
+    // epub.js exposes this at runtime, but omits it from its type declarations.
+    pause?: number;
+};
+
+interface ReaderLocation {
+    start: { cfi: string };
+}
+
+interface PreparationOptions {
+    locations: LocationMap;
+    rendition: Pick<Rendition, 'display' | 'on' | 'off'> & { location?: ReaderLocation };
+    startPercentage: number;
+    onProgress: (percentage: number) => void;
+    beforeIndexing?: () => Promise<unknown>;
+    loadLocations: () => Promise<string | null>;
+    saveLocations: (locations: string) => Promise<void>;
+}
+
+function restoreLocations(locations: LocationMap, cached: string | null) {
+    if (!cached) return false;
+    try {
+        const entries: unknown = JSON.parse(cached);
+        if (!Array.isArray(entries) || !entries.length || !entries.every(entry => (
+            typeof entry === 'string' && entry.startsWith('epubcfi(') && entry.endsWith(')')
+        ))) return false;
+        locations.load(cached);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+export function prepareEpubLocations({
+    locations, rendition, startPercentage, onProgress,
+    beforeIndexing = () => Promise.resolve(), loadLocations, saveLocations
+}: PreparationOptions) {
+    let cancelled = false;
+    let indexed = false;
+    let initialCfi = rendition.location?.start.cfi;
+    let currentCfi = initialCfi;
+    let moved = false;
+
+    const reportProgress = () => {
+        if (cancelled || !indexed || !currentCfi) return;
+        const percentage = locations.percentageFromCfi(currentCfi);
+        if (Number.isFinite(percentage)) onProgress(percentage);
+    };
+    const relocated = (location: ReaderLocation) => {
+        currentCfi = location.start.cfi;
+        initialCfi ??= currentCfi;
+        moved ||= currentCfi !== initialCfi;
+        reportProgress();
+    };
+    rendition.on('relocated', relocated);
+
+    const cancel = () => {
+        cancelled = true;
+        rendition.off('relocated', relocated);
+    };
+
+    const ready = (async () => {
+        // Let the first page paint before parsing the remaining chapters.
+        await beforeIndexing();
+        if (cancelled) return;
+
+        // The default 100 ms pause per section adds seconds to large books.
+        // Zero still yields through epub.js's timer between sections.
+        locations.pause = 0;
+        const cached = await loadLocations();
+        if (cancelled) return;
+        const restored = restoreLocations(locations, cached);
+        if (!restored) await locations.generate(LOCATION_BREAK_SIZE);
+        if (cancelled) return;
+
+        // A page turn while indexing takes precedence over a delayed resume.
+        const shouldResume = startPercentage > 0 && !moved;
+        const cfiBeforeResume = currentCfi;
+        if (shouldResume) {
+            await rendition.display(locations.cfiFromPercentage(startPercentage));
+        }
+        if (cancelled) return;
+
+        indexed = true;
+        // display() can resolve before epub.js emits the resumed location.
+        // Keep the saved progress until that event instead of reporting page 0.
+        if (!shouldResume || currentCfi !== cfiBeforeResume) reportProgress();
+        if (!restored) await saveLocations(locations.save());
+    })().catch(error => {
+        cancel();
+        throw error;
+    });
+
+    return { ready, cancel };
+}


### PR DESCRIPTION
### Changes

In a local comparison, opening a six-book EPUB omnibus reached its first usable page in **0.20 seconds instead of 20.17 seconds**, about a **99% reduction**. This displays the first page before generating the full location map, removes EPUB.js's fixed 100 ms pause between sections while retaining browser yields, and caches completed maps in IndexedDB for reopening. Existing saved progress is retained until valid progress is available, and page turns during indexing take precedence over a delayed resume. Unusable cache entries are regenerated, and storage failures fall back to uncached generation.

| Omnibus EPUB | Current master | With this change |
| --- | ---: | ---: |
| First usable page, cold context | 20.17 s | **0.20 s** |
| Location map ready, cold context | 20.17 s | 3.07 s |
| Location map ready, warm context | 20.18 s | 0.21 s |

Medians of three opens per build and cache condition, using the same 6.75 MB EPUB with 171 spine items in a production-compiled BookPlayer harness, desktop Edge and local HTTP. Exact saved-percentage restoration still waits for the map; these figures describe this local desktop workload. [The measurement method, samples and validation results](https://github.com/daniel-stilman/jellyfin/blob/df536b8255be53158cdd6b43c33b3a022f82cde7/custom-build/READER-PERFORMANCE.md#epub-startup-current-master-contribution) include the other four EPUBs checked.

### Issues

Fixes #8422.

### Code assistance

Codex was used to investigate the loading delays, implement the changes, and develop and run regression tests and benchmarks.

---

* [ ] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls).
