### PR TITLE
Fix stuck card play overlay after clicking a card

### DIFF
--- a/src/components/cardbuilder/card.scss
+++ b/src/components/cardbuilder/card.scss
@@ -858,8 +858,19 @@ button::-moz-focus-inner {
     background: transparent !important;
 }
 
-.card-hoverable:focus-within,
 .card-hoverable:hover {
+    .cardOverlayContainer,
+    .cardOverlayButton-hover {
+        opacity: 1;
+    }
+}
+
+// Show the overlay for keyboard focus only. `:focus-within` also matched
+// mouse-click focus, which left the play overlay stuck on a card after it
+// was clicked (e.g. returning to a library grid via the back button). Kept
+// as a separate rule so the `:hover` rule above still applies on browsers
+// that don't support `:has()`.
+.card-hoverable:has(:focus-visible) {
     .cardOverlayContainer,
     .cardOverlayButton-hover {
         opacity: 1;


### PR DESCRIPTION
### Changes

The card hover overlay (play button and action buttons) was revealed with `.card-hoverable:focus-within`, which matches mouse-click focus as well as keyboard focus. After a card is clicked, focus stays inside it, so the overlay stays visible until the user clicks elsewhere. The most visible symptom is a play button stuck on a card after returning to a library grid via the back button, independent of the mouse position.

This reveals the overlay for keyboard focus only, using `:has(:focus-visible)`, so a mouse click no longer leaves it stuck while keyboard navigation still shows it. It is kept as a separate rule from `:hover` so the hover overlay keeps working on browsers that do not support `:has()`.

### Issues

<!-- No existing issue found. -->

### Code assistance

Diagnosis and fix were developed with LLM assistance (Claude). The overlay was reproduced against a live 12.0.0 client with browser automation to confirm it is driven by focus rather than hover, and that `:has(:focus-visible)` matches only keyboard focus (not mouse-click focus) while `:hover` is unaffected. The change was written and compiled with dart-sass locally.

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a *substantive* review of another web PR.