### PR TITLE
Fix indicator icon color in safari

### DIFF
--- a/src/themes/_base/_theme.scss
+++ b/src/themes/_base/_theme.scss
@@ -457,6 +457,11 @@ a[data-role="button"],
 .playedIndicator {
     background: var(--jf-palette-primary-main, $primary-main);
     color: var(--jf-palette-primary-contrastText, $primary-contrastText);
+
+    // Safari is failing to render the SVG fill color with "currentColor" here
+    & > svg {
+        fill: var(--jf-palette-primary-contrastText, $primary-contrastText);
+    }
 }
 
 .mainDrawer,


### PR DESCRIPTION
### Changes
Safari doesn't seem to like `fill: currentColor` for the played indicator icon svgs so the icon is invisible. This makes the fill color the same as the text color.

### Issues
None

### Code assistance
Zed autocomplete

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
