### PR TITLE
Resume the setup wizard with previously saved credentials

### DIFF
--- a/src/apps/wizard/controllers/user/index.js
+++ b/src/apps/wizard/controllers/user/index.js
@@ -3,6 +3,8 @@ import toast from 'components/toast/toast';
 import globalize from 'lib/globalize';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
 import Dashboard from 'utils/dashboard';
+import { toApi } from 'utils/jellyfin-apiclient/compat';
+import saveStartupUser from './saveStartupUser';
 
 import 'styles/dashboard.scss';
 import 'elements/emby-input/emby-input';
@@ -15,33 +17,30 @@ function nextWizardPage() {
         });
 }
 
-function onUpdateUserComplete(result) {
-    console.debug('[Wizard > User] user update complete:', result);
+function onUpdateUserComplete() {
     loading.hide();
     nextWizardPage();
 }
 
-async function onUpdateUserError(result) {
-    const message = await result.text();
-    console.warn('[Wizard > User] user update failed:', message);
-    toast(globalize.translate('ErrorDefault'));
+function onUpdateUserError(result) {
+    toast(globalize.translate([401, 403].includes(result?.response?.status) ? 'MessageInvalidUser' : 'ErrorDefault'));
     loading.hide();
 }
 
 function submit(form) {
     loading.show();
     const apiClient = ServerConnections.currentApiClient();
-    apiClient
-        .ajax({
-            type: 'POST',
-            data: JSON.stringify({
-                Name: form.querySelector('#txtUsername').value.trim(),
-                Password: form.querySelector('#txtManualPassword').value
-            }),
-            url: apiClient.getUrl('Startup/User'),
-            contentType: 'application/json'
+    saveStartupUser(
+        toApi(apiClient),
+        form.querySelector('#txtUsername').value.trim(),
+        form.querySelector('#txtManualPassword').value
+    )
+        .then(async result => {
+            if (result) {
+                await apiClient.onAuthenticated(apiClient, result);
+            }
+            onUpdateUserComplete();
         })
-        .then(onUpdateUserComplete)
         .catch(onUpdateUserError);
 }
 

--- a/src/apps/wizard/controllers/user/saveStartupUser.test.ts
+++ b/src/apps/wizard/controllers/user/saveStartupUser.test.ts
@@ -1,0 +1,75 @@
+import { Jellyfin } from '@jellyfin/sdk';
+import { AxiosError, type AxiosResponse } from 'axios';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import saveStartupUser from './saveStartupUser';
+
+const { updateStartupUser, authenticateUserByName } = vi.hoisted(() => ({
+    updateStartupUser: vi.fn(),
+    authenticateUserByName: vi.fn()
+}));
+vi.mock('@jellyfin/sdk/lib/utils/api/startup-api', () => ({
+    getStartupApi: () => ({ updateStartupUser })
+}));
+vi.mock('utils/sdk/authentication-api', () => ({
+    getAuthenticationApi: () => ({ authenticateUserByName })
+}));
+
+const api = new Jellyfin({
+    clientInfo: { name: 'Test', version: '1' },
+    deviceInfo: { name: 'Test', id: 'test-device' }
+}).createApi('http://localhost');
+
+function httpError(status: number) {
+    return new AxiosError('Request failed', undefined, undefined, undefined, { status } as AxiosResponse);
+}
+
+describe('saveStartupUser', () => {
+    beforeEach(() => {
+        updateStartupUser.mockReset().mockResolvedValue({});
+        authenticateUserByName.mockReset();
+    });
+
+    it('saves the initial credentials without authenticating again', async () => {
+        await expect(saveStartupUser(api, 'admin', 'synthetic-secret')).resolves.toBeUndefined();
+        expect(updateStartupUser).toHaveBeenCalledWith({
+            // Synthetic credentials are only passed to the mocked SDK.
+            // eslint-disable-next-line sonarjs/no-hardcoded-passwords
+            startupUserDto: { Name: 'admin', Password: 'synthetic-secret' }
+        });
+        expect(authenticateUserByName).not.toHaveBeenCalled();
+    });
+
+    it('returns the authenticated session when setup already saved the password', async () => {
+        const session = { AccessToken: 'synthetic-token', User: { Id: 'test-user' } };
+        updateStartupUser.mockRejectedValue(httpError(403));
+        authenticateUserByName.mockResolvedValue({ data: session });
+        await expect(saveStartupUser(api, 'admin', 'synthetic-secret')).resolves.toEqual(session);
+        expect(authenticateUserByName).toHaveBeenCalledWith({
+            authenticateUserByName: { Username: 'admin', Pw: 'synthetic-secret' }
+        });
+        expect(updateStartupUser).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects incorrect credentials without retrying the password update', async () => {
+        const failure = httpError(401);
+        updateStartupUser.mockRejectedValue(httpError(403));
+        authenticateUserByName.mockRejectedValue(failure);
+        await expect(saveStartupUser(api, 'admin', 'incorrect')).rejects.toBe(failure);
+        expect(updateStartupUser).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([400, 401, 404, 500])('preserves HTTP %s errors', async status => {
+        const failure = httpError(status);
+        updateStartupUser.mockRejectedValue(failure);
+        await expect(saveStartupUser(api, 'admin', 'synthetic-secret')).rejects.toBe(failure);
+        expect(authenticateUserByName).not.toHaveBeenCalled();
+    });
+
+    it('preserves network failures', async () => {
+        const failure = new Error('Offline');
+        updateStartupUser.mockRejectedValue(failure);
+        await expect(saveStartupUser(api, 'admin', 'synthetic-secret')).rejects.toBe(failure);
+        expect(authenticateUserByName).not.toHaveBeenCalled();
+    });
+});

--- a/src/apps/wizard/controllers/user/saveStartupUser.ts
+++ b/src/apps/wizard/controllers/user/saveStartupUser.ts
@@ -1,0 +1,23 @@
+import type { Api } from '@jellyfin/sdk';
+import { getStartupApi } from '@jellyfin/sdk/lib/utils/api/startup-api';
+import { isAxiosError } from 'axios';
+
+import { getAuthenticationApi } from 'utils/sdk/authentication-api';
+
+/** Save the initial credentials, or authenticate if an interrupted setup already saved them. */
+export default async function saveStartupUser(api: Api, name: string, password: string) {
+    try {
+        await getStartupApi(api).updateStartupUser({
+            startupUserDto: { Name: name, Password: password }
+        });
+    } catch (error) {
+        if (!isAxiosError(error) || error.response?.status !== 403) {
+            throw error;
+        }
+
+        const { data } = await getAuthenticationApi(api).authenticateUserByName({
+            authenticateUserByName: { Username: name, Pw: password }
+        });
+        return data;
+    }
+}


### PR DESCRIPTION
### Changes

If setup is interrupted after the initial password has been saved, submitting the user step again returns HTTP 403 because the server refuses to overwrite the existing password. After that 403 response, this change authenticates with the supplied credentials and continues only if authentication succeeds. The existing password is not overwritten. All 170 Web tests, the type check, and the production build pass. Browser testing also confirmed that an incorrect password stays on the user step and the correct password reaches the next page.

### Issues

No linked issue. Related work: #8268 and #7503 rewrite the setup wizard; this change fixes resuming the existing legacy wizard.

### Code assistance

The contributor edited the Chinese explanation below from a Codex-provided technical outline. The English text is an AI-assisted translation of that explanation, with technical wording checked against the implementation. Codex also assisted with code extraction/adaptation and testing.

### Chinese explanation

**支持恢复中断的初始化向导** 初始密码保存后，若向导中途异常退出，再次进入提交会因状态冲突被服务端返回 403。现改为先使用输入的当前密码进行认证，鉴权成功后才允许继续后续流程，避免覆盖已有密码。Web 端 170 项测试、类型检查及生产构建均已通过；经浏览器实测，输错密码无法继续，输对后可正常进入下一页。

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls).

The tests and browser checks above were run with Codex. This is a draft while the contributor completes the outstanding review items and overlap with the wizard rewrite is assessed.
