### PR TITLE
Show the book OSD when navigating with the keyboard

### DIFF
--- a/src/plugins/bookPlayer/BookOsd/BookOsd.tsx
+++ b/src/plugins/bookPlayer/BookOsd/BookOsd.tsx
@@ -92,15 +92,22 @@ const BookOsd: FC<BookOsdProps> = ({
             setVisible(state => !state);
         };
 
+        const onKeyDown = () => {
+            scheduleHide();
+            setVisible(true);
+        };
+
         scheduleHide();
         document.addEventListener('pointermove', onPointerMove);
         document.addEventListener('click', onClick);
+        document.addEventListener('keydown', onKeyDown);
 
         return () => {
             clearTimeout(timeout.current);
             updateFullscreen(false);
             document.removeEventListener('pointermove', onPointerMove);
             document.removeEventListener('click', onClick);
+            document.removeEventListener('keydown', onKeyDown);
         };
     }, [scheduleHide, updateFullscreen]);
 


### PR DESCRIPTION
### Changes
Changes to add an eventlistener on keydown, similar to webvideo, so the OSD stays visible as you page through books.
Paging already works by keyboard, the OSD just can't be recovered at all once it auto hides, so you're moving through a long PDF with no idea where you are.

Progress bar in #8320 works and was what I was after, among other things, for web interface. It's gated on the same visibility flag, so by keyboard it can't be seen either.

Tested: .pdf | .epub | .cbz

### Issues
None

### Code assistance
None

---

* [X] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-web/blob/master/CONTRIBUTING.md).
* [X] I have tested these changes.
* [X] I have verified that this is not duplicating changes in an existing PR.
* [X] I have provided a *substantive* review of [another web PR](https://github.com/jellyfin/jellyfin-web/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
