### PR TITLE
Add user selection to quick connect form for admins

### DIFF
--- a/src/apps/legacy/routes/quickConnect/index.tsx
+++ b/src/apps/legacy/routes/quickConnect/index.tsx
@@ -2,17 +2,25 @@ import { getAuthenticationApi } from '@jellyfin/sdk/lib/utils/api/authentication
 import React, { FC, FormEvent, useCallback, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 
+import Loading from 'components/loading/LoadingComponent';
 import Page from 'components/Page';
-import globalize from 'lib/globalize';
-import Input from 'elements/emby-input/Input';
 import Button from 'elements/emby-button/Button';
+import Input from 'elements/emby-input/Input';
+import SelectElement from 'elements/SelectElement';
 import { useApi } from 'hooks/useApi';
+import { useUsers } from 'hooks/useUsers';
+import globalize from 'lib/globalize';
 
 import './quickConnect.scss';
 
 const QuickConnectPage: FC = () => {
     const { api, user } = useApi();
+    const {
+        data: users,
+        isPending
+    } = useUsers();
     const [ searchParams ] = useSearchParams();
+    const userIdDefault = searchParams.get('userId') ?? user?.Id;
     const [ code, setCode ] = useState(searchParams.get('code') ?? '');
     const [ error, setError ] = useState<string>();
     const [ success, setSuccess ] = useState(false);
@@ -31,13 +39,14 @@ const QuickConnectPage: FC = () => {
             return;
         }
 
+        const userId = form.querySelector<HTMLSelectElement>('#userId')?.value;
+
         if (!api) {
             console.error('[QuickConnect] cannot authorize, missing api instance');
             setError('UnknownError');
             return;
         }
 
-        const userId = searchParams.get('userId') ?? user?.Id;
         const normalizedCode = code.replace(/\s/g, '');
         console.log('[QuickConnect] authorizing code %s as user %s', normalizedCode, userId);
 
@@ -52,7 +61,9 @@ const QuickConnectPage: FC = () => {
             .catch(() => {
                 setError('QuickConnectAuthorizeFail');
             });
-    }, [api, code, searchParams, user?.Id]);
+    }, [ api, code ]);
+
+    if (isPending) return <Loading />;
 
     return (
         <Page
@@ -89,6 +100,21 @@ const QuickConnectPage: FC = () => {
                             </div>
                         ) : (
                             <>
+                                {user?.Policy?.IsAdministrator && (
+                                    <div className='selectContainer'>
+                                        <SelectElement
+                                            id='userId'
+                                            label='LabelUser'
+                                        >
+                                            {
+                                                users
+                                                    ?.filter(u => !u.Policy?.IsDisabled)
+                                                    .map(u => `<option value=${u.Id} ${u.Id === userIdDefault ? 'selected' : ''}>${u.Name}</option>`)
+                                            }
+                                        </SelectElement>
+                                    </div>
+                                )}
+
                                 <div className='inputContainer'>
                                     <Input
                                         value={code}

--- a/src/apps/legacy/routes/quickConnect/index.tsx
+++ b/src/apps/legacy/routes/quickConnect/index.tsx
@@ -1,3 +1,4 @@
+import escapeHTML from 'escape-html';
 import { getAuthenticationApi } from '@jellyfin/sdk/lib/utils/api/authentication-api';
 import React, { FC, FormEvent, useCallback, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
@@ -109,7 +110,11 @@ const QuickConnectPage: FC = () => {
                                             {
                                                 users
                                                     ?.filter(u => !u.Policy?.IsDisabled)
-                                                    .map(u => `<option value=${u.Id} ${u.Id === userIdDefault ? 'selected' : ''}>${u.Name}</option>`)
+                                                    .map(u => (
+                                                        `<option value=${u.Id} ${u.Id === userIdDefault ? 'selected' : ''}>`
+                                                        + escapeHTML(u.Name)
+                                                        + '</option>'
+                                                    ))
                                             }
                                         </SelectElement>
                                     </div>

--- a/src/elements/SelectElement.tsx
+++ b/src/elements/SelectElement.tsx
@@ -1,8 +1,8 @@
-import React, { FunctionComponent } from 'react';
+import React, { FC } from 'react';
 
 import globalize from 'lib/globalize';
 
-const createSelectElement = ({ name, id, required, label, option }: { name?: string, id?: string, required?: string, label?: string, option?: React.ReactNode }) => ({
+const createSelectElement = ({ name, id, required, label, options }: { name?: string, id?: string, required?: string, label?: string, options?: string | string[] }) => ({
     __html: `<select
         is="emby-select"
         ${name}
@@ -10,27 +10,27 @@ const createSelectElement = ({ name, id, required, label, option }: { name?: str
         ${required}
         label="${label}"
     >
-        ${option}
+        ${options}
     </select>`
 });
 
-type IProps = {
+type SelectElementProps = {
     name?: string;
     id?: string;
-    required?: string;
-    label?: string;
-    children?: React.ReactNode
+    required?: boolean;
+    label: string;
+    children?: string | string[];
 };
 
-const SelectElement: FunctionComponent<IProps> = ({ name, id, required, label, children }: IProps) => {
+const SelectElement: FC<SelectElementProps> = ({ name, id, required, label, children }) => {
     return (
         <div
             dangerouslySetInnerHTML={createSelectElement({
                 name: name ? `name='${name}'` : '',
                 id: id,
-                required: required ? `required='${required}'` : '',
+                required: required ? 'required="required"' : '',
                 label: globalize.translate(label),
-                option: children
+                options: children
             })}
         />
     );

--- a/src/elements/SelectElement.tsx
+++ b/src/elements/SelectElement.tsx
@@ -26,8 +26,8 @@ const SelectElement: FC<SelectElementProps> = ({ name, id, required, label, chil
     return (
         <div
             dangerouslySetInnerHTML={createSelectElement({
-                name: name ? `name='${name}'` : '',
-                id: id,
+                name: name ? `name="${name}"` : '',
+                id,
                 required: required ? 'required="required"' : '',
                 label: globalize.translate(label),
                 options: children


### PR DESCRIPTION
### Changes
Adds a user menu to the quick connect form for admins

<img width="833" height="373" alt="Screenshot 2026-09-11 at 10-50-34 Quick Connect" src="https://github.com/user-attachments/assets/27af342a-2e10-45c6-9c71-6be55b1d5daa" />

### Issues
Fixes https://github.com/jellyfin/jellyfin-web/issues/8265

### Code assistance
Zed autocomplete

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
