### PR TITLE
Validate plugin repositories before saving

### DIFF
--- a/src/apps/dashboard/features/plugins/api/useSetRepositories.test.ts
+++ b/src/apps/dashboard/features/plugins/api/useSetRepositories.test.ts
@@ -1,0 +1,58 @@
+import { AxiosError } from 'axios';
+import type { RepositoryInfo } from '@jellyfin/sdk/lib/generated-client/models/repository-info';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSetRepositories } from './useSetRepositories';
+
+const { post, save } = vi.hoisted(() => ({ post: vi.fn(), save: vi.fn() }));
+vi.mock('hooks/useApi', () => ({ useApi: () => ({ api: {
+    basePath: 'https://server.example/jellyfin',
+    authorizationHeader: 'test-authorization',
+    axiosInstance: { post }
+} }) }));
+vi.mock('@tanstack/react-query', () => ({ useMutation: (options: unknown) => options }));
+vi.mock('utils/query/queryClient', () => ({ queryClient: { invalidateQueries: vi.fn() } }));
+vi.mock('@jellyfin/sdk/lib/utils/api/plugin-api', () => ({ getPluginApi: () => ({ setRepositories: save }) }));
+
+describe('repository validation before saving', () => {
+    const repository: RepositoryInfo = { Name: 'Test', Url: 'https://repo.example/manifest.json', Enabled: true };
+    const run = (validateRepository?: RepositoryInfo) => {
+        const mutation = useSetRepositories() as unknown as {
+            mutationFn: (params: { repositoryInfo: RepositoryInfo[]; validateRepository?: RepositoryInfo }) => Promise<unknown>;
+        };
+        return mutation.mutationFn({ repositoryInfo: [ repository ], validateRepository });
+    };
+
+    beforeEach(() => {
+        post.mockReset().mockResolvedValue({ status: 204 });
+        save.mockReset().mockResolvedValue({ status: 204 });
+    });
+
+    it('does not save when validation fails', async () => {
+        post.mockRejectedValue(new Error('Invalid repository'));
+        await expect(run(repository)).rejects.toThrow('Invalid repository');
+        expect(save).not.toHaveBeenCalled();
+    });
+
+    it('authenticates validation and saves only after it succeeds', async () => {
+        await run(repository);
+        expect(post).toHaveBeenCalledWith('https://server.example/jellyfin/Repositories/Validate', repository, {
+            headers: { Authorization: 'test-authorization' }
+        });
+        expect(save).toHaveBeenCalledWith({ repositoryInfo: [ repository ] });
+        expect(post.mock.invocationCallOrder[0]).toBeLessThan(save.mock.invocationCallOrder[0]);
+    });
+
+    it.each([ 404, 405 ])('preserves adding on older servers without validation (HTTP %s)', async (status) => {
+        const error = new AxiosError('Endpoint unavailable');
+        Object.assign(error, { response: { status } });
+        post.mockRejectedValue(error);
+        await run(repository);
+        expect(save).toHaveBeenCalledWith({ repositoryInfo: [ repository ] });
+    });
+
+    it('can remove or disable repositories without contacting them', async () => {
+        await run();
+        expect(post).not.toHaveBeenCalled();
+        expect(save).toHaveBeenCalledWith({ repositoryInfo: [ repository ] });
+    });
+});

--- a/src/apps/dashboard/features/plugins/api/useSetRepositories.ts
+++ b/src/apps/dashboard/features/plugins/api/useSetRepositories.ts
@@ -1,17 +1,34 @@
+import { isAxiosError } from 'axios';
 import { useMutation } from '@tanstack/react-query';
 import { useApi } from 'hooks/useApi';
 import { queryClient } from 'utils/query/queryClient';
 import { QueryKey } from './queryKey';
 import { getPluginApi } from '@jellyfin/sdk/lib/utils/api/plugin-api';
