### PR TITLE
Keep previous search results visible while a new search loads

### DIFF
--- a/src/apps/legacy/features/search/api/useSearchItems.ts
+++ b/src/apps/legacy/features/search/api/useSearchItems.ts
@@ -1,7 +1,7 @@
 import { BaseItemKind } from '@jellyfin/sdk/lib/generated-client/models/base-item-kind';
 import type { BaseItemDto } from '@jellyfin/sdk/lib/generated-client/models/base-item-dto';
 import { CollectionType } from '@jellyfin/sdk/lib/generated-client/models/collection-type';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { CardShape } from 'components/cardbuilder/utils/shape';
 import { useApi } from '../../../../../hooks/useApi';
 import { addSection, getCardOptionsFromType, getItemTypesFromCollectionType, getTitleFromType, isLivetv, isMovies, isMusic, isTVShows, sortSections } from '../utils/search';
@@ -103,6 +103,8 @@ export const useSearchItems = (
             && !!isVideosEnabled
             && !!isLiveTvEnabled
             && !!isProgramsEnabled
-        )
+        ),
+        // Keep showing the previous results while a new search term is loading
+        placeholderData: keepPreviousData
     });
 };

--- a/src/apps/legacy/features/search/components/SearchResults.tsx
+++ b/src/apps/legacy/features/search/components/SearchResults.tsx
@@ -1,4 +1,4 @@
-import React, { type FC } from 'react';
+import React, { type FC, useMemo } from 'react';
 import { useSearchItems } from '../api/useSearchItems';
 import globalize from 'lib/globalize';
 import Loading from 'components/loading/LoadingComponent';
@@ -22,11 +22,26 @@ const SearchResults: FC<SearchResultsProps> = ({
     collectionType,
     query
 }) => {
-    const { data, isPending } = useSearchItems(parentId, collectionType, query?.trim());
+    const { data, isPending, isPlaceholderData } = useSearchItems(parentId, collectionType, query?.trim());
 
-    if (isPending) return <Loading />;
+    // Build the card options once per result set so rows are not rebuilt on every render
+    const sections = useMemo(() => (data || []).map(section => ({
+        ...section,
+        cardOptions: {
+            shape: CardShape.AutoOverflow,
+            scalable: true,
+            showTitle: true,
+            overlayText: false,
+            centerText: true,
+            allowBottomPadding: false,
+            ...section.cardOptions
+        }
+    })), [ data ]);
 
-    if (!data?.length) {
+    // Show the spinner without unmounting the previous results while a new search is loading
+    if (isPending || (isPlaceholderData && !sections.length)) return <Loading />;
+
+    if (!sections.length) {
         return (
             <div className='noItemsMessage centerMessage'>
                 {globalize.translate('SearchResultsEmpty', query)}
@@ -48,22 +63,15 @@ const SearchResults: FC<SearchResultsProps> = ({
                 key={`${section.title}-${index}`}
                 title={globalize.translate(section.title)}
                 items={section.items}
-                cardOptions={{
-                    shape: CardShape.AutoOverflow,
-                    scalable: true,
-                    showTitle: true,
-                    overlayText: false,
-                    centerText: true,
-                    allowBottomPadding: false,
-                    ...section.cardOptions
-                }}
+                cardOptions={section.cardOptions}
             />
         );
     };
 
     return (
         <div className={'searchResults padded-top padded-bottom-page'}>
-            {data.map((section, index) => renderSection(section, index))}
+            {isPlaceholderData && <Loading />}
+            {sections.map((section, index) => renderSection(section, index))}
         </div>
     );
 };


### PR DESCRIPTION
### Changes
Keep the previous search results on screen while a new search term loads, instead of unmounting every row and showing only a spinner. The search query now uses `keepPreviousData` as placeholder data, the spinner renders alongside the existing rows, and the per-section card options are memoized so rows only rebuild when the result set actually changes.

Before, every new character blanked the page and rebuilt the full DOM. That is noticeable on slow devices, and unavoidable when typing letter by letter with a mouse or on-screen keyboard, since each character lands slower than the 500 ms debounce.

<img width="1440" height="710" alt="after-ki-mid-search" src="https://github.com/user-attachments/assets/c0d283f8-1b6d-4ffb-87a4-eb40d6a62c53" />
<img width="1440" height="710" alt="after-kin-settled" src="https://github.com/user-attachments/assets/7f7ce63a-b796-4111-a433-73c1a77fd283" />

### Issues
No dedicated issue. Addresses the slow-typing case raised in the #4478 discussion.

### Code assistance
The code and this description were drafted with Claude Code and reviewed by me. Tested against demo.jellyfin.org: type check, lint, unit tests, and manual checks that rows stay mounted and clickable while a new term loads.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
