### PR TITLE
Don't serve plugin versions from a stale package cache

### DIFF
--- a/src/apps/dashboard/features/plugins/api/usePackageInfo.ts
+++ b/src/apps/dashboard/features/plugins/api/usePackageInfo.ts
@@ -8,17 +8,16 @@ import { useApi } from 'hooks/useApi';
 
 import { QueryKey } from './queryKey';
 import { queryClient } from 'utils/query/queryClient';
-import type { PackageInfo } from '@jellyfin/sdk/lib/generated-client/models/package-info';
+import { getPackagesQuery } from './usePackages';
 
 const fetchPackageInfo = async (
     api: Api,
     params: PluginApiGetPackageInfoRequest,
     options?: AxiosRequestConfig
 ) => {
-    const packagesData = queryClient.getQueryData([ QueryKey.Packages ]) as PackageInfo[];
-    if (packagesData && params.assemblyGuid) {
-        // Use cached query to avoid re-fetching
-        const pkg = packagesData.find(v => v.guid === params.assemblyGuid);
+    if (params.assemblyGuid) {
+        const packages = await queryClient.fetchQuery(getPackagesQuery(api));
+        const pkg = packages.find(v => v.guid === params.assemblyGuid);
 
         if (pkg) {
             return pkg;

--- a/src/apps/dashboard/features/plugins/api/usePackages.ts
+++ b/src/apps/dashboard/features/plugins/api/usePackages.ts
@@ -16,7 +16,7 @@ const fetchPackages = async (
     return response.data;
 };
 
-const getPackagesQuery = (
+export const getPackagesQuery = (
     api?: Api
 ) => queryOptions({
     queryKey: [ QueryKey.Packages ],


### PR DESCRIPTION
The plugin details page reads the package catalog straight out of the query cache via `getQueryData`, which ignores both staleness and invalidation.

### Changes
Route the lookup through the packages query so it refetches when the catalog is stale or has been invalidated

### Issues
<!--
Tag any issues that this PR solves here.
ex. Fixes #
-->

### Code assistance
None

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