+import type { RepositoryInfo } from '@jellyfin/sdk/lib/generated-client/models/repository-info';
 import { PluginApiSetRepositoriesRequest } from '@jellyfin/sdk/lib/generated-client/api/plugin-api';
 
 export const useSetRepositories = () => {
     const { api } = useApi();
     return useMutation({
-        mutationFn: (params: PluginApiSetRepositoriesRequest) => (
-            getPluginApi(api!)
-                .setRepositories(params)
-        ),
+        mutationFn: async ({ validateRepository, ...params }: PluginApiSetRepositoriesRequest & { validateRepository?: RepositoryInfo }) => {
+            if (validateRepository) {
+                // Use the authenticated server to fetch the manifest, avoiding browser CORS restrictions.
+                // Replace with the generated SDK method when it is available.
+                try {
+                    await api!.axiosInstance.post(`${api!.basePath}/Repositories/Validate`, validateRepository, {
+                        headers: { Authorization: api!.authorizationHeader }
+                    });
+                } catch (error) {
+                    // Older supported servers have no validation endpoint. Manifest failures
+                    // from servers that support validation use 400, never 404 or 405.
+                    if (!isAxiosError(error) || ![ 404, 405 ].includes(error.response?.status ?? 0)) {
+                        throw error;
+                    }
+                }
+            }
+
+            return getPluginApi(api!).setRepositories(params);
+        },
         onSuccess: () => {
             void queryClient.invalidateQueries({
                 queryKey: [ QueryKey.Repositories ]

--- a/src/apps/dashboard/features/plugins/components/NewRepositoryForm.tsx
+++ b/src/apps/dashboard/features/plugins/components/NewRepositoryForm.tsx
@@ -6,18 +6,22 @@ import globalize from 'lib/globalize';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import Button from '@mui/material/Button';
+import Alert from '@mui/material/Alert';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 
 type IProps = {
     open: boolean;
+    isPending: boolean;
+    hasError: boolean;
     onClose: () => void;
     onAdd: (repository: RepositoryInfo) => void;
 };
 
-const NewRepositoryForm = ({ open, onClose, onAdd }: IProps) => {
+const NewRepositoryForm = ({ open, onClose, onAdd, isPending, hasError }: IProps) => {
     const onSubmit = useCallback((e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
+        if (isPending) return;
 
         const formData = new FormData(e.currentTarget);
         const data = Object.fromEntries(formData.entries());
@@ -29,7 +33,7 @@ const NewRepositoryForm = ({ open, onClose, onAdd }: IProps) => {
         };
 
         onAdd(repository);
-    }, [ onAdd ]);
+    }, [ onAdd, isPending ]);
 
     return (
         <Dialog
@@ -48,7 +52,9 @@ const NewRepositoryForm = ({ open, onClose, onAdd }: IProps) => {
 
             <DialogContent>
                 <Stack spacing={3}>
+                    {hasError && <Alert severity='error'>{globalize.translate('RepositoryAddError')}</Alert>}
                     <TextField
+                        disabled={isPending}
                         name='Name'
                         label={globalize.translate('LabelRepositoryName')}
                         helperText={globalize.translate('LabelRepositoryNameHelp')}
@@ -60,6 +66,8 @@ const NewRepositoryForm = ({ open, onClose, onAdd }: IProps) => {
                     />
 
                     <TextField
+                        disabled={isPending}
+                        required
                         name='Url'
                         label={globalize.translate('LabelRepositoryUrl')}
                         helperText={globalize.translate('LabelRepositoryUrlHelp')}
@@ -70,10 +78,11 @@ const NewRepositoryForm = ({ open, onClose, onAdd }: IProps) => {
 
             <DialogActions>
                 <Button
+                    disabled={isPending}
                     onClick={onClose}
                     variant='text'
                 >{globalize.translate('ButtonCancel')}</Button>
-                <Button type='submit'>{globalize.translate('Add')}</Button>
+                <Button type='submit' loading={isPending}>{globalize.translate('Add')}</Button>
             </DialogActions>
         </Dialog>
     );

--- a/src/apps/dashboard/routes/plugins/repositories.test.tsx
+++ b/src/apps/dashboard/routes/plugins/repositories.test.tsx
@@ -1,0 +1,65 @@
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Component } from './repositories';
+
+const { mutate } = vi.hoisted(() => ({ mutate: vi.fn() }));
+vi.mock('lib/globalize', () => ({ default: { translate: (key: string) => key } }));
+vi.mock('components/Page', () => ({ default: ({ children }: React.PropsWithChildren) => <div>{children}</div> }));
+vi.mock('components/loading/LoadingComponent', () => ({ default: () => null }));
+vi.mock('apps/dashboard/features/plugins/components/RepositoryListItem', () => ({ default: () => null }));
+vi.mock('apps/dashboard/features/plugins/api/useRepositories', () => ({
+    useRepositories: () => ({ data: [], isPending: false, isError: false })
+}));
+vi.mock('apps/dashboard/features/plugins/api/useSetRepositories', () => ({
+    useSetRepositories: () => ({ mutate, isPending: false })
+}));
+
+describe('Adding a plugin repository', () => {
+    let container: HTMLDivElement;
+    let root: Root;
+
+    beforeEach(() => {
+        // React requires this exact global name for act() in custom test environments.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+        container = document.createElement('div');
+        document.body.appendChild(container);
+        root = createRoot(container);
+        mutate.mockReset();
+        act(() => root.render(<Component />));
+        const button = container.querySelector('button');
+        act(() => button?.click());
+        const name = document.querySelector<HTMLInputElement>('input[name="Name"]');
+        const url = document.querySelector<HTMLInputElement>('input[name="Url"]');
+        name!.value = 'Invalid repository';
+        url!.value = 'https://example.com/missing.json';
+    });
+
+    afterEach(() => {
+        act(() => root.unmount());
+        container.remove();
+    });
+
+    it('keeps the entered values and shows an error when adding fails', () => {
+        mutate.mockImplementation((_params, options) => {
+            options.onError?.(new Error('404'));
+            options.onSettled?.();
+        });
+        act(() => {
+            document.querySelector('form')!.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+        });
+        expect(document.querySelector('[role="dialog"]')?.getAttribute('aria-hidden')).not.toBe('true');
+        expect(document.querySelector('[role="alert"]')?.textContent).toBe('RepositoryAddError');
+        expect(document.querySelector<HTMLInputElement>('input[name="Url"]')?.value).toBe('https://example.com/missing.json');
+    });
+
+    it('requests validation of the new repository before saving', () => {
+        act(() => {
+            document.querySelector('form')!.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+        });
+        expect(mutate.mock.calls[0][0].validateRepository).toEqual({
+            Name: 'Invalid repository', Url: 'https://example.com/missing.json', Enabled: true
+        });
+    });
+});

--- a/src/apps/dashboard/routes/plugins/repositories.tsx
+++ b/src/apps/dashboard/routes/plugins/repositories.tsx
@@ -19,6 +19,7 @@ export const Component = () => {
     const { data: repositories, isPending, isError } = useRepositories();
     const [ isRepositoryFormOpen, setIsRepositoryFormOpen ] = useState(false);
     const setRepositories = useSetRepositories();
+    const [ hasAddError, setHasAddError ] = useState(false);
 
     const onDelete = useCallback((repository: RepositoryInfo) => {
         if (repositories) {
@@ -29,27 +30,35 @@ export const Component = () => {
     }, [ repositories, setRepositories ]);
 
     const onRepositoryAdd = useCallback((repository: RepositoryInfo) => {
-        if (repositories) {
+        if (repositories && !setRepositories.isPending) {
+            setHasAddError(false);
             setRepositories.mutate({
                 repositoryInfo: [
                     ...repositories,
                     repository
-                ]
+                ],
+                validateRepository: repository
             }, {
-                onSettled: () => {
+                onSuccess: () => {
                     setIsRepositoryFormOpen(false);
+                },
+                onError: () => {
+                    setHasAddError(true);
                 }
             });
         }
     }, [ repositories, setRepositories ]);
 
     const openRepositoryForm = useCallback(() => {
+        setHasAddError(false);
         setIsRepositoryFormOpen(true);
     }, []);
 
     const onRepositoryFormClose = useCallback(() => {
-        setIsRepositoryFormOpen(false);
-    }, []);
+        if (!setRepositories.isPending) {
+            setIsRepositoryFormOpen(false);
+        }
+    }, [ setRepositories.isPending ]);
 
     if (isPending) {
         return <Loading />;
@@ -65,6 +74,8 @@ export const Component = () => {
                 open={isRepositoryFormOpen}
                 onClose={onRepositoryFormClose}
                 onAdd={onRepositoryAdd}
+                isPending={setRepositories.isPending}
+                hasError={hasAddError}
             />
             <Box className='content-primary'>
                 {isError ? (

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1533,6 +1533,7 @@
     "ReplaceAllMetadata": "Replace all metadata",
     "ReplaceExistingImages": "Replace existing images",
     "ReplaceTrickplayImages": "Replace existing trickplay images",
+    "RepositoryAddError": "Unable to add the repository. Check that the URL points to a valid plugin manifest and is reachable by your server, then try again.",
     "RepositoriesPageLoadError": "Failed to load repositories",
     "Retry": "Retry",
     "RetryWithGlobalSearch": "Retry with a global search",


### PR DESCRIPTION
### Changes

I also encountered the problem reported in jellyfin/jellyfin#14267: an invalid plugin repository can still be saved successfully.

Original Chinese: “无效插件仓库也能保存成功”“我也遇到了同样的问题”。

I have translated this from Chinese with an LLM.

### Issues

Related to jellyfin/jellyfin#14267.

Companion server PR: https://github.com/jellyfin/jellyfin/pull/18010

### Code assistance

OpenAI Codex: investigation, implementation, automated tests, and code review.

### Validation

- Vitest: 169 passed, 0 failed.
- TypeScript: passed.
- ESLint on changed TypeScript/TSX files: passed.

### Draft checklist

- [ ] Before/after screenshots.
- [ ] Generated TypeScript SDK method for the companion server endpoint; currently uses the SDK's authenticated Axios instance.

---

* [ ] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md). (SDK integration pending.)
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [ ] I have provided a substantive review of another web PR.
